### PR TITLE
Env-driven email from-address (mail.openvpm.com)

### DIFF
--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -14,7 +14,7 @@ function getResend(): Resend | null {
   return resend;
 }
 
-const DEFAULT_FROM = "noreply@openpims.dev";
+const DEFAULT_FROM = process.env.EMAIL_FROM || "OpenVPM <noreply@mail.openvpm.com>";
 
 // ---------------------------------------------------------------------------
 // Shared layout helpers


### PR DESCRIPTION
The transactional email default sender was hardcoded to `noreply@openpims.dev` (a stale placeholder). This makes it read `EMAIL_FROM`, defaulting to the verified OpenVPM sender on `mail.openvpm.com`.

Needed so the hosted app (app.openvpm.com) sends login links / notifications from a domain we actually control + have verified in Resend. `mail.openvpm.com` is being verified now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)