### PR TITLE
Marketing hero: lead with the live demo (open-source posture)

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -181,7 +181,7 @@ export default function LandingPage() {
             >
               <CheckCircle2 className="w-4 h-4 text-teal-600" />
               <span className="text-sm font-medium text-teal-700">
-                Free and open source &mdash; AGPLv3, forever
+                Free and open source &middot; AGPLv3, forever
               </span>
             </div>
             <h1
@@ -207,17 +207,17 @@ export default function LandingPage() {
               style={{ animationDelay: "300ms" }}
             >
               <a
-                href={cloudSignupUrl}
+                href={demoLoginUrl}
                 className="inline-flex items-center justify-center gap-2 rounded-lg bg-teal-600 px-8 py-3.5 text-base font-semibold text-white shadow-lg shadow-teal-600/25 hover:bg-teal-700 hover:shadow-teal-600/30 transition-all w-full sm:w-auto"
               >
-                Start Cloud Trial
+                Try the Live Demo
                 <ArrowRight className="w-4 h-4" />
               </a>
               <a
-                href={demoLoginUrl}
+                href={cloudSignupUrl}
                 className="inline-flex items-center justify-center gap-2 rounded-lg border-2 border-teal-100 bg-white px-8 py-3.5 text-base font-semibold text-teal-700 hover:border-teal-200 hover:bg-teal-50 transition-all w-full sm:w-auto"
               >
-                Try the Live Demo
+                Start Cloud Trial
               </a>
               <a
                 href="https://github.com/evangauer/openvpm"


### PR DESCRIPTION
## Summary

A small open-source-posture fix to the homepage hero.

The hero headline leads OSS-first ("The veterinary industry's open-source moment is here") but the most prominent CTA was **Start Cloud Trial** (the paid hosted product). This reorders so the primary (filled) button is the zero-commitment **Try the Live Demo**, and **Start Cloud Trial** becomes the secondary (outline) button. This matches the tone the pricing section already uses ("the open-source PIMS stays fully unlocked when you self-host; Cloud is the managed service for clinics that want us to run it").

Also swaps the hero badge's em dash (`&mdash;`) for a middot, per the no-em-dash copy voice.

## Note (optional follow-up)
There are 5 more `&mdash;` em dashes in the page body (lines ~413, 440, 595–596, 681). Left out of this PR to keep it focused on the hero; happy to sweep them separately.

## Testing
- [x] `pnpm --filter @openpims/www type-check` passes. (No logic change — CTA order + one HTML entity.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)