### PR TITLE
Disable prepared statements on pooled DB connections

### DIFF
--- a/packages/db/client.ts
+++ b/packages/db/client.ts
@@ -12,10 +12,22 @@ function getConnectionString() {
   return url;
 }
 
+// Supabase's transaction pooler (PgBouncer, port 6543) does not support the
+// prepared statements postgres-js uses by default, so disable them for pooled
+// connections. Direct/local connections keep prepares on for performance.
+function isPooledConnection(url: string): boolean {
+  return (
+    url.includes("pooler.supabase.com") ||
+    url.includes(":6543") ||
+    url.includes("pgbouncer=true")
+  );
+}
+
 export const db = new Proxy({} as ReturnType<typeof drizzle<typeof schema>>, {
   get(_target, prop) {
     if (!_db) {
-      const client = postgres(getConnectionString());
+      const url = getConnectionString();
+      const client = postgres(url, isPooledConnection(url) ? { prepare: false } : {});
       _db = drizzle(client, { schema });
     }
     return (_db as any)[prop];


### PR DESCRIPTION
## Summary

The hosted app connects to Supabase through the **transaction pooler** (PgBouncer, port 6543), which does not support prepared statements. `postgres-js` enables prepared statements by default, so without this change the production app would hit prepared-statement errors on Vercel.

This detects a pooled `DATABASE_URL` (`pooler.supabase.com`, `:6543`, or `pgbouncer=true`) and passes `{ prepare: false }`. Direct and local connections keep prepares on for performance.

Verified against the prod Supabase project: the least-privilege `openpims_app` role connects cleanly through the IPv4 shared pooler with this setting; RLS is enabled on 46 tables / 49 policies; security advisor = 0 lints.

## Type of Change

- [x] Bug fix (production DB connectivity)

## Testing

- [x] `current_user` confirms connection as `openpims_app` via `aws-1-us-east-2.pooler.supabase.com:6543`
- CI runs type-check / test / build

🤖 Generated with [Claude Code](https://claude.com/claude-code)