### PR TITLE
SMS Phase 2: self-serve Messaging tab + provisioning + consent

### DIFF
--- a/apps/web/app/(dashboard)/clients/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/clients/[id]/edit/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 
 export default function EditClientPage() {
@@ -21,6 +22,7 @@ export default function EditClientPage() {
     state: "",
     zip: "",
   });
+  const [smsConsent, setSmsConsent] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const { data: client, isLoading } = trpc.clients.getById.useQuery(
@@ -40,6 +42,7 @@ export default function EditClientPage() {
         state: client.state ?? "",
         zip: client.zip ?? "",
       });
+      setSmsConsent(client.smsConsent ?? false);
     }
   }, [client]);
 
@@ -73,6 +76,7 @@ export default function EditClientPage() {
       city: form.city.trim() || undefined,
       state: form.state.trim() || undefined,
       zip: form.zip.trim() || undefined,
+      smsConsent,
     });
   };
 
@@ -166,6 +170,23 @@ export default function EditClientPage() {
             />
           </div>
         </div>
+
+        <label className="flex items-start gap-2 rounded-md border border-border p-3 text-sm">
+          <Checkbox
+            checked={smsConsent}
+            onChange={(e) => setSmsConsent(e.target.checked)}
+            className="mt-0.5"
+          />
+          <span>
+            <span className="font-medium">
+              Client agrees to receive text messages
+            </span>
+            <span className="block text-xs text-muted-foreground">
+              Appointment and care reminders by SMS. They can reply STOP to opt out
+              anytime.
+            </span>
+          </span>
+        </label>
 
         <div>
           <label className="text-sm font-medium" htmlFor="address">

--- a/apps/web/app/(dashboard)/clients/new/page.tsx
+++ b/apps/web/app/(dashboard)/clients/new/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 
 export default function NewClientPage() {
@@ -20,6 +21,7 @@ export default function NewClientPage() {
     state: "",
     zip: "",
   });
+  const [smsConsent, setSmsConsent] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const createClient = trpc.clients.create.useMutation({
@@ -51,6 +53,7 @@ export default function NewClientPage() {
       city: form.city.trim() || undefined,
       state: form.state.trim() || undefined,
       zip: form.zip.trim() || undefined,
+      smsConsent,
     });
   };
 
@@ -138,6 +141,23 @@ export default function NewClientPage() {
             />
           </div>
         </div>
+
+        <label className="flex items-start gap-2 rounded-md border border-border p-3 text-sm">
+          <Checkbox
+            checked={smsConsent}
+            onChange={(e) => setSmsConsent(e.target.checked)}
+            className="mt-0.5"
+          />
+          <span>
+            <span className="font-medium">
+              Client agrees to receive text messages
+            </span>
+            <span className="block text-xs text-muted-foreground">
+              Appointment and care reminders by SMS. They can reply STOP to opt out
+              anytime.
+            </span>
+          </span>
+        </label>
 
         <div>
           <label className="text-sm font-medium" htmlFor="address">

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -26,18 +26,20 @@ import {
   ImageIcon,
   Mail,
   Copy,
+  MessageSquare,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { AccentColorPicker } from "@/components/brand/accent-color-picker";
+import { MessagingTab } from "@/components/settings/messaging-tab";
 import { cn, isValidEmail } from "@/lib/utils";
 import { toast } from "sonner";
 import { regionDefaults } from "@/lib/locale/format";
 import { useCurrencyFormatter } from "@/lib/locale/useCurrency";
 
 // ── Types ───────────────────────────────────────────────────
-type Tab = "practice" | "staff" | "appointmentTypes" | "rooms" | "data" | "templates" | "billing";
+type Tab = "practice" | "staff" | "appointmentTypes" | "rooms" | "data" | "templates" | "messaging" | "billing";
 
 const tabs: { id: Tab; label: string; icon: React.ElementType }[] = [
   { id: "practice", label: "Practice Info", icon: Settings },
@@ -46,6 +48,7 @@ const tabs: { id: Tab; label: string; icon: React.ElementType }[] = [
   { id: "rooms", label: "Rooms", icon: DoorOpen },
   { id: "data", label: "Data", icon: Database },
   { id: "templates", label: "Templates", icon: Layers },
+  { id: "messaging", label: "Messaging", icon: MessageSquare },
   { id: "billing", label: "Plan & Billing", icon: CreditCard },
 ];
 
@@ -174,6 +177,7 @@ function SettingsPageInner() {
         {activeTab === "rooms" && <RoomsTab />}
         {activeTab === "data" && <DataTab />}
         {activeTab === "templates" && <TemplatesTab />}
+        {activeTab === "messaging" && <MessagingTab />}
         {activeTab === "billing" && <BillingTab />}
       </div>
     </div>

--- a/apps/web/components/settings/messaging-tab.tsx
+++ b/apps/web/components/settings/messaging-tab.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Loader2,
+  MessageSquare,
+  Phone,
+  Plus,
+  Send,
+  Check,
+  ShieldCheck,
+  Search,
+} from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { toast } from "sonner";
+
+type StatusLocation = {
+  locationId: string;
+  name: string;
+  isPrimary: boolean;
+  existingPhone: string | null;
+  messaging: {
+    senderE164: string | null;
+    numberSource: "hosted" | "purchased" | "toll_free" | null;
+    registrationStatus:
+      | "not_started"
+      | "pending"
+      | "active"
+      | "action_required"
+      | "failed"
+      | "suspended";
+    registrationDetail: string | null;
+    enabled: boolean;
+  } | null;
+};
+
+const REGISTRATION_BADGE: Record<
+  NonNullable<StatusLocation["messaging"]>["registrationStatus"],
+  { label: string; variant: "success" | "warning" | "destructive" | "secondary" }
+> = {
+  not_started: { label: "Not started", variant: "secondary" },
+  pending: { label: "Registration pending", variant: "warning" },
+  active: { label: "Active", variant: "success" },
+  action_required: { label: "Action required", variant: "warning" },
+  failed: { label: "Failed", variant: "destructive" },
+  suspended: { label: "Suspended", variant: "destructive" },
+};
+
+export function MessagingTab() {
+  const { data, isLoading } = trpc.messaging.getStatus.useQuery();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const usage = data?.usage;
+  const consent = data?.consent;
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      <div className="space-y-1">
+        <h2 className="flex items-center gap-2 text-lg font-semibold">
+          <MessageSquare className="h-5 w-5" /> Messaging
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Text appointment reminders from each location&apos;s own number. Clients
+          who reply land in your inbox; STOP opt-outs are handled automatically.
+        </p>
+      </div>
+
+      {/* Usage + consent summary */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <SummaryStat
+          label="SMS this month"
+          value={
+            usage
+              ? usage.includedSms != null
+                ? `${usage.smsUsed} / ${usage.includedSms.toLocaleString()}`
+                : String(usage.smsUsed)
+              : "—"
+          }
+          hint={usage?.includedSms != null ? "included" : undefined}
+        />
+        <SummaryStat label="Clients opted in" value={String(consent?.optedIn ?? 0)} />
+        <SummaryStat label="Opted out (STOP)" value={String(consent?.suppressed ?? 0)} />
+      </div>
+
+      {/* Per-location setup */}
+      <div className="space-y-4">
+        {(data?.locations ?? []).map((loc) => (
+          <LocationCard key={loc.locationId} loc={loc as StatusLocation} />
+        ))}
+        {data?.locations.length === 0 && (
+          <p className="rounded-lg border border-dashed border-border p-6 text-sm text-muted-foreground">
+            Add a location in Practice Info to set up texting.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SummaryStat({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 text-xl font-semibold">
+        {value}
+        {hint && <span className="ml-1 text-xs font-normal text-muted-foreground">{hint}</span>}
+      </p>
+    </div>
+  );
+}
+
+function LocationCard({ loc }: { loc: StatusLocation }) {
+  const utils = trpc.useUtils();
+  const refresh = () => utils.messaging.getStatus.invalidate();
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-6">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{loc.name}</span>
+          {loc.isPrimary && <Badge variant="secondary">Primary</Badge>}
+        </div>
+        {loc.messaging && (
+          <Badge variant={REGISTRATION_BADGE[loc.messaging.registrationStatus].variant}>
+            {REGISTRATION_BADGE[loc.messaging.registrationStatus].label}
+          </Badge>
+        )}
+      </div>
+
+      {loc.messaging ? (
+        <ConfiguredLocation loc={loc} onChanged={refresh} />
+      ) : (
+        <SetupFlow loc={loc} onChanged={refresh} />
+      )}
+    </div>
+  );
+}
+
+function ConfiguredLocation({
+  loc,
+  onChanged,
+}: {
+  loc: StatusLocation;
+  onChanged: () => void;
+}) {
+  const m = loc.messaging!;
+  const [testTo, setTestTo] = useState("");
+
+  const setEnabled = trpc.messaging.setEnabled.useMutation({
+    onSuccess: () => onChanged(),
+    onError: (e) => toast.error(e.message),
+  });
+  const testSend = trpc.messaging.testSend.useMutation({
+    onSuccess: () => toast.success("Test message sent"),
+    onError: (e) => toast.error(e.message),
+  });
+
+  return (
+    <div className="mt-4 space-y-4">
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <Phone className="h-4 w-4 text-muted-foreground" />
+        <span className="font-medium">{m.senderE164 ?? "—"}</span>
+        {m.numberSource && (
+          <Badge variant="outline">
+            {m.numberSource === "hosted"
+              ? "Your existing number"
+              : m.numberSource === "purchased"
+                ? "New local number"
+                : "Toll-free"}
+          </Badge>
+        )}
+      </div>
+
+      {m.registrationDetail && m.registrationStatus !== "active" && (
+        <p className="rounded-md bg-muted/50 p-3 text-xs text-muted-foreground">
+          {m.registrationDetail}
+        </p>
+      )}
+
+      <label className="flex items-center gap-2 text-sm">
+        <Checkbox
+          checked={m.enabled}
+          disabled={setEnabled.isPending}
+          onChange={(e) =>
+            setEnabled.mutate({ locationId: loc.locationId, enabled: e.target.checked })
+          }
+        />
+        Sending enabled
+      </label>
+
+      <div className="flex flex-wrap items-end gap-2 border-t border-border pt-4">
+        <label className="space-y-1.5">
+          <span className="text-xs font-medium text-muted-foreground">
+            Send a test message to
+          </span>
+          <Input
+            value={testTo}
+            onChange={(e) => setTestTo(e.target.value)}
+            placeholder="+1 555 555 0123"
+            className="w-48"
+          />
+        </label>
+        <Button
+          variant="outline"
+          disabled={!testTo || testSend.isPending}
+          onClick={() => testSend.mutate({ locationId: loc.locationId, to: testTo })}
+        >
+          {testSend.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Send className="mr-2 h-4 w-4" />
+          )}
+          Send test
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SetupFlow({
+  loc,
+  onChanged,
+}: {
+  loc: StatusLocation;
+  onChanged: () => void;
+}) {
+  const utils = trpc.useUtils();
+  const [eligibility, setEligibility] = useState<{
+    eligible: boolean;
+    detail?: string;
+  } | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [areaCode, setAreaCode] = useState("");
+  const [numbers, setNumbers] = useState<{ phoneNumber: string; monthlyCost: string | null }[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  const provision = trpc.messaging.provisionNumber.useMutation({
+    onSuccess: () => {
+      toast.success("Number set up — carrier registration is now in progress.");
+      onChanged();
+    },
+    onError: (e) => toast.error(e.message),
+  });
+
+  async function checkExisting() {
+    setChecking(true);
+    try {
+      const r = await utils.messaging.checkEligibility.fetch({ locationId: loc.locationId });
+      setEligibility(r);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Eligibility check failed");
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  async function search() {
+    setSearching(true);
+    try {
+      const r = await utils.messaging.searchNumbers.fetch(
+        areaCode ? { areaCode } : {}
+      );
+      setNumbers(r);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Number search failed");
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  return (
+    <div className="mt-4 space-y-5">
+      <p className="text-sm text-muted-foreground">
+        Set up texting for this location. Most clinics text-enable the number
+        clients already know.
+      </p>
+
+      {/* Option 1: text-enable existing number */}
+      <div className="space-y-2 rounded-md border border-border p-4">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <ShieldCheck className="h-4 w-4" /> Text-enable your existing number
+        </div>
+        {loc.existingPhone ? (
+          <>
+            <p className="text-xs text-muted-foreground">
+              Keep {loc.existingPhone} for calls; we add texting to it (no porting).
+            </p>
+            {eligibility === null ? (
+              <Button variant="outline" size="sm" onClick={checkExisting} disabled={checking}>
+                {checking ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Search className="mr-2 h-4 w-4" />
+                )}
+                Check eligibility
+              </Button>
+            ) : eligibility.eligible ? (
+              <div className="space-y-2">
+                <p className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+                  <Check className="h-3.5 w-3.5" /> Eligible to text-enable.
+                </p>
+                <Button
+                  size="sm"
+                  disabled={provision.isPending}
+                  onClick={() =>
+                    provision.mutate({ locationId: loc.locationId, mode: "host" })
+                  }
+                >
+                  {provision.isPending && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  Text-enable {loc.existingPhone}
+                </Button>
+              </div>
+            ) : (
+              <p className="text-xs text-amber-600 dark:text-amber-400">
+                {eligibility.detail ??
+                  "This number can't be text-enabled. Use a new local number below."}
+              </p>
+            )}
+          </>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Add a phone number to this location (Practice Info) to text-enable it.
+          </p>
+        )}
+      </div>
+
+      {/* Option 2: new local number */}
+      <div className="space-y-2 rounded-md border border-border p-4">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <Plus className="h-4 w-4" /> Get a new local number
+        </div>
+        <div className="flex items-end gap-2">
+          <label className="space-y-1.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              Area code (optional)
+            </span>
+            <Input
+              value={areaCode}
+              onChange={(e) => setAreaCode(e.target.value.replace(/\D/g, "").slice(0, 3))}
+              placeholder="415"
+              className="w-24"
+            />
+          </label>
+          <Button variant="outline" size="sm" onClick={search} disabled={searching}>
+            {searching ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Search className="mr-2 h-4 w-4" />
+            )}
+            Search
+          </Button>
+        </div>
+        {numbers.length > 0 && (
+          <ul className="divide-y divide-border rounded-md border border-border">
+            {numbers.map((n) => (
+              <li
+                key={n.phoneNumber}
+                className="flex items-center justify-between gap-2 px-3 py-2 text-sm"
+              >
+                <span className="font-medium">{n.phoneNumber}</span>
+                <div className="flex items-center gap-2">
+                  {n.monthlyCost && (
+                    <span className="text-xs text-muted-foreground">
+                      ${n.monthlyCost}/mo
+                    </span>
+                  )}
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={provision.isPending}
+                    onClick={() =>
+                      provision.mutate({
+                        locationId: loc.locationId,
+                        mode: "buy",
+                        phoneNumber: n.phoneNumber,
+                      })
+                    }
+                  >
+                    Use
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/ui/checkbox.tsx
+++ b/apps/web/components/ui/checkbox.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+/** Minimal styled checkbox (native input) matching the app's form controls. */
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={cn(
+        "h-4 w-4 cursor-pointer rounded border-border accent-primary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Checkbox.displayName = "Checkbox";

--- a/apps/web/lib/messaging/__tests__/telnyx-provisioning.test.ts
+++ b/apps/web/lib/messaging/__tests__/telnyx-provisioning.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { parseAvailableNumbers } from "../telnyx-provisioning";
+
+describe("parseAvailableNumbers", () => {
+  it("maps phone numbers and monthly cost", () => {
+    expect(
+      parseAvailableNumbers({
+        data: [
+          { phone_number: "+14157271696", cost_information: { monthly_cost: "1.00000" } },
+          { phone_number: "+14158735087", cost_information: { monthly_cost: "1.00000" } },
+        ],
+      })
+    ).toEqual([
+      { phoneNumber: "+14157271696", monthlyCost: "1.00000" },
+      { phoneNumber: "+14158735087", monthlyCost: "1.00000" },
+    ]);
+  });
+
+  it("drops entries without a phone number and tolerates missing cost", () => {
+    expect(
+      parseAvailableNumbers({
+        data: [{ cost_information: { monthly_cost: "1.0" } }, { phone_number: "+15555550100" }],
+      })
+    ).toEqual([{ phoneNumber: "+15555550100", monthlyCost: null }]);
+  });
+
+  it("returns [] for an empty/missing data array", () => {
+    expect(parseAvailableNumbers({})).toEqual([]);
+  });
+});

--- a/apps/web/lib/messaging/telnyx-provisioning.ts
+++ b/apps/web/lib/messaging/telnyx-provisioning.ts
@@ -143,3 +143,56 @@ export async function checkHostedEligibility(
     detail: row?.reason,
   };
 }
+
+// --- Mutating operations (spend money / change account state) ----------------
+
+/** Create a messaging profile (sender pool + inbound webhook + A2P binding). */
+export async function createMessagingProfile(opts: {
+  name: string;
+  webhookUrl: string;
+}): Promise<{ id: string }> {
+  const json = await telnyxRequest<{ data?: { id?: string } }>(
+    "POST",
+    "/messaging_profiles",
+    {
+      name: opts.name,
+      webhook_url: opts.webhookUrl,
+      webhook_api_version: "2",
+    }
+  );
+  const id = json.data?.id;
+  if (!id) throw new TelnyxError("Telnyx did not return a messaging profile id", 502);
+  return { id };
+}
+
+/** Purchase a new local number and assign it to a messaging profile. */
+export async function buyNumber(opts: {
+  phoneNumber: string;
+  messagingProfileId: string;
+}): Promise<{ orderId: string; status: string | null }> {
+  const json = await telnyxRequest<{ data?: { id?: string; status?: string } }>(
+    "POST",
+    "/number_orders",
+    {
+      phone_numbers: [{ phone_number: opts.phoneNumber }],
+      messaging_profile_id: opts.messagingProfileId,
+    }
+  );
+  return { orderId: json.data?.id ?? "", status: json.data?.status ?? null };
+}
+
+/** Text-enable an existing (non-Telnyx) number via a hosted-SMS order. */
+export async function createHostedOrder(opts: {
+  phoneNumber: string;
+  messagingProfileId: string;
+}): Promise<{ orderId: string; status: string | null }> {
+  const json = await telnyxRequest<{ data?: { id?: string; status?: string } }>(
+    "POST",
+    "/messaging_hosted_number_orders",
+    {
+      phone_numbers: [opts.phoneNumber],
+      messaging_profile_id: opts.messagingProfileId,
+    }
+  );
+  return { orderId: json.data?.id ?? "", status: json.data?.status ?? null };
+}

--- a/apps/web/lib/messaging/telnyx-provisioning.ts
+++ b/apps/web/lib/messaging/telnyx-provisioning.ts
@@ -1,0 +1,145 @@
+/**
+ * Telnyx provisioning (v2 REST) for self-serve SMS onboarding. This module holds
+ * the API integration; the messaging tRPC router orchestrates it and persists
+ * results to `location_messaging`.
+ *
+ * Read-only operations (number search, hosted-SMS eligibility) are safe to call
+ * anytime. Mutating operations (buy/host a number, register A2P brand/campaign)
+ * spend money / require an L2-verified account and are added as the self-serve
+ * flow is wired up.
+ */
+
+const TELNYX_BASE = "https://api.telnyx.com/v2";
+
+export class TelnyxError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message);
+    this.name = "TelnyxError";
+  }
+}
+
+export class TelnyxNotConfiguredError extends Error {
+  constructor() {
+    super("Telnyx is not configured (TELNYX_API_KEY missing).");
+    this.name = "TelnyxNotConfiguredError";
+  }
+}
+
+function apiKey(): string {
+  const key = process.env.TELNYX_API_KEY;
+  if (!key) throw new TelnyxNotConfiguredError();
+  return key;
+}
+
+/** Thin authed JSON request to the Telnyx v2 API. Throws TelnyxError on non-2xx. */
+async function telnyxRequest<T = unknown>(
+  method: string,
+  path: string,
+  body?: unknown
+): Promise<T> {
+  const res = await fetch(`${TELNYX_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey()}`,
+      "Content-Type": "application/json",
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  const text = await res.text();
+  const json = text ? safeJson(text) : undefined;
+  if (!res.ok) {
+    throw new TelnyxError(telnyxErrorMessage(json) ?? `Telnyx ${res.status}`, res.status);
+  }
+  return json as T;
+}
+
+function safeJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Telnyx returns `{ errors: [{ detail, title }] }` on failure. */
+function telnyxErrorMessage(json: unknown): string | undefined {
+  const errors = (json as { errors?: Array<{ detail?: string; title?: string }> })?.errors;
+  if (!errors?.length) return undefined;
+  return errors
+    .map((e) => e.detail || e.title)
+    .filter(Boolean)
+    .join("; ");
+}
+
+export interface AvailableNumber {
+  phoneNumber: string;
+  /** Monthly cost in USD, as returned by Telnyx (string). */
+  monthlyCost: string | null;
+}
+
+/**
+ * Search purchasable local numbers that support SMS, optionally by US area code.
+ * Read-only.
+ */
+export async function searchAvailableNumbers(opts: {
+  areaCode?: string;
+  limit?: number;
+}): Promise<AvailableNumber[]> {
+  const params = new URLSearchParams();
+  params.set("filter[country_code]", "US");
+  params.set("filter[features][]", "sms");
+  params.set("filter[limit]", String(Math.min(opts.limit ?? 10, 50)));
+  if (opts.areaCode) params.set("filter[national_destination_code]", opts.areaCode);
+  const json = await telnyxRequest<{ data?: TelnyxAvailableNumber[] }>(
+    "GET",
+    `/available_phone_numbers?${params.toString()}`
+  );
+  return parseAvailableNumbers(json);
+}
+
+interface TelnyxAvailableNumber {
+  phone_number?: string;
+  cost_information?: { monthly_cost?: string };
+}
+
+/** Pure: map a Telnyx available-numbers response to our shape. */
+export function parseAvailableNumbers(json: {
+  data?: TelnyxAvailableNumber[];
+}): AvailableNumber[] {
+  return (json.data ?? [])
+    .filter((n): n is TelnyxAvailableNumber & { phone_number: string } =>
+      Boolean(n.phone_number)
+    )
+    .map((n) => ({
+      phoneNumber: n.phone_number,
+      monthlyCost: n.cost_information?.monthly_cost ?? null,
+    }));
+}
+
+export interface HostedEligibility {
+  eligible: boolean;
+  detail?: string;
+}
+
+/**
+ * Check whether an existing number can be text-enabled (hosted SMS) without a
+ * voice port. Read-only. Telnyx returns per-number eligibility; we collapse to a
+ * single verdict for the given number.
+ */
+export async function checkHostedEligibility(
+  phoneNumber: string
+): Promise<HostedEligibility> {
+  const json = await telnyxRequest<{
+    data?: Array<{ eligible?: boolean; phone_number?: string; reason?: string }>;
+  }>("POST", "/messaging_hosted_number_orders/eligibility_numbers", {
+    phone_numbers: [phoneNumber],
+  });
+  const row = (json.data ?? [])[0];
+  return {
+    eligible: Boolean(row?.eligible),
+    detail: row?.reason,
+  };
+}

--- a/apps/web/server/routers/_app.ts
+++ b/apps/web/server/routers/_app.ts
@@ -28,6 +28,7 @@ import { wellnessRouter } from "./wellness";
 import { waitlistRouter } from "./waitlist";
 import { subscriptionRouter } from "./subscription";
 import { adminRouter } from "./admin";
+import { messagingRouter } from "./messaging";
 
 export const appRouter = createRouter({
   auth: authRouter,
@@ -59,6 +60,7 @@ export const appRouter = createRouter({
   waitlist: waitlistRouter,
   subscription: subscriptionRouter,
   admin: adminRouter,
+  messaging: messagingRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/server/routers/clients.ts
+++ b/apps/web/server/routers/clients.ts
@@ -118,12 +118,17 @@ export const clientsRouter = createRouter({
         state: z.string().optional(),
         zip: z.string().optional(),
         notes: z.string().optional(),
+        smsConsent: z.boolean().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
+      const { smsConsent, ...rest } = input;
+      const consent = smsConsent
+        ? { smsConsent: true, smsConsentAt: new Date(), smsConsentSource: "intake" }
+        : {};
       const [client] = await ctx.db
         .insert(clients)
-        .values({ ...input, practiceId: ctx.practiceId })
+        .values({ ...rest, ...consent, practiceId: ctx.practiceId })
         .returning();
       return client!;
     }),
@@ -141,10 +146,20 @@ export const clientsRouter = createRouter({
         state: z.string().optional(),
         zip: z.string().optional(),
         notes: z.string().optional(),
+        smsConsent: z.boolean().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const { id, ...data } = input;
+      const { id, smsConsent, ...rest } = input;
+      const data: Record<string, unknown> = { ...rest };
+      // Record consent transitions with an audit timestamp + source.
+      if (smsConsent !== undefined) {
+        data.smsConsent = smsConsent;
+        if (smsConsent) {
+          data.smsConsentAt = new Date();
+          data.smsConsentSource = "intake";
+        }
+      }
       const [client] = await ctx.db
         .update(clients)
         .set(data)

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -12,9 +12,13 @@ import {
 import { usageForPractice, currentPeriodMonth } from "@/lib/billing/usage";
 import { getPlan } from "@/lib/billing/plans";
 import { normalizeE164 } from "@/lib/messaging";
+import { sendSms } from "@/lib/sms";
 import {
   searchAvailableNumbers,
   checkHostedEligibility,
+  createMessagingProfile,
+  buyNumber,
+  createHostedOrder,
   TelnyxNotConfiguredError,
 } from "@/lib/messaging/telnyx-provisioning";
 
@@ -158,5 +162,137 @@ export const messagingRouter = createRouter({
       } catch (e) {
         throw provisioningError(e);
       }
+    }),
+
+  /**
+   * Stand up a texting number for a location: create a messaging profile (with
+   * our inbound webhook), then either text-enable the location's existing number
+   * (host) or buy a new local number, and save the config. Leaves the location
+   * disabled + registration pending (carrier A2P approval precedes sending).
+   */
+  provisionNumber: adminOnly
+    .input(
+      z.object({
+        locationId: z.string().uuid(),
+        mode: z.enum(["host", "buy"]),
+        // Required for "buy"; for "host" we use the location's existing number.
+        phoneNumber: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const [loc] = await ctx.db
+        .select({ id: locations.id, name: locations.name, phone: locations.phone })
+        .from(locations)
+        .where(
+          and(
+            eq(locations.id, input.locationId),
+            eq(locations.practiceId, ctx.practiceId)
+          )
+        )
+        .limit(1);
+      if (!loc) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Location not found" });
+      }
+
+      const e164 = normalizeE164(
+        input.mode === "host" ? loc.phone : input.phoneNumber
+      );
+      if (!e164) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            input.mode === "host"
+              ? "Add a valid phone number to this location before text-enabling it."
+              : "Select a valid number to purchase.",
+        });
+      }
+
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+      const webhookUrl = `${appUrl}/api/webhooks/telnyx`;
+
+      try {
+        const profile = await createMessagingProfile({
+          name: `${loc.name} — OpenVPM`,
+          webhookUrl,
+        });
+        const numberSource = input.mode === "host" ? "hosted" : "purchased";
+        if (input.mode === "host") {
+          await createHostedOrder({ phoneNumber: e164, messagingProfileId: profile.id });
+        } else {
+          await buyNumber({ phoneNumber: e164, messagingProfileId: profile.id });
+        }
+
+        await ctx.db
+          .insert(locationMessaging)
+          .values({
+            practiceId: ctx.practiceId,
+            locationId: loc.id,
+            provider: "telnyx",
+            messagingProfileId: profile.id,
+            senderE164: e164,
+            numberSource,
+            registrationStatus: "pending",
+            registrationDetail:
+              "Carrier registration (A2P 10DLC) in progress — required before messages can send; typically 1–2 weeks.",
+            enabled: false,
+          })
+          .onConflictDoUpdate({
+            target: locationMessaging.locationId,
+            set: {
+              provider: "telnyx",
+              messagingProfileId: profile.id,
+              senderE164: e164,
+              numberSource,
+              registrationStatus: "pending",
+              updatedAt: new Date(),
+            },
+          });
+
+        return { ok: true, senderE164: e164, numberSource };
+      } catch (e) {
+        throw provisioningError(e);
+      }
+    }),
+
+  /** Turn sending on/off for a location (independent of registration state). */
+  setEnabled: adminOnly
+    .input(z.object({ locationId: z.string().uuid(), enabled: z.boolean() }))
+    .mutation(async ({ ctx, input }) => {
+      const [updated] = await ctx.db
+        .update(locationMessaging)
+        .set({ enabled: input.enabled, updatedAt: new Date() })
+        .where(
+          and(
+            eq(locationMessaging.locationId, input.locationId),
+            eq(locationMessaging.practiceId, ctx.practiceId)
+          )
+        )
+        .returning();
+      if (!updated) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Set up a number for this location first.",
+        });
+      }
+      return { ok: true, enabled: updated.enabled };
+    }),
+
+  /** Send a test SMS to a staff number from the location's sender. */
+  testSend: adminOnly
+    .input(z.object({ locationId: z.string().uuid(), to: z.string().min(7) }))
+    .mutation(async ({ ctx, input }) => {
+      const result = await sendSms({
+        to: input.to,
+        body: "OpenVPM test message — your texting is set up correctly.",
+        practiceId: ctx.practiceId,
+        locationId: input.locationId,
+      });
+      if (!result.success) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: result.error ?? "Test send failed.",
+        });
+      }
+      return { ok: true, id: result.sid };
     }),
 });

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -1,0 +1,162 @@
+import { z } from "zod";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { createRouter, protectedProcedure, requireRole } from "../trpc";
+import {
+  locations,
+  locationMessaging,
+  clients,
+  smsSuppressions,
+  practices,
+} from "@openpims/db";
+import { usageForPractice, currentPeriodMonth } from "@/lib/billing/usage";
+import { getPlan } from "@/lib/billing/plans";
+import { normalizeE164 } from "@/lib/messaging";
+import {
+  searchAvailableNumbers,
+  checkHostedEligibility,
+  TelnyxNotConfiguredError,
+} from "@/lib/messaging/telnyx-provisioning";
+
+const adminOnly = protectedProcedure.use(requireRole("admin"));
+
+/** Map a thrown provisioning error to a tRPC error the UI can show. */
+function provisioningError(e: unknown): TRPCError {
+  if (e instanceof TelnyxNotConfiguredError) {
+    return new TRPCError({ code: "PRECONDITION_FAILED", message: e.message });
+  }
+  return new TRPCError({
+    code: "BAD_GATEWAY",
+    message: e instanceof Error ? e.message : "Messaging provider request failed",
+  });
+}
+
+export const messagingRouter = createRouter({
+  /**
+   * Per-location messaging status + this month's SMS usage + consent stats.
+   * Drives the Settings → Messaging tab.
+   */
+  getStatus: adminOnly.query(async ({ ctx }) => {
+    const locs = await ctx.db
+      .select({
+        locationId: locations.id,
+        name: locations.name,
+        isPrimary: locations.isPrimary,
+        existingPhone: locations.phone,
+        provider: locationMessaging.provider,
+        senderE164: locationMessaging.senderE164,
+        numberSource: locationMessaging.numberSource,
+        registrationStatus: locationMessaging.registrationStatus,
+        registrationDetail: locationMessaging.registrationDetail,
+        enabled: locationMessaging.enabled,
+      })
+      .from(locations)
+      .leftJoin(
+        locationMessaging,
+        eq(locationMessaging.locationId, locations.id)
+      )
+      .where(
+        and(eq(locations.practiceId, ctx.practiceId), isNull(locations.deletedAt))
+      );
+
+    const period = currentPeriodMonth();
+    const smsUsed = await usageForPractice(ctx.practiceId, "sms", period);
+
+    const [practice] = await ctx.db
+      .select({ tier: practices.subscriptionTier })
+      .from(practices)
+      .where(eq(practices.id, ctx.practiceId))
+      .limit(1);
+    const includedSms = getPlan(practice?.tier ?? "free")?.includedSmsPerMonth ?? null;
+
+    const [consentRow] = await ctx.db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(clients)
+      .where(
+        and(
+          eq(clients.practiceId, ctx.practiceId),
+          eq(clients.smsConsent, true),
+          isNull(clients.deletedAt)
+        )
+      );
+    const [suppressedRow] = await ctx.db
+      .select({ n: sql<number>`count(*)::int` })
+      .from(smsSuppressions)
+      .where(eq(smsSuppressions.practiceId, ctx.practiceId));
+
+    return {
+      locations: locs.map((l) => ({
+        locationId: l.locationId,
+        name: l.name,
+        isPrimary: l.isPrimary,
+        existingPhone: l.existingPhone,
+        messaging: l.provider
+          ? {
+              provider: l.provider,
+              senderE164: l.senderE164,
+              numberSource: l.numberSource,
+              registrationStatus: l.registrationStatus,
+              registrationDetail: l.registrationDetail,
+              enabled: l.enabled,
+            }
+          : null,
+      })),
+      usage: { period, smsUsed, includedSms },
+      consent: {
+        optedIn: consentRow?.n ?? 0,
+        suppressed: suppressedRow?.n ?? 0,
+      },
+    };
+  }),
+
+  /** Search purchasable local SMS numbers, optionally by US area code. */
+  searchNumbers: adminOnly
+    .input(
+      z.object({
+        areaCode: z
+          .string()
+          .regex(/^\d{3}$/, "Area code must be 3 digits")
+          .optional(),
+        limit: z.number().int().min(1).max(20).optional(),
+      })
+    )
+    .query(async ({ input }) => {
+      try {
+        return await searchAvailableNumbers(input);
+      } catch (e) {
+        throw provisioningError(e);
+      }
+    }),
+
+  /** Can this location's existing number be text-enabled (hosted SMS, no port)? */
+  checkEligibility: adminOnly
+    .input(z.object({ locationId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const [loc] = await ctx.db
+        .select({ phone: locations.phone })
+        .from(locations)
+        .where(
+          and(
+            eq(locations.id, input.locationId),
+            eq(locations.practiceId, ctx.practiceId)
+          )
+        )
+        .limit(1);
+      if (!loc) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Location not found" });
+      }
+      const e164 = normalizeE164(loc.phone);
+      if (!e164) {
+        return {
+          eligible: false,
+          detail:
+            "Add a valid phone number to this location before checking eligibility.",
+        };
+      }
+      try {
+        return await checkHostedEligibility(e164);
+      } catch (e) {
+        throw provisioningError(e);
+      }
+    }),
+});


### PR DESCRIPTION
Builds on #30 (SMS foundation, merged). Adds the self-serve experience.

## What's new
- **Settings → Messaging tab** (`components/settings/messaging-tab.tsx`): per-location setup wizard — check hosted-SMS eligibility and text-enable the clinic's existing number, or search/buy a new local number; enable/disable sending; send a test; usage + consent summary. Honest "registration pending" states.
- **messaging tRPC router**: `getStatus`, `searchNumbers`, `checkEligibility`, `provisionNumber` (create messaging profile + host/buy number + save config), `setEnabled`, `testSend` (admin-only).
- **Telnyx provisioning service** (`lib/messaging/telnyx-provisioning.ts`): authed v2 client + number search, hosted-SMS eligibility, profile create, buy/host orders.
- **Client SMS consent**: a consent checkbox (with STOP disclosure) on client create/edit, wired through `clients.create/update` (stamps consent timestamp + source). Adds a `Checkbox` primitive.

## Deferred (intentionally)
A2P brand/campaign registration — gated on Telnyx L2 verification; not shipping untested API calls or storing EIN. Provisioning sets a clear "registration pending" state.

## Safety / tests
- Admin-only mutations; provisioning errors surface gracefully. No secrets in diff.
- 264 unit tests pass, tsc clean. DB schema for this already applied in #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)