### PR TITLE
Legal pages: terms of service + privacy policy

### DIFF
--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -230,6 +230,24 @@ function RegisterPageInner() {
               <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
               Free for 14 days. No credit card required.
             </p>
+
+            <p className="text-center text-xs text-slate-400">
+              By creating a workspace you agree to the{" "}
+              <Link
+                href="/legal/terms"
+                className="underline underline-offset-2 hover:text-slate-600"
+              >
+                Terms of Service
+              </Link>{" "}
+              and{" "}
+              <Link
+                href="/legal/privacy"
+                className="underline underline-offset-2 hover:text-slate-600"
+              >
+                Privacy Policy
+              </Link>
+              .
+            </p>
           </form>
 
           <p className="mt-8 text-center text-sm text-slate-500">

--- a/apps/web/app/legal/layout.tsx
+++ b/apps/web/app/legal/layout.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Legal - OpenVPM",
+  description: "OpenVPM terms of service and privacy policy",
+};
+
+export default function LegalLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-surface">
+      <header className="border-b border-border bg-card">
+        <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-4">
+          <Link href="/" className="font-heading text-lg font-semibold">
+            OpenVPM
+          </Link>
+          <nav className="flex gap-4 text-sm text-muted-foreground">
+            <Link href="/legal/terms" className="hover:text-foreground">
+              Terms
+            </Link>
+            <Link href="/legal/privacy" className="hover:text-foreground">
+              Privacy
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-3xl px-4 py-10">
+        <article className="space-y-6 text-sm leading-6 text-foreground [&_h1]:font-heading [&_h1]:text-3xl [&_h1]:font-semibold [&_h2]:mt-8 [&_h2]:font-heading [&_h2]:text-xl [&_h2]:font-semibold [&_p]:text-muted-foreground [&_li]:text-muted-foreground [&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-6">
+          {children}
+        </article>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/app/legal/privacy/page.tsx
+++ b/apps/web/app/legal/privacy/page.tsx
@@ -1,0 +1,109 @@
+export const metadata = {
+  title: "Privacy Policy - OpenVPM",
+};
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <h1>Privacy Policy</h1>
+      <p>Last updated: July 7, 2026</p>
+
+      <p>
+        This policy explains what OpenVPM Cloud collects, why, and the choices
+        you have. In short: your practice&apos;s data belongs to your
+        practice. We use it to run the service, not to sell or advertise.
+      </p>
+
+      <h2>What we collect</h2>
+      <ul>
+        <li>
+          <strong>Account data:</strong> names, emails, and roles for your
+          staff accounts, plus your practice&apos;s name and settings.
+        </li>
+        <li>
+          <strong>Practice records:</strong> the clients, patients,
+          appointments, medical records, messages, and invoices your team
+          enters. We process this data on your behalf; your practice controls
+          it.
+        </li>
+        <li>
+          <strong>Billing data:</strong> subscription status and usage counts.
+          Card details go directly to Stripe; we never see full card numbers.
+        </li>
+        <li>
+          <strong>Service logs:</strong> technical logs and error reports that
+          help us keep the service reliable and secure.
+        </li>
+        <li>
+          <strong>Optional analytics:</strong> only if you choose &quot;Allow
+          Analytics&quot; in the cookie banner. Essential cookies for secure
+          sign-in are always on; advertising cookies are never used.
+        </li>
+      </ul>
+
+      <h2>How we use data</h2>
+      <ul>
+        <li>To provide, secure, and improve the service.</li>
+        <li>
+          To send messages you ask us to send (appointment reminders, client
+          messages, receipts) and account emails.
+        </li>
+        <li>
+          To power optional AI features. AI requests are processed by our AI
+          provider to answer the request; we do not let providers train their
+          models on your practice data.
+        </li>
+        <li>We do not sell personal data. We do not run ads.</li>
+      </ul>
+
+      <h2>Who helps us run the service</h2>
+      <p>
+        We use a small set of service providers to operate OpenVPM: cloud
+        hosting and databases, file storage, Stripe for payments, an email
+        delivery provider, an SMS carrier, and an AI provider for the
+        assistant. Each processes data only to provide their service to us.
+      </p>
+
+      <h2>Retention and deletion</h2>
+      <ul>
+        <li>
+          Practice records stay as long as your account is active. Your
+          practice controls its own retention duties for medical records.
+        </li>
+        <li>
+          You can export everything at any time from Settings, and an admin
+          can request account deletion in the product. After closure we keep
+          data exportable for at least 60 days, then delete it from live
+          systems and let backups age out.
+        </li>
+      </ul>
+
+      <h2>Security</h2>
+      <p>
+        Data is encrypted in transit, access is role-based, every practice is
+        isolated at the database layer with row-level security, and hosted
+        data is backed up regularly. No system is perfectly secure, but we
+        treat your records like the medical data they are. If a breach ever
+        affects your data, we will notify you as the law requires.
+      </p>
+
+      <h2>Your choices</h2>
+      <ul>
+        <li>Export your data at any time.</li>
+        <li>Request deletion of your account and data.</li>
+        <li>Change the analytics cookie choice from the cookie preferences link.</li>
+        <li>
+          Pet owners: your vet&apos;s practice controls your records. Contact
+          the practice for questions, corrections, or deletion.
+        </li>
+      </ul>
+
+      <h2>Changes and contact</h2>
+      <p>
+        If we change this policy in a way that matters, we will tell you by
+        email or in the product first. Questions or requests:
+        hello@openvpm.com.
+      </p>
+    </>
+  );
+}

