### PR TITLE
Fix hosted read-only bug (RLS-scoped guard) + soft email verification

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -67,12 +67,10 @@ function LoginPageInner() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
-  const [showVerifyHint, setShowVerifyHint] = useState(false);
   const [loading, setLoading] = useState(false);
 
   async function signInWith(emailValue: string, passwordValue: string) {
     setError("");
-    setShowVerifyHint(false);
     setLoading(true);
     setEmail(emailValue);
     setPassword(passwordValue);
@@ -86,14 +84,7 @@ function LoginPageInner() {
     setLoading(false);
 
     if (result?.error) {
-      // Unverified hosted accounts can't sign in yet — send them to the
-      // "check your inbox" screen (with resend) instead of a dead-end error.
-      if (result.error.includes("EMAIL_NOT_VERIFIED")) {
-        router.push(`/verify-email?email=${encodeURIComponent(emailValue)}`);
-        return;
-      }
-      setError("Invalid email or password.");
-      setShowVerifyHint(true);
+      setError("Invalid email or password");
     } else {
       router.push(nextPath);
       router.refresh();
@@ -164,19 +155,7 @@ function LoginPageInner() {
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (
             <div className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
-              <p>{error}</p>
-              {showVerifyHint && (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Just signed up?{" "}
-                  <Link
-                    href={`/verify-email?email=${encodeURIComponent(email)}`}
-                    className="text-primary hover:underline"
-                  >
-                    Verify your email
-                  </Link>{" "}
-                  first.
-                </p>
-              )}
+              {error}
             </div>
           )}
 

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -48,16 +48,10 @@ function RegisterPageInner() {
   const [loading, setLoading] = useState(false);
 
   const registerMutation = trpc.auth.register.useMutation({
-    onSuccess: async (data) => {
-      // Hosted: verification is required before access. Send the user to the
-      // "check your inbox" screen instead of dropping them into a read-only app.
-      if (data.verificationRequired) {
-        router.push(
-          `/verify-email?email=${encodeURIComponent(email.trim().toLowerCase())}`
-        );
-        return;
-      }
-      // Self-host: no verification needed — sign in immediately.
+    onSuccess: async () => {
+      // Sign in immediately so the new practice lands directly in its trial.
+      // Email verification is soft (a nudge banner in-app), not a gate, so we
+      // never block the trial/onboarding on an email round-trip.
       const result = await signIn("credentials", {
         email: email.trim().toLowerCase(),
         password,

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from "@/components/common/error-boundary";
 import { TourProvider } from "@/components/tour/tour-provider";
 import { OnboardingJourney } from "@/components/onboarding/journey-overlay";
 import { BrandTheme } from "@/components/brand/brand-theme";
+import { VerifyEmailBanner } from "@/components/layout/verify-email-banner";
 
 export default function DashboardLayout({
   children,
@@ -37,6 +38,7 @@ export default function DashboardLayout({
         <Sidebar />
         <div className="flex flex-1 flex-col overflow-hidden">
           <TopBar onSearchOpen={() => setSearchOpen(true)} />
+          <VerifyEmailBanner />
           <main id="main-content" className="flex-1 overflow-y-auto bg-surface p-6">
             <ErrorBoundary>{children}</ErrorBoundary>
           </main>

--- a/apps/web/components/layout/verify-email-banner.tsx
+++ b/apps/web/components/layout/verify-email-banner.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Mail, X, Loader2, Check } from "lucide-react";
+import { trpc } from "@/lib/trpc";
+
+const DISMISS_KEY = "ovpm_verify_email_dismissed";
+
+/**
+ * Soft email-verification nudge. Verification is NOT a gate (signup lands
+ * straight in the trial); this is a non-blocking reminder shown only on the
+ * hosted service while the signed-in user's email is unverified. Dismissible
+ * for the session, with a one-click resend.
+ */
+export function VerifyEmailBanner() {
+  const [dismissed, setDismissed] = useState(true); // assume dismissed until we read storage
+  const { data } = trpc.auth.me.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+  const resend = trpc.auth.resendVerification.useMutation();
+
+  useEffect(() => {
+    setDismissed(sessionStorage.getItem(DISMISS_KEY) === "1");
+  }, []);
+
+  if (dismissed) return null;
+  if (!data?.verificationEnabled || data.emailVerified) return null;
+
+  function dismiss() {
+    sessionStorage.setItem(DISMISS_KEY, "1");
+    setDismissed(true);
+  }
+
+  return (
+    <div className="flex items-center gap-3 border-b border-amber-200 bg-amber-50 px-6 py-2.5 text-sm text-amber-900">
+      <Mail className="h-4 w-4 shrink-0" />
+      <p className="flex-1">
+        {resend.isSuccess ? (
+          <span className="inline-flex items-center gap-1.5">
+            <Check className="h-4 w-4" /> Verification email sent. Check your inbox (and spam).
+          </span>
+        ) : (
+          <>
+            Verify your email{data.email ? ` (${data.email})` : ""} to secure your
+            account and keep reminders deliverable.
+          </>
+        )}
+      </p>
+      {!resend.isSuccess && (
+        <button
+          type="button"
+          disabled={resend.isPending || !data.email}
+          onClick={() => data.email && resend.mutate({ email: data.email })}
+          className="inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-white px-2.5 py-1 text-xs font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-50"
+        >
+          {resend.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+          Resend email
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss"
+        className="rounded p-1 text-amber-700 hover:bg-amber-100"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -5,10 +5,6 @@ import { db } from "@openpims/db/client";
 import { users } from "@openpims/db";
 import { eq } from "drizzle-orm";
 import { withSystem } from "@/lib/tenant-db";
-import { billingEnforced } from "@/lib/billing/plans";
-
-/** Thrown-error code the login page maps to the "verify your email" state. */
-export const EMAIL_NOT_VERIFIED = "EMAIL_NOT_VERIFIED";
 
 declare module "next-auth" {
   interface Session {
@@ -64,14 +60,9 @@ export const authOptions: NextAuthOptions = {
         const isValid = await compare(credentials.password, user.passwordHash);
         if (!isValid) return null;
 
-        // Hosted: require a verified email before granting a session, so a new
-        // signup can't slip past verification into a confusing read-only app.
-        // Self-host stays frictionless (no email round-trip). The login page maps
-        // this thrown code to the "verify your email" + resend UI.
-        if (billingEnforced() && !user.emailVerifiedAt) {
-          throw new Error(EMAIL_NOT_VERIFIED);
-        }
-
+        // Email verification is a SOFT requirement on hosted: new users sign in
+        // immediately after signup (so the trial + onboarding aren't blocked by
+        // an email round-trip) and are nudged to confirm via an in-app banner.
         return {
           id: user.id,
           email: user.email,

--- a/apps/web/server/__tests__/guards.test.ts
+++ b/apps/web/server/__tests__/guards.test.ts
@@ -53,7 +53,11 @@ describe("viewer read-only guard", () => {
 
   it("blocks hosted lapsed accounts from protected mutations before resolver writes", async () => {
     vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
-    const db: Record<string, unknown> = {
+    // The read-only guard now runs inside withTenant (a transaction) so the
+    // practice lookup is RLS-scoped. The tx exposes execute() (for the
+    // set_config RLS call) and the select() chain returning a lapsed practice.
+    const tx: Record<string, unknown> = {
+      execute: async () => undefined,
       select: () => ({
         from: () => ({
           where: () => ({
@@ -67,6 +71,10 @@ describe("viewer read-only guard", () => {
           }),
         }),
       }),
+    };
+    const db: Record<string, unknown> = {
+      transaction: async (fn: (t: unknown) => unknown) => fn(tx),
+      execute: async () => undefined,
     };
     const caller = callerFor("front_desk", db);
     await expect(

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -376,11 +376,17 @@ export const authRouter = createRouter({
         role: users.role,
         practiceId: users.practiceId,
         avatarUrl: users.avatarUrl,
+        emailVerifiedAt: users.emailVerifiedAt,
       })
       .from(users)
       .where(eq(users.id, ctx.user.id))
       .limit(1);
 
-    return user;
+    return {
+      ...user,
+      // Soft email-verification nudge: only relevant on the hosted service.
+      emailVerified: Boolean(user?.emailVerifiedAt),
+      verificationEnabled: billingEnforced(),
+    };
   }),
 });

--- a/apps/web/server/trpc.ts
+++ b/apps/web/server/trpc.ts
@@ -101,39 +101,45 @@ export const protectedProcedure = t.procedure.use(
         message: "Your account has read-only (viewer) access.",
       });
     }
-    if (
-      type === "mutation" &&
-      billingEnforced() &&
-      !HOSTED_READ_ONLY_MUTATION_ALLOWLIST.has(path)
-    ) {
-      const [practice] = await ctx.db
-        .select({
-          tier: practices.subscriptionTier,
-          billingStatus: practices.billingStatus,
-          trialEndsAt: practices.trialEndsAt,
-        })
-        .from(practices)
-        .where(eq(practices.id, ctx.session.user.practiceId))
-        .limit(1);
-      if (
-        !hasHostedFullAccess(
-          practice?.tier,
-          practice?.billingStatus,
-          practice?.trialEndsAt
-        )
-      ) {
-        throw new TRPCError({
-          code: "FORBIDDEN",
-          message:
-            "OpenVPM Cloud is read-only until your trial or subscription is active. You can still manage billing and export your data.",
-        });
-      }
-    }
-
     const user = ctx.session.user;
     // Run the whole request in a tenant DB context so Postgres RLS scopes every
     // query to this practice (defense-in-depth behind the app-layer filters).
     return withTenant(ctx.db, user.practiceId, async (tx) => {
+      // Hosted read-only guard: block mutations unless the practice has an
+      // active trial or subscription. This MUST run inside withTenant (via tx),
+      // not on the raw connection — under the least-privilege production role
+      // RLS only returns the practices row when app.current_practice_id is set,
+      // so a context-less lookup returns zero rows and would wrongly read-only
+      // every tenant (the owner role used in dev bypasses RLS and hid this).
+      if (
+        type === "mutation" &&
+        billingEnforced() &&
+        !HOSTED_READ_ONLY_MUTATION_ALLOWLIST.has(path)
+      ) {
+        const [practice] = await tx
+          .select({
+            tier: practices.subscriptionTier,
+            billingStatus: practices.billingStatus,
+            trialEndsAt: practices.trialEndsAt,
+          })
+          .from(practices)
+          .where(eq(practices.id, user.practiceId))
+          .limit(1);
+        if (
+          !hasHostedFullAccess(
+            practice?.tier,
+            practice?.billingStatus,
+            practice?.trialEndsAt
+          )
+        ) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message:
+              "OpenVPM Cloud is read-only until your trial or subscription is active. You can still manage billing and export your data.",
+          });
+        }
+      }
+
       const result = await next({
         ctx: { session: ctx.session, user, practiceId: user.practiceId, db: tx },
       });


### PR DESCRIPTION
## The bug (P0) — every hosted mutation was blocked
The hosted read-only guard in `protectedProcedure` (`server/trpc.ts`) looked up the practice on the **raw `ctx.db` BEFORE the `withTenant()` wrapper**. Under the least-privilege production DB role (RLS enforced), that query sets no `app.current_practice_id`, so the `practices` policy `USING (app_rls_bypass() OR id = app_current_practice_id())` matched nothing → **0 rows** → `hasHostedFullAccess(undefined)` → `false` → **read-only for every hosted mutation, even valid trialing practices**.

Confirmed against prod: 5 practices `trialing` with future `trial_ends_at` all hit read-only. It passed earlier only because dev/self-host uses the DB **owner role (bypasses RLS)**, so the context-less query still returned the row.

**Fix:** run the guard's practice lookup **inside `withTenant` (via `tx`)** so RLS resolves the row. `requireFeature` already ran inside `withTenant`, so only the pre-check was mis-scoped.

## Soft email verification (P1)
The hard gate from #25 added friction and a stale-session trap. Reverted to **soft**: `authorize()` no longer blocks unverified hosted logins; signup **auto-logs-in straight into the trial**. The verification email still sends; `resendVerification` + the verify-email page are kept.

## Soft nudge (P2)
`auth.me` now returns `emailVerified`/`verificationEnabled`; a **dismissible `VerifyEmailBanner`** nudges unverified hosted users with one-click resend. Never blocks.

## Verification
- `pnpm type-check` clean; `pnpm vitest run` → 221 passed. `guards.test.ts` updated (the guard now runs in a transaction).
- Note: the RLS bug **cannot reproduce in local tests** (owner role bypasses RLS); definitive check is on prod after deploy — register fresh → auto-onboarding → Continue (a mutation) succeeds, no read-only.

## Follow-up
Consider extending the RLS tenant-isolation CI job to exercise one authed mutation as the restricted role, which would have caught this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)