### PR TITLE
fix(ops): cron auth (Vercel Bearer) + advisory health checks

### DIFF
--- a/apps/web/app/api/cron/backup/route.ts
+++ b/apps/web/app/api/cron/backup/route.ts
@@ -6,6 +6,7 @@ import { exportPracticeData, backupKey } from "@/lib/backup/export";
 import { uploadFile } from "@/lib/s3";
 import { alertOps } from "@/lib/alerts";
 import { withSystem, withTenant } from "@/lib/tenant-db";
+import { cronAuthError } from "@/lib/cron-auth";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -13,10 +14,8 @@ export const maxDuration = 300;
 // Scheduled per-practice backup → object storage. A clinic gets a daily,
 // restorable JSON snapshot of its data, independent of the live DB.
 export async function GET(request: Request) {
-  const cronSecret = request.headers.get("x-cron-secret");
-  if (!cronSecret || cronSecret !== process.env.CRON_SECRET) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const authError = cronAuthError(request);
+  if (authError) return authError;
 
   const today = new Date().toISOString().slice(0, 10);
   let ok = 0;

--- a/apps/web/app/api/cron/reminders/route.ts
+++ b/apps/web/app/api/cron/reminders/route.ts
@@ -11,13 +11,11 @@ import {
 import { sendAppointmentReminder } from "@/lib/email";
 import { alertOps } from "@/lib/alerts";
 import { withSystem, withTenant } from "@/lib/tenant-db";
+import { cronAuthError } from "@/lib/cron-auth";
 
 export async function GET(request: Request) {
-  // Validate the cron secret to prevent unauthorized access
-  const cronSecret = request.headers.get("x-cron-secret");
-  if (!cronSecret || cronSecret !== process.env.CRON_SECRET) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const authError = cronAuthError(request);
+  if (authError) return authError;
 
   try {
     const now = new Date();

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -55,11 +55,12 @@ function requiredAiEnvNames(): string[] {
   return [isGemini ? "GOOGLE_API_KEY" : "ANTHROPIC_API_KEY"];
 }
 
-const HOSTED_OPS_ENV_NAMES = [
-  "OPS_ALERT_WEBHOOK_URL",
-  "CRON_SECRET",
-  "PLATFORM_ADMIN_EMAILS",
-];
+// Required ops envs: cron auth + platform admin access must be present.
+const HOSTED_OPS_ENV_NAMES = ["CRON_SECRET", "PLATFORM_ADMIN_EMAILS"];
+
+// Advisory ops envs: recommended for prod observability but not required to
+// serve requests, so they do not gate the health `ok` / status code.
+const HOSTED_OPS_ALERTING_ENV_NAMES = ["OPS_ALERT_WEBHOOK_URL"];
 
 function hostedEnvCheck(
   names: string[],
@@ -77,7 +78,10 @@ function hostedEnvCheck(
 
 export async function GET() {
   const startedAt = Date.now();
-  const checks: Record<string, { ok: boolean; detail?: string }> = {};
+  const checks: Record<
+    string,
+    { ok: boolean; detail?: string; advisory?: boolean }
+  > = {};
 
   try {
     await db.execute(sql`select 1`);
@@ -106,10 +110,6 @@ export async function GET() {
       HOSTED_EMAIL_ENV_NAMES,
       "Hosted email envs present"
     );
-    checks.hostedSms = hostedEnvCheck(
-      HOSTED_SMS_ENV_NAMES,
-      "Hosted SMS envs present"
-    );
     checks.hostedAi = hostedEnvCheck(
       requiredAiEnvNames(),
       "Hosted AI envs present"
@@ -118,6 +118,21 @@ export async function GET() {
       HOSTED_OPS_ENV_NAMES,
       "Hosted ops envs present"
     );
+
+    // Advisory checks are reported but do NOT gate readiness — a 200 means "can
+    // serve requests", not "every optional capability is wired". SMS is deferred
+    // until Twilio is provisioned; ops alerting (Slack webhook) is recommended.
+    checks.hostedSms = {
+      ...hostedEnvCheck(HOSTED_SMS_ENV_NAMES, "Hosted SMS envs present"),
+      advisory: true,
+    };
+    checks.hostedOpsAlerting = {
+      ...hostedEnvCheck(
+        HOSTED_OPS_ALERTING_ENV_NAMES,
+        "Ops alerting configured"
+      ),
+      advisory: true,
+    };
   } else {
     checks.hostedConfig = {
       ok: true,
@@ -125,7 +140,9 @@ export async function GET() {
     };
   }
 
-  const ok = Object.values(checks).every((check) => check.ok);
+  // Advisory checks are excluded from the readiness gate (status code) but are
+  // still returned so operators can see what's intentionally deferred.
+  const ok = Object.values(checks).every((check) => check.advisory || check.ok);
   return NextResponse.json(
     {
       ok,

--- a/apps/web/lib/__tests__/cron-auth.test.ts
+++ b/apps/web/lib/__tests__/cron-auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { isCronAuthorized } from "../cron-auth";
+
+function req(headers: Record<string, string>): Request {
+  return new Request("http://localhost/api/cron/test", { headers });
+}
+
+describe("isCronAuthorized", () => {
+  const ORIGINAL = process.env.CRON_SECRET;
+
+  beforeEach(() => {
+    process.env.CRON_SECRET = "s3cret-value";
+  });
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = ORIGINAL;
+  });
+
+  it("accepts the Vercel Cron `Authorization: Bearer <secret>` header", () => {
+    expect(isCronAuthorized(req({ authorization: "Bearer s3cret-value" }))).toBe(true);
+  });
+
+  it("accepts a lowercase `bearer` scheme", () => {
+    expect(isCronAuthorized(req({ authorization: "bearer s3cret-value" }))).toBe(true);
+  });
+
+  it("accepts the `x-cron-secret` fallback header (manual/local triggers)", () => {
+    expect(isCronAuthorized(req({ "x-cron-secret": "s3cret-value" }))).toBe(true);
+  });
+
+  it("rejects a wrong secret in either header", () => {
+    expect(isCronAuthorized(req({ authorization: "Bearer nope" }))).toBe(false);
+    expect(isCronAuthorized(req({ "x-cron-secret": "nope" }))).toBe(false);
+  });
+
+  it("rejects when no auth header is provided", () => {
+    expect(isCronAuthorized(req({}))).toBe(false);
+  });
+
+  it("rejects everything when CRON_SECRET is unset", () => {
+    delete process.env.CRON_SECRET;
+    expect(isCronAuthorized(req({ authorization: "Bearer s3cret-value" }))).toBe(false);
+    expect(isCronAuthorized(req({ "x-cron-secret": "s3cret-value" }))).toBe(false);
+  });
+});

--- a/apps/web/lib/cron-auth.ts
+++ b/apps/web/lib/cron-auth.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import crypto from "node:crypto";
+
+/**
+ * Whether a scheduled-job (cron) invocation is authorized.
+ *
+ * Vercel Cron triggers the route with `Authorization: Bearer <CRON_SECRET>` — it
+ * cannot set arbitrary custom headers from vercel.json, so the older
+ * `x-cron-secret` check silently 401'd every Vercel-triggered run. We accept the
+ * Bearer header (production) AND keep `x-cron-secret` as a fallback for manual /
+ * local triggering (curl, scripts). If `CRON_SECRET` is unset we never authorize
+ * — an unauthenticated cron sweep would be a cross-tenant data risk.
+ */
+export function isCronAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+
+  const authorization = request.headers.get("authorization");
+  const bearer = authorization?.toLowerCase().startsWith("bearer ")
+    ? authorization.slice(7).trim()
+    : null;
+  const provided = bearer ?? request.headers.get("x-cron-secret");
+
+  return !!provided && safeEqual(provided, secret);
+}
+
+/**
+ * Returns a 401 `NextResponse` to short-circuit a cron route with, or `null`
+ * when the request is authorized.
+ */
+export function cronAuthError(request: Request): NextResponse | null {
+  return isCronAuthorized(request)
+    ? null
+    : NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ab, bb);
+}


### PR DESCRIPTION
## Why
Two production loose-ends, both invisible until now:

1. **Crons were silently 401'ing.** `cron/reminders` and `cron/backup` gated on a custom `x-cron-secret` header, but **Vercel Cron can't set custom headers** — it sends `Authorization: Bearer <CRON_SECRET>`. So the two crons defined in `vercel.json` were rejecting every scheduled run: **no automatic appointment reminders, no daily backups in prod.**
2. **Health was a false red.** `/api/health` returned `ok:false` (503) purely because Twilio SMS (intentionally deferred) and `OPS_ALERT_WEBHOOK_URL` (optional) were unset — even though DB, billing, storage, email, and AI are all green.

## What
- Add `lib/cron-auth.ts`: accept the Vercel `Authorization: Bearer` header **and** keep `x-cron-secret` as a manual/local fallback. Constant-time compare; deny when `CRON_SECRET` is unset. Wire into both cron routes (and any future cron).
- Health: stop gating readiness on intentionally-deferred/optional capabilities. **SMS** and **ops alerting** are now *advisory* — reported in the payload but they don't flip `ok` or the status code. `CRON_SECRET` + `PLATFORM_ADMIN_EMAILS` stay required under `hostedOps`.
- Unit tests for the cron auth decision (Bearer, x-cron-secret, wrong secret, missing, unset).

## Verify
- `pnpm --filter @openpims/web type-check` ✅, `pnpm test` ✅ (28 files / 227 tests incl. new cron-auth).
- After deploy: `curl https://app.openvpm.com/api/health` → `ok:true` with `hostedSms`/`hostedOpsAlerting` shown as advisory; trigger a cron with `Authorization: Bearer $CRON_SECRET` → 200.

## Follow-ups (not in this PR)
- Set `OPS_ALERT_WEBHOOK_URL` to a real Slack webhook so `alertOps()` delivers (currently logs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)