### PR TITLE
Add a clear email-verification gate to hosted signup

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -67,10 +67,12 @@ function LoginPageInner() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [showVerifyHint, setShowVerifyHint] = useState(false);
   const [loading, setLoading] = useState(false);
 
   async function signInWith(emailValue: string, passwordValue: string) {
     setError("");
+    setShowVerifyHint(false);
     setLoading(true);
     setEmail(emailValue);
     setPassword(passwordValue);
@@ -84,7 +86,14 @@ function LoginPageInner() {
     setLoading(false);
 
     if (result?.error) {
-      setError("Invalid email or password");
+      // Unverified hosted accounts can't sign in yet — send them to the
+      // "check your inbox" screen (with resend) instead of a dead-end error.
+      if (result.error.includes("EMAIL_NOT_VERIFIED")) {
+        router.push(`/verify-email?email=${encodeURIComponent(emailValue)}`);
+        return;
+      }
+      setError("Invalid email or password.");
+      setShowVerifyHint(true);
     } else {
       router.push(nextPath);
       router.refresh();
@@ -155,7 +164,19 @@ function LoginPageInner() {
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (
             <div className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
-              {error}
+              <p>{error}</p>
+              {showVerifyHint && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Just signed up?{" "}
+                  <Link
+                    href={`/verify-email?email=${encodeURIComponent(email)}`}
+                    className="text-primary hover:underline"
+                  >
+                    Verify your email
+                  </Link>{" "}
+                  first.
+                </p>
+              )}
             </div>
           )}
 

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -48,7 +48,16 @@ function RegisterPageInner() {
   const [loading, setLoading] = useState(false);
 
   const registerMutation = trpc.auth.register.useMutation({
-    onSuccess: async () => {
+    onSuccess: async (data) => {
+      // Hosted: verification is required before access. Send the user to the
+      // "check your inbox" screen instead of dropping them into a read-only app.
+      if (data.verificationRequired) {
+        router.push(
+          `/verify-email?email=${encodeURIComponent(email.trim().toLowerCase())}`
+        );
+        return;
+      }
+      // Self-host: no verification needed — sign in immediately.
       const result = await signIn("credentials", {
         email: email.trim().toLowerCase(),
         password,

--- a/apps/web/app/(auth)/verify-email/page.tsx
+++ b/apps/web/app/(auth)/verify-email/page.tsx
@@ -3,11 +3,21 @@
 import { Suspense, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
+import { MailCheck, Loader2 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 
 function VerifyEmailInner() {
   const params = useSearchParams();
   const token = params.get("token") ?? "";
+  const email = params.get("email") ?? "";
+
+  // Two modes: confirm a token (clicked from the email), or the post-signup
+  // "check your inbox" pending screen (no token) with a resend option.
+  if (token) return <ConfirmToken token={token} />;
+  return <PendingVerification email={email} />;
+}
+
+function ConfirmToken({ token }: { token: string }) {
   const [status, setStatus] = useState<"verifying" | "ok" | "error">("verifying");
   const ran = useRef(false);
 
@@ -19,44 +29,119 @@ function VerifyEmailInner() {
   useEffect(() => {
     if (ran.current) return;
     ran.current = true;
-    if (!token) {
-      setStatus("error");
-      return;
-    }
     verify.mutate({ token });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [token]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-surface">
+    <Shell>
+      {status === "verifying" && (
+        <p className="mt-3 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Verifying your email…
+        </p>
+      )}
+      {status === "ok" && (
+        <>
+          <p className="mt-3 text-sm text-foreground">
+            Your email is verified. You can sign in and start your free trial.
+          </p>
+          <Link
+            href="/login?next=/"
+            className="mt-6 inline-block rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Sign in and continue
+          </Link>
+        </>
+      )}
+      {status === "error" && (
+        <>
+          <p className="mt-3 text-sm text-destructive">
+            This verification link is invalid or has expired.
+          </p>
+          <Link
+            href="/verify-email"
+            className="mt-6 inline-block text-sm text-primary hover:underline"
+          >
+            Send a new link
+          </Link>
+        </>
+      )}
+    </Shell>
+  );
+}
+
+function PendingVerification({ email }: { email: string }) {
+  const [sent, setSent] = useState(false);
+  const resend = trpc.auth.resendVerification.useMutation({
+    onSuccess: () => setSent(true),
+  });
+
+  return (
+    <Shell>
+      <div className="mt-4 flex justify-center">
+        <span className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <MailCheck className="h-6 w-6" />
+        </span>
+      </div>
+      <h2 className="mt-4 font-heading text-lg font-semibold text-foreground">
+        Check your inbox
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {email ? (
+          <>
+            We sent a verification link to{" "}
+            <span className="font-medium text-foreground">{email}</span>. Click it
+            to activate your account and start your free trial.
+          </>
+        ) : (
+          <>
+            We sent a verification link to your email. Click it to activate your
+            account and start your free trial.
+          </>
+        )}
+      </p>
+
+      {sent ? (
+        <p className="mt-6 rounded-md border border-primary/20 bg-primary/5 p-3 text-sm text-primary">
+          Sent. If it&apos;s not in your inbox, check spam.
+        </p>
+      ) : (
+        <button
+          type="button"
+          disabled={!email || resend.isPending}
+          onClick={() => email && resend.mutate({ email })}
+          className="mt-6 inline-flex items-center justify-center gap-2 rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:border-primary hover:text-primary disabled:opacity-50"
+        >
+          {resend.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : null}
+          Resend verification email
+        </button>
+      )}
+
+      <p className="mt-6 text-xs text-muted-foreground">
+        Wrong address?{" "}
+        <Link href="/register" className="text-primary hover:underline">
+          Use a different email
+        </Link>
+      </p>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Already verified?{" "}
+        <Link href="/login" className="text-primary hover:underline">
+          Sign in
+        </Link>
+      </p>
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface p-4">
       <div className="w-full max-w-sm rounded-lg border border-border bg-card p-8 text-center">
         <h1 className="font-heading text-2xl font-bold text-foreground">OpenVPM</h1>
-        {status === "verifying" && (
-          <p className="mt-3 text-sm text-muted-foreground">Verifying your email…</p>
-        )}
-        {status === "ok" && (
-          <>
-            <p className="mt-3 text-sm text-foreground">
-              Your email is verified. You can now sign in and start your free trial.
-            </p>
-            <Link
-              href="/login?next=/"
-              className="mt-6 inline-block rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-            >
-              Sign in and continue
-            </Link>
-          </>
-        )}
-        {status === "error" && (
-          <>
-            <p className="mt-3 text-sm text-destructive">
-              This verification link is invalid or has expired.
-            </p>
-            <Link href="/login" className="mt-6 inline-block text-sm text-primary hover:underline">
-              Back to sign in
-            </Link>
-          </>
-        )}
+        {children}
       </div>
     </div>
   );

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -5,6 +5,10 @@ import { db } from "@openpims/db/client";
 import { users } from "@openpims/db";
 import { eq } from "drizzle-orm";
 import { withSystem } from "@/lib/tenant-db";
+import { billingEnforced } from "@/lib/billing/plans";
+
+/** Thrown-error code the login page maps to the "verify your email" state. */
+export const EMAIL_NOT_VERIFIED = "EMAIL_NOT_VERIFIED";
 
 declare module "next-auth" {
   interface Session {
@@ -60,9 +64,14 @@ export const authOptions: NextAuthOptions = {
         const isValid = await compare(credentials.password, user.passwordHash);
         if (!isValid) return null;
 
-        // Email verification is a SOFT requirement on hosted: new users sign in
-        // immediately after signup (so onboarding + the value tour aren't blocked
-        // by an email round-trip) and are nudged to confirm via an in-app banner.
+        // Hosted: require a verified email before granting a session, so a new
+        // signup can't slip past verification into a confusing read-only app.
+        // Self-host stays frictionless (no email round-trip). The login page maps
+        // this thrown code to the "verify your email" + resend UI.
+        if (billingEnforced() && !user.emailVerifiedAt) {
+          throw new Error(EMAIL_NOT_VERIFIED);
+        }
+
         return {
           id: user.id,
           email: user.email,

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -228,6 +228,55 @@ export const authRouter = createRouter({
       return { ok: true };
     }),
 
+  /** Resend the email-verification link. Generic response (no enumeration). */
+  resendVerification: publicProcedure
+    .input(z.object({ email: z.string().email() }))
+    .mutation(async ({ ctx, input }) => {
+      const { success } = rateLimit({
+        key: `verifyresend:${input.email}`,
+        limit: 5,
+        windowMs: 3600000,
+      });
+      if (!success) {
+        throw new TRPCError({
+          code: "TOO_MANY_REQUESTS",
+          message: "Too many requests. Please try again later.",
+        });
+      }
+
+      const [user] = await ctx.db
+        .select({
+          id: users.id,
+          email: users.email,
+          name: users.name,
+          emailVerifiedAt: users.emailVerifiedAt,
+        })
+        .from(users)
+        .where(eq(users.email, input.email.trim().toLowerCase()))
+        .limit(1);
+
+      // Only send for an existing, not-yet-verified account. Respond the same
+      // either way so the endpoint can't be used to probe for accounts.
+      if (user && !user.emailVerifiedAt) {
+        try {
+          const token = await createAuthToken({
+            userId: user.id,
+            email: user.email,
+            type: "email_verify",
+            db: ctx.db,
+          });
+          await sendVerificationEmail({
+            to: user.email,
+            name: user.name,
+            verifyUrl: `${appBaseUrl()}/verify-email?token=${token}`,
+          });
+        } catch (err) {
+          console.error("[resendVerification] email failed:", err);
+        }
+      }
+      return { ok: true };
+    }),
+
   /** Request a password-reset email. Always succeeds (no account enumeration). */
   requestPasswordReset: publicProcedure
     .input(z.object({ email: z.string().email() }))


### PR DESCRIPTION
## Problem
On hosted signup the user was **auto-logged straight into the app** while email verification was only a silent, soft requirement with **no UI**. Users sailed past it and hit the confusing billing **read-only wall** with no idea they needed to verify their email. (The read-only wall itself is the trial/billing guard — a separate, correct mechanism — but with no verification step surfaced, the flow felt broken.)

## Fix — verification is now a clear, guided step
- **`lib/auth.ts`** — on hosted (`billingEnforced()`), reject sign-in for an unverified email with a coded `EMAIL_NOT_VERIFIED`. **Self-host stays frictionless** (no email round-trip; the gate is skipped).
- **register page** — when verification is required, route to a **"Check your inbox"** screen instead of auto-signing-in. Self-host still auto-signs-in.
- **verify-email page** — handles both the token-confirm flow and the pending "check your inbox" state, with a **resend** button + change-email link.
- **auth router** — `resendVerification` (rate-limited, no account enumeration).
- **login page** — unverified sign-ins are routed to the verify screen; any failure also shows a "verify your email first" hint link.

## Important: the trial still starts at signup
Verification gates **access**, not the trial. `register` still sets `billing_status='trialing'` + 14-day `trial_ends_at`, so a verified new practice lands in a fully-usable trial — no read-only wall.

## Verification
- `pnpm type-check` clean; `pnpm vitest run` → 221 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)