### PR TITLE
Agent: provider-agnostic via Vercel AI SDK (Gemini + Claude)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,8 +68,14 @@ IDEXX_API_KEY=
 ANTECH_API_KEY=
 ZOETIS_API_KEY=
 
-# OpenVPM Agent (AI). Without ANTHROPIC_API_KEY the agent UI shows a setup
-# notice and agent runs are disabled; everything else works normally.
+# OpenVPM Agent (AI). Provider-agnostic via the Vercel AI SDK: the model is
+# chosen by AI_MODEL and the provider is inferred from the id. Set the matching
+# API key. Without a key the agent UI shows a setup notice and runs are
+# disabled; everything else works normally.
+# Examples: AI_MODEL="gemini-2.5-flash" (needs GOOGLE_API_KEY) or
+#           AI_MODEL="claude-sonnet-4-6" (needs ANTHROPIC_API_KEY).
+AI_MODEL=
+GOOGLE_API_KEY=
 ANTHROPIC_API_KEY=
-# Optional model override for the agent (defaults to claude-sonnet-4-6).
+# Legacy alias for AI_MODEL (still honored; defaults to claude-sonnet-4-6).
 AGENT_MODEL=

--- a/apps/web/app/(dashboard)/agent/page.tsx
+++ b/apps/web/app/(dashboard)/agent/page.tsx
@@ -46,8 +46,9 @@ export default function AgentPage() {
         <div className="mb-4 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
           <div>
-            The agent is not configured yet. Set <code className="font-mono">ANTHROPIC_API_KEY</code>{" "}
-            in your environment to enable agent runs.
+            The agent is not configured yet. Set <code className="font-mono">GOOGLE_API_KEY</code>{" "}
+            (for Gemini) or <code className="font-mono">ANTHROPIC_API_KEY</code> (for Claude) in
+            your environment to enable agent runs.
           </div>
         </div>
       )}

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -46,7 +46,13 @@ const HOSTED_SMS_ENV_NAMES = [
   "TWILIO_PHONE_NUMBER",
 ];
 
