### PR TITLE
feat(email): branded lifecycle emails — shell + welcome, receipt, dunning

### DIFF
--- a/apps/web/app/api/webhooks/stripe-subscription/route.ts
+++ b/apps/web/app/api/webhooks/stripe-subscription/route.ts
@@ -8,6 +8,11 @@ import { tierForStripePrice, normalizeBillingStatus } from "@/lib/billing/plans"
 import { syncPracticeSubscriptionQuantities } from "@/lib/billing/subscription-sync";
 import { alertOps } from "@/lib/alerts";
 import { withSystem } from "@/lib/tenant-db";
+import {
+  sendPaymentReceiptEmail,
+  sendPaymentFailedEmail,
+} from "@/lib/email";
+import { sendLifecycleEmail } from "@/lib/email-lifecycle";
 
 /**
  * Stripe webhook for hosted-SaaS subscriptions — a SEPARATE endpoint from the
@@ -92,6 +97,36 @@ export async function POST(req: NextRequest) {
         break;
       }
 
+      case "invoice.payment_succeeded": {
+        const inv = event.data.object as Stripe.Invoice;
+        const customerId =
+          typeof inv.customer === "string" ? inv.customer : inv.customer?.id;
+        // Only a real (non-$0) charge warrants a receipt — skip the $0 invoice
+        // Stripe emits at trial start.
+        if (customerId && (inv.amount_paid ?? 0) > 0) {
+          const practice = await practiceForCustomer(customerId);
+          if (practice?.email) {
+            const to = practice.email;
+            const practiceName = practice.name ?? "your practice";
+            await sendLifecycleEmail({
+              practiceId: practice.id,
+              to,
+              emailType: "receipt",
+              dedupeKey: `lc:receipt:${inv.id}`,
+              send: () =>
+                sendPaymentReceiptEmail({
+                  to,
+                  practiceName,
+                  amount: formatMoney(inv.amount_paid, inv.currency),
+                  periodLabel: invoicePeriodLabel(inv),
+                  invoiceUrl: inv.hosted_invoice_url ?? undefined,
+                }),
+            });
+          }
+        }
+        break;
+      }
+
       case "invoice.payment_failed": {
         const inv = event.data.object as Stripe.Invoice;
         const customerId =
@@ -107,6 +142,25 @@ export async function POST(req: NextRequest) {
             "Subscription payment failed",
             `Stripe customer ${customerId} had a failed subscription payment; marked past_due.`,
           );
+          const practice = await practiceForCustomer(customerId);
+          if (practice?.email) {
+            const to = practice.email;
+            const practiceName = practice.name ?? "your practice";
+            await sendLifecycleEmail({
+              practiceId: practice.id,
+              to,
+              emailType: "dunning",
+              // One dunning email per Stripe retry attempt.
+              dedupeKey: `lc:dunning:${inv.id}:${inv.attempt_count ?? 0}`,
+              send: () =>
+                sendPaymentFailedEmail({
+                  to,
+                  practiceName,
+                  amount: formatMoney(inv.amount_due, inv.currency),
+                  nextRetryDate: formatUnixDate(inv.next_payment_attempt),
+                }),
+            });
+          }
         }
         break;
       }
@@ -159,4 +213,46 @@ async function applySubscription(sub: Stripe.Subscription) {
       subscriptionId: sub.id,
     })
   );
+}
+
+/** Look up a practice's id / email / name by its Stripe customer id. */
+async function practiceForCustomer(customerId: string) {
+  const [p] = await withSystem(db, (tx) =>
+    tx
+      .select({
+        id: practices.id,
+        email: practices.email,
+        name: practices.name,
+      })
+      .from(practices)
+      .where(eq(practices.stripeCustomerId, customerId))
+      .limit(1),
+  );
+  return p ?? null;
+}
+
+function formatMoney(
+  cents: number | null | undefined,
+  currency: string | null | undefined,
+): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: (currency ?? "usd").toUpperCase(),
+  }).format((cents ?? 0) / 100);
+}
+
+function formatUnixDate(sec: number | null | undefined): string | undefined {
+  if (!sec) return undefined;
+  return new Date(sec * 1000).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function invoicePeriodLabel(inv: Stripe.Invoice): string {
+  const s = formatUnixDate(inv.period_start);
+  const e = formatUnixDate(inv.period_end);
+  if (s && e) return `${s} – ${e}`;
+  return e ?? s ?? "";
 }

--- a/apps/web/lib/email-lifecycle.ts
+++ b/apps/web/lib/email-lifecycle.ts
@@ -1,0 +1,103 @@
+import { eq } from "drizzle-orm";
+import { db } from "@openpims/db/client";
+import { communications } from "@openpims/db";
+import { withSystem } from "@/lib/tenant-db";
+import { alertOps } from "@/lib/alerts";
+
+type SendResult = { success: boolean; id?: string; error?: string };
+
+/**
+ * Send a system lifecycle email exactly once, recording it in the practice's
+ * communications history.
+ *
+ * Idempotency: we first try to claim a row keyed by `dedupeKey` (unique index);
+ * if the row already exists, the email was already sent/in-flight and we no-op.
+ * This is race-safe under Stripe webhook redelivery and cron re-runs.
+ *
+ * On a hard send failure we alert ops. For cron-triggered mail (`retryOnFail`)
+ * we delete the claim so the next run retries; for webhook mail we keep it
+ * (Stripe redelivers the event anyway) so customers never get duplicates.
+ */
+export async function sendLifecycleEmail(opts: {
+  practiceId: string;
+  to: string;
+  emailType: string;
+  dedupeKey: string;
+  send: () => Promise<SendResult>;
+  retryOnFail?: boolean;
+}): Promise<{ sent: boolean; deduped: boolean }> {
+  // Never throw into the caller (Stripe webhook / cron). Any infra error
+  // (incl. a not-yet-migrated dedupe column) degrades to "not sent" + an alert.
+  try {
+    // 1. Atomic claim — no row back means someone already claimed this key.
+    const claimed = await withSystem(db, (tx) =>
+      tx
+        .insert(communications)
+        .values({
+          practiceId: opts.practiceId,
+          clientId: null,
+          channel: "email",
+          direction: "outbound",
+          subject: opts.emailType,
+          content: opts.emailType,
+          status: "pending",
+          dedupeKey: opts.dedupeKey,
+        })
+        .onConflictDoNothing({ target: communications.dedupeKey })
+        .returning({ id: communications.id }),
+    );
+
+    const row = claimed[0];
+    if (!row) {
+      return { sent: false, deduped: true };
+    }
+
+    // 2. Send.
+    let result: SendResult;
+    try {
+      result = await opts.send();
+    } catch (err) {
+      result = {
+        success: false,
+        error: err instanceof Error ? err.message : "send threw",
+      };
+    }
+
+    // 3. Record the outcome.
+    if (result.success) {
+      await withSystem(db, (tx) =>
+        tx
+          .update(communications)
+          .set({ status: "sent" })
+          .where(eq(communications.id, row.id)),
+      );
+      return { sent: true, deduped: false };
+    }
+
+    await alertOps(
+      "Lifecycle email failed",
+      `${opts.emailType} → ${opts.to}: ${result.error ?? "unknown error"}`,
+    );
+
+    if (opts.retryOnFail) {
+      // Drop the claim so the next cron sweep can try again.
+      await withSystem(db, (tx) =>
+        tx.delete(communications).where(eq(communications.id, row.id)),
+      );
+    } else {
+      await withSystem(db, (tx) =>
+        tx
+          .update(communications)
+          .set({ status: "failed" })
+          .where(eq(communications.id, row.id)),
+      );
+    }
+    return { sent: false, deduped: false };
+  } catch (err) {
+    await alertOps(
+      "Lifecycle email error",
+      `${opts.emailType} → ${opts.to}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { sent: false, deduped: false };
+  }
+}

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -1,4 +1,11 @@
 import { Resend } from "resend";
+import {
+  openvpmBrand,
+  renderWelcomeEmail,
+  renderTrialEndingEmail,
+  renderPaymentReceiptEmail,
+  renderPaymentFailedEmail,
+} from "@openpims/email";
 
 // ---------------------------------------------------------------------------
 // Resend client – initialised lazily so the module can be imported even when
@@ -86,6 +93,8 @@ export async function sendEmail(options: {
   subject: string;
   html: string;
   from?: string;
+  replyTo?: string;
+  headers?: Record<string, string>;
 }): Promise<{ success: boolean; id?: string; error?: string }> {
   const client = getResend();
 
@@ -107,6 +116,8 @@ export async function sendEmail(options: {
       to: options.to,
       subject: options.subject,
       html: options.html,
+      ...(options.replyTo ? { replyTo: options.replyTo } : {}),
+      ...(options.headers ? { headers: options.headers } : {}),
     });
 
     if (error) {
@@ -335,4 +346,94 @@ export async function sendStaffInviteEmail(data: {
     html,
   });
   return { success: result.success };
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle emails (branded via @openpims/email — React Email)
+// ---------------------------------------------------------------------------
+
+const SUPPORT_ADDRESS =
+  process.env.EMAIL_SUPPORT_ADDRESS || "evan@openvpm.com";
+
+/** Welcome email sent when a practice signs up (hosted trial). */
+export async function sendWelcomeEmail(data: {
+  to: string;
+  practiceName: string;
+  trialDays?: number;
+}): Promise<{ success: boolean; id?: string; error?: string }> {
+  const brand = openvpmBrand();
+  const { subject, html } = await renderWelcomeEmail({
+    brand,
+    practiceName: data.practiceName,
+    trialDays: data.trialDays ?? 14,
+  });
+  return sendEmail({ to: data.to, subject, html, replyTo: SUPPORT_ADDRESS });
+}
+
+/** Trial-ending nudge (T-7 / T-3 / T-1). Promotional → carries unsubscribe. */
+export async function sendTrialEndingEmail(data: {
+  to: string;
+  practiceName: string;
+  daysLeft: number;
+  trialEndDate: string;
+  monthlyPrice?: string;
+  billingUrl?: string;
+}): Promise<{ success: boolean; id?: string; error?: string }> {
+  const brand = openvpmBrand();
+  const billingUrl = data.billingUrl ?? `${brand.appUrl}/settings?tab=billing`;
+  const { subject, html } = await renderTrialEndingEmail({
+    brand,
+    practiceName: data.practiceName,
+    daysLeft: data.daysLeft,
+    trialEndDate: data.trialEndDate,
+    monthlyPrice: data.monthlyPrice ?? "$99",
+    billingUrl,
+    unsubscribeUrl: billingUrl,
+  });
+  return sendEmail({
+    to: data.to,
+    subject,
+    html,
+    replyTo: SUPPORT_ADDRESS,
+    headers: { "List-Unsubscribe": `<${billingUrl}>` },
+  });
+}
+
+/** Receipt sent on a successful subscription payment. */
+export async function sendPaymentReceiptEmail(data: {
+  to: string;
+  practiceName: string;
+  amount: string;
+  periodLabel: string;
+  invoiceUrl?: string;
+}): Promise<{ success: boolean; id?: string; error?: string }> {
+  const brand = openvpmBrand();
+  const { subject, html } = await renderPaymentReceiptEmail({
+    brand,
+    practiceName: data.practiceName,
+    amount: data.amount,
+    periodLabel: data.periodLabel,
+    invoiceUrl: data.invoiceUrl,
+  });
+  return sendEmail({ to: data.to, subject, html, replyTo: SUPPORT_ADDRESS });
+}
+
+/** Dunning email sent on a failed subscription payment. */
+export async function sendPaymentFailedEmail(data: {
+  to: string;
+  practiceName: string;
+  amount: string;
+  nextRetryDate?: string;
+  billingUrl?: string;
+}): Promise<{ success: boolean; id?: string; error?: string }> {
+  const brand = openvpmBrand();
+  const billingUrl = data.billingUrl ?? `${brand.appUrl}/settings?tab=billing`;
+  const { subject, html } = await renderPaymentFailedEmail({
+    brand,
+    practiceName: data.practiceName,
+    amount: data.amount,
+    nextRetryDate: data.nextRetryDate,
+    billingUrl,
+  });
+  return sendEmail({ to: data.to, subject, html, replyTo: SUPPORT_ADDRESS });
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
-  transpilePackages: ["@openpims/api", "@openpims/db"],
+  transpilePackages: ["@openpims/api", "@openpims/db", "@openpims/email"],
 };
 
 module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@aws-sdk/s3-request-presigner": "^3.700.0",
     "@openpims/api": "workspace:*",
     "@openpims/db": "workspace:*",
+    "@openpims/email": "workspace:*",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -8,7 +8,11 @@ import { rateLimit } from "@/lib/rate-limit";
 import { seedPractice, seedDemoData } from "@/lib/onboarding/defaults";
 import { billingEnforced, TRIAL_DAYS } from "@/lib/billing/plans";
 import { createAuthToken, consumeAuthToken } from "@/lib/auth-tokens";
-import { sendVerificationEmail, sendPasswordResetEmail } from "@/lib/email";
+import {
+  sendVerificationEmail,
+  sendPasswordResetEmail,
+  sendWelcomeEmail,
+} from "@/lib/email";
 import { appBaseUrl, exposeAuthLinksForPreview } from "@/lib/app-url";
 
 /** Display name from explicit input, else derived from the email local-part. */
@@ -198,6 +202,20 @@ export const authRouter = createRouter({
         } catch (err) {
           console.error("[register] verification email failed:", err);
           verificationEmailSent = false;
+        }
+      }
+
+      // Send a branded welcome email (hosted only). Non-fatal — signup succeeds
+      // regardless of delivery.
+      if (billingEnforced()) {
+        try {
+          await sendWelcomeEmail({
+            to: user!.email,
+            practiceName: input.practiceName.trim(),
+            trialDays: TRIAL_DAYS,
+          });
+        } catch (err) {
+          console.error("[register] welcome email failed:", err);
         }
       }
 

--- a/packages/db/schema/communications.ts
+++ b/packages/db/schema/communications.ts
@@ -8,6 +8,7 @@ import {
   jsonb,
   timestamp,
   index,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 import { baseColumns } from "./common";
@@ -35,19 +36,32 @@ export const commStatusEnum = pgEnum("comm_status", [
   "failed",
 ]);
 
-export const communications = pgTable("communications", {
-  ...baseColumns(),
-  practiceId: uuid("practice_id")
-    .notNull()
-    .references(() => practices.id),
-  clientId: uuid("client_id").references(() => clients.id),
-  channel: channelEnum("channel").notNull(),
-  direction: directionEnum("direction").notNull(),
-  subject: varchar("subject", { length: 255 }),
-  content: text("content"),
-  status: commStatusEnum("status").notNull().default("pending"),
-  assignedTo: uuid("assigned_to").references(() => users.id),
-});
+export const communications = pgTable(
+  "communications",
+  {
+    ...baseColumns(),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    clientId: uuid("client_id").references(() => clients.id),
+    channel: channelEnum("channel").notNull(),
+    direction: directionEnum("direction").notNull(),
+    subject: varchar("subject", { length: 255 }),
+    content: text("content"),
+    status: commStatusEnum("status").notNull().default("pending"),
+    assignedTo: uuid("assigned_to").references(() => users.id),
+    // Idempotency key for system-sent lifecycle emails (welcome, receipt,
+    // dunning, trial-ending, usage). Null for ordinary client comms — Postgres
+    // treats NULLs as distinct, so the unique index only constrains real keys
+    // and makes "send exactly once" race-safe under webhook/cron retries.
+    dedupeKey: varchar("dedupe_key", { length: 160 }),
+  },
+  (table) => ({
+    dedupeKeyIdx: uniqueIndex("communications_dedupe_key_idx").on(
+      table.dedupeKey
+    ),
+  })
+);
 
 export const webhooks = pgTable("webhooks", {
   ...baseColumns(),

--- a/packages/email/.gitignore
+++ b/packages/email/.gitignore
@@ -1,0 +1,2 @@
+.preview/
+dist/

--- a/packages/email/index.ts
+++ b/packages/email/index.ts
@@ -1,2 +1,10 @@
-// Email templates barrel export
-export {};
+// @openpims/email — branded transactional email templates (React Email).
+// Transport + send logic lives in the app; this package only renders HTML.
+export { openvpmBrand } from "./src/brand";
+export type { Brand } from "./src/brand";
+export { theme } from "./src/theme";
+export * from "./src/render";
+export type { WelcomeEmailProps } from "./src/templates/WelcomeEmail";
+export type { TrialEndingEmailProps } from "./src/templates/TrialEndingEmail";
+export type { PaymentReceiptEmailProps } from "./src/templates/PaymentReceiptEmail";
+export type { PaymentFailedEmailProps } from "./src/templates/PaymentFailedEmail";

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -6,12 +6,20 @@
   "exports": {
     ".": "./index.ts"
   },
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "preview": "tsx preview.tsx"
+  },
   "dependencies": {
     "@react-email/components": "^0.0.25",
+    "@react-email/render": "^1.0.2",
     "react": "^18.3.0"
   },
   "devDependencies": {
     "@openpims/config": "workspace:*",
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.3.0",
+    "tsx": "^4.19.2",
     "typescript": "^5.5.0"
   }
 }

--- a/packages/email/preview.tsx
+++ b/packages/email/preview.tsx
@@ -1,0 +1,57 @@
+/**
+ * Render every lifecycle template to ./.preview/*.html with sample props so the
+ * design can be eyeballed in a browser. Run: `pnpm --filter @openpims/email preview`.
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { openvpmBrand } from "./src/brand";
+import {
+  renderWelcomeEmail,
+  renderTrialEndingEmail,
+  renderPaymentReceiptEmail,
+  renderPaymentFailedEmail,
+} from "./src/render";
+
+const brand = openvpmBrand();
+const practiceName = "Cedar Animal Hospital";
+const billingUrl = `${brand.appUrl}/settings?tab=billing`;
+const outDir = "./.preview";
+
+async function main() {
+  mkdirSync(outDir, { recursive: true });
+  const emails = {
+    welcome: await renderWelcomeEmail({ brand, practiceName, trialDays: 14 }),
+    "trial-ending": await renderTrialEndingEmail({
+      brand,
+      practiceName,
+      daysLeft: 3,
+      trialEndDate: "July 10, 2026",
+      monthlyPrice: "$99",
+      billingUrl,
+      unsubscribeUrl: `${brand.appUrl}/settings?tab=billing`,
+    }),
+    receipt: await renderPaymentReceiptEmail({
+      brand,
+      practiceName,
+      amount: "$99.00",
+      periodLabel: "Jun 10 – Jul 10, 2026",
+      invoiceUrl: "https://example.com/invoice",
+    }),
+    "payment-failed": await renderPaymentFailedEmail({
+      brand,
+      practiceName,
+      amount: "$99.00",
+      nextRetryDate: "July 3, 2026",
+      billingUrl,
+    }),
+  };
+
+  for (const [name, r] of Object.entries(emails)) {
+    writeFileSync(`${outDir}/${name}.html`, r.html);
+    console.log(`wrote ${outDir}/${name}.html  —  ${r.subject}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/email/src/brand.ts
+++ b/packages/email/src/brand.ts
@@ -1,0 +1,36 @@
+/**
+ * Brand identity passed into every email shell. Defaults resolve OpenVPM's
+ * hosted identity from env (so app + emails stay in sync), with sane fallbacks
+ * for local rendering / previews.
+ */
+export interface Brand {
+  /** Display name in the header wordmark. */
+  name: string;
+  /** Legal/company name shown in the footer. */
+  companyName: string;
+  /** Reply-To + footer contact address. */
+  supportEmail: string;
+  /** Physical mailing address (CAN-SPAM for promotional nudges). Optional. */
+  companyAddress?: string;
+  /** Base URL of the hosted app (CTAs). */
+  appUrl: string;
+  /** Marketing site URL. */
+  marketingUrl: string;
+  /**
+   * Optional hosted logo image (PNG recommended — most email clients strip
+   * SVG). When omitted, the shell renders a CSS wordmark that works everywhere.
+   */
+  logoUrl?: string;
+}
+
+export function openvpmBrand(): Brand {
+  return {
+    name: "OpenVPM",
+    companyName: process.env.EMAIL_COMPANY_NAME || "OpenVPM",
+    supportEmail: process.env.EMAIL_SUPPORT_ADDRESS || "evan@openvpm.com",
+    companyAddress: process.env.EMAIL_COMPANY_ADDRESS || undefined,
+    appUrl: process.env.NEXT_PUBLIC_APP_URL || "https://app.openvpm.com",
+    marketingUrl: "https://openvpm.com",
+    logoUrl: process.env.EMAIL_LOGO_URL || undefined,
+  };
+}

--- a/packages/email/src/components/Button.tsx
+++ b/packages/email/src/components/Button.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Button as REButton } from "@react-email/components";
+import { theme } from "../theme";
+
+/** Primary CTA — teal-600, white text, rounded-lg (matches the site button). */
+export function Button({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <REButton
+      href={href}
+      style={{
+        backgroundColor: theme.brand,
+        color: "#ffffff",
+        fontFamily: theme.fontHeading,
+        fontSize: "15px",
+        fontWeight: 600,
+        borderRadius: `${theme.radius}px`,
+        padding: "13px 26px",
+        textDecoration: "none",
+        display: "inline-block",
+      }}
+    >
+      {children}
+    </REButton>
+  );
+}

--- a/packages/email/src/components/EmailLayout.tsx
+++ b/packages/email/src/components/EmailLayout.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+import {
+  Html,
+  Head,
+  Body,
+  Container,
+  Section,
+  Row,
+  Column,
+  Text,
+  Img,
+  Preview,
+} from "@react-email/components";
+import { theme } from "../theme";
+import type { Brand } from "../brand";
+import { Footer } from "./Footer";
+
+/**
+ * The single branded shell every OpenVPM email uses: soft slate page, a brand
+ * wordmark header, a clean white rounded card for the body, and the footer.
+ * Visually matched to openvpm.com (teal-600, DM Sans heading, Inter body).
+ */
+export function EmailLayout({
+  brand,
+  preview,
+  unsubscribeUrl,
+  children,
+}: {
+  brand: Brand;
+  preview: string;
+  unsubscribeUrl?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Html lang="en">
+      <Head />
+      <Preview>{preview}</Preview>
+      <Body
+        style={{
+          backgroundColor: theme.page,
+          margin: 0,
+          padding: 0,
+          fontFamily: theme.fontBody,
+          color: theme.text,
+        }}
+      >
+        <Container
+          style={{
+            maxWidth: "600px",
+            width: "100%",
+            margin: "0 auto",
+            padding: "32px 16px",
+          }}
+        >
+          {/* Brand header */}
+          <Section style={{ padding: "0 8px 20px" }}>
+            {brand.logoUrl ? (
+              <Img
+                src={brand.logoUrl}
+                alt={brand.name}
+                height="32"
+                style={{ height: "32px", width: "auto" }}
+              />
+            ) : (
+              <Row>
+                <Column style={{ width: "40px", verticalAlign: "middle" }}>
+                  <div
+                    style={{
+                      width: "32px",
+                      height: "32px",
+                      backgroundColor: theme.brand,
+                      borderRadius: "8px",
+                      textAlign: "center",
+                      lineHeight: "32px",
+                      fontSize: "16px",
+                    }}
+                  >
+                    🐾
+                  </div>
+                </Column>
+                <Column style={{ verticalAlign: "middle" }}>
+                  <Text
+                    style={{
+                      fontFamily: theme.fontHeading,
+                      fontWeight: 700,
+                      fontSize: "20px",
+                      letterSpacing: "-0.4px",
+                      color: theme.text,
+                      margin: 0,
+                    }}
+                  >
+                    OpenVPM
+                  </Text>
+                </Column>
+              </Row>
+            )}
+          </Section>
+
+          {/* Body card */}
+          <Section
+            style={{
+              backgroundColor: theme.card,
+              borderRadius: `${theme.radiusLg}px`,
+              border: `1px solid ${theme.border}`,
+              padding: "40px",
+            }}
+          >
+            {children}
+          </Section>
+
+          {/* Footer */}
+          <Footer brand={brand} unsubscribeUrl={unsubscribeUrl} />
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/packages/email/src/components/Footer.tsx
+++ b/packages/email/src/components/Footer.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import { Section, Text, Link } from "@react-email/components";
+import { theme } from "../theme";
+import type { Brand } from "../brand";
+
+/**
+ * Footer with company identity + support contact. For promotional nudges
+ * (trial-ending, usage warnings) pass `unsubscribeUrl` to surface a preferences
+ * link; transactional mail (receipts, dunning) omits it.
+ */
+export function Footer({
+  brand,
+  unsubscribeUrl,
+}: {
+  brand: Brand;
+  unsubscribeUrl?: string;
+}) {
+  return (
+    <Section style={{ padding: "24px 8px 0" }}>
+      <Text
+        style={{
+          fontFamily: theme.fontBody,
+          fontSize: "13px",
+          lineHeight: "1.6",
+          color: theme.subtle,
+          margin: 0,
+        }}
+      >
+        <strong style={{ color: theme.muted }}>{brand.companyName}</strong>
+        {"  ·  "}
+        <Link
+          href={`mailto:${brand.supportEmail}`}
+          style={{ color: theme.subtle, textDecoration: "underline" }}
+        >
+          {brand.supportEmail}
+        </Link>
+        {brand.companyAddress ? (
+          <>
+            <br />
+            {brand.companyAddress}
+          </>
+        ) : null}
+      </Text>
+      <Text
+        style={{
+          fontFamily: theme.fontBody,
+          fontSize: "12px",
+          lineHeight: "1.6",
+          color: theme.faint,
+          margin: "10px 0 0",
+        }}
+      >
+        You&apos;re receiving this because you have an OpenVPM account.
+        {unsubscribeUrl ? (
+          <>
+            {"  "}
+            <Link
+              href={unsubscribeUrl}
+              style={{ color: theme.faint, textDecoration: "underline" }}
+            >
+              Manage email preferences
+            </Link>
+            .
+          </>
+        ) : null}
+      </Text>
+    </Section>
+  );
+}

--- a/packages/email/src/components/InfoCard.tsx
+++ b/packages/email/src/components/InfoCard.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { Section } from "@react-email/components";
+import { theme } from "../theme";
+
+type Tone = "brand" | "success" | "warning" | "danger";
+
+const TONES: Record<Tone, { bg: string; border: string }> = {
+  brand: { bg: theme.brandTint, border: theme.brandTintBorder },
+  success: { bg: theme.successTint, border: theme.successBorder },
+  warning: { bg: theme.warningTint, border: theme.warningBorder },
+  danger: { bg: theme.dangerTint, border: theme.dangerBorder },
+};
+
+/** Tinted, bordered panel for highlighting an amount, date, or usage stat. */
+export function InfoCard({
+  tone = "brand",
+  children,
+}: {
+  tone?: Tone;
+  children: React.ReactNode;
+}) {
+  const t = TONES[tone];
+  return (
+    <Section
+      style={{
+        backgroundColor: t.bg,
+        border: `1px solid ${t.border}`,
+        borderRadius: "12px",
+        padding: "20px 24px",
+        margin: "24px 0",
+      }}
+    >
+      {children}
+    </Section>
+  );
+}

--- a/packages/email/src/components/Typography.tsx
+++ b/packages/email/src/components/Typography.tsx
@@ -1,0 +1,81 @@
+import * as React from "react";
+import { Heading as REHeading, Text } from "@react-email/components";
+import { theme } from "../theme";
+
+/** Email H1 — DM Sans, tight tracking, like the site headings. */
+export function Heading({ children }: { children: React.ReactNode }) {
+  return (
+    <REHeading
+      as="h1"
+      style={{
+        fontFamily: theme.fontHeading,
+        fontSize: "24px",
+        fontWeight: 700,
+        letterSpacing: "-0.02em",
+        lineHeight: "1.25",
+        color: theme.text,
+        margin: "0 0 16px",
+      }}
+    >
+      {children}
+    </REHeading>
+  );
+}
+
+export function Paragraph({
+  children,
+  muted,
+}: {
+  children: React.ReactNode;
+  muted?: boolean;
+}) {
+  return (
+    <Text
+      style={{
+        fontFamily: theme.fontBody,
+        fontSize: "15px",
+        lineHeight: "1.65",
+        color: muted ? theme.muted : theme.text,
+        margin: "0 0 16px",
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+/** Small uppercase label, e.g. inside an InfoCard. */
+export function Label({ children }: { children: React.ReactNode }) {
+  return (
+    <Text
+      style={{
+        fontFamily: theme.fontBody,
+        fontSize: "12px",
+        fontWeight: 600,
+        textTransform: "uppercase",
+        letterSpacing: "0.06em",
+        color: theme.subtle,
+        margin: "0 0 4px",
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+/** Big emphasized value, e.g. an amount or a date. */
+export function Stat({ children }: { children: React.ReactNode }) {
+  return (
+    <Text
+      style={{
+        fontFamily: theme.fontHeading,
+        fontSize: "22px",
+        fontWeight: 700,
+        color: theme.text,
+        margin: 0,
+      }}
+    >
+      {children}
+    </Text>
+  );
+}

--- a/packages/email/src/render.tsx
+++ b/packages/email/src/render.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import { render } from "@react-email/render";
+import { WelcomeEmail, type WelcomeEmailProps } from "./templates/WelcomeEmail";
+import {
+  TrialEndingEmail,
+  type TrialEndingEmailProps,
+} from "./templates/TrialEndingEmail";
+import {
+  PaymentReceiptEmail,
+  type PaymentReceiptEmailProps,
+} from "./templates/PaymentReceiptEmail";
+import {
+  PaymentFailedEmail,
+  type PaymentFailedEmailProps,
+} from "./templates/PaymentFailedEmail";
+
+export interface RenderedEmail {
+  subject: string;
+  html: string;
+}
+
+export async function renderWelcomeEmail(
+  p: WelcomeEmailProps,
+): Promise<RenderedEmail> {
+  return {
+    subject: `Welcome to OpenVPM, ${p.practiceName}`,
+    html: await render(<WelcomeEmail {...p} />),
+  };
+}
+
+export async function renderTrialEndingEmail(
+  p: TrialEndingEmailProps,
+): Promise<RenderedEmail> {
+  const when = p.daysLeft <= 1 ? "tomorrow" : `in ${p.daysLeft} days`;
+  return {
+    subject: `Your OpenVPM trial ends ${when}`,
+    html: await render(<TrialEndingEmail {...p} />),
+  };
+}
+
+export async function renderPaymentReceiptEmail(
+  p: PaymentReceiptEmailProps,
+): Promise<RenderedEmail> {
+  return {
+    subject: `Your OpenVPM receipt — ${p.amount}`,
+    html: await render(<PaymentReceiptEmail {...p} />),
+  };
+}
+
+export async function renderPaymentFailedEmail(
+  p: PaymentFailedEmailProps,
+): Promise<RenderedEmail> {
+  return {
+    subject: "Action needed: your OpenVPM payment didn't go through",
+    html: await render(<PaymentFailedEmail {...p} />),
+  };
+}

--- a/packages/email/src/templates/PaymentFailedEmail.tsx
+++ b/packages/email/src/templates/PaymentFailedEmail.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { Section } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { Button } from "../components/Button";
+import { InfoCard } from "../components/InfoCard";
+import { Heading, Paragraph, Label, Stat } from "../components/Typography";
+import type { Brand } from "../brand";
+
+export interface PaymentFailedEmailProps {
+  brand: Brand;
+  practiceName: string;
+  amount: string; // e.g. "$99.00"
+  nextRetryDate?: string; // e.g. "July 3, 2026"
+  billingUrl: string;
+}
+
+export function PaymentFailedEmail({
+  brand,
+  practiceName,
+  amount,
+  nextRetryDate,
+  billingUrl,
+}: PaymentFailedEmailProps) {
+  return (
+    <EmailLayout
+      brand={brand}
+      preview="Your OpenVPM payment didn't go through — update your billing"
+    >
+      <Heading>Your payment didn&apos;t go through</Heading>
+      <Paragraph>
+        Hi {practiceName}, we couldn&apos;t process your latest OpenVPM payment
+        of <strong>{amount}</strong>. This usually means a card expired or was
+        replaced — it&apos;s a quick fix.
+      </Paragraph>
+
+      <InfoCard tone="danger">
+        <Label>What happens next</Label>
+        <Paragraph>
+          {nextRetryDate
+            ? `We'll automatically try again on ${nextRetryDate}. Update your card before then to avoid any interruption.`
+            : "Update your card to keep your workspace active and avoid any interruption."}
+        </Paragraph>
+      </InfoCard>
+
+      <Section style={{ margin: "8px 0" }}>
+        <Button href={billingUrl}>Update billing</Button>
+      </Section>
+
+      <Paragraph muted>
+        Your data is safe. If a payment ultimately doesn&apos;t clear, your
+        workspace becomes read-only — nothing is deleted, and reactivating takes
+        one click. Need a hand? Just reply to this email.
+      </Paragraph>
+    </EmailLayout>
+  );
+}

--- a/packages/email/src/templates/PaymentReceiptEmail.tsx
+++ b/packages/email/src/templates/PaymentReceiptEmail.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { Section, Row, Column } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { Button } from "../components/Button";
+import { InfoCard } from "../components/InfoCard";
+import { Heading, Paragraph, Label, Stat } from "../components/Typography";
+import type { Brand } from "../brand";
+
+export interface PaymentReceiptEmailProps {
+  brand: Brand;
+  practiceName: string;
+  amount: string; // e.g. "$99.00"
+  periodLabel: string; // e.g. "Jun 10 – Jul 10, 2026"
+  invoiceUrl?: string;
+}
+
+export function PaymentReceiptEmail({
+  brand,
+  practiceName,
+  amount,
+  periodLabel,
+  invoiceUrl,
+}: PaymentReceiptEmailProps) {
+  return (
+    <EmailLayout
+      brand={brand}
+      preview={`Your OpenVPM receipt — ${amount}`}
+    >
+      <Heading>Payment received</Heading>
+      <Paragraph>
+        Thanks, {practiceName}. We&apos;ve received your payment — here are the
+        details for your records.
+      </Paragraph>
+
+      <InfoCard tone="success">
+        <Row>
+          <Column>
+            <Label>Amount paid</Label>
+            <Stat>{amount}</Stat>
+          </Column>
+          <Column style={{ textAlign: "right", verticalAlign: "top" }}>
+            <Label>Billing period</Label>
+            <Paragraph>{periodLabel}</Paragraph>
+          </Column>
+        </Row>
+      </InfoCard>
+
+      {invoiceUrl ? (
+        <Section style={{ margin: "8px 0" }}>
+          <Button href={invoiceUrl}>View invoice</Button>
+        </Section>
+      ) : null}
+
+      <Paragraph muted>
+        You can review every invoice and update your payment method anytime in
+        billing settings. Questions? Just reply to this email.
+      </Paragraph>
+    </EmailLayout>
+  );
+}

--- a/packages/email/src/templates/TrialEndingEmail.tsx
+++ b/packages/email/src/templates/TrialEndingEmail.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import { Section } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { Button } from "../components/Button";
+import { InfoCard } from "../components/InfoCard";
+import { Heading, Paragraph, Label, Stat } from "../components/Typography";
+import type { Brand } from "../brand";
+
+export interface TrialEndingEmailProps {
+  brand: Brand;
+  practiceName: string;
+  daysLeft: number;
+  trialEndDate: string; // e.g. "July 10, 2026"
+  monthlyPrice: string; // e.g. "$99"
+  billingUrl: string;
+  unsubscribeUrl?: string;
+}
+
+export function TrialEndingEmail({
+  brand,
+  practiceName,
+  daysLeft,
+  trialEndDate,
+  monthlyPrice,
+  billingUrl,
+  unsubscribeUrl,
+}: TrialEndingEmailProps) {
+  const whenLabel =
+    daysLeft <= 1 ? "tomorrow" : `in ${daysLeft} days`;
+  return (
+    <EmailLayout
+      brand={brand}
+      preview={`Your OpenVPM trial ends ${whenLabel} — add billing to keep your data`}
+      unsubscribeUrl={unsubscribeUrl}
+    >
+      <Heading>Your trial ends {whenLabel}</Heading>
+      <Paragraph>
+        Hi {practiceName}, your OpenVPM trial ends on{" "}
+        <strong>{trialEndDate}</strong>. Add billing now to keep running without
+        interruption — your schedule, records, and everything you&apos;ve set up
+        stay exactly as they are.
+      </Paragraph>
+
+      <InfoCard tone="warning">
+        <Label>Simple, flat pricing</Label>
+        <Stat>{monthlyPrice}/location per month</Stat>
+        <Paragraph muted>
+          Unlimited staff, with AI and SMS allowances included. Cancel anytime.
+        </Paragraph>
+      </InfoCard>
+
+      <Section style={{ margin: "8px 0" }}>
+        <Button href={billingUrl}>Add billing</Button>
+      </Section>
+
+      <Paragraph muted>
+        If your trial lapses, your workspace simply becomes read-only — nothing
+        is deleted, and you can reactivate anytime by adding billing.
+      </Paragraph>
+    </EmailLayout>
+  );
+}

--- a/packages/email/src/templates/WelcomeEmail.tsx
+++ b/packages/email/src/templates/WelcomeEmail.tsx
@@ -1,0 +1,70 @@
+import * as React from "react";
+import { Section, Text } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { Button } from "../components/Button";
+import { InfoCard } from "../components/InfoCard";
+import { Heading, Paragraph, Label } from "../components/Typography";
+import { theme } from "../theme";
+import type { Brand } from "../brand";
+
+export interface WelcomeEmailProps {
+  brand: Brand;
+  practiceName: string;
+  trialDays: number;
+}
+
+const STEPS = [
+  "Take the 60-second tour of the schedule, records, and billing.",
+  "Make it yours — add your logo, accent color, and invite your team.",
+  "Ask the AI assistant something, like “which pets are overdue for vaccines?”",
+];
+
+export function WelcomeEmail({
+  brand,
+  practiceName,
+  trialDays,
+}: WelcomeEmailProps) {
+  return (
+    <EmailLayout
+      brand={brand}
+      preview={`Welcome to OpenVPM — your ${trialDays}-day trial is ready`}
+    >
+      <Heading>Welcome to OpenVPM 🎉</Heading>
+      <Paragraph>
+        Hi {practiceName}, your workspace is ready. We set it up with a sample
+        practice — real clients, pets, and appointments — so the app feels alive
+        from the very first minute.
+      </Paragraph>
+      <Paragraph muted>
+        Your {trialDays}-day trial is fully featured. No card needed, and your
+        data is always yours to export.
+      </Paragraph>
+
+      <Section style={{ margin: "28px 0 8px" }}>
+        <Button href={brand.appUrl}>Open your dashboard</Button>
+      </Section>
+
+      <InfoCard tone="brand">
+        <Label>Get started</Label>
+        {STEPS.map((s, i) => (
+          <Text
+            key={i}
+            style={{
+              fontFamily: theme.fontBody,
+              fontSize: "14px",
+              lineHeight: "1.6",
+              color: theme.text,
+              margin: i === 0 ? "6px 0 0" : "10px 0 0",
+            }}
+          >
+            <span style={{ color: theme.brand, fontWeight: 700 }}>→</span> {s}
+          </Text>
+        ))}
+      </InfoCard>
+
+      <Paragraph muted>
+        Questions? Just reply to this email — it reaches a real person.
+      </Paragraph>
+    </EmailLayout>
+  );
+}

--- a/packages/email/src/theme.ts
+++ b/packages/email/src/theme.ts
@@ -1,0 +1,42 @@
+/**
+ * Email design tokens, mirrored from the marketing site (openvpm.com):
+ * teal-600 brand, DM Sans headings / Inter body, clean white cards on a soft
+ * slate page. Kept as plain values so every template stays consistent.
+ */
+export const theme = {
+  // Brand
+  brand: "#0d9488", // teal-600
+  brandDark: "#0f766e", // teal-700
+  brandTint: "#f0fdfa", // teal-50
+  brandTintBorder: "#ccfbf1", // teal-100
+
+  // Text
+  text: "#0f172a", // slate-900
+  muted: "#475569", // slate-600
+  subtle: "#64748b", // slate-500
+  faint: "#94a3b8", // slate-400
+
+  // Surfaces
+  page: "#f1f5f9", // slate-100
+  card: "#ffffff",
+  border: "#e2e8f0", // slate-200
+
+  // Semantic tints (for InfoCard tones)
+  successTint: "#f0fdf4",
+  successBorder: "#bbf7d0",
+  successText: "#15803d",
+  warningTint: "#fffbeb",
+  warningBorder: "#fde68a",
+  warningText: "#b45309",
+  dangerTint: "#fef2f2",
+  dangerBorder: "#fecaca",
+  dangerText: "#b91c1c",
+
+  // Shape & type
+  radius: 8,
+  radiusLg: 16,
+  fontBody:
+    "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+  fontHeading:
+    "'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@openpims/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@openpims/email':
+        specifier: workspace:*
+        version: link:../../packages/email
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,7 +138,7 @@ importers:
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       resend:
         specifier: ^6.9.4
-        version: 6.9.4(@react-email/render@1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 6.9.4(@react-email/render@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -250,6 +250,9 @@ importers:
       '@react-email/components':
         specifier: ^0.0.25
         version: 0.0.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-email/render':
+        specifier: ^1.0.2
+        version: 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -257,6 +260,15 @@ importers:
       '@openpims/config':
         specifier: workspace:*
         version: link:../config
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      '@types/react':
+        specifier: ^18.3.0
+        version: 18.3.28
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -1696,6 +1708,13 @@ packages:
 
   '@react-email/render@1.0.1':
     resolution: {integrity: sha512-W3gTrcmLOVYnG80QuUp22ReIT/xfLsVJ+n7ghSlG2BITB8evNABn1AO2rGQoXuK84zKtDAlxCdm3hRyIpZdGSA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/render@1.4.0':
+    resolution: {integrity: sha512-ZtJ3noggIvW1ZAryoui95KJENKdCzLmN5F7hyZY1F/17B1vwzuxHB7YkuCg0QqHjDivc5axqYEYdIOw4JIQdUw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3450,6 +3469,11 @@ packages:
 
   preact@10.29.0:
     resolution: {integrity: sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==}
+
+  prettier@3.8.5:
+    resolution: {integrity: sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   pretty-format@3.8.0:
     resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
@@ -5450,6 +5474,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-promise-suspense: 0.3.4
 
+  '@react-email/render@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-promise-suspense: 0.3.4
+
   '@react-email/row@0.0.10(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -7208,6 +7240,8 @@ snapshots:
 
   preact@10.29.0: {}
 
+  prettier@3.8.5: {}
+
   pretty-format@3.8.0: {}
 
   prismjs@1.29.0: {}
@@ -7428,12 +7462,12 @@ snapshots:
   regenerator-runtime@0.13.11:
     optional: true
 
-  resend@6.9.4(@react-email/render@1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
+  resend@6.9.4(@react-email/render@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       postal-mime: 2.7.3
       svix: 1.86.0
     optionalDependencies:
-      '@react-email/render': 1.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-email/render': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   resolve-pkg-maps@1.0.0: {}
 


### PR DESCRIPTION
Branded transactional email system, **visually matched to openvpm.com** (teal-600 `#0d9488`, DM Sans headings / Inter body, `rounded-lg` teal buttons, clean white card, paw + wordmark header, company-identity footer). Turns the revenue-critical billing moments — which previously only alerted ops — into real customer emails.

## What's in this PR
- **`packages/email`** (React Email): shared `EmailLayout` shell + `Button`/`InfoCard`/`Footer`/`Typography`, brand tokens (`theme.ts`) + identity (`brand.ts`, env-driven). Four templates: **Welcome, Trial-ending, Payment receipt, Payment failed (dunning)**. `render.tsx` → `{ subject, html }`.
- **App wiring**: `lib/email.ts` branded send wrappers (+ `replyTo`/`List-Unsubscribe` support); `@openpims/email` added to deps + `transpilePackages`.
- **Idempotency**: `communications.dedupeKey` (nullable + unique index — NULLs stay distinct so client comms are untouched) and `lib/email-lifecycle.ts` `sendLifecycleEmail` (atomic claim → send → record in comms history; never throws into the caller).
- **Live triggers**: welcome on hosted signup (`auth.register`); **receipt** on `invoice.payment_succeeded` (skips the \$0 trial invoice) and **dunning** on `invoice.payment_failed`, each idempotent.

## Preview the design
Open these (already generated on disk; regenerate with `pnpm --filter @openpims/email preview`):
```
packages/email/.preview/{welcome,trial-ending,receipt,payment-failed}.html
```

## Deploy prerequisites
1. **Apply the dedupe column**: `pnpm --filter @openpims/db db:push` (the `communications.dedupe_key` column + index) before this ships. `sendLifecycleEmail` degrades gracefully if it's missing, but the webhook emails won't dedupe/send until it exists.
2. **Stripe**: enable `invoice.payment_succeeded` on the subscription webhook endpoint (failed + subscription.* already on).
3. Optional: set `EMAIL_SUPPORT_ADDRESS`, `EMAIL_COMPANY_ADDRESS` (CAN-SPAM for the nudges), `EMAIL_LOGO_URL` (hosted PNG; otherwise the CSS wordmark renders everywhere).

## Verify
`pnpm type-check` ✅ (web + email), `pnpm test` ✅ (221). Locally: `stripe trigger invoice.payment_succeeded` / `invoice.payment_failed` against the subscription webhook → receipt/dunning render + log once (second delivery dedupes).

## Follow-ups (next PRs)
- **Lifecycle cron** (trial-ending T-7/3/1 + usage 80/100%) — reuses #28's `cron-auth`, so it lands after #28 merges.
- Phase 3: subscription-confirmed / canceled / trial-expired templates; migrate existing client/auth emails onto the shared shell (fixes the blank-`practiceName` header bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)