### PR TITLE
Pricing: flat $99/location, unlimited staff (drop per-seat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,12 +285,11 @@ Self-hosting stays fully unlocked and free. Leave `HOSTED_BILLING_ENABLED` unset
 
 OpenVPM Cloud is the hosted service for clinics that do not want to run infrastructure. It includes a 14-day no-card trial with all features enabled, then bills one simple plan:
 
-- $49/month per active, non-deleted location
-- $10/month per active, non-deleted staff user, all roles included
+- $99/month per active, non-deleted location, with unlimited staff (all roles included)
 - Included monthly SMS and AI allowances, with Stripe-metered overages
 - Enterprise deployments are custom/contact-sales
 
-Hosted Stripe setup uses separate recurring prices for `STRIPE_PRICE_CLOUD_LOCATION` and `STRIPE_PRICE_CLOUD_USER`. `STRIPE_PRICE_CLOUD` is legacy-only for existing subscriptions and is not used for new checkout.
+Hosted Stripe setup uses one recurring per-location price in `STRIPE_PRICE_CLOUD_LOCATION`. `STRIPE_PRICE_CLOUD_USER` and `STRIPE_PRICE_CLOUD` are legacy-only for existing subscriptions and are not used for new checkout.
 
 For hosted deployment details, see [docs/hosted-cloud-production.md](docs/hosted-cloud-production.md).
 

--- a/apps/web/app/(dashboard)/onboarding/page.tsx
+++ b/apps/web/app/(dashboard)/onboarding/page.tsx
@@ -203,11 +203,9 @@ export default function OnboardingPage() {
             </div>
             <div className="flex justify-between">
               <span className="text-muted-foreground">
-                {subscription.data?.billableSeatCount ?? 1} active staff user
+                {subscription.data?.billableSeatCount ?? 1} staff
               </span>
-              <span className="font-medium">
-                {money(subscription.data?.seatUnitPriceMonthlyUsd)}/mo each
-              </span>
+              <span className="font-medium">unlimited, included</span>
             </div>
             <div className="border-t border-border pt-3">
               <div className="flex items-end justify-between">

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -615,9 +615,12 @@ function BillingTab() {
             </p>
           </div>
           <div>
-            <p className="text-muted-foreground">Billable staff</p>
+            <p className="text-muted-foreground">Staff</p>
             <p className="font-medium">
-              {data.billableSeatCount} x ${data.seatUnitPriceMonthlyUsd}/mo
+              {data.billableSeatCount}
+              {data.seatUnitPriceMonthlyUsd > 0
+                ? ` x $${data.seatUnitPriceMonthlyUsd}/mo`
+                : " (unlimited, included)"}
             </p>
           </div>
           <div>
@@ -727,16 +730,18 @@ function PlanGrid({
           >
             <h4 className="font-heading text-base font-semibold">{p.name}</h4>
             <p className="mt-1 text-2xl font-bold">
-              {p.locationUnitPriceMonthlyUsd === null || p.seatUnitPriceMonthlyUsd === null ? (
+              {p.locationUnitPriceMonthlyUsd === null ? (
                 "Custom"
-              ) : p.locationUnitPriceMonthlyUsd === 0 && p.seatUnitPriceMonthlyUsd === 0 ? (
+              ) : p.locationUnitPriceMonthlyUsd === 0 ? (
                 "Free"
               ) : (
                 <>
                   ${p.locationUnitPriceMonthlyUsd}
                   <span className="text-sm font-normal text-muted-foreground">/location</span>
                   <span className="block text-sm font-normal text-muted-foreground">
-                    + ${p.seatUnitPriceMonthlyUsd}/staff/mo
+                    {p.seatUnitPriceMonthlyUsd && p.seatUnitPriceMonthlyUsd > 0
+                      ? `+ $${p.seatUnitPriceMonthlyUsd}/staff/mo`
+                      : "unlimited staff"}
                   </span>
                 </>
               )}

--- a/apps/web/lib/billing/__tests__/plans.test.ts
+++ b/apps/web/lib/billing/__tests__/plans.test.ts
@@ -95,7 +95,7 @@ describe("trials", () => {
 });
 
 describe("PLANS pricing", () => {
-  it("uses hybrid Cloud pricing, free self-host, and custom enterprise", () => {
+  it("uses flat per-location Cloud pricing, free self-host, and custom enterprise", () => {
     expect(PLANS.free.locationUnitPriceMonthlyUsd).toBe(0);
     expect(PLANS.free.seatUnitPriceMonthlyUsd).toBe(0);
     expect(PLANS.cloud.locationUnitPriceMonthlyUsd).toBe(
@@ -108,9 +108,10 @@ describe("PLANS pricing", () => {
     expect(PLANS.enterprise.seatUnitPriceMonthlyUsd).toBeNull();
   });
 
-  it("estimates base Cloud subscription from locations and billable staff", () => {
-    expect(estimatedCloudBaseMonthlyUsd(2, 5)).toBe(148);
-    expect(estimatedCloudBaseMonthlyUsd(0, 0)).toBe(49);
+  it("estimates base Cloud subscription from locations (flat, unlimited staff)", () => {
+    // Flat per-location model: staff count does not affect the base.
+    expect(estimatedCloudBaseMonthlyUsd(2, 5)).toBe(198);
+    expect(estimatedCloudBaseMonthlyUsd(0, 0)).toBe(99);
   });
 });
 

--- a/apps/web/lib/billing/plans.ts
+++ b/apps/web/lib/billing/plans.ts
@@ -6,10 +6,10 @@
  * product. We monetize hosting + scale (locations) + heavy usage, not by locking
  * the open core.
  *
- * Pricing (managed Cloud): ONE simple self-serve tier with hybrid billing:
- * $49/mo per active location + $10/mo per active staff user. ALL features are
- * included while trialing/active, with metered overage for SMS / AI usage
- * beyond included monthly allowances. Enterprise = custom.
+ * Pricing (managed Cloud): ONE simple self-serve tier — flat $99/mo per active
+ * location, unlimited staff. ALL features are included while trialing/active,
+ * with generous included SMS / AI allowances and metered overage beyond.
+ * Enterprise = custom.
  */
 
 export type PlanTier = "free" | "cloud" | "enterprise";
@@ -38,9 +38,10 @@ export const ALL_FEATURES: Feature[] = [
   "integrations",
 ];
 
-/** Managed Cloud list prices. */
-export const CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD = 49;
-export const CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD = 10;
+/** Managed Cloud list price: flat per active location, unlimited staff. */
+export const CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD = 99;
+/** No per-seat charge under the flat model (kept at 0 for type/back-compat). */
+export const CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD = 0;
 
 /** Env vars holding Stripe Price IDs for hosted billing (PRIVATE). */
 export const STRIPE_PRICE_CLOUD_LOCATION_ENV = "STRIPE_PRICE_CLOUD_LOCATION";
@@ -99,12 +100,12 @@ export const PLANS: Record<PlanTier, PlanDefinition> = {
     locationUnitPriceMonthlyUsd: CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD,
     seatUnitPriceMonthlyUsd: CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD,
     blurb:
-      "We host it: the full PIMS, managed, with every feature - agent, SMS, reporting, API, multi-location, integrations. $49/mo per location + $10/mo per staff user.",
-    seatLimit: null, // billed by quantity, not capped
-    locationLimit: null, // billed by quantity, not capped
+      "We host it: the full PIMS, managed, with every feature - agent, SMS, reporting, API, multi-location, integrations. $99/mo per location, unlimited staff.",
+    seatLimit: null, // unlimited staff under the flat model
+    locationLimit: null, // billed by location quantity, not capped
     features: [...ALL_FEATURES],
-    includedSmsPerMonth: 500,
-    includedAiRunsPerMonth: 200,
+    includedSmsPerMonth: 1000,
+    includedAiRunsPerMonth: 1000,
     stripeLocationPriceEnv: STRIPE_PRICE_CLOUD_LOCATION_ENV,
     stripeSeatPriceEnv: STRIPE_PRICE_CLOUD_USER_ENV,
     selfServe: true,

--- a/apps/web/lib/billing/subscription-sync.ts
+++ b/apps/web/lib/billing/subscription-sync.ts
@@ -131,10 +131,10 @@ export async function syncPracticeSubscriptionQuantities(opts: {
 
   const locationPriceId = process.env[STRIPE_PRICE_CLOUD_LOCATION_ENV];
   const seatPriceId = process.env[STRIPE_PRICE_CLOUD_USER_ENV];
-  if (!locationPriceId || !seatPriceId) {
+  if (!locationPriceId) {
     const state = buildState(
       "error",
-      "Stripe Cloud location/user price IDs are not configured.",
+      "Stripe Cloud location price ID is not configured.",
       counts
     );
     await writeBillingSyncState(db, practiceId, state);
@@ -151,17 +151,21 @@ export async function syncPracticeSubscriptionQuantities(opts: {
     const subscription = await stripe.subscriptions.retrieve(subscriptionId);
     const items = subscription.items.data;
     const locationItem = items.find((item) => item.price?.id === locationPriceId);
-    const seatItem = items.find((item) => item.price?.id === seatPriceId);
+    // Flat model bills locations only; legacy subscriptions may also carry a
+    // per-seat item, which we keep in sync for back-compat when present.
+    const seatItem = seatPriceId
+      ? items.find((item) => item.price?.id === seatPriceId)
+      : undefined;
     const legacyPriceId = process.env[STRIPE_PRICE_CLOUD_LEGACY_ENV];
     const hasLegacyItem =
       !!legacyPriceId && items.some((item) => item.price?.id === legacyPriceId);
 
-    if (!locationItem || !seatItem) {
+    if (!locationItem) {
       const state = buildState(
         hasLegacyItem ? "legacy" : "error",
         hasLegacyItem
-          ? "Legacy Cloud subscription detected; split quantity sync skipped."
-          : "Stripe subscription is missing the Cloud location or staff-user item.",
+          ? "Legacy Cloud subscription detected; quantity sync skipped."
+          : "Stripe subscription is missing the Cloud location item.",
         counts
       );
       await writeBillingSyncState(db, practiceId, state);
@@ -174,18 +178,25 @@ export async function syncPracticeSubscriptionQuantities(opts: {
       return state;
     }
 
-    await Promise.all([
+    const updates = [
       stripe.subscriptionItems.update(locationItem.id, {
         quantity: counts.locationCount,
       }),
-      stripe.subscriptionItems.update(seatItem.id, {
-        quantity: counts.billableSeatCount,
-      }),
-    ]);
+    ];
+    if (seatItem) {
+      updates.push(
+        stripe.subscriptionItems.update(seatItem.id, {
+          quantity: counts.billableSeatCount,
+        })
+      );
+    }
+    await Promise.all(updates);
 
     const state = buildState(
       "ok",
-      `Synced ${counts.locationCount} location(s) and ${counts.billableSeatCount} staff seat(s). Estimated base ${estimatedCloudBaseMonthlyUsd(counts.locationCount, counts.billableSeatCount)} USD/mo.`,
+      `Synced ${counts.locationCount} location(s)${
+        seatItem ? ` and ${counts.billableSeatCount} staff seat(s)` : ", unlimited staff"
+      }. Estimated base ${estimatedCloudBaseMonthlyUsd(counts.locationCount, counts.billableSeatCount)} USD/mo.`,
       counts
     );
     await writeBillingSyncState(db, practiceId, state);

--- a/apps/web/server/routers/subscription.ts
+++ b/apps/web/server/routers/subscription.ts
@@ -130,8 +130,8 @@ export const subscriptionRouter = createRouter({
     .input(z.object({ tier: z.enum(["cloud"]).default("cloud") }))
     .mutation(async ({ ctx, input }) => {
       const plan = PLANS[input.tier];
-      const { locationPriceId, seatPriceId } = cloudCheckoutPriceIds();
-      if (!plan.selfServe || !locationPriceId || !seatPriceId) {
+      const { locationPriceId } = cloudCheckoutPriceIds();
+      if (!plan.selfServe || !locationPriceId) {
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
           message: "This plan isn't available for checkout yet.",
@@ -161,7 +161,6 @@ export const subscriptionRouter = createRouter({
       const result = await createSubscriptionCheckoutSession({
         lineItems: [
           { priceId: locationPriceId, quantity: counts.locationCount },
-          { priceId: seatPriceId, quantity: counts.billableSeatCount },
         ],
         practiceId: ctx.practiceId,
         customerId: practice?.stripeCustomerId ?? undefined,

--- a/apps/www/app/install/install-content.tsx
+++ b/apps/www/app/install/install-content.tsx
@@ -318,7 +318,7 @@ export function InstallContent() {
               <div className="rounded-xl border border-teal-100 bg-teal-50/30 p-5 text-sm text-center">
                 <p className="font-medium text-gray-800 mb-1">Cloud pricing</p>
                 <p className="text-gray-600">
-                  $49/month per active location + $10/month per active staff user.{" "}
+                  $99/month per active location, unlimited staff.{" "}
                   <a href="/#pricing" className="text-teal-600 font-medium hover:underline">
                     View pricing &rarr;
                   </a>

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -847,11 +847,11 @@ export default function LandingPage() {
               </p>
               <div className="mt-6">
                 <div className="flex items-end gap-2">
-                  <span className="text-4xl font-bold font-heading text-gray-900">$49</span>
+                  <span className="text-4xl font-bold font-heading text-gray-900">$99</span>
                   <span className="pb-1 text-sm text-gray-500">/ active location / mo</span>
                 </div>
                 <div className="mt-1 text-sm font-medium text-gray-700">
-                  + $10 / active staff user / mo
+                  Unlimited staff. No per-user fees.
                 </div>
               </div>
               <ul className="mt-6 space-y-3 text-sm text-gray-700">

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -87,12 +87,13 @@ For local or staging signup tests without real email delivery, set `OPENVPM_EXPO
 
 Create one Stripe product for OpenVPM Cloud with recurring monthly prices:
 
-- Cloud location: `$49/month`, env `STRIPE_PRICE_CLOUD_LOCATION`
-- Cloud staff user: `$10/month`, env `STRIPE_PRICE_CLOUD_USER`
+- Cloud location: `$99/month`, env `STRIPE_PRICE_CLOUD_LOCATION` (flat per active location, unlimited staff)
 - SMS overage metered price, env `STRIPE_PRICE_SMS_OVERAGE`
 - AI overage metered price, env `STRIPE_PRICE_AI_OVERAGE`
 
-The app creates one subscription with two recurring line items. Quantity sync updates active non-deleted locations and active non-deleted staff users.
+`STRIPE_PRICE_CLOUD_USER` (legacy per-seat) and `STRIPE_PRICE_CLOUD` (legacy single price) are only kept for mapping existing subscriptions; new checkout uses the per-location price only.
+
+The app creates one subscription with a single recurring per-location line item. Quantity sync updates the active non-deleted location count.
 
 Webhook endpoint:
 


### PR DESCRIPTION
## Summary

Switches OpenVPM Cloud from **$49/location + $10/staff-user** to a single, simple **flat $99/month per active location, unlimited staff**. This is the easiest "yes" in a market where incumbents charge **$200–380 per veterinarian/month**, and it removes the per-user penalty that taxed clinics for adding support staff.

## Changes
- **Billing model** (`lib/billing/plans.ts`): location price $99, seat price $0, updated blurb + generous included allowances (1000 SMS / 1000 AI runs).
- **Checkout + sync**: new subscriptions use a single per-location line item (`subscription.ts`); quantity sync treats the per-seat item as optional/legacy so existing subscriptions keep working (`subscription-sync.ts`).
- **In-app UI**: settings + onboarding show "unlimited staff, included" instead of a $0/seat row.
- **Marketing/docs**: homepage pricing, install page, README, and the hosted-production runbook now say $99/location, unlimited staff.
- **Tests** updated for the flat estimate.

Legacy `STRIPE_PRICE_CLOUD_USER` / `STRIPE_PRICE_CLOUD` envs are retained only for mapping existing subscriptions.

## Follow-on (Phase 1b)
Stripe metered-overage billing for SMS/AI (usage metering infra already exists; current posture stays generous-unmetered).

## Testing
- [x] `pnpm type-check`, `pnpm test` (215), `pnpm build` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)