### PR TITLE
Portable RLS migration + RLS tenant-isolation CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,43 @@ jobs:
 
       - run: pnpm build
         # Note: next build includes linting — no separate lint step needed
+
+  rls:
+    name: RLS tenant isolation
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: openpims
+          POSTGRES_PASSWORD: openpims
+          POSTGRES_DB: openpims
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U openpims"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://openpims:openpims@localhost:5432/openpims
+      OPENPIMS_APP_DB_PASSWORD: openpims_app
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      # Create the schema, apply RLS (+ least-priv role), then prove tenant
+      # isolation against a real Postgres on every PR.
+      - run: pnpm --filter @openpims/db exec drizzle-kit push --force
+
+      - run: pnpm --filter @openpims/db db:rls
+
+      - run: pnpm --filter @openpims/db db:rls:test

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -116,4 +116,16 @@ CREATE POLICY reference_delete ON drug_interactions FOR DELETE USING (app_rls_by
 --    don't put tenant RLS on them; instead we revoke the Supabase data-API roles
 --    so they're unreachable that way. The app connects via a direct Postgres
 --    role, never anon/authenticated.
-REVOKE ALL ON auth_tokens, sessions, verification_tokens FROM anon, authenticated;
+--    Guarded so the migration stays portable: anon/authenticated only exist on
+--    Supabase, so on vanilla Postgres (local / CI) this is a no-op.
+DO $$
+DECLARE r text;
+BEGIN
+  FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
+      EXECUTE format(
+        'REVOKE ALL ON auth_tokens, sessions, verification_tokens FROM %I', r
+      );
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary

Phase 4 (testing), part 1: turn the tenant-isolation RLS into a verified, every-PR guarantee.

### Two changes
1. **Portable RLS migration.** `packages/db/rls/enable-rls.sql` revoked privileges from Supabase's `anon`/`authenticated` roles unconditionally, so `db:rls` **failed on vanilla Postgres** (`role "anon" does not exist`) — locally and in CI. The REVOKE is now guarded to no-op when those roles are absent, so the migration applies cleanly everywhere and still locks down the Supabase data API in production.
2. **RLS CI job.** New `rls` job: Postgres service → `drizzle-kit push --force` → `db:rls` (applies policies + creates the least-priv `openpims_app` role) → `db:rls:test`. This proves tenant isolation on every PR.

### Verified locally
All 5 isolation checks pass against a real database:
- ✓ tenant A sees only A's clients · ✓ tenant B sees only B's
- ✓ cross-tenant INSERT blocked · ✓ no context → zero rows · ✓ owner/system bypass works

### What's deferred
The full **e2e signup→checkout** Playwright flow is best added once the preview is deployed (so it runs against a real running app + Stripe test). Billing-enforcement is already covered (`guards.test.ts` + `plans.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)