--- a/apps/web/app/legal/terms/page.tsx
+++ b/apps/web/app/legal/terms/page.tsx
@@ -1,0 +1,122 @@
+export const metadata = {
+  title: "Terms of Service - OpenVPM",
+};
+
+export default function TermsPage() {
+  return (
+    <>
+      <h1>Terms of Service</h1>
+      <p>Last updated: July 7, 2026</p>
+
+      <p>
+        These terms cover OpenVPM Cloud, the hosted veterinary practice
+        management service at app.openvpm.com. By creating an account or using
+        the service, you agree to them. If you self-host the open-source
+        edition of OpenVPM, these terms do not apply; your use is governed by
+        the software license in the code repository.
+      </p>
+
+      <h2>What OpenVPM is</h2>
+      <p>
+        OpenVPM is practice management software for veterinary clinics. It
+        stores your practice&apos;s records, helps you schedule and bill, and
+        sends messages to your clients. OpenVPM is a tool for your team. It is
+        not a veterinarian and it does not give medical advice. Your team is
+        responsible for all clinical decisions and for meeting the
+        record-keeping rules that apply to your practice.
+      </p>
+
+      <h2>Your account</h2>
+      <ul>
+        <li>You must give accurate information when you sign up.</li>
+        <li>
+          You are responsible for what happens under your practice&apos;s
+          accounts. Keep passwords private and remove staff access when people
+          leave.
+        </li>
+        <li>You must be authorized to act for the practice you register.</li>
+      </ul>
+
+      <h2>Your data belongs to you</h2>
+      <p>
+        Your practice&apos;s records are yours. You can export your full data
+        at any time from Settings. If you close your account, you can take
+        your data with you. We do not sell your data and we do not use your
+        clients&apos; information for advertising.
+      </p>
+
+      <h2>Fees and trials</h2>
+      <ul>
+        <li>
+          New practices get a free trial. We tell you the length and terms
+          when you sign up. Trials that end without a subscription lose access
+          to paid features, but you can still export your data.
+        </li>
+        <li>
+          Paid plans are billed through Stripe at the prices shown when you
+          subscribe, per active location, plus any usage charges we describe
+          in the product.
+        </li>
+        <li>
+          Payments your clients make to your practice go to your own Stripe
+          account. OpenVPM may charge a small platform fee on those payments,
+          shown in the product.
+        </li>
+      </ul>
+
+      <h2>Acceptable use</h2>
+      <ul>
+        <li>Follow the laws that apply to you, including messaging-consent rules for texts and emails.</li>
+        <li>Do not try to break, overload, or probe the service.</li>
+        <li>Do not use the service to store or send unlawful content.</li>
+      </ul>
+
+      <h2>Messaging</h2>
+      <p>
+        OpenVPM sends texts and emails on your behalf. You are the sender: you
+        must have consent from your clients, honor opt-outs, and follow rules
+        like the TCPA. OpenVPM enforces opt-outs automatically and blocks
+        sends to suppressed contacts, but responsibility for lawful messaging
+        stays with your practice.
+      </p>
+
+      <h2>Availability and support</h2>
+      <p>
+        We work hard to keep OpenVPM available and back up hosted data
+        regularly. Like any online service, we cannot promise zero downtime.
+        We announce planned maintenance ahead of time when we can.
+      </p>
+
+      <h2>Ending service</h2>
+      <p>
+        You can cancel at any time. After cancellation or trial expiry, we
+        keep your data available to export for at least 60 days, then we may
+        delete it. We can suspend or end accounts that break these terms or
+        do not pay, with notice when reasonable.
+      </p>
+
+      <h2>Disclaimers and liability</h2>
+      <p>
+        The service is provided &quot;as is.&quot; To the extent the law
+        allows, OpenVPM is not liable for indirect damages, and our total
+        liability for any claim is limited to the fees you paid us in the 12
+        months before the claim. Nothing in these terms limits liability that
+        cannot be limited by law.
+      </p>
+
+      <h2>Changes</h2>
+      <p>
+        We may update these terms. If a change matters, we will tell you by
+        email or in the product before it takes effect. Continuing to use the
+        service after a change means you accept it.
+      </p>
+
+      <h2>Contact and governing law</h2>
+      <p>
+        Questions? Email hello@openvpm.com. These terms are governed by the
+        laws of the State of Delaware, USA, without regard to conflict-of-law
+        rules.
+      </p>
+    </>
+  );
+}

