### PR TITLE
Fix stale MIT license references in marketing copy

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -94,7 +94,7 @@ const stats = [
   { value: "21", label: "API Modules" },
   { value: "150+", label: "Endpoints" },
   { value: "16", label: "Schema Files" },
-  { value: "MIT", label: "License" },
+  { value: "AGPLv3", label: "License" },
 ];
 
 const painPoints = [
@@ -815,7 +815,7 @@ export default function LandingPage() {
               </div>
               <ul className="mt-6 space-y-3 text-sm text-gray-600">
                 {[
-                  "Full source code under MIT license",
+                  "Full source code under the AGPLv3 license",
                   "All PIMS modules and API access",
                   "Docker/Vercel deployment paths",
                   "Bring your own database, storage, email, SMS, and AI keys",


### PR DESCRIPTION
## Summary

The repo is AGPLv3 (commit `9a1cc2c` relicensed from MIT), but two marketing references still said "MIT":

- `apps/www/app/page.tsx:97` — hero stats badge `{ value: "MIT", label: "License" }` (the relicense commit missed it)
- `apps/www/app/page.tsx:818` — Self-host pricing bullet "Full source code under MIT license" (reintroduced by the cloud-launch pricing section, which was branched from the pre-relicense `main`)

Both now read **AGPLv3**, consistent with `LICENSE`, the README badge/body, and the footer.

## Type of Change

- [x] Bug fix (copy/messaging correctness)

## Testing

- [x] Repo-wide scan confirms no remaining genuine "MIT" license references
- CI runs type-check / test / build

🤖 Generated with [Claude Code](https://claude.com/claude-code)