### PR TITLE
Payment refunds: Stripe-backed for cards, once per payment

### DIFF
--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -1180,6 +1180,21 @@ function PaymentSection({
     },
   });
 
+  const refundPayment = trpc.billing.refundPayment.useMutation({
+    onSuccess: () => {
+      toast.success("Payment refunded");
+      utils.billing.listPayments.invalidate({ invoiceId });
+      utils.billing.listInvoices.invalidate();
+      utils.billing.getInvoice.invalidate({ id: invoiceId });
+      utils.billing.arSummary.invalidate();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+  const { data: paymentSession } = useSession();
+  const canRefund = paymentSession?.user?.role === "admin";
+
   const remaining = Math.max(0, Number(invoiceBalanceDue ?? 0));
   const amountInputMax = Math.min(remaining, BILLING_UNIT_PRICE_MAX);
   const canCollect =
@@ -1463,6 +1478,7 @@ function PaymentSection({
               <th className="py-2 text-left font-medium text-muted-foreground">
                 Notes
               </th>
+              {canRefund && <th className="py-2" />}
             </tr>
           </thead>
           <tbody>
@@ -1479,7 +1495,13 @@ function PaymentSection({
                       )
                     : "\u2014"}
                 </td>
-                <td className="py-2 text-right tabular-nums font-medium text-green-600">
+                <td
+                  className={`py-2 text-right tabular-nums font-medium ${
+                    Number(payment.amount) < 0
+                      ? "text-destructive"
+                      : "text-green-600"
+                  }`}
+                >
                   {formatCurrency(payment.amount)}
                 </td>
                 <td className="py-2 capitalize text-muted-foreground">
@@ -1491,6 +1513,30 @@ function PaymentSection({
                 <td className="py-2 text-muted-foreground">
                   {payment.notes || "\u2014"}
                 </td>
+                {canRefund && (
+                  <td className="py-2 text-right">
+                    {Number(payment.amount) > 0 && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 px-2 text-xs text-muted-foreground hover:text-destructive"
+                        disabled={refundPayment.isPending}
+                        onClick={() => {
+                          if (
+                            !window.confirm(
+                              `Refund ${formatCurrency(payment.amount)}? Card payments are refunded through Stripe.`
+                            )
+                          ) {
+                            return;
+                          }
+                          refundPayment.mutate({ paymentId: payment.id });
+                        }}
+                      >
+                        Refund
+                      </Button>
+                    )}
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>

--- a/apps/web/lib/__tests__/stripe.test.ts
+++ b/apps/web/lib/__tests__/stripe.test.ts
@@ -490,3 +490,25 @@ describe("construct Stripe webhook events", () => {
     );
   });
 });
+
+describe("parseStripeCheckoutExternalId", () => {
+  it("parses platform and Connect checkout external ids", async () => {
+    const { parseStripeCheckoutExternalId } = await import("@/lib/stripe");
+
+    expect(parseStripeCheckoutExternalId("stripe:checkout:cs_123")).toEqual({
+      sessionId: "cs_123",
+    });
+    expect(
+      parseStripeCheckoutExternalId("stripe:connect:acct_9:checkout:cs_456")
+    ).toEqual({ connectedAccountId: "acct_9", sessionId: "cs_456" });
+  });
+
+  it("returns null for manual payments and unknown formats", async () => {
+    const { parseStripeCheckoutExternalId } = await import("@/lib/stripe");
+
+    expect(parseStripeCheckoutExternalId(null)).toBeNull();
+    expect(parseStripeCheckoutExternalId(undefined)).toBeNull();
+    expect(parseStripeCheckoutExternalId("refund:payment:abc")).toBeNull();
+    expect(parseStripeCheckoutExternalId("stripe:refund:re_1")).toBeNull();
+  });
+});

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -40,6 +40,72 @@ export async function createCheckoutSession(data: {
   return { url: stripeCheckoutRedirectUrl(session.url) };
 }
 
+/**
+ * Parse a payments.external_id written by the checkout webhooks.
+ * `stripe:checkout:<session>` is a platform charge (self-host / legacy);
+ * `stripe:connect:<acct>:checkout:<session>` is a Connect destination charge.
+ * Returns null for non-Stripe payments (cash, check, manual).
+ */
+export function parseStripeCheckoutExternalId(
+  externalId: string | null | undefined
+): { sessionId: string; connectedAccountId?: string } | null {
+  if (!externalId) return null;
+  const connect = externalId.match(/^stripe:connect:([^:]+):checkout:(.+)$/);
+  if (connect) {
+    return { connectedAccountId: connect[1]!, sessionId: connect[2]! };
+  }
+  const platform = externalId.match(/^stripe:checkout:(.+)$/);
+  if (platform) {
+    return { sessionId: platform[1]! };
+  }
+  return null;
+}
+
+/**
+ * Refund a card payment recorded from a Checkout session. Throws on any
+ * Stripe failure — a refund the staff believes happened must never silently
+ * not happen. Returns null when the payment is not a Stripe payment.
+ */
+export async function refundStripeCheckoutPayment(data: {
+  externalId: string | null | undefined;
+  amountCents: number;
+}): Promise<{ refundId: string } | null> {
+  const parsed = parseStripeCheckoutExternalId(data.externalId);
+  if (!parsed) return null;
+  if (!stripe) {
+    throw new Error("Stripe is not configured; cannot refund a card payment.");
+  }
+
+  const requestOptions = parsed.connectedAccountId
+    ? { stripeAccount: parsed.connectedAccountId }
+    : undefined;
+  const session = requestOptions
+    ? await stripe.checkout.sessions.retrieve(parsed.sessionId, requestOptions)
+    : await stripe.checkout.sessions.retrieve(parsed.sessionId);
+  const paymentIntent =
+    typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : session.payment_intent?.id;
+  if (!paymentIntent) {
+    throw new Error(
+      `Stripe Checkout session has no payment intent to refund: ${parsed.sessionId}`
+    );
+  }
+
+  const params: Stripe.RefundCreateParams = {
+    payment_intent: paymentIntent,
+    amount: data.amountCents,
+    // On Connect destination charges, return the platform fee too so the
+    // clinic is never out of pocket for a refund.
+    ...(parsed.connectedAccountId ? { refund_application_fee: true } : {}),
+  };
+  const refund = requestOptions
+    ? await stripe.refunds.create(params, requestOptions)
+    : await stripe.refunds.create(params);
+
+  return { refundId: refund.id };
+}
+
 export function buildInvoiceCheckoutSessionParams(data: {
   invoiceId: string;
   amount: number;

--- a/apps/web/server/__tests__/billing-refunds.test.ts
+++ b/apps/web/server/__tests__/billing-refunds.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  recordAuditLog: vi.fn(async () => undefined),
+  dispatchWebhookEvent: vi.fn(async () => undefined),
+  loadClientReceipt: vi.fn(async (): Promise<unknown> => null),
+  deliverClientReceipt: vi.fn(async () => undefined),
+  refundStripeCheckoutPayment: vi.fn(
+    async (): Promise<{ refundId: string } | null> => null
+  ),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: mocks.recordAuditLog,
+}));
+
+vi.mock("@/lib/webhook-dispatcher", () => ({
+  dispatchWebhookEvent: mocks.dispatchWebhookEvent,
+}));
+
+vi.mock("@/lib/billing/client-receipts", () => ({
+  loadClientReceipt: mocks.loadClientReceipt,
+  deliverClientReceipt: mocks.deliverClientReceipt,
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  createCheckoutSession: vi.fn(),
+  createConnectAccount: vi.fn(),
+  createConnectAccountLink: vi.fn(),
+  createConnectLoginLink: vi.fn(),
+  refundStripeCheckoutPayment: mocks.refundStripeCheckoutPayment,
+  retrieveConnectAccount: vi.fn(),
+}));
+
+const { billingRouter } = await import("../routers/billing");
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+const INVOICE_ID = "00000000-0000-0000-0000-000000000002";
+const PAYMENT_ID = "00000000-0000-0000-0000-000000000003";
+
+const paidInvoice = {
+  id: INVOICE_ID,
+  total: "100.00",
+  paidAmount: "100.00",
+  status: "paid",
+  isEstimate: false,
+};
+
+const cardPayment = {
+  id: PAYMENT_ID,
+  invoiceId: INVOICE_ID,
+  amount: "100.00",
+  method: "online",
+  externalId: "stripe:connect:acct_9:checkout:cs_456",
+};
+
+function callerWithDb(db: Record<string, unknown>, role = "admin") {
+  const session = {
+    user: {
+      id: USER_ID,
+      email: "admin@example.com",
+      name: "Admin",
+      role,
+      practiceId: PRACTICE_ID,
+    },
+  };
+  return billingRouter.createCaller({ db, session } as never);
+}
+
+function thenableRows(result: unknown[]) {
+  return {
+    limit: vi.fn(async () => result),
+    then: (
+      resolve: (value: unknown[]) => unknown,
+      reject?: (e: unknown) => unknown
+    ) => Promise.resolve(result).then(resolve, reject),
+  };
+}
+
+function createDb(opts: {
+  selectResults: unknown[][];
+  refundRow?: Record<string, unknown>;
+  updateReturns?: unknown[][];
+}) {
+  const selectResults = [...opts.selectResults];
+  const select = vi.fn(() => {
+    const result = selectResults.shift() ?? [];
+    const afterWhere = thenableRows(result);
+    const builder = {
+      from: vi.fn(() => builder),
+      leftJoin: vi.fn(() => builder),
+      where: vi.fn(() => afterWhere),
+      orderBy: vi.fn(async () => result),
+      limit: vi.fn(async () => result),
+    };
+    return builder;
+  });
+
+  const refundRow = opts.refundRow ?? {
+    id: "00000000-0000-0000-0000-000000000009",
+    invoiceId: INVOICE_ID,
+    amount: "-100.00",
+    notes: "Refund of recorded payment",
+  };
+  const insertReturning = vi.fn(async () => [refundRow]);
+  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insert = vi.fn(() => ({ values: insertValues }));
+
+  const updateReturns = [...(opts.updateReturns ?? [[{ id: INVOICE_ID }]])];
+  const updateWhere = vi.fn(() => ({
+    returning: vi.fn(async () => updateReturns.shift() ?? []),
+    then: (resolve: (v: unknown) => unknown) => Promise.resolve(resolve([])),
+  }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+
+  const db: Record<string, unknown> = {
+    transaction: async (fn: (tx: unknown) => unknown) => fn(db),
+    execute: vi.fn(async () => undefined),
+    select,
+    insert,
+    update,
+  };
+  return { db, select, insert, insertValues, updateSet };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mocks.refundStripeCheckoutPayment.mockResolvedValue(null);
+});
+
+describe("billing refunds", () => {
+  it("refunds a card payment through Stripe and reopens the invoice", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [cardPayment], // payment lookup
+        [], // no existing refund
+        [paidInvoice], // invoice
+        [], // adjustments
+      ],
+    });
+    mocks.refundStripeCheckoutPayment.mockResolvedValue({
+      refundId: "re_123",
+    });
+
+    await callerWithDb(db).refundPayment({
+      paymentId: PAYMENT_ID,
+      reason: "Owner cancelled",
+    });
+
+    expect(insertValues).toHaveBeenCalledWith({
+      invoiceId: INVOICE_ID,
+      amount: "-100.00",
+      method: "online",
+      receivedBy: USER_ID,
+      externalId: `refund:payment:${PAYMENT_ID}`,
+      notes: "Refund: Owner cancelled",
+    });
+    // A fully refunded paid invoice reopens for collection.
+    expect(updateSet).toHaveBeenCalledWith({
+      paidAmount: "0.00",
+      status: "sent",
+    });
+    expect(mocks.refundStripeCheckoutPayment).toHaveBeenCalledWith({
+      externalId: "stripe:connect:acct_9:checkout:cs_456",
+      amountCents: 10000,
+    });
+    expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
+      PRACTICE_ID,
+      "invoice.refunded",
+      expect.objectContaining({
+        id: INVOICE_ID,
+        paymentId: PAYMENT_ID,
+        amount: "100.00",
+        paidAmount: "0.00",
+      })
+    );
+  });
+
+  it("requires the admin role", async () => {
+    const { db } = createDb({ selectResults: [] });
+
+    await expect(
+      callerWithDb(db, "front_desk").refundPayment({ paymentId: PAYMENT_ID })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.refundStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
+  it("refuses a second refund of the same payment before touching Stripe", async () => {
+    const { db, insert } = createDb({
+      selectResults: [
+        [cardPayment],
+        [{ id: "existing-refund" }], // refund already recorded
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).refundPayment({ paymentId: PAYMENT_ID })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "This payment has already been refunded.",
+    });
+    expect(mocks.refundStripeCheckoutPayment).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("refuses to refund a refund row", async () => {
+    const { db } = createDb({
+      selectResults: [[{ ...cardPayment, amount: "-100.00" }]],
+    });
+
+    await expect(
+      callerWithDb(db).refundPayment({ paymentId: PAYMENT_ID })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Only payments can be refunded.",
+    });
+  });
+
+  it("caps partial refunds at the original payment amount", async () => {
+    const { db } = createDb({
+      selectResults: [[cardPayment], [], [paidInvoice], []],
+    });
+
+    await expect(
+      callerWithDb(db).refundPayment({
+        paymentId: PAYMENT_ID,
+        amount: "150.00",
+      })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Refund exceeds the original payment.",
+    });
+    expect(mocks.refundStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a Stripe refund failure and records nothing", async () => {
+    const { db } = createDb({
+      selectResults: [[cardPayment], [], [paidInvoice], []],
+    });
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mocks.refundStripeCheckoutPayment.mockRejectedValue(
+      new Error("stripe down")
+    );
+
+    try {
+      await expect(
+        callerWithDb(db).refundPayment({ paymentId: PAYMENT_ID })
+      ).rejects.toMatchObject({
+        code: "BAD_GATEWAY",
+        message: "Stripe could not process the refund. Nothing was recorded.",
+      });
+      expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("refunds manual payments without calling Stripe APIs", async () => {
+    const manualPayment = {
+      ...cardPayment,
+      method: "cash",
+      externalId: null,
+    };
+    const { db, insertValues } = createDb({
+      selectResults: [[manualPayment], [], [paidInvoice], []],
+    });
+
+    await callerWithDb(db).refundPayment({ paymentId: PAYMENT_ID });
+
+    // The helper is still consulted, but a null externalId is not a Stripe
+    // payment, so no Stripe refund happens (mock resolves null).
+    expect(mocks.refundStripeCheckoutPayment).toHaveBeenCalledWith({
+      externalId: null,
+      amountCents: 10000,
+    });
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: "-100.00",
+        method: "cash",
+        externalId: `refund:payment:${PAYMENT_ID}`,
+      })
+    );
+  });
+});

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -14,6 +14,7 @@ import {
   createConnectAccount,
   createConnectAccountLink,
   createConnectLoginLink,
+  refundStripeCheckoutPayment,
   retrieveConnectAccount,
 } from "@/lib/stripe";
 import { billingEnforced } from "@/lib/billing/plans";
@@ -1374,6 +1375,183 @@ export const billingRouter = createRouter({
           )
         )
         .orderBy(desc(payments.receivedAt));
+    }),
+
+  /**
+   * Refund a recorded payment, at most once per payment. Card payments are
+   * refunded at Stripe inside the same transaction that records the refund:
+   * the unique refund external id is inserted first (a concurrent attempt
+   * dies on the index before reaching Stripe) and the Stripe call runs last
+   * (a Stripe failure rolls the local record back). Recorded as a negative
+   * payment row so paid-amount recomputation and AR stay consistent.
+   */
+  refundPayment: protectedProcedure
+    .use(requireRole("admin"))
+    .input(
+      z.object({
+        paymentId: z.string().uuid(),
+        amount: paymentAmountSchema.optional(),
+        reason: z
+          .string()
+          .trim()
+          .max(BILLING_ADJUSTMENT_REASON_MAX_LENGTH)
+          .optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const [payment] = await ctx.db
+        .select({
+          id: payments.id,
+          invoiceId: payments.invoiceId,
+          amount: payments.amount,
+          method: payments.method,
+          externalId: payments.externalId,
+        })
+        .from(payments)
+        .where(
+          and(
+            eq(payments.id, input.paymentId),
+            paymentPracticeScope(ctx),
+            isNull(payments.deletedAt)
+          )
+        )
+        .limit(1);
+
+      if (!payment) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Payment not found" });
+      }
+
+      const originalCents = moneyToCents(payment.amount);
+      if (originalCents <= 0) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Only payments can be refunded.",
+        });
+      }
+
+      const refundExternalId = `refund:payment:${payment.id}`;
+      const [existingRefund] = await ctx.db
+        .select({ id: payments.id })
+        .from(payments)
+        .where(
+          and(
+            eq(payments.externalId, refundExternalId),
+            isNull(payments.deletedAt)
+          )
+        )
+        .limit(1);
+      if (existingRefund) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "This payment has already been refunded.",
+        });
+      }
+
+      const amountCents = input.amount
+        ? moneyToCents(input.amount)
+        : originalCents;
+      if (amountCents <= 0 || amountCents > originalCents) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Refund exceeds the original payment.",
+        });
+      }
+
+      const invoice = await getInvoiceForPractice(ctx, payment.invoiceId);
+      const adjustedCents = await getInvoiceAdjustmentTotalCents(
+        ctx,
+        payment.invoiceId
+      );
+      const paidBeforeCents = moneyToCents(invoice.paidAmount);
+      const paidAfterCents = paidBeforeCents - amountCents;
+      const updates: Record<string, any> = {
+        paidAmount: centsToMoney(paidAfterCents),
+      };
+      if (
+        invoice.status === "paid" &&
+        paidAfterCents + adjustedCents < moneyToCents(invoice.total)
+      ) {
+        // A refunded balance reopens the invoice for collection.
+        updates.status = "sent";
+      }
+
+      const refund = await ctx.db.transaction(async (tx) => {
+        const [createdRefund] = await tx
+          .insert(payments)
+          .values({
+            invoiceId: payment.invoiceId,
+            amount: centsToMoney(-amountCents),
+            method: payment.method,
+            receivedBy: ctx.user.id,
+            externalId: refundExternalId,
+            notes: input.reason
+              ? `Refund: ${input.reason}`
+              : "Refund of recorded payment",
+          })
+          .returning();
+
+        const [updatedInvoice] = await tx
+          .update(invoices)
+          .set(updates)
+          .where(
+            and(
+              eq(invoices.id, payment.invoiceId),
+              eq(invoices.practiceId, ctx.practiceId),
+              isNull(invoices.deletedAt),
+              eq(invoices.isEstimate, false),
+              eq(invoices.status, invoice.status),
+              eq(invoices.paidAmount, invoice.paidAmount ?? "0"),
+              invoiceAdjustmentTotalMatches(adjustedCents)
+            )
+          )
+          .returning({ id: invoices.id });
+
+        if (!updatedInvoice) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Invoice changed while refunding. Refresh and try again.",
+          });
+        }
+
+        // Real money moves last so any failure above (including the unique
+        // refund id) means Stripe was never called; a Stripe failure here
+        // rolls back the local record.
+        const stripeRefund = await refundStripeCheckoutPayment({
+          externalId: payment.externalId,
+          amountCents,
+        }).catch((err) => {
+          console.error("[billing] Stripe refund failed:", err);
+          throw new TRPCError({
+            code: "BAD_GATEWAY",
+            message:
+              "Stripe could not process the refund. Nothing was recorded.",
+          });
+        });
+
+        if (stripeRefund) {
+          await tx
+            .update(payments)
+            .set({
+              notes: `${createdRefund!.notes} (Stripe refund ${stripeRefund.refundId})`,
+            })
+            .where(eq(payments.id, createdRefund!.id));
+        }
+
+        return createdRefund!;
+      });
+
+      await dispatchWebhookEvent(ctx.practiceId, "invoice.refunded", {
+        id: payment.invoiceId,
+        paymentId: payment.id,
+        refundId: refund.id,
+        amount: centsToMoney(amountCents),
+        paidAmount: centsToMoney(paidAfterCents),
+        total: invoice.total,
+        source: "dashboard",
+      });
+
+      return refund;
     }),
 
   /**


### PR DESCRIPTION
## Summary
Step 4 (money path) slice 3 — the audit found no refund path anywhere. This adds one:

- **`billing.refundPayment`** (admin-only): full or partial, at most once per payment. Card payments are refunded **at Stripe** by parsing the recorded checkout external id (`stripe:checkout:…` platform / `stripe:connect:<acct>:checkout:…` Connect), retrieving the session's payment intent on the right account, and creating the refund — returning the platform application fee on Connect so the clinic is never out of pocket. Manual (cash/check) payments record-only.
- **Atomicity:** the refund is recorded as a negative payment row with unique external id `refund:payment:<id>`, inserted *first* inside the transaction (concurrent double-clicks die on the unique index before Stripe is called), with the Stripe call *last* (a Stripe failure rolls the local record back — "Nothing was recorded"). `paidAmount` stays consistent because webhook recomputation already sums payment rows.
- **Invoice lifecycle:** a refund that reopens a balance flips a paid invoice back to `sent`; an `invoice.refunded` webhook event fires for integrations.
- **UI:** admin-only Refund action per positive payment row in the invoice panel; refund rows render red.

Known follow-up (documented, not in this PR): reconciling refunds issued directly in the Stripe dashboard via `charge.refunded` webhook events.

## Verification
- `tsc --noEmit` clean; full vitest suite green: 219 files / 1,944 tests.
- New tests: Stripe-backed refund with invoice reopen + webhook payload; role gate; double-refund refusal before any Stripe call; refund-of-refund refusal; partial-refund cap; Stripe-failure surfacing with nothing recorded; manual-payment refunds without Stripe; external-id parser (platform/Connect/manual formats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)