### PR TITLE
Contact sales link → evan@openvpm.com

### DIFF
--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -799,7 +799,7 @@ function PlanGrid({
                 </Button>
               ) : !p.selfServe ? (
                 <a
-                  href="mailto:sales@openvpm.com?subject=OpenVPM%20Enterprise"
+                  href="mailto:evan@openvpm.com?subject=OpenVPM%20Enterprise"
                   className="text-xs font-medium text-primary hover:underline"
                 >
                   Contact sales


### PR DESCRIPTION
Match the marketing site: the in-app Enterprise 'Contact sales' mailto now points at evan@openvpm.com (delivers via Google Workspace). The old sales@ alias no longer routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)