### PR TITLE
Wire metered AI/SMS overage via Stripe Billing Meters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,19 +26,22 @@ STRIPE_WEBHOOK_SECRET=
 
 # Hosted SaaS subscriptions (managed service only — leave HOSTED_BILLING_ENABLED
 # unset for self-host so the OSS edition runs fully unlocked). Cloud has a
-# 14-day no-card trial, then bills $49/mo per active location + $10/mo per
-# active staff user. When enabled, the split recurring Stripe prices must be set.
+# 14-day no-card trial, then bills a flat $99/mo per active location, unlimited
+# staff. When enabled, the recurring Stripe prices below must be set.
 HOSTED_BILLING_ENABLED=
-# Cloud recurring Prices. Checkout creates one subscription with both items.
+# Cloud recurring Prices. New checkout uses the per-location price; the per-user
+# price is the $0 flat-model seat item (still required so the plan is purchasable
+# and the health check passes).
 STRIPE_PRICE_CLOUD_LOCATION=
 STRIPE_PRICE_CLOUD_USER=
 # Legacy one-price Cloud Price. Do not use for new checkout; kept only so old
 # Stripe subscription webhooks still map to the Cloud tier.
 STRIPE_PRICE_CLOUD=
-# Metered overage Prices for usage beyond the included monthly allowances.
-# CURRENTLY UNUSED — launch billing is generous-unmetered: SMS/AI keep working
-# past the included allowance (no Stripe metering is wired; ops is alerted on
-# usage spikes instead). Safe to leave blank; revisit if overage billing is added.
+# Metered overage Prices (Stripe Billing Meters) for usage beyond the included
+# monthly allowance (1,000 AI actions + 1,000 SMS). Each is a graduated metered
+# price whose first 1,000 units are $0, then $0.05/AI action and $0.03/SMS. When
+# set, checkout adds them as quantity-less subscription items and recordUsage()
+# reports meter events. Leave blank to keep usage recorded-but-unbilled.
 STRIPE_PRICE_SMS_OVERAGE=
 STRIPE_PRICE_AI_OVERAGE=
 # Separate webhook endpoint secret for customer.subscription.* events.

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -637,11 +637,11 @@ function BillingTab() {
             </p>
           </div>
           <div>
-            <p className="text-muted-foreground">AI runs this month</p>
+            <p className="text-muted-foreground">AI actions this month</p>
             <p className="font-medium">
               {data.usage.aiRuns}
               {currentPlan?.includedAiRunsPerMonth != null
-                ? ` / ${currentPlan.includedAiRunsPerMonth} included`
+                ? ` / ${currentPlan.includedAiRunsPerMonth.toLocaleString()} included`
                 : ""}
             </p>
           </div>
@@ -707,6 +707,8 @@ function PlanGrid({
     locationLimit: number | null;
     includedSmsPerMonth: number | null;
     includedAiRunsPerMonth: number | null;
+    aiOveragePriceUsd: number | null;
+    smsOveragePriceUsd: number | null;
     selfServe: boolean;
     purchasable: boolean;
   }>;
@@ -754,10 +756,20 @@ function PlanGrid({
                 {p.locationLimit === 1 ? "" : "s"}
               </li>
               {p.includedSmsPerMonth ? (
-                <li>{p.includedSmsPerMonth} SMS/mo included</li>
+                <li>
+                  {p.includedSmsPerMonth.toLocaleString()} SMS/mo included
+                  {p.smsOveragePriceUsd
+                    ? `, then $${p.smsOveragePriceUsd}/SMS`
+                    : ""}
+                </li>
               ) : null}
               {p.includedAiRunsPerMonth ? (
-                <li>{p.includedAiRunsPerMonth} AI runs/mo included</li>
+                <li>
+                  {p.includedAiRunsPerMonth.toLocaleString()} AI actions/mo included
+                  {p.aiOveragePriceUsd
+                    ? `, then $${p.aiOveragePriceUsd}/action`
+                    : ""}
+                </li>
               ) : null}
               {p.features.length > 0 ? (
                 p.features.map((f) => (

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -13,9 +13,10 @@ function configured(name: string): boolean {
   return Boolean(process.env[name]);
 }
 
-// Overage price envs (STRIPE_PRICE_SMS_OVERAGE / STRIPE_PRICE_AI_OVERAGE) are
-// intentionally NOT required: launch billing is generous-unmetered, so Stripe
-// usage metering is not wired and those prices are unused. See lib/billing/usage.ts.
+// Overage price envs (STRIPE_PRICE_SMS_OVERAGE / STRIPE_PRICE_AI_OVERAGE) drive
+// metered overage via Stripe Billing Meters. They are NOT required here so the
+// app still boots before the meters are configured (and so usage is recorded
+// even when overage billing is intentionally off). See lib/billing/usage.ts.
 const HOSTED_BILLING_ENV_NAMES = [
   "STRIPE_SECRET_KEY",
   "STRIPE_SUBSCRIPTION_WEBHOOK_SECRET",

--- a/apps/web/lib/__tests__/stripe.test.ts
+++ b/apps/web/lib/__tests__/stripe.test.ts
@@ -28,6 +28,26 @@ describe("buildSubscriptionCheckoutSessionParams", () => {
     });
   });
 
+  it("adds metered overage items without a quantity", () => {
+    const params = buildSubscriptionCheckoutSessionParams({
+      practiceId: "practice_123",
+      customerId: "cus_123",
+      lineItems: [
+        { priceId: "price_location", quantity: 3 },
+        { priceId: "price_ai_overage", metered: true },
+        { priceId: "price_sms_overage", metered: true },
+      ],
+      successUrl: "https://app.example.com/success",
+      cancelUrl: "https://app.example.com/cancel",
+    });
+
+    expect(params.line_items).toEqual([
+      { price: "price_location", quantity: 3 },
+      { price: "price_ai_overage" },
+      { price: "price_sms_overage" },
+    ]);
+  });
+
   it("requires payment collection when no trial is passed", () => {
     const params = buildSubscriptionCheckoutSessionParams({
       practiceId: "practice_123",

--- a/apps/web/lib/billing/__tests__/plans.test.ts
+++ b/apps/web/lib/billing/__tests__/plans.test.ts
@@ -11,11 +11,16 @@ import {
   hasHostedFullAccess,
   estimatedCloudBaseMonthlyUsd,
   tierForStripePrice,
+  cloudMeteredPriceIds,
   STRIPE_PRICE_CLOUD_LOCATION_ENV,
   STRIPE_PRICE_CLOUD_USER_ENV,
   STRIPE_PRICE_CLOUD_LEGACY_ENV,
+  STRIPE_PRICE_AI_OVERAGE_ENV,
+  STRIPE_PRICE_SMS_OVERAGE_ENV,
   CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD,
   CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD,
+  CLOUD_AI_OVERAGE_PRICE_USD,
+  CLOUD_SMS_OVERAGE_PRICE_USD,
   ALL_FEATURES,
 } from "../plans";
 
@@ -134,6 +139,30 @@ describe("hosted full access", () => {
     expect(hasHostedFullAccess("cloud", "past_due", future, now, true)).toBe(false);
     expect(hasHostedFullAccess("cloud", "canceled", future, now, true)).toBe(false);
     expect(hasHostedFullAccess("free", "none", null, now, true)).toBe(false);
+  });
+});
+
+describe("metered overage", () => {
+  it("cloud carries included allowances + overage prices; free/enterprise do not bill overage", () => {
+    expect(PLANS.cloud.includedAiRunsPerMonth).toBe(1000);
+    expect(PLANS.cloud.includedSmsPerMonth).toBe(1000);
+    expect(PLANS.cloud.aiOveragePriceUsd).toBe(CLOUD_AI_OVERAGE_PRICE_USD);
+    expect(PLANS.cloud.smsOveragePriceUsd).toBe(CLOUD_SMS_OVERAGE_PRICE_USD);
+    expect(PLANS.free.aiOveragePriceUsd).toBeNull();
+    expect(PLANS.enterprise.smsOveragePriceUsd).toBeNull();
+  });
+
+  it("cloudMeteredPriceIds reads the configured overage price envs", () => {
+    expect(cloudMeteredPriceIds()).toEqual({
+      aiOveragePriceId: undefined,
+      smsOveragePriceId: undefined,
+    });
+    vi.stubEnv(STRIPE_PRICE_AI_OVERAGE_ENV, "price_ai");
+    vi.stubEnv(STRIPE_PRICE_SMS_OVERAGE_ENV, "price_sms");
+    expect(cloudMeteredPriceIds()).toEqual({
+      aiOveragePriceId: "price_ai",
+      smsOveragePriceId: "price_sms",
+    });
   });
 });
 

--- a/apps/web/lib/billing/plans.ts
+++ b/apps/web/lib/billing/plans.ts
@@ -43,6 +43,16 @@ export const CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD = 99;
 /** No per-seat charge under the flat model (kept at 0 for type/back-compat). */
 export const CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD = 0;
 
+/**
+ * Metered overage list prices (USD per unit) beyond the included monthly
+ * allowance. Set ~2-3x our marginal cost so heavy users stay margin-positive
+ * while the price is still cheap and transparent for the clinic. The included
+ * allowance is modeled as the $0 first tier on the Stripe metered price, so
+ * these only bill past `includedAiRunsPerMonth` / `includedSmsPerMonth`.
+ */
+export const CLOUD_AI_OVERAGE_PRICE_USD = 0.05;
+export const CLOUD_SMS_OVERAGE_PRICE_USD = 0.03;
+
 /** Env vars holding Stripe Price IDs for hosted billing (PRIVATE). */
 export const STRIPE_PRICE_CLOUD_LOCATION_ENV = "STRIPE_PRICE_CLOUD_LOCATION";
 export const STRIPE_PRICE_CLOUD_USER_ENV = "STRIPE_PRICE_CLOUD_USER";
@@ -69,6 +79,10 @@ export interface PlanDefinition {
   includedSmsPerMonth: number | null;
   /** Included monthly AI agent runs before metered overage. null = unlimited/custom. */
   includedAiRunsPerMonth: number | null;
+  /** USD per AI action beyond the included allowance. null = no metered overage. */
+  aiOveragePriceUsd: number | null;
+  /** USD per SMS beyond the included allowance. null = no metered overage. */
+  smsOveragePriceUsd: number | null;
   /** Env var holding the recurring location Stripe Price ID for this tier. */
   stripeLocationPriceEnv?: string;
   /** Env var holding the recurring staff-user Stripe Price ID for this tier. */
@@ -92,6 +106,8 @@ export const PLANS: Record<PlanTier, PlanDefinition> = {
     features: [],
     includedSmsPerMonth: 0,
     includedAiRunsPerMonth: 0,
+    aiOveragePriceUsd: null,
+    smsOveragePriceUsd: null,
     selfServe: true,
   },
   cloud: {
@@ -106,6 +122,8 @@ export const PLANS: Record<PlanTier, PlanDefinition> = {
     features: [...ALL_FEATURES],
     includedSmsPerMonth: 1000,
     includedAiRunsPerMonth: 1000,
+    aiOveragePriceUsd: CLOUD_AI_OVERAGE_PRICE_USD,
+    smsOveragePriceUsd: CLOUD_SMS_OVERAGE_PRICE_USD,
     stripeLocationPriceEnv: STRIPE_PRICE_CLOUD_LOCATION_ENV,
     stripeSeatPriceEnv: STRIPE_PRICE_CLOUD_USER_ENV,
     selfServe: true,
@@ -122,6 +140,8 @@ export const PLANS: Record<PlanTier, PlanDefinition> = {
     features: [...ALL_FEATURES],
     includedSmsPerMonth: null,
     includedAiRunsPerMonth: null,
+    aiOveragePriceUsd: null,
+    smsOveragePriceUsd: null,
     selfServe: false,
   },
 };
@@ -155,6 +175,22 @@ export function cloudCheckoutPriceIds(): {
   return {
     locationPriceId: process.env[STRIPE_PRICE_CLOUD_LOCATION_ENV],
     seatPriceId: process.env[STRIPE_PRICE_CLOUD_USER_ENV],
+  };
+}
+
+/**
+ * Metered overage Stripe Price IDs (AI + SMS), if configured. These are added
+ * as additional, quantity-less subscription items at checkout so Stripe meters
+ * usage and bills overage beyond the included allowance. Absent = no overage
+ * billing wired (the app still records usage and alerts ops on spikes).
+ */
+export function cloudMeteredPriceIds(): {
+  aiOveragePriceId?: string;
+  smsOveragePriceId?: string;
+} {
+  return {
+    aiOveragePriceId: process.env[STRIPE_PRICE_AI_OVERAGE_ENV],
+    smsOveragePriceId: process.env[STRIPE_PRICE_SMS_OVERAGE_ENV],
   };
 }
 

--- a/apps/web/lib/billing/stripe-meters.ts
+++ b/apps/web/lib/billing/stripe-meters.ts
@@ -1,0 +1,47 @@
+import { stripe } from "@/lib/stripe";
+import type { UsageKind } from "./usage";
+
+/**
+ * Stripe Billing Meters bridge. Each metered usage event we record locally is
+ * also reported to Stripe as a meter event so Stripe aggregates it over the
+ * billing period and bills overage beyond the included allowance (which is the
+ * $0 first tier of the metered price). The legacy usage-records API is gone as
+ * of API version 2025-03-31.basil; meter events are the supported path.
+ *
+ * Meter event names must match the `event_name` configured on the Stripe meters
+ * (see docs/hosted-cloud-production.md). Customer mapping is by `stripe_customer_id`.
+ */
+const METER_EVENT_NAMES: Record<UsageKind, string> = {
+  ai_run: "openvpm_ai_run",
+  sms: "openvpm_sms",
+};
+
+export function meterEventName(kind: UsageKind): string {
+  return METER_EVENT_NAMES[kind];
+}
+
+/**
+ * Report a single metered usage event to Stripe. Fire-and-forget: never throws
+ * into the caller (usage recording must not fail a clinic's action). No-op when
+ * Stripe is not configured. `identifier` makes the event idempotent across retries.
+ */
+export async function recordMeterEvent(opts: {
+  kind: UsageKind;
+  stripeCustomerId: string;
+  value?: number;
+  identifier?: string;
+}): Promise<void> {
+  if (!stripe) return;
+  try {
+    await stripe.billing.meterEvents.create({
+      event_name: meterEventName(opts.kind),
+      payload: {
+        stripe_customer_id: opts.stripeCustomerId,
+        value: String(Math.max(0, opts.value ?? 1)),
+      },
+      ...(opts.identifier ? { identifier: opts.identifier } : {}),
+    });
+  } catch (e) {
+    console.error("[meter] failed to record Stripe meter event", opts.kind, e);
+  }
+}

--- a/apps/web/lib/billing/usage.ts
+++ b/apps/web/lib/billing/usage.ts
@@ -1,20 +1,22 @@
+import { randomUUID } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { db } from "@openpims/db/client";
-import { usageRecords } from "@openpims/db";
+import { usageRecords, practices } from "@openpims/db";
 import { withSystem } from "@/lib/tenant-db";
 import { alertOps } from "@/lib/alerts";
 import { billingEnforced } from "./plans";
+import { recordMeterEvent } from "./stripe-meters";
 
 export type UsageKind = "sms" | "ai_run";
 
 /**
- * Soft abuse thresholds for the generous-unmetered launch model. We do NOT cap
- * usage — SMS/AI keep working past the included allowance — but we alert ops
- * once when a practice crosses a high monthly threshold so abuse is visible.
+ * Soft abuse thresholds. Overage past the included allowance (1,000/mo) now
+ * bills via Stripe meters, so these sit well ABOVE the allowance and only flag
+ * genuinely abnormal volume to ops — not normal paid overage. We never hard-cap.
  */
 export const ABUSE_ALERT_THRESHOLDS: Record<UsageKind, number> = {
-  sms: 2000,
-  ai_run: 1000,
+  sms: 5000,
+  ai_run: 5000,
 };
 
 /** Pure: did `kind` cross its abuse threshold moving from `before` to `after`? */
@@ -56,8 +58,40 @@ export async function recordUsage(opts: {
       })
     );
     await maybeAlertOnSpike(opts.practiceId, opts.kind, periodMonth, quantity);
+    await maybeMeterToStripe(opts.practiceId, opts.kind, quantity);
   } catch (e) {
     console.error("[usage] failed to record", opts.kind, e);
+  }
+}
+
+/**
+ * Report the event to Stripe's meter so overage bills automatically. Only fires
+ * once the practice has a Stripe customer (i.e. a subscription exists) — usage
+ * during the pre-checkout no-card trial has no customer and stays free. The
+ * local `usageRecords` row remains the source of truth for display/reconcile.
+ */
+async function maybeMeterToStripe(
+  practiceId: string,
+  kind: UsageKind,
+  quantity: number
+): Promise<void> {
+  try {
+    const [practice] = await withSystem(db, (tx) =>
+      tx
+        .select({ stripeCustomerId: practices.stripeCustomerId })
+        .from(practices)
+        .where(eq(practices.id, practiceId))
+        .limit(1)
+    );
+    if (!practice?.stripeCustomerId) return;
+    await recordMeterEvent({
+      kind,
+      stripeCustomerId: practice.stripeCustomerId,
+      value: quantity,
+      identifier: randomUUID(),
+    });
+  } catch (e) {
+    console.error("[usage] meter event failed", kind, e);
   }
 }
 
@@ -79,7 +113,7 @@ async function maybeAlertOnSpike(
     if (crossesAbuseThreshold(kind, before, after)) {
       await alertOps(
         `usage spike: ${kind}`,
-        `Practice ${practiceId} crossed ${ABUSE_ALERT_THRESHOLDS[kind]} ${kind} events in ${periodMonth} (now ${after}). Launch is generous-unmetered — review for abuse.`
+        `Practice ${practiceId} crossed ${ABUSE_ALERT_THRESHOLDS[kind]} ${kind} events in ${periodMonth} (now ${after}). Overage is billed past the included allowance — review for abuse.`
       );
     }
   } catch (e) {

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -57,7 +57,7 @@ export async function constructWebhookEvent(
  * map the resulting subscription back to a practice.
  */
 export async function createSubscriptionCheckoutSession(data: {
-  lineItems: Array<{ priceId: string; quantity: number }>;
+  lineItems: Array<{ priceId: string; quantity?: number; metered?: boolean }>;
   practiceId: string;
   customerId?: string | null;
   customerEmail?: string | null;
@@ -77,7 +77,7 @@ export async function createSubscriptionCheckoutSession(data: {
 }
 
 export function buildSubscriptionCheckoutSessionParams(data: {
-  lineItems: Array<{ priceId: string; quantity: number }>;
+  lineItems: Array<{ priceId: string; quantity?: number; metered?: boolean }>;
   practiceId: string;
   customerId?: string | null;
   customerEmail?: string | null;
@@ -93,10 +93,13 @@ export function buildSubscriptionCheckoutSessionParams(data: {
   return {
     mode: "subscription",
     payment_method_collection: hasTrial ? "if_required" : "always",
-    line_items: data.lineItems.map((item) => ({
-      price: item.priceId,
-      quantity: Math.max(0, item.quantity),
-    })),
+    // Metered prices (usage-based overage) must be added WITHOUT a quantity;
+    // licensed prices (per-location) carry the active count.
+    line_items: data.lineItems.map((item) =>
+      item.metered
+        ? { price: item.priceId }
+        : { price: item.priceId, quantity: Math.max(0, item.quantity ?? 0) }
+    ),
     ...(data.customerId
       ? { customer: data.customerId }
       : { customer_email: data.customerEmail ?? undefined }),

--- a/apps/web/server/routers/subscription.ts
+++ b/apps/web/server/routers/subscription.ts
@@ -12,6 +12,7 @@ import {
   PLAN_ORDER,
   billingEnforced,
   cloudCheckoutPriceIds,
+  cloudMeteredPriceIds,
   estimatedCloudBaseMonthlyUsd,
   CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD,
   CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD,
@@ -111,6 +112,8 @@ export const subscriptionRouter = createRouter({
           locationLimit: p.locationLimit,
           includedSmsPerMonth: p.includedSmsPerMonth,
           includedAiRunsPerMonth: p.includedAiRunsPerMonth,
+          aiOveragePriceUsd: p.aiOveragePriceUsd,
+          smsOveragePriceUsd: p.smsOveragePriceUsd,
           selfServe: p.selfServe,
           purchasable: purchasable(t),
         };
@@ -151,10 +154,18 @@ export const subscriptionRouter = createRouter({
         new Date(practice.trialEndsAt).getTime() > Date.now()
           ? practice.trialEndsAt
           : null;
+      // Per-location licensed item, plus the metered overage items (AI + SMS)
+      // when configured. Metered items carry no quantity; Stripe meters them.
+      const { aiOveragePriceId, smsOveragePriceId } = cloudMeteredPriceIds();
+      const lineItems: Array<{
+        priceId: string;
+        quantity?: number;
+        metered?: boolean;
+      }> = [{ priceId: locationPriceId, quantity: counts.locationCount }];
+      if (aiOveragePriceId) lineItems.push({ priceId: aiOveragePriceId, metered: true });
+      if (smsOveragePriceId) lineItems.push({ priceId: smsOveragePriceId, metered: true });
       const result = await createSubscriptionCheckoutSession({
-        lineItems: [
-          { priceId: locationPriceId, quantity: counts.locationCount },
-        ],
+        lineItems,
         practiceId: ctx.practiceId,
         customerId: practice?.stripeCustomerId ?? undefined,
         customerEmail: practice?.email ?? ctx.session.user.email,

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -85,15 +85,23 @@ For local or staging signup tests without real email delivery, set `OPENVPM_EXPO
 
 ## Stripe Setup
 
-Create one Stripe product for OpenVPM Cloud with recurring monthly prices:
+Create one Stripe product for OpenVPM Cloud with these recurring monthly prices:
 
-- Cloud location: `$99/month`, env `STRIPE_PRICE_CLOUD_LOCATION` (flat per active location, unlimited staff)
-- SMS overage metered price, env `STRIPE_PRICE_SMS_OVERAGE`
-- AI overage metered price, env `STRIPE_PRICE_AI_OVERAGE`
+- Cloud location: `$99/month`, env `STRIPE_PRICE_CLOUD_LOCATION` (flat per active location, unlimited staff).
+- `$0/month` seat price, env `STRIPE_PRICE_CLOUD_USER` — the flat-model seat item. It is not added to new checkout, but the env must be set (the plan only shows as purchasable, and `/api/health` only passes, when both location and user prices are present).
+- AI overage metered price, env `STRIPE_PRICE_AI_OVERAGE`.
+- SMS overage metered price, env `STRIPE_PRICE_SMS_OVERAGE`.
 
-`STRIPE_PRICE_CLOUD_USER` (legacy per-seat) and `STRIPE_PRICE_CLOUD` (legacy single price) are only kept for mapping existing subscriptions; new checkout uses the per-location price only.
+`STRIPE_PRICE_CLOUD` (legacy single price) is only kept for mapping existing subscriptions; new checkout never uses it.
 
-The app creates one subscription with a single recurring per-location line item. Quantity sync updates the active non-deleted location count.
+### Included allowance + metered overage (Stripe Billing Meters)
+
+The Cloud plan includes **1,000 AI actions + 1,000 SMS per month**, then bills **$0.05/AI action** and **$0.03/SMS**. This is modeled with Stripe Billing Meters (the legacy usage-records API is gone as of API version 2025-03-31.basil):
+
+1. Create two meters — `openvpm_ai_run` and `openvpm_sms` — with sum aggregation, value payload key `value`, and customer mapping by `stripe_customer_id`. The event names must match `lib/billing/stripe-meters.ts`.
+2. Create a graduated metered price per meter with the included allowance as the $0 first tier: tiers `[{ up_to: 1000, unit_amount: 0 }, { up_to: inf, unit_amount: 5 }]` for AI (cents) and `… unit_amount: 3` for SMS, each with `recurring.usage_type=metered` and `recurring.meter=<meter id>`. Wire to `STRIPE_PRICE_AI_OVERAGE` / `STRIPE_PRICE_SMS_OVERAGE`.
+
+Checkout creates one subscription: a per-location licensed item (quantity = active non-deleted locations, kept current by quantity sync) plus the two quantity-less metered items. `recordUsage()` writes the local `usage_records` row (display/reconcile source of truth) and, once the practice has a Stripe customer, reports a meter event so Stripe bills overage automatically. Pre-checkout no-card trial usage has no customer and stays free. Leaving the overage price envs unset keeps usage recorded but unbilled.
 
 Webhook endpoint:
 


### PR DESCRIPTION
## What

Turns the already-recorded hosted usage (`usage_records`) into automatic Stripe charges beyond the included monthly allowance. Finalizes the locked pricing model: **flat \$99/location, unlimited staff, 1,000 AI actions + 1,000 SMS included, then \$0.05/AI action and \$0.03/SMS**.

This was the one missing piece of the hosted billing path — checkout, trial, webhooks, quantity sync, usage recording, and read-only lapsed enforcement already existed.

## How

- **`lib/billing/stripe-meters.ts`** (new): `recordMeterEvent()` bridge to Stripe meter events (`openvpm_ai_run` / `openvpm_sms`), fire-and-forget.
- **`lib/billing/usage.ts`**: after the `usage_records` insert, report a meter event when the practice has a Stripe customer (pre-checkout no-card trial usage has none → stays free). Raised abuse thresholds above the allowance (5,000) now that normal overage bills; idempotent meter identifiers.
- **`lib/billing/plans.ts`**: overage unit-price constants + per-plan fields + `cloudMeteredPriceIds()` reading `STRIPE_PRICE_AI_OVERAGE` / `_SMS_OVERAGE`.
- **`lib/stripe.ts`**: checkout builder adds metered prices **without** a quantity.
- **`server/routers/subscription.ts`**: `createCheckout` adds the two metered items when configured; catalog surfaces overage rates.
- **Settings billing UI**: shows included allowance + overage rate.
- **`.env.example` + `docs/hosted-cloud-production.md`**: document the meters; drop the stale "generous-unmetered" / \$49+\$10 notes.

The included allowance is modeled as the **\$0 first tier of each graduated metered price**, so overage only bills past 1,000. Overage envs stay optional so the app still boots (and records usage) before the meters are configured.

## Verification

- `pnpm type-check` clean; `pnpm vitest run` → 221 passed (added coverage for metered line items + overage helpers).
- Stripe **test-mode** meters + graduated prices + subscription webhook created against the OpenVPM Cloud product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)