--- a/apps/web/app/portal/layout.tsx
+++ b/apps/web/app/portal/layout.tsx
@@ -33,6 +33,15 @@ export default function PortalLayout({
           <span className="mx-2" aria-hidden="true">
             ·
           </span>
+          <a
+            href="/legal/privacy"
+            className="underline-offset-2 hover:text-gray-600 hover:underline"
+          >
+            Privacy
+          </a>
+          <span className="mx-2" aria-hidden="true">
+            ·
+          </span>
           <CookiePreferencesLink className="underline-offset-2 hover:text-gray-600 hover:underline" />
         </div>
       </footer>

--- a/apps/web/lib/__tests__/legal-pages.test.ts
+++ b/apps/web/lib/__tests__/legal-pages.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("legal pages", () => {
+  it("publishes terms and privacy with the load-bearing commitments", () => {
+    const terms = readFileSync("app/legal/terms/page.tsx", "utf8");
+    const privacy = readFileSync("app/legal/privacy/page.tsx", "utf8");
+
+    expect(terms).toContain("Terms of Service");
+    expect(terms).toContain("Your data belongs to you");
+    expect(terms).toContain("not a veterinarian");
+    expect(terms).toContain("hello@openvpm.com");
+    expect(privacy).toContain("Privacy Policy");
+    expect(privacy).toContain("We do not sell personal data");
+    expect(privacy).toContain("row-level security");
+    expect(privacy).toContain("hello@openvpm.com");
+  });
+
+  it("links the terms from signup and privacy from the portal", () => {
+    const register = readFileSync("app/(auth)/register/page.tsx", "utf8");
+    const portal = readFileSync("app/portal/layout.tsx", "utf8");
+
+    expect(register).toContain('href="/legal/terms"');
+    expect(register).toContain('href="/legal/privacy"');
+    expect(portal).toContain('href="/legal/privacy"');
+  });
+});


### PR DESCRIPTION
## Summary
Closes P1-1 of the production plan (no Terms/Privacy anywhere — a blocker for charging real clinics):

- **`/legal/terms`** — plain-language ToS: the tool-not-a-vet disclaimer, account responsibility, **your-data-belongs-to-you + export**, no-card trial posture, per-location pricing + platform fee on client payments, acceptable use, messaging-consent responsibility (TCPA; opt-outs enforced automatically), availability, **60-day post-closure export window**, liability limits, Delaware governing law.
- **`/legal/privacy`** — what's collected and why, practice-controls-records framing (including for pet owners), Stripe-holds-cards, **no selling data / no ads / no AI training on practice data**, service-provider categories, retention + deletion, RLS isolation + encryption, cookie choices tied to the consent banner.
- Signup shows "By creating a workspace you agree to…" with both links; the portal footer links Privacy alongside the cookie-preferences trigger.

## ⚠️ Needs Evan before GA
- **Legal review of both documents** — this is careful, conservative draft copy, not counsel-approved text.
- Confirm **Delaware** as governing law (placeholder default) and the **60-day** retention window.
- A cookie-policy subsection lives inside Privacy rather than a separate page — fine for launch unless counsel says otherwise.

## Verification
- `tsc --noEmit` clean; full vitest suite green: 220 files / 1,947 tests (new test pins the load-bearing commitments + links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)