-const HOSTED_AI_ENV_NAMES = ["ANTHROPIC_API_KEY"];
+// AI is provider-agnostic: the model is chosen by AI_MODEL and the provider is
+// inferred from the id, so require the matching API key (Gemini vs Claude).
+function requiredAiEnvNames(): string[] {
+  const model = process.env.AI_MODEL || process.env.AGENT_MODEL || "claude-sonnet-4-6";
+  const isGemini = /^(google\/|models\/)?gemini/i.test(model);
+  return [isGemini ? "GOOGLE_API_KEY" : "ANTHROPIC_API_KEY"];
+}
 
 const HOSTED_OPS_ENV_NAMES = [
   "OPS_ALERT_WEBHOOK_URL",
@@ -104,7 +110,7 @@ export async function GET() {
       "Hosted SMS envs present"
     );
     checks.hostedAi = hostedEnvCheck(
-      HOSTED_AI_ENV_NAMES,
+      requiredAiEnvNames(),
       "Hosted AI envs present"
     );
     checks.hostedOps = hostedEnvCheck(

--- a/apps/web/lib/agent/__tests__/runner.test.ts
+++ b/apps/web/lib/agent/__tests__/runner.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isAgentConfigured } from "../runner";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("isAgentConfigured (provider-agnostic)", () => {
+  it("a Gemini model is configured only with GOOGLE_API_KEY", () => {
+    vi.stubEnv("AI_MODEL", "gemini-2.5-flash");
+    vi.stubEnv("GOOGLE_API_KEY", "");
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test"); // wrong provider's key
+    expect(isAgentConfigured()).toBe(false);
+    vi.stubEnv("GOOGLE_API_KEY", "AIza-test");
+    expect(isAgentConfigured()).toBe(true);
+  });
+
+  it("a Claude model is configured only with ANTHROPIC_API_KEY", () => {
+    vi.stubEnv("AI_MODEL", "claude-sonnet-4-6");
+    vi.stubEnv("ANTHROPIC_API_KEY", "");
+    vi.stubEnv("GOOGLE_API_KEY", "AIza-test"); // wrong provider's key
+    expect(isAgentConfigured()).toBe(false);
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+    expect(isAgentConfigured()).toBe(true);
+  });
+
+  it("defaults to Claude when AI_MODEL/AGENT_MODEL are unset", () => {
+    vi.stubEnv("AI_MODEL", "");
+    vi.stubEnv("AGENT_MODEL", "");
+    vi.stubEnv("GOOGLE_API_KEY", "");
+    vi.stubEnv("ANTHROPIC_API_KEY", "sk-ant-test");
+    expect(isAgentConfigured()).toBe(true);
+  });
+});

--- a/apps/web/lib/agent/runner.ts
+++ b/apps/web/lib/agent/runner.ts
@@ -1,14 +1,19 @@
-import Anthropic from "@anthropic-ai/sdk";
-import {
-  AGENT_TOOLS,
-  anthropicToolDefs,
-  getTool,
-  type AgentToolContext,
-} from "./tools";
+import { generateText, stepCountIs, tool, type ToolSet } from "ai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { AGENT_TOOLS, type AgentToolContext } from "./tools";
 import { recordUsage } from "@/lib/billing/usage";
 
-const DEFAULT_MODEL = process.env.AGENT_MODEL || "claude-sonnet-4-6";
+/**
+ * Provider-agnostic agent runner (Vercel AI SDK). The active model is chosen by
+ * `AI_MODEL` (falling back to the legacy `AGENT_MODEL`); the provider is inferred
+ * from the model id, so the same code runs on Gemini or Claude with only an env
+ * change. Each tool already carries a Zod schema, which the AI SDK consumes
+ * directly, and the SDK runs the tool-use loop for us up to MAX_ITERATIONS.
+ */
+const DEFAULT_MODEL = "claude-sonnet-4-6";
 const MAX_ITERATIONS = 8;
+const MAX_OUTPUT_TOKENS = 1024;
 
 const SYSTEM_PROMPT = `You are the OpenVPM Agent, an operations assistant embedded in an open-source veterinary practice management system.
 
@@ -36,21 +41,81 @@ export interface AgentRunResult {
 export class AgentNotConfiguredError extends Error {
   constructor() {
     super(
-      "OpenVPM Agent is not configured. Set ANTHROPIC_API_KEY to enable agent runs."
+      "OpenVPM Agent is not configured. Set an AI key (GOOGLE_API_KEY for Gemini, or ANTHROPIC_API_KEY for Claude) to enable agent runs."
     );
     this.name = "AgentNotConfiguredError";
   }
 }
 
+/** Resolve the model id from request override → AI_MODEL → legacy AGENT_MODEL → default. */
+function activeModelId(override?: string): string {
+  return override || process.env.AI_MODEL || process.env.AGENT_MODEL || DEFAULT_MODEL;
+}
+
+/** Google (Gemini) vs Anthropic (Claude) inferred from the model id. */
+function isGoogleModel(modelId: string): boolean {
+  return /^(google\/|models\/)?gemini/i.test(modelId);
+}
+
+function googleApiKey(): string | undefined {
+  return process.env.GOOGLE_API_KEY ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+}
+
+/** Whether the configured provider has its API key set. */
 export function isAgentConfigured(): boolean {
-  return Boolean(process.env.ANTHROPIC_API_KEY);
+  return isGoogleModel(activeModelId())
+    ? Boolean(googleApiKey())
+    : Boolean(process.env.ANTHROPIC_API_KEY);
+}
+
+/** Build an AI SDK model instance for the given model id. */
+function resolveModel(modelId: string) {
+  if (isGoogleModel(modelId)) {
+    const google = createGoogleGenerativeAI({ apiKey: googleApiKey() });
+    return google(modelId.replace(/^google\//, ""));
+  }
+  const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  return anthropic(modelId.replace(/^anthropic\//, ""));
+}
+
+/**
+ * Build the AI SDK tool set from AGENT_TOOLS. Write tools are gated behind
+ * `allowWrites`; every call (and any error) is captured into `sink` so the
+ * caller can report exactly what the agent did, mirroring the prior runner.
+ */
+function buildToolSet(
+  ctx: AgentToolContext,
+  allowWrites: boolean,
+  sink: AgentToolCall[]
+): ToolSet {
+  const entries = AGENT_TOOLS.map((t) => [
+    t.name,
+    tool({
+      description: t.description,
+      inputSchema: t.zod,
+      execute: async (args: unknown) => {
+        const call: AgentToolCall = { name: t.name, input: args };
+        try {
+          if (!t.readOnly && !allowWrites) {
+            call.error = "Write tools are disabled for this run.";
+          } else {
+            call.result = await t.execute(args, ctx);
+          }
+        } catch (e) {
+          call.error = e instanceof Error ? e.message : "Tool execution failed";
+        }
+        sink.push(call);
+        return call.error ? { error: call.error } : call.result;
+      },
+    }),
+  ] as const);
+  return Object.fromEntries(entries) as ToolSet;
 }
 
 /**
  * Run the OpenVPM Agent against a natural-language instruction. Executes a
- * tool-use loop with Claude, scoped to the caller's practice. Write tools are
- * gated behind `allowWrites` (default false) so a read-only run can never
- * mutate data.
+ * tool-use loop scoped to the caller's practice. Write tools are gated behind
+ * `allowWrites` (default false) so a read-only run can never mutate data.
  */
 export async function runAgent(opts: {
   instruction: string;
@@ -58,91 +123,32 @@ export async function runAgent(opts: {
   allowWrites?: boolean;
   model?: string;
 }): Promise<AgentRunResult> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new AgentNotConfiguredError();
+  const modelId = activeModelId(opts.model);
+  const hasKey = isGoogleModel(modelId)
+    ? Boolean(googleApiKey())
+    : Boolean(process.env.ANTHROPIC_API_KEY);
+  if (!hasKey) throw new AgentNotConfiguredError();
 
-  const client = new Anthropic({ apiKey });
   const allowWrites = opts.allowWrites ?? false;
 
   // Meter the agent run for hosted billing (no-op on self-host).
   void recordUsage({ practiceId: opts.context.practiceId, kind: "ai_run" });
 
-  // Prompt caching: cache the (static) system prompt and tool defs across the
-  // loop's turns so only the growing message tail is re-billed at full rate.
-  const system: Anthropic.TextBlockParam[] = [
-    { type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } },
-  ];
-  const toolDefs = anthropicToolDefs() as Anthropic.Tool[];
-  if (toolDefs.length > 0) {
-    toolDefs[toolDefs.length - 1]!.cache_control = { type: "ephemeral" };
-  }
-
-  const messages: Anthropic.MessageParam[] = [
-    { role: "user", content: opts.instruction },
-  ];
-
   const toolCalls: AgentToolCall[] = [];
-  let stopReason: string | null = null;
-
-  for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
-    const response = await client.messages.create({
-      model: opts.model || DEFAULT_MODEL,
-      max_tokens: 1024,
-      system,
-      tools: toolDefs,
-      messages,
-    });
-    stopReason = response.stop_reason;
-
-    messages.push({ role: "assistant", content: response.content });
-
-    if (response.stop_reason !== "tool_use") {
-      const text = response.content
-        .filter((b): b is Anthropic.TextBlock => b.type === "text")
-        .map((b) => b.text)
-        .join("\n")
-        .trim();
-      return { text, toolCalls, iterations: iteration, stopReason };
-    }
-
-    const toolUses = response.content.filter(
-      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use"
-    );
-    const toolResults: Anthropic.ToolResultBlockParam[] = [];
-
-    for (const use of toolUses) {
-      const tool = getTool(use.name);
-      const call: AgentToolCall = { name: use.name, input: use.input };
-
-      if (!tool) {
-        call.error = `Unknown tool: ${use.name}`;
-      } else if (!tool.readOnly && !allowWrites) {
-        call.error = "Write tools are disabled for this run.";
-      } else {
-        try {
-          call.result = await tool.execute(use.input, opts.context);
-        } catch (e) {
-          call.error = e instanceof Error ? e.message : "Tool execution failed";
-        }
-      }
-
-      toolCalls.push(call);
-      toolResults.push({
-        type: "tool_result",
-        tool_use_id: use.id,
-        content: JSON.stringify(call.error ? { error: call.error } : call.result),
-        is_error: Boolean(call.error),
-      });
-    }
-
-    messages.push({ role: "user", content: toolResults });
-  }
+  const result = await generateText({
+    model: resolveModel(modelId),
+    system: SYSTEM_PROMPT,
+    prompt: opts.instruction,
+    tools: buildToolSet(opts.context, allowWrites, toolCalls),
+    stopWhen: stepCountIs(MAX_ITERATIONS),
+    maxOutputTokens: MAX_OUTPUT_TOKENS,
+  });
 
   return {
-    text: "Agent reached the maximum number of steps without finishing.",
+    text: result.text.trim(),
     toolCalls,
-    iterations: MAX_ITERATIONS,
-    stopReason,
+    iterations: result.steps.length,
+    stopReason: result.finishReason ?? null,
   };
 }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.86",
+    "@ai-sdk/google": "^3.0.83",
     "@anthropic-ai/sdk": "^0.71.0",
     "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/s3-request-presigner": "^3.700.0",
@@ -35,6 +37,7 @@
     "@trpc/react-query": "^11.0.0",
     "@trpc/server": "^11.0.0",
     "@vercel/analytics": "^2.0.1",
+    "ai": "^6.0.209",
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.86
+        version: 3.0.86(zod@3.25.76)
+      '@ai-sdk/google':
+        specifier: ^3.0.83
+        version: 3.0.83(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.71.0
         version: 0.71.2(zod@3.25.76)
@@ -78,7 +84,7 @@ importers:
         version: 11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3)
       '@trpc/next':
         specifier: ^11.0.0
-        version: 11.13.4(@tanstack/react-query@5.90.21(react@18.3.1))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/react-query@11.13.4(@tanstack/react-query@5.90.21(react@18.3.1))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(react@18.3.1)(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        version: 11.13.4(@tanstack/react-query@5.90.21(react@18.3.1))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/react-query@11.13.4(@tanstack/react-query@5.90.21(react@18.3.1))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(react@18.3.1)(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@trpc/react-query':
         specifier: ^11.0.0
         version: 11.13.4(@tanstack/react-query@5.90.21(react@18.3.1))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(react@18.3.1)(typescript@5.9.3)
@@ -87,7 +93,10 @@ importers:
         version: 11.13.4(typescript@5.9.3)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 2.0.1(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      ai:
+        specifier: ^6.0.209
+        version: 6.0.209(zod@3.25.76)
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
@@ -102,7 +111,7 @@ importers:
         version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@libsql/client-wasm@0.17.0)(postgres@3.4.8)
+        version: 0.45.1(@libsql/client-wasm@0.17.0)(@opentelemetry/api@1.9.1)(postgres@3.4.8)
       jspdf:
         specifier: ^4.2.1
         version: 4.2.1
@@ -111,10 +120,10 @@ importers:
         version: 0.577.0(react@18.3.1)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-auth:
         specifier: ^4.24.0
-        version: 4.24.13(next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.24.13(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
         specifier: ^0.4.0
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -187,13 +196,13 @@ importers:
     dependencies:
       '@next/third-parties':
         specifier: ^16.2.4
-        version: 16.2.4(next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 16.2.4(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@18.3.1)
       next:
         specifier: ^14.2.0
-        version: 14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -258,7 +267,7 @@ importers:
         version: 16.6.1
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@libsql/client-wasm@0.17.0)(postgres@3.4.8)
+        version: 0.45.1(@libsql/client-wasm@0.17.0)(@opentelemetry/api@1.9.1)(postgres@3.4.8)
       postgres:
         specifier: ^3.4.0
         version: 3.4.8
@@ -296,6 +305,34 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@ai-sdk/anthropic@3.0.86':
+    resolution: {integrity: sha512-IVUaTOz46dNniRaALEvphV5WOqPfKTJRZlJhJabz3kaXk1QiwdnzWQhKMKLiprD+872E9YHqmmyFNFFH1MfnBQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@3.0.134':
+    resolution: {integrity: sha512-PfUkQp01EihEyNM6e+nexXmVANiY5KcHMui/MmaHsC4KVVQYh/MwPeOsD3bTPu63e581BKO+AwaPPNmD4x943A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/google@3.0.83':
+    resolution: {integrity: sha512-Pz7aCX0dy+5x+r4K/37HbLZNaPtPL4q2NduzJW64VffLv5sI9Nb478wAd7PlH2r2asiypJsz/Jerf9draTciUA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.30':
+    resolution: {integrity: sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1196,6 +1233,10 @@ packages:
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
@@ -2083,6 +2124,9 @@ packages:
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -2372,6 +2416,10 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -2408,6 +2456,12 @@ packages:
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
+
+  ai@6.0.209:
+    resolution: {integrity: sha512-NE7uErmxOe+i77BPT1+AhW4wr7xzilbQLsKVmvGEyil5AjaF6C/m92hlPI4Xwtnv5n77D/29bizwcR27/S/gSQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2885,6 +2939,10 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -3099,6 +3157,9 @@ packages:
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -4050,6 +4111,36 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@3.0.86(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/gateway@3.0.134(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.76
+
+  '@ai-sdk/google@3.0.83(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.30(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 3.25.76
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
   '@alloc/quick-lru@5.2.0': {}
 
   '@anthropic-ai/sdk@0.71.2(zod@3.25.76)':
@@ -4907,9 +4998,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.33':
     optional: true
 
-  '@next/third-parties@16.2.4(next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@next/third-parties@16.2.4(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      next: 14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       third-party-capital: 1.0.20
 
@@ -4926,6 +5017,8 @@ snapshots:
       fastq: 1.20.1
 
   '@one-ini/wasm@0.1.1': {}
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@panva/hkdf@1.2.1': {}
 
@@ -5854,6 +5947,8 @@ snapshots:
 
   '@stablelib/base64@1.0.1': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.5':
@@ -6035,11 +6130,11 @@ snapshots:
       '@trpc/server': 11.13.4(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@trpc/next@11.13.4(@tanstack/react-query@5.90.21(react@18.3.1))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/react-query@11.13.4(@tanstack/react-query@5.90.21(react@18.3.1))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(react@18.3.1)(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@trpc/next@11.13.4(@tanstack/react-query@5.90.21(react@18.3.1))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/react-query@11.13.4(@tanstack/react-query@5.90.21(react@18.3.1))(@trpc/client@11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(react@18.3.1)(typescript@5.9.3))(@trpc/server@11.13.4(typescript@5.9.3))(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
       '@trpc/client': 11.13.4(@trpc/server@11.13.4(typescript@5.9.3))(typescript@5.9.3)
       '@trpc/server': 11.13.4(typescript@5.9.3)
-      next: 14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       typescript: 5.9.3
@@ -6121,10 +6216,12 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@vercel/analytics@2.0.1(next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+  '@vercel/analytics@2.0.1(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
     optionalDependencies:
-      next: 14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
+
+  '@vercel/oidc@3.2.0': {}
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -6173,6 +6270,14 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  ai@6.0.209(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.134(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@3.25.76)
+      '@opentelemetry/api': 1.9.1
+      zod: 3.25.76
 
   ansi-regex@5.0.1: {}
 
@@ -6467,9 +6572,10 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.1(@libsql/client-wasm@0.17.0)(postgres@3.4.8):
+  drizzle-orm@0.45.1(@libsql/client-wasm@0.17.0)(@opentelemetry/api@1.9.1)(postgres@3.4.8):
     optionalDependencies:
       '@libsql/client-wasm': 0.17.0
+      '@opentelemetry/api': 1.9.1
       postgres: 3.4.8
 
   dunder-proto@1.0.1:
@@ -6634,6 +6740,8 @@ snapshots:
       '@types/estree': 1.0.9
 
   eventemitter3@4.0.7: {}
+
+  eventsource-parser@3.1.0: {}
 
   expect-type@1.3.0: {}
 
@@ -6848,6 +6956,8 @@ snapshots:
       '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
+  json-schema@0.4.0: {}
+
   jsonwebtoken@9.0.3:
     dependencies:
       jws: 4.0.1
@@ -6978,13 +7088,13 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next-auth@4.24.13(next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-auth@4.24.13(next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.2
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.29.0
@@ -6998,7 +7108,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next@14.2.35(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.35(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -7019,6 +7129,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.33
       '@next/swc-win32-ia32-msvc': 14.2.33
       '@next/swc-win32-x64-msvc': 14.2.33
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.58.2
     transitivePeerDependencies:
       - '@babel/core'


### PR DESCRIPTION
## Summary

Makes the in-app AI agent **provider-agnostic** so it can run on **Gemini** (cheap, for launch) or **Claude**, switchable by a single env var. The agent was previously hardcoded to the Anthropic SDK.

## How
- Refactors `lib/agent/runner.ts` to the **Vercel AI SDK** (`ai` v6 + `@ai-sdk/google` + `@ai-sdk/anthropic`): a small provider resolver picks `google(...)` or `anthropic(...)` from the model id, and `generateText({ tools, stopWhen: stepCountIs(8) })` runs the tool loop.
- Each tool's **existing Zod schema** (`AgentTool.zod`) feeds the SDK directly — no schema duplication. The `allowWrites` write-gate and per-call reporting are preserved.
- **Public API unchanged**: `runAgent` / `AgentRunResult` / `isAgentConfigured` keep their shapes, so `server/routers/agent.ts` and the UI are untouched.

## Config
- `AI_MODEL` chooses the model (legacy `AGENT_MODEL` still honored). Provider inferred from the id.
- Set the matching key: `GOOGLE_API_KEY` for `gemini-*`, `ANTHROPIC_API_KEY` for `claude-*`.
- Health check + the agent UI's setup notice are now provider-aware.

## Notes
- Dropped the Anthropic-only ephemeral prompt-cache directives (minor cost; Gemini has no equivalent). Can be re-added via provider options later.
- Self-host is unaffected: the agent is a hosted-gated feature, and self-hosters can point `AI_MODEL` at whichever provider they have a key for.

## Testing
- [x] `pnpm type-check`, `pnpm test` (218, +3 for provider resolution), `pnpm build` all green.
- Live Gemini smoke test pending a `GOOGLE_API_KEY` (Phase 0 deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)