### PR TITLE
Route hosted portal payments to the practice's Stripe Connect account

### DIFF
--- a/apps/web/app/api/portal/checkout/route.test.ts
+++ b/apps/web/app/api/portal/checkout/route.test.ts
@@ -35,6 +35,10 @@ const mocks = vi.hoisted(() => {
     ),
     billingEnforced: vi.fn(() => false),
     hasHostedFullAccess: vi.fn(() => true),
+    getChargeableStripeConnectAccountId: vi.fn(
+      async (): Promise<string | null> => null
+    ),
+    stripeConnectApplicationFeeAmount: vi.fn((): number | undefined => 250),
     rateLimit: vi.fn(async () => ({
       success: true,
       remaining: 9,
@@ -71,6 +75,12 @@ vi.mock("@/lib/stripe", () => ({
 vi.mock("@/lib/billing/plans", () => ({
   billingEnforced: mocks.billingEnforced,
   hasHostedFullAccess: mocks.hasHostedFullAccess,
+}));
+
+vi.mock("@/lib/billing/payment-accounts", () => ({
+  getChargeableStripeConnectAccountId:
+    mocks.getChargeableStripeConnectAccountId,
+  stripeConnectApplicationFeeAmount: mocks.stripeConnectApplicationFeeAmount,
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
@@ -159,6 +169,8 @@ afterEach(() => {
   });
   mocks.billingEnforced.mockReturnValue(false);
   mocks.hasHostedFullAccess.mockReturnValue(true);
+  mocks.getChargeableStripeConnectAccountId.mockResolvedValue(null);
+  mocks.stripeConnectApplicationFeeAmount.mockReturnValue(250);
   mocks.rateLimit.mockResolvedValue({
     success: true,
     remaining: 9,
@@ -466,8 +478,66 @@ describe("portal checkout route", () => {
           `https://portal.example.com/portal/portal-token/invoices?payment=success&invoice=${INVOICE_ID}`,
         cancelUrl:
           `https://portal.example.com/portal/portal-token/invoices?payment=cancelled&invoice=${INVOICE_ID}`,
+        connectedAccountId: undefined,
+        applicationFeeAmount: undefined,
       })
     );
+    // Self-host: the platform Stripe key IS the practice's account.
+    expect(mocks.getChargeableStripeConnectAccountId).not.toHaveBeenCalled();
+  });
+
+  it("hosted: routes portal checkout through the practice's Connect account", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.getChargeableStripeConnectAccountId.mockResolvedValue("acct_123");
+    mocks.selectResults.push(
+      [client()],
+      [invoice()],
+      [{ amount: "10.00" }],
+      [{ name: "Biscuit" }],
+      [practice({ tier: "cloud", billingStatus: "active" })]
+    );
+
+    const response = await POST(
+      portalRequest({ token: "portal-token", invoiceId: INVOICE_ID })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.getChargeableStripeConnectAccountId).toHaveBeenCalledWith(
+      mocks.db,
+      PRACTICE_ID
+    );
+    expect(mocks.stripeConnectApplicationFeeAmount).toHaveBeenCalledWith(6500);
+    expect(mocks.createCheckoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoiceId: INVOICE_ID,
+        amount: 6500,
+        connectedAccountId: "acct_123",
+        applicationFeeAmount: 250,
+      })
+    );
+  });
+
+  it("hosted: refuses portal checkout when the practice has no chargeable Connect account", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.getChargeableStripeConnectAccountId.mockResolvedValue(null);
+    mocks.selectResults.push(
+      [client()],
+      [invoice()],
+      [{ amount: "10.00" }],
+      [{ name: "Biscuit" }],
+      [practice({ tier: "cloud", billingStatus: "active" })]
+    );
+
+    const response = await POST(
+      portalRequest({ token: "portal-token", invoiceId: INVOICE_ID })
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "Online payments are not set up for this clinic yet. Please call the clinic to pay.",
+    });
+    expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/apps/web/app/api/portal/checkout/route.ts
+++ b/apps/web/app/api/portal/checkout/route.ts
@@ -13,6 +13,10 @@ import { createCheckoutSession } from "@/lib/stripe";
 import { withSystem } from "@/lib/tenant-db";
 import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
 import {
+  getChargeableStripeConnectAccountId,
+  stripeConnectApplicationFeeAmount,
+} from "@/lib/billing/payment-accounts";
+import {
   invoiceBalanceCents,
   moneyToCents,
 } from "@/lib/billing/invoice-balance";
@@ -281,6 +285,24 @@ export async function POST(req: NextRequest) {
         );
       }
 
+      // On hosted, client money must land in the practice's own Stripe
+      // account (Connect destination charge), exactly like the staff
+      // "Take Card" path. A platform charge would put clinic revenue in
+      // OpenVPM's account. Self-host keeps the platform charge: there the
+      // configured Stripe key IS the practice's own account.
+      const connectedAccountId = billingEnforced()
+        ? await getChargeableStripeConnectAccountId(tx, invoice.practiceId)
+        : null;
+      if (billingEnforced() && !connectedAccountId) {
+        return NextResponse.json(
+          {
+            error:
+              "Online payments are not set up for this clinic yet. Please call the clinic to pay.",
+          },
+          { status: 503 },
+        );
+      }
+
       const origin = req.nextUrl.origin;
       const result = await createCheckoutSession({
         invoiceId: invoice.id,
@@ -289,6 +311,10 @@ export async function POST(req: NextRequest) {
         clientName: `${client.firstName} ${client.lastName}`,
         description,
         currency: practice.currency ?? "usd",
+        connectedAccountId: connectedAccountId ?? undefined,
+        applicationFeeAmount: connectedAccountId
+          ? stripeConnectApplicationFeeAmount(amountCents)
+          : undefined,
         successUrl: buildPortalPaymentReturnUrl({
           origin,
           token,

--- a/apps/web/lib/billing/payment-accounts.ts
+++ b/apps/web/lib/billing/payment-accounts.ts
@@ -1,3 +1,6 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { practicePaymentAccounts } from "@openpims/db";
+import type { Database } from "@openpims/db/client";
 import { stripeConnectApplicationFeeBps } from "@/lib/stripe-config";
 
 export const STRIPE_CONNECT_PROVIDER = "stripe_connect";
@@ -27,6 +30,52 @@ type StripeConnectAccountLike = {
     disabled_reason?: string | null;
   } | null;
 };
+
+export function isChargeableStripeConnectAccount(
+  row: {
+    onboardingStatus: string;
+    chargesEnabled: boolean;
+    payoutsEnabled: boolean;
+  } | null
+): boolean {
+  return (
+    !!row &&
+    row.onboardingStatus === "active" &&
+    row.chargesEnabled &&
+    row.payoutsEnabled
+  );
+}
+
+/**
+ * The practice's chargeable Stripe Connect account id, or null. On hosted,
+ * client card money must land in the practice's own Stripe account — every
+ * client-facing checkout (staff and portal) gates on this.
+ */
+export async function getChargeableStripeConnectAccountId(
+  db: Database,
+  practiceId: string
+): Promise<string | null> {
+  const [row] = await db
+    .select({
+      stripeAccountId: practicePaymentAccounts.stripeAccountId,
+      onboardingStatus: practicePaymentAccounts.onboardingStatus,
+      chargesEnabled: practicePaymentAccounts.chargesEnabled,
+      payoutsEnabled: practicePaymentAccounts.payoutsEnabled,
+    })
+    .from(practicePaymentAccounts)
+    .where(
+      and(
+        eq(practicePaymentAccounts.practiceId, practiceId),
+        eq(practicePaymentAccounts.provider, STRIPE_CONNECT_PROVIDER),
+        isNull(practicePaymentAccounts.deletedAt)
+      )
+    )
+    .limit(1);
+
+  return isChargeableStripeConnectAccount(row ?? null)
+    ? row!.stripeAccountId
+    : null;
+}
 
 export function stripeConnectApplicationFeeAmount(
   paymentAmountCents: number

--- a/apps/web/server/__tests__/portal-invoices.test.ts
+++ b/apps/web/server/__tests__/portal-invoices.test.ts
@@ -149,6 +149,66 @@ describe("portal invoices", () => {
     ]);
   });
 
+  it("hosted: advertises portal payments only with a chargeable Connect account", async () => {
+    vi.stubEnv("STRIPE_SECRET_KEY", " sk_test_123 ");
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.hasHostedFullAccess.mockReturnValue(true);
+    const invoiceRow = {
+      id: INVOICE_ID,
+      status: "sent",
+      subtotal: "100.00",
+      tax: "0.00",
+      total: "100.00",
+      paidAmount: "0.00",
+      adjustedAmount: "0.00",
+      dueDate: "2026-07-15",
+      createdAt: new Date("2026-07-01T12:00:00Z"),
+      isEstimate: false,
+      patientName: "Juniper",
+    };
+    const practiceRow = {
+      currency: "usd",
+      country: "US",
+      timezone: "America/New_York",
+      tier: "cloud",
+      billingStatus: "active",
+      trialEndsAt: null,
+    };
+
+    const withConnect = createDb([
+      [{ id: CLIENT_ID, practiceId: PRACTICE_ID }],
+      ACTIVE_PRACTICE,
+      [practiceRow],
+      [
+        {
+          stripeAccountId: "acct_123",
+          onboardingStatus: "active",
+          chargesEnabled: true,
+          payoutsEnabled: true,
+        },
+      ],
+      [invoiceRow],
+    ]);
+    await expect(
+      callerWithDb(withConnect.db).getInvoices({ token: TOKEN })
+    ).resolves.toEqual([
+      expect.objectContaining({ id: INVOICE_ID, onlinePaymentsEnabled: true }),
+    ]);
+
+    const withoutConnect = createDb([
+      [{ id: CLIENT_ID, practiceId: PRACTICE_ID }],
+      ACTIVE_PRACTICE,
+      [practiceRow],
+      [],
+      [invoiceRow],
+    ]);
+    await expect(
+      callerWithDb(withoutConnect.db).getInvoices({ token: TOKEN })
+    ).resolves.toEqual([
+      expect.objectContaining({ id: INVOICE_ID, onlinePaymentsEnabled: false }),
+    ]);
+  });
+
   it("does not advertise portal payments when hosted billing has gated the practice", async () => {
     vi.stubEnv("STRIPE_SECRET_KEY", " sk_test_123 ");
     mocks.billingEnforced.mockReturnValue(true);

--- a/apps/web/server/routers/portal.ts
+++ b/apps/web/server/routers/portal.ts
@@ -31,6 +31,7 @@ import {
 } from "@/lib/portal/booking";
 import { findOpenSlots } from "@/lib/scheduling/availability";
 import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
+import { getChargeableStripeConnectAccountId } from "@/lib/billing/payment-accounts";
 import { clinicalDateInput } from "@/lib/records/clinical-inputs";
 import {
   PORTAL_ACCESS_TOKEN_MAX_LENGTH,
@@ -719,16 +720,23 @@ export const portalRouter = createRouter({
       const country = practice.country ?? "US";
       const timezone = practice.timezone ?? null;
       const hostedBillingEnforced = billingEnforced();
+      // On hosted, the portal Pay button additionally requires the practice's
+      // Stripe Connect account — client money goes to the clinic, never to
+      // the platform account. Mirrors the /api/portal/checkout gate.
       const onlinePaymentsEnabled =
         stripeConfigured() &&
         (!hostedBillingEnforced ||
-          hasHostedFullAccess(
+          (hasHostedFullAccess(
             practice.tier,
             practice.billingStatus,
             practice.trialEndsAt,
             new Date(),
             hostedBillingEnforced
-          ));
+          ) &&
+            (await getChargeableStripeConnectAccountId(
+              ctx.db,
+              client.practiceId
+            )) !== null));
 
       const rows = await ctx.db
         .select({


### PR DESCRIPTION
## Summary
Step 4 (money path) slice 1 — fixes a money-routing inconsistency found while mapping the billing surface:

- **Before:** the client portal's "Pay Online" created a **platform charge** — on hosted, a pet owner's invoice payment landed in *OpenVPM's* Stripe account. The staff "Take Card" path already (correctly) used a Connect **destination charge** into the practice's account.
- **After:** on hosted (`HOSTED_BILLING_ENABLED`), portal checkout requires the practice's chargeable Connect account and builds the same destination charge with the platform application fee. The recording path is unchanged plumbing: connected-account sessions already flow through `/api/webhooks/stripe-connect` with existing idempotency.
- The portal invoices query's `onlinePaymentsEnabled` now mirrors the gate, so the Pay button doesn't render for clinics without payments set up; if checkout is hit anyway it returns 503 with friendly copy.
- **Self-host unchanged:** the configured Stripe key *is* the practice's own account, so the platform charge remains correct there (covered by an explicit test).

New shared helper `getChargeableStripeConnectAccountId` in `lib/billing/payment-accounts.ts`, used by both the checkout route and the portal router.

## Verification
- `tsc --noEmit` clean; full vitest suite green: 217 files / 1,929 tests.
- New tests: hosted portal checkout uses the Connect account + fee; hosted without Connect → 503 and no Stripe call; self-host never queries Connect; portal `onlinePaymentsEnabled` true only with a chargeable account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)