### PR TITLE
Split-seam fixes: dedupe appBaseUrl + standardize contact email

### DIFF
--- a/apps/web/server/routers/subscription.ts
+++ b/apps/web/server/routers/subscription.ts
@@ -25,16 +25,9 @@ import {
   syncPracticeSubscriptionQuantities,
   type BillingSyncState,
 } from "@/lib/billing/subscription-sync";
+import { appBaseUrl } from "@/lib/app-url";
 
 const adminProcedure = protectedProcedure.use(requireRole("admin"));
-
-function appBaseUrl(): string {
-  return (
-    process.env.NEXT_PUBLIC_APP_URL ??
-    process.env.NEXTAUTH_URL ??
-    "http://localhost:3000"
-  );
-}
 
 /** Whether a tier can be bought self-serve (Stripe price configured). */
 function purchasable(tier: keyof typeof PLANS): boolean {

--- a/apps/www/app/install/install-content.tsx
+++ b/apps/www/app/install/install-content.tsx
@@ -374,8 +374,8 @@ export function InstallContent() {
               <ExternalLink className="w-3 h-3" />
             </a>{" "}
             or email us at{" "}
-            <a href="mailto:evan@gettalky.ai" className="text-teal-600 hover:underline">
-              evan@gettalky.ai
+            <a href="mailto:hello@openvpm.com" className="text-teal-600 hover:underline">
+              hello@openvpm.com
             </a>
           </p>
         </div>
@@ -392,8 +392,8 @@ export function InstallContent() {
               </h2>
               <p className="text-teal-100 max-w-lg mx-auto mb-6">
                 Reach out at{" "}
-                <a href="mailto:evan@gettalky.ai" className="text-white underline underline-offset-2">
-                  evan@gettalky.ai
+                <a href="mailto:hello@openvpm.com" className="text-white underline underline-offset-2">
+                  hello@openvpm.com
                 </a>{" "}
                 or open an issue on GitHub.
               </p>

--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -952,10 +952,10 @@ export default function LandingPage() {
               <p className="mt-8 text-teal-200 text-sm">
                 Questions? Reach out at{" "}
                 <a
-                  href="mailto:evan@gettalky.ai"
+                  href="mailto:hello@openvpm.com"
                   className="text-white underline underline-offset-2 hover:text-teal-100"
                 >
-                  evan@gettalky.ai
+                  hello@openvpm.com
                 </a>
               </p>
             </div>

--- a/apps/www/app/why/page.tsx
+++ b/apps/www/app/why/page.tsx
@@ -251,8 +251,8 @@ export default function WhyPage() {
               </div>
               <p className="mt-8 text-teal-200 text-sm">
                 Questions?{" "}
-                <a href="mailto:evan@gettalky.ai" className="text-white underline underline-offset-2 hover:text-teal-100">
-                  evan@gettalky.ai
+                <a href="mailto:hello@openvpm.com" className="text-white underline underline-offset-2 hover:text-teal-100">
+                  hello@openvpm.com
                 </a>
               </p>
             </div>

--- a/apps/www/components/footer.tsx
+++ b/apps/www/components/footer.tsx
@@ -61,10 +61,10 @@ export function MarketingFooter() {
               GitHub
             </a>
             <a
-              href="mailto:evan@gettalky.ai"
+              href="mailto:hello@openvpm.com"
               className="text-sm text-gray-500 hover:text-teal-600 transition-colors"
             >
-              evan@gettalky.ai
+              hello@openvpm.com
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Phase 3 cleanup of the marketing/app/open-source seams. On inspection most flagged "seams" were already correct (CTAs are env-driven and default to production; `?intent=cloud` tailors the signup heading; the Self-host/Free labels are clearly framed), so this PR is small and targeted:

- **Dedupe `appBaseUrl`**: `server/routers/subscription.ts` had its own byte-identical copy; it now imports the shared `lib/app-url` helper, so Stripe redirect URLs come from one source.
- **Standardize the contact email**: the public site used `evan@gettalky.ai` (your Talky brand) in 5 spots — footer, homepage, why page, and twice on install. All now use **`hello@openvpm.com`** for brand/open-source consistency. Enterprise keeps `sales@openvpm.com`.

## Action needed (you) — make hello@openvpm.com live (~2 min, free)
`openvpm.com` is on **Namecheap** with email forwarding already active. In the Namecheap dashboard: **Domain List → openvpm.com → Manage → Email Forwarding (Redirect Email)** → add a **catch-all** `*@openvpm.com → evan@gettalky.ai` (covers both `hello@` and `sales@`). No DNS migration, no Cloudflare needed.

## Testing
- [x] web + www `type-check`, web `test` (215) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)