### PR TITLE
Marketing site: content hub (/blog) + email subscribe

### DIFF
--- a/apps/www/app/api/subscribe/route.ts
+++ b/apps/www/app/api/subscribe/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Content/newsletter subscribe. Captures to Slack today (same channel as the
+// waitlist) so no signup is lost; point this at a real ESP list when one is
+// wired (see the co-founder memo / growth playbook).
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const email = body.email?.trim();
+    const source = body.source?.trim() || "site";
+
+    if (!email || !EMAIL_REGEX.test(email)) {
+      return NextResponse.json(
+        { error: "Please enter a valid email address." },
+        { status: 400 }
+      );
+    }
+
+    const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+    if (!webhookUrl) {
+      console.error("Missing SLACK_WEBHOOK_URL");
+      return NextResponse.json(
+        { error: "Subscribe is temporarily unavailable." },
+        { status: 503 }
+      );
+    }
+
+    const slackPayload = {
+      text: `New OpenVPM subscriber — ${email}`,
+      blocks: [
+        {
+          type: "header",
+          text: { type: "plain_text", text: "📰 New OpenVPM subscriber" },
+        },
+        {
+          type: "section",
+          fields: [
+            { type: "mrkdwn", text: `*Email:*\n${email}` },
+            { type: "mrkdwn", text: `*Source:*\n${source}` },
+          ],
+        },
+        {
+          type: "context",
+          elements: [
+            { type: "mrkdwn", text: `openvpm.com · ${new Date().toISOString()}` },
+          ],
+        },
+      ],
+    };
+
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(slackPayload),
+    });
+
+    if (!res.ok) {
+      console.error("Slack webhook error:", res.status, await res.text());
+      return NextResponse.json(
+        { error: "Something went wrong. Please try again." },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Subscribe error:", error);
+    return NextResponse.json(
+      { error: "Something went wrong. Please try again." },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/www/app/blog/[slug]/page.tsx
+++ b/apps/www/app/blog/[slug]/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft, Github } from "lucide-react";
+import { posts, getPost } from "@/lib/posts";
+import { PostContent } from "@/components/blog/post-content";
+import { SubscribeForm } from "@/components/subscribe-form";
+
+export function generateStaticParams() {
+  return posts.map((p) => ({ slug: p.slug }));
+}
+
+export function generateMetadata({ params }: { params: { slug: string } }): Metadata {
+  const post = getPost(params.slug);
+  if (!post) return { title: "Not found" };
+  return {
+    title: post.title,
+    description: post.excerpt,
+    openGraph: { title: post.title, description: post.excerpt, type: "article" },
+  };
+}
+
+export default function PostPage({ params }: { params: { slug: string } }) {
+  const post = getPost(params.slug);
+  if (!post) notFound();
+
+  return (
+    <article className="py-16 sm:py-24">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-1.5 text-sm text-teal-600 hover:text-teal-700 mb-8"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          All writing
+        </Link>
+
+        <div className="flex items-center gap-3 text-sm text-gray-400 mb-4">
+          <time>{post.date}</time>
+          <span>·</span>
+          <span>{post.author}</span>
+          <span>·</span>
+          <span>{post.readingMinutes} min read</span>
+        </div>
+        <h1 className="text-3xl sm:text-4xl font-bold font-heading text-gray-900 tracking-tight leading-tight mb-8">
+          {post.title}
+        </h1>
+
+        <PostContent blocks={post.content} />
+
+        {/* Conversion: every post ends with a way to engage. */}
+        <div className="mt-12 rounded-2xl border border-gray-100 bg-gray-50/60 p-6 sm:p-8">
+          <h2 className="text-lg font-semibold font-heading text-gray-900 mb-2">
+            We&apos;re building this in the open
+          </h2>
+          <p className="text-sm text-gray-600 mb-5">
+            OpenVPM is free and MIT licensed. Try the live demo, star the repo, or
+            subscribe and tell us where we&apos;re wrong — the harder the feedback, the better.
+          </p>
+          <div className="flex flex-wrap gap-3 mb-6">
+            <a
+              href="https://demo.openvpm.com/login"
+              className="inline-flex items-center gap-2 rounded-lg bg-teal-600 px-4 py-2 text-sm font-semibold text-white hover:bg-teal-700 transition-colors"
+            >
+              Try the live demo
+            </a>
+            <a
+              href="https://github.com/evangauer/openvpm"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border-2 border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:border-teal-200 hover:text-teal-600 transition-colors"
+            >
+              <Github className="w-4 h-4" />
+              Star on GitHub
+            </a>
+          </div>
+          <SubscribeForm source={`post:${post.slug}`} />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/apps/www/app/blog/page.tsx
+++ b/apps/www/app/blog/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { posts } from "@/lib/posts";
+import { SubscribeForm } from "@/components/subscribe-form";
+
+export const metadata: Metadata = {
+  title: "Writing",
+  description:
+    "Notes on building open, API-first veterinary software — owning your data, open APIs, and AI agents in the clinic.",
+};
+
+export default function BlogIndexPage() {
+  return (
+    <div className="py-16 sm:py-24">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-12">
+          <h1 className="text-4xl sm:text-5xl font-bold font-heading text-gray-900 tracking-tight mb-4">
+            Writing
+          </h1>
+          <p className="text-lg text-gray-600 max-w-2xl">
+            Notes on building veterinary software in the open — owning your data,
+            open APIs, and putting AI agents to work in the clinic. We publish our
+            thinking here and we want yours back.
+          </p>
+        </div>
+
+        <div className="space-y-8">
+          {posts.map((post) => (
+            <article
+              key={post.slug}
+              className="group rounded-2xl border border-gray-100 bg-white p-6 sm:p-8 hover:border-teal-200 hover:shadow-lg hover:shadow-teal-50 transition-all"
+            >
+              <div className="flex items-center gap-3 text-sm text-gray-400 mb-3">
+                <time>{post.date}</time>
+                <span>·</span>
+                <span>{post.readingMinutes} min read</span>
+              </div>
+              <h2 className="text-2xl font-bold font-heading text-gray-900 tracking-tight mb-2">
+                <Link href={`/blog/${post.slug}`} className="hover:text-teal-700">
+                  {post.title}
+                </Link>
+              </h2>
+              <p className="text-gray-600 leading-relaxed mb-4">{post.excerpt}</p>
+              <Link
+                href={`/blog/${post.slug}`}
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-teal-600 group-hover:text-teal-700"
+              >
+                Read
+                <ArrowRight className="w-4 h-4" />
+              </Link>
+            </article>
+          ))}
+        </div>
+
+        <div className="mt-14 rounded-2xl border border-teal-100 bg-teal-50/40 p-8 text-center">
+          <h2 className="text-xl font-semibold font-heading text-gray-900 mb-2">
+            Get new writing by email
+          </h2>
+          <p className="text-gray-600 mb-6 max-w-md mx-auto">
+            No spam — just our notes on open veterinary software as we publish them.
+            Reply with your thoughts; we read every one.
+          </p>
+          <div className="max-w-sm mx-auto">
+            <SubscribeForm source="blog" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/www/app/sitemap.ts
+++ b/apps/www/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { posts } from "@/lib/posts";
 
 const baseUrl = "https://openvpm.com";
 
@@ -10,5 +11,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${baseUrl}/why`, lastModified: now, changeFrequency: "monthly", priority: 0.7 },
     { url: `${baseUrl}/install`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
     { url: `${baseUrl}/updates`, lastModified: now, changeFrequency: "weekly", priority: 0.6 },
+    { url: `${baseUrl}/blog`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
+    ...posts.map((p) => ({
+      url: `${baseUrl}/blog/${p.slug}`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    })),
   ];
 }

--- a/apps/www/components/blog/post-content.tsx
+++ b/apps/www/components/blog/post-content.tsx
@@ -1,0 +1,47 @@
+import type { Block } from "@/lib/posts";
+
+export function PostContent({ blocks }: { blocks: Block[] }) {
+  return (
+    <div className="space-y-5">
+      {blocks.map((block, i) => {
+        switch (block.type) {
+          case "h2":
+            return (
+              <h2
+                key={i}
+                className="text-xl sm:text-2xl font-bold font-heading text-gray-900 tracking-tight pt-2"
+              >
+                {block.text}
+              </h2>
+            );
+          case "quote":
+            return (
+              <blockquote
+                key={i}
+                className="border-l-4 border-teal-300 pl-5 py-1 text-lg font-heading text-gray-700 italic"
+              >
+                {block.text}
+              </blockquote>
+            );
+          case "ul":
+            return (
+              <ul key={i} className="space-y-2 pl-1">
+                {block.items.map((item, j) => (
+                  <li key={j} className="flex items-start gap-2 text-gray-600 leading-relaxed">
+                    <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-teal-500" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            );
+          default:
+            return (
+              <p key={i} className="text-gray-600 leading-relaxed text-[17px]">
+                {block.text}
+              </p>
+            );
+        }
+      })}
+    </div>
+  );
+}

--- a/apps/www/components/footer.tsx
+++ b/apps/www/components/footer.tsx
@@ -42,6 +42,9 @@ export function MarketingFooter() {
             <Link href="/why" className="text-sm text-gray-500 hover:text-teal-600 transition-colors">
               Why Open Source
             </Link>
+            <Link href="/blog" className="text-sm text-gray-500 hover:text-teal-600 transition-colors">
+              Writing
+            </Link>
             <Link href="/updates" className="text-sm text-gray-500 hover:text-teal-600 transition-colors">
               Updates
             </Link>

--- a/apps/www/components/nav.tsx
+++ b/apps/www/components/nav.tsx
@@ -29,6 +29,7 @@ const navLinks = [
   { label: "Features", href: "/features" },
   { label: "Install", href: "/install" },
   { label: "Why Open Source", href: "/why" },
+  { label: "Writing", href: "/blog" },
   { label: "Updates", href: "/updates" },
 ];
 

--- a/apps/www/components/subscribe-form.tsx
+++ b/apps/www/components/subscribe-form.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight, CheckCircle2, Loader2 } from "lucide-react";
+
+type Step = "idle" | "submitting" | "success" | "error";
+
+export function SubscribeForm({ source }: { source?: string }) {
+  const [step, setStep] = useState<Step>("idle");
+  const [email, setEmail] = useState("");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim()) return;
+    setStep("submitting");
+    setErrorMsg("");
+    try {
+      const res = await fetch("/api/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim(), source }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setStep("error");
+        setErrorMsg(data.error || "Something went wrong. Please try again.");
+        return;
+      }
+      setStep("success");
+    } catch {
+      setStep("error");
+      setErrorMsg("Something went wrong. Please try again.");
+    }
+  };
+
+  if (step === "success") {
+    return (
+      <div className="flex items-center justify-center gap-2 py-2 text-teal-700 font-medium">
+        <CheckCircle2 className="w-5 h-5 shrink-0" />
+        Subscribed — talk soon.
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2">
+      <input
+        type="email"
+        required
+        placeholder="you@clinic.com"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        disabled={step === "submitting"}
+        className="flex-1 rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent disabled:opacity-60"
+      />
+      <button
+        type="submit"
+        disabled={step === "submitting"}
+        className="inline-flex items-center justify-center gap-2 rounded-xl bg-teal-600 px-5 py-3 text-sm font-semibold text-white hover:bg-teal-700 transition-colors disabled:opacity-60"
+      >
+        {step === "submitting" ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            Subscribing…
+          </>
+        ) : (
+          <>
+            Subscribe
+            <ArrowRight className="w-4 h-4" />
+          </>
+        )}
+      </button>
+      {step === "error" && (
+        <p className="text-sm text-red-600 sm:absolute sm:mt-14">{errorMsg}</p>
+      )}
+    </form>
+  );
+}

--- a/apps/www/lib/posts.ts
+++ b/apps/www/lib/posts.ts
@@ -1,0 +1,99 @@
+/**
+ * Thought-leadership content for the OpenVPM blog. Stored as structured blocks
+ * (zero dependencies, fully type-checked) and rendered by app/blog. Add a post
+ * by appending to `posts` — newest first.
+ */
+
+export type Block =
+  | { type: "p"; text: string }
+  | { type: "h2"; text: string }
+  | { type: "ul"; items: string[] }
+  | { type: "quote"; text: string };
+
+export interface Post {
+  slug: string;
+  title: string;
+  /** Display date, e.g. "June 3, 2026". */
+  date: string;
+  author: string;
+  excerpt: string;
+  readingMinutes: number;
+  content: Block[];
+}
+
+export const posts: Post[] = [
+  {
+    slug: "why-veterinary-software-should-be-open",
+    title: "Why veterinary software should be open",
+    date: "June 3, 2026",
+    author: "Evan Gauer",
+    excerpt:
+      "Every other part of the clinic is built on standards. The software that runs it shouldn't be a locked box you rent forever.",
+    readingMinutes: 4,
+    content: [
+      { type: "p", text: "Walk into any veterinary clinic and almost everything follows a standard. Drugs have monographs. Labs report against reference ranges. Anesthesia has protocols. Then you get to the software that ties it all together — the practice management system — and the standards disappear. Your data lives in a format only the vendor can read. The API, if there is one, is locked behind a partnership team. And the bill arrives every month whether the software got better or not." },
+      { type: "h2", text: "Closed software is a tax on the whole industry" },
+      { type: "p", text: "When the system of record is closed, every good idea downstream gets harder. A reminder tool has to beg for integration access. An AI scribe can read but not write. A new analytics product can't get the data out. The clinic that wants to switch finds out their five years of records are effectively hostage. None of this is about bad people — it's about incentives. A closed PIMS makes more money the harder it is to leave." },
+      { type: "quote", text: "The best software for veterinary medicine should be built with the veterinary community, not sold to it." },
+      { type: "h2", text: "What open changes" },
+      { type: "ul", items: [
+        "Your data is yours. Full export, any time, in a format you can read — no lock-in, no exit fee.",
+        "Anyone can build on it. A documented, read-write API means the next great tool doesn't need anyone's permission.",
+        "The roadmap follows real clinics, not a sales quota. Features ship because a practice needed them.",
+        "Trust is inspectable. The code is public. You can see exactly what happens to a patient record.",
+      ] },
+      { type: "p", text: "OpenVPM is our attempt to prove this can exist and be good — not a stripped-down toy, but a modern PIMS with a real API that a clinic could actually run. It's MIT licensed and it always will be." },
+      { type: "p", text: "We don't think we have all the answers. We think the answers come faster in the open. If you run a clinic, build in this space, or just have opinions about how it should work, we want them — the harder the better." },
+    ],
+  },
+  {
+    slug: "own-your-data-a-second-pims-you-control",
+    title: "Own your data: a second PIMS you control",
+    date: "June 3, 2026",
+    author: "Evan Gauer",
+    excerpt:
+      "You don't have to rip out the system you run today to start owning your data. Connect a second PIMS — one you control — alongside it.",
+    readingMinutes: 5,
+    content: [
+      { type: "p", text: "The most common reaction we hear from practices is some version of: \"I love the idea, but changing my PIMS is a nightmare I'm not signing up for.\" That's not resistance — it's wisdom. A PIMS migration is one of the riskiest things a clinic can do. So we stopped asking for one." },
+      { type: "h2", text: "The model: connect, don't switch" },
+      { type: "p", text: "Instead of rip-and-replace, picture a second PIMS that runs alongside the one you already use — and that you fully own. You connect it with an API key, your data flows in, and now you have a live, exportable copy of your practice's records in a system you control. No migration weekend. No retraining the front desk. Your incumbent keeps doing its job while you quietly gain leverage over your own data." },
+      { type: "ul", items: [
+        "Attach your existing PIMS by API key and mirror your records into a system you own.",
+        "Build on the open API — reminders, analytics, AI agents — without asking a vendor for permission.",
+        "Export everything, anytime. The whole point is that leaving is always easy.",
+        "When you're ready, run it as your primary. Or never. The choice stays yours.",
+      ] },
+      { type: "h2", text: "Where this goes" },
+      { type: "p", text: "The near-term is self-hostable and open: clone it, run it, connect it. The next step is making it effortless — a hosted option where a clinic logs in, attaches their current system, and watches their owned copy populate, no DevOps required. Same open core underneath; we just run the boring parts for you." },
+      { type: "quote", text: "Owning your data shouldn't require a migration. It should require an API key." },
+      { type: "p", text: "This is the part we're actively building, and it's where outside input matters most. If your PIMS has an API we should mirror, tell us. If it doesn't, tell us that too — that's a story worth telling." },
+    ],
+  },
+  {
+    slug: "agents-belong-in-the-back-office",
+    title: "Agents belong in the back office, not just the chat box",
+    date: "June 3, 2026",
+    author: "Evan Gauer",
+    excerpt:
+      "The exciting thing about AI in veterinary medicine isn't a chatbot on the website. It's an agent that can actually do the busywork — if the PIMS lets it.",
+    readingMinutes: 4,
+    content: [
+      { type: "p", text: "Most \"AI for vets\" right now is a chat box bolted onto a website. It can answer questions. What it can't do is the thing that would actually help a short-staffed clinic: the work. Surface the patients overdue for vaccines. Draft the recall list. Look up a weight-based dose. Find the open slot and book the visit. That work lives inside the PIMS — and an agent can only do it if the PIMS has a real, write-capable API." },
+      { type: "h2", text: "Why the closed PIMS blocks this" },
+      { type: "p", text: "An agent is only as useful as the tools it can call. If the system of record won't let software write back — create the appointment, record the note, update the record — then the agent is stuck reading. That's the wall most veterinary AI hits today. It's not a model problem. It's an access problem." },
+      { type: "h2", text: "What we're building" },
+      { type: "p", text: "OpenVPM ships with an agent that operates on the practice's own data through the same open API any developer can use. It works through typed tools — find a client, pull a clinical summary, calculate a dose, find an open slot, book it — and every write is gated for a human to confirm. It's scoped to a single practice and fully inspectable, because it's open source." },
+      { type: "ul", items: [
+        "Tools, not guesses — the agent acts on real records or it doesn't act.",
+        "Human-in-the-loop on every write. The clinic stays in control.",
+        "Bring your own model key. Nothing is hidden; the whole thing is auditable.",
+      ] },
+      { type: "p", text: "We think the clinics that win the next decade won't be the ones with the fanciest chatbot. They'll be the ones whose software lets them put the boring, repetitive work on autopilot — safely. That requires an open foundation. So we're building one." },
+    ],
+  },
+];
+
+export function getPost(slug: string): Post | undefined {
+  return posts.find((p) => p.slug === slug);
+}


### PR DESCRIPTION
## Why
Veterinary software adoption runs on thought leadership and community, not feature lists. This stands up a real content engine on the marketing site to drive people to, capture interest, and build a critical community around the open project.

## What
- **/blog** — a zero-dependency, type-safe post model + renderer, seeded with 3 essays that carry the thesis:
  - *Why veterinary software should be open*
  - *Own your data: a second PIMS you control* (connect-by-API-key, eventual hosted self-service)
  - *Agents belong in the back office, not just the chat box*
- **Email subscribe** (`/api/subscribe` + form) framed for content; posts to Slack today (same channel as the waitlist) so nothing is lost — point at a real ESP list when wired.
- Each post ends with try-the-demo / star / subscribe CTAs. Wired into nav, footer, and sitemap (incl. per-post URLs for SEO).

## Open-source safety
Marketing-site only (`apps/www`). Nothing touches the open-source app; no telemetry added to the product.

## Notes
- Stacked on `fix/lockfile-tiptap` (PR #3) for green CI. Minor nav/footer/sitemap overlap with PR #4 (feedback) — trivial rebase.
- See the co-founder memo for the repo-split plan (extract the marketing site to its own repo so the public repo stays the pure product).

## Verified
`pnpm --filter @openpims/www type-check` + `build` pass; /blog (+ 3 posts) prerender, /api/subscribe compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)