### PR TITLE
Add apps/web/vercel.json (hosted app build config + crons)

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm build",
+  "outputDirectory": ".next",
+  "crons": [
+    {
+      "path": "/api/cron/reminders",
+      "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/backup",
+      "schedule": "0 3 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The hosted app deploys as its own Vercel project with **Root Directory `apps/web`**. Vercel reads `vercel.json` from the root directory, so the app needs its own (the repo-root `vercel.json` is only seen by repo-root projects, and `apps/www` already has its own).

This adds `apps/web/vercel.json` with:
- Monorepo install (`cd ../.. && pnpm install --frozen-lockfile`) + Next.js build — mirrors `apps/www/vercel.json`.
- The two hosted crons that live in `apps/web`: `/api/cron/reminders` (daily 8am) and `/api/cron/backup` (daily 3am), both protected by `CRON_SECRET`.

## Type of Change

- [x] Other: deployment configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)