### PR TITLE
Dogfood fix: atomic settings JSON writes (lost-update race)

### DIFF
--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -219,11 +219,15 @@ describe("settings admin stale target safety", () => {
       updatedRows: [],
     });
 
+    // completeOnboarding writes with a guarded atomic update: the
+    // active-practice predicate excludes missing/deleted rows, so zero
+    // updated rows surfaces as NOT_FOUND and no fallback state is created.
     await expect(callerWithDb(db).completeOnboarding()).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
     });
-    expect(updateSet).not.toHaveBeenCalled();
+    expect(updateSet).toHaveBeenCalledTimes(1);
+    updateSet.mockClear();
 
     await expect(
       callerWithDb(db).updatePractice({ name: "Neighborhood Veterinary" })

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -147,6 +147,28 @@ const journeyStepIdInput = z
  */
 export const ESTABLISHED_PRACTICE_PATIENT_THRESHOLD = 5;
 
+/**
+ * Atomic JSONB patches for practices.settings. Wizard mutations land
+ * concurrently (finishing fires while the step cursor is still persisting);
+ * read-modify-write of the whole JSON loses whichever write commits first,
+ * so patches must merge in-database against the current row.
+ */
+function settingsMergePatch(patch: Record<string, unknown>) {
+  return sql`coalesce(${practices.settings}, '{}'::jsonb) || ${JSON.stringify(patch)}::jsonb`;
+}
+
+function settingsRemoveKey(key: string) {
+  return sql`coalesce(${practices.settings}, '{}'::jsonb) - ${key}`;
+}
+
+function onboardingStateMergePatch(patch: Record<string, unknown>) {
+  return sql`jsonb_set(
+    coalesce(${practices.settings}, '{}'::jsonb),
+    '{onboardingState}',
+    coalesce(${practices.settings}->'onboardingState', '{}'::jsonb) || ${JSON.stringify(patch)}::jsonb
+  )`;
+}
+
 function staffAdminRosterLockKey(practiceId: string) {
   return `settings:staff-admin-roster:${practiceId}`;
 }
@@ -787,19 +809,18 @@ export const settingsRouter = createRouter({
 
   /** Mark onboarding complete. */
   completeOnboarding: adminProcedure.mutation(async ({ ctx }) => {
-    const [practice] = await ctx.db
-      .select({ settings: practices.settings })
-      .from(practices)
+    const [updated] = await ctx.db
+      .update(practices)
+      .set({
+        settings: settingsMergePatch({
+          onboardingCompletedAt: new Date().toISOString(),
+        }),
+      })
       .where(activePracticeWhere(ctx.practiceId))
-      .limit(1);
-    if (!practice) {
+      .returning({ id: practices.id });
+    if (!updated) {
       throw practiceNotFound();
     }
-    const settings = (practice.settings ?? {}) as PracticeSettings;
-    await ctx.db
-      .update(practices)
-      .set({ settings: { ...settings, onboardingCompletedAt: new Date().toISOString() } })
-      .where(activePracticeWhere(ctx.practiceId));
     return { ok: true };
   }),
 
@@ -833,25 +854,17 @@ export const settingsRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const [practice] = await ctx.db
-        .select({ settings: practices.settings })
-        .from(practices)
+      const patch: Record<string, unknown> = { tourStatus: input.status };
+      if (input.lastStepId != null) patch.lastStepId = input.lastStepId;
+
+      const [updated] = await ctx.db
+        .update(practices)
+        .set({ settings: onboardingStateMergePatch(patch) })
         .where(activePracticeWhere(ctx.practiceId))
-        .limit(1);
-      if (!practice) {
+        .returning({ id: practices.id });
+      if (!updated) {
         throw practiceNotFound();
       }
-      const settings = (practice.settings ?? {}) as PracticeSettings;
-      const onboardingState = {
-        ...(settings.onboardingState ?? {}),
-        tourStatus: input.status,
-        lastStepId:
-          input.lastStepId ?? settings.onboardingState?.lastStepId ?? null,
-      };
-      await ctx.db
-        .update(practices)
-        .set({ settings: { ...settings, onboardingState } })
-        .where(activePracticeWhere(ctx.practiceId));
       return { ok: true };
     }),
 
@@ -868,49 +881,32 @@ export const settingsRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const [practice] = await ctx.db
-        .select({ settings: practices.settings })
-        .from(practices)
+      const patch: Record<string, unknown> = {};
+      if (input.stepId != null) patch.journeyStepId = input.stepId;
+      if (input.dismissed !== undefined) patch.journeyDismissed = input.dismissed;
+      if (Object.keys(patch).length === 0) return { ok: true };
+
+      const [updated] = await ctx.db
+        .update(practices)
+        .set({ settings: onboardingStateMergePatch(patch) })
         .where(activePracticeWhere(ctx.practiceId))
-        .limit(1);
-      if (!practice) {
+        .returning({ id: practices.id });
+      if (!updated) {
         throw practiceNotFound();
       }
-      const settings = (practice.settings ?? {}) as PracticeSettings;
-      const onboardingState = {
-        ...(settings.onboardingState ?? {}),
-        journeyStepId:
-          input.stepId ?? settings.onboardingState?.journeyStepId ?? null,
-        ...(input.dismissed !== undefined
-          ? { journeyDismissed: input.dismissed }
-          : {}),
-      };
-      await ctx.db
-        .update(practices)
-        .set({ settings: { ...settings, onboardingState } })
-        .where(activePracticeWhere(ctx.practiceId));
       return { ok: true };
     }),
 
   /** Dismiss the dashboard "finish setup" card. */
   dismissSetup: adminProcedure.mutation(async ({ ctx }) => {
-    const [practice] = await ctx.db
-      .select({ settings: practices.settings })
-      .from(practices)
+    const [updated] = await ctx.db
+      .update(practices)
+      .set({ settings: onboardingStateMergePatch({ setupDismissed: true }) })
       .where(activePracticeWhere(ctx.practiceId))
-      .limit(1);
-    if (!practice) {
+      .returning({ id: practices.id });
+    if (!updated) {
       throw practiceNotFound();
     }
-    const settings = (practice.settings ?? {}) as PracticeSettings;
-    const onboardingState = {
-      ...(settings.onboardingState ?? {}),
-      setupDismissed: true,
-    };
-    await ctx.db
-      .update(practices)
-      .set({ settings: { ...settings, onboardingState } })
-      .where(activePracticeWhere(ctx.practiceId));
     return { ok: true };
   }),
 
@@ -1024,10 +1020,9 @@ export const settingsRouter = createRouter({
           );
       }
     }
-    const { demoData: _omit, ...rest } = settings;
     await ctx.db
       .update(practices)
-      .set({ settings: rest })
+      .set({ settings: settingsRemoveKey("demoData") })
       .where(activePracticeWhere(ctx.practiceId));
     return { ok: true };
   }),
@@ -1047,7 +1042,7 @@ export const settingsRouter = createRouter({
     const demoData = await seedDemoData(ctx.db, { practiceId: ctx.practiceId });
     await ctx.db
       .update(practices)
-      .set({ settings: { ...settings, demoData } })
+      .set({ settings: settingsMergePatch({ demoData }) })
       .where(activePracticeWhere(ctx.practiceId));
     return { ok: true, alreadyPresent: false };
   }),

--- a/e2e/dogfood.spec.ts
+++ b/e2e/dogfood.spec.ts
@@ -1,0 +1,355 @@
+import { test, expect, type Page } from "@playwright/test";
+import path from "path";
+import fs from "fs";
+
+/**
+ * Phase 5 dogfood: "run the clinic for a day" on a freshly registered
+ * practice (Track B). Local-only driver; screenshots go to DOGFOOD_SHOTS.
+ * Not part of CI — run section by section with --grep "Dogfood".
+ */
+
+const BASE = process.env.DOGFOOD_URL ?? "http://localhost:3004";
+const SHOTS =
+  process.env.DOGFOOD_SHOTS ??
+  path.resolve(__dirname, "../.dogfood-shots");
+const EMAIL = process.env.DOGFOOD_EMAIL ?? "dogfood-admin@example.com";
+const PASSWORD = process.env.DOGFOOD_PASSWORD ?? "dogfood-password-1";
+const PRACTICE = "Aspen Creek Animal Hospital";
+
+test.use({ baseURL: BASE, viewport: { width: 1440, height: 900 } });
+test.describe.configure({ mode: "serial" });
+
+let shotIndex = 0;
+async function shot(page: Page, name: string) {
+  fs.mkdirSync(SHOTS, { recursive: true });
+  shotIndex += 1;
+  await page
+    .screenshot({
+      path: path.join(SHOTS, `${String(shotIndex).padStart(2, "0")}-${name}.png`),
+      fullPage: false,
+    })
+    .catch(() => {});
+}
+
+async function login(page: Page) {
+  await page.goto("/login", { waitUntil: "networkidle" });
+  await page.fill("#email", EMAIL);
+  await page.fill("#password", PASSWORD);
+  await Promise.all([
+    page.waitForURL((url) => url.pathname === "/", { timeout: 30_000 }),
+    page.click('button[type="submit"]'),
+  ]);
+  await page.waitForTimeout(1000);
+  // If the wizard re-opens, park it; individual tests reopen what they need.
+  const later = page.getByText(/finish later/i).first();
+  if (await later.isVisible().catch(() => false)) {
+    await later.click();
+    await page.waitForTimeout(500);
+  }
+  const cookie = page.getByRole("button", { name: /essential only/i });
+  if (await cookie.isVisible().catch(() => false)) await cookie.click();
+}
+
+test("Dogfood A: signup, wizard, dashboard", async ({ page }) => {
+  test.setTimeout(300_000);
+
+  await page.goto("/register", { waitUntil: "networkidle" });
+  await shot(page, "register");
+  await page.fill("#practiceName", PRACTICE);
+  await page.fill("#email", EMAIL);
+  await page.fill("#password", PASSWORD);
+  await Promise.all([
+    page.waitForURL((url) => url.pathname === "/", { timeout: 60_000 }),
+    page.click('button[type="submit"]'),
+  ]);
+  await page.waitForLoadState("networkidle");
+  await page.waitForTimeout(2500);
+  await shot(page, "after-signup");
+
+  // Cookie banner first so it never blocks wizard buttons.
+  const cookie = page.getByRole("button", { name: /essential only/i });
+  if (await cookie.isVisible().catch(() => false)) await cookie.click();
+
+  // Walk the "Make it yours" wizard by always clicking the primary action.
+  for (let step = 0; step < 12; step++) {
+    await page.waitForTimeout(900);
+    const overlay = page.getByText(/make it yours/i).first();
+    if (!(await overlay.isVisible().catch(() => false))) break;
+    await shot(page, `wizard-step-${step}`);
+    const actions = [
+      /^continue$/i,
+      /^next$/i,
+      /skip for now/i,
+      /^skip$/i,
+      /^finish$/i,
+      /^done$/i,
+      /go to dashboard/i,
+      /not now/i,
+      /maybe later/i,
+    ];
+    let clicked = false;
+    for (const pattern of actions) {
+      const btn = page.getByRole("button", { name: pattern }).first();
+      if (await btn.isEnabled().catch(() => false)) {
+        await btn.click();
+        clicked = true;
+        break;
+      }
+    }
+    if (!clicked) {
+      // Step needs input we can't infer; bail out via finish-later.
+      const later = page.getByText(/finish later/i).first();
+      if (await later.isVisible().catch(() => false)) await later.click();
+      break;
+    }
+  }
+  await page.waitForTimeout(1500);
+  // A tour prompt may follow the wizard; decline so the run stays scripted.
+  for (const decline of [/not now/i, /skip tour/i, /maybe later/i]) {
+    const btn = page.getByRole("button", { name: decline }).first();
+    if (await btn.isVisible().catch(() => false)) {
+      await btn.click();
+      break;
+    }
+  }
+  await page.waitForTimeout(800);
+  await shot(page, "dashboard-after-wizard");
+
+  await expect(
+    page.getByText(new RegExp(PRACTICE.split(" ")[0]!, "i")).first()
+  ).toBeVisible();
+});
+
+test("Dogfood B: client, patient, appointment, whiteboard", async ({ page }) => {
+  test.setTimeout(300_000);
+  await login(page);
+
+  // Client with SMS consent (idempotent: skip if Riley already exists)
+  await page.goto("/clients", { waitUntil: "networkidle" });
+  await page.fill('input[placeholder="Search clients..."]', "Riley");
+  await page.waitForTimeout(1200);
+  const rileyExists = await page
+    .getByText(/riley bennett/i)
+    .first()
+    .isVisible()
+    .catch(() => false);
+  if (!rileyExists) {
+    await page.getByRole("button", { name: /new client/i }).first().click();
+    await page.waitForTimeout(800);
+    await shot(page, "new-client-form");
+    await page.getByLabel(/first name/i).fill("Riley");
+    await page.getByLabel(/last name/i).fill("Bennett");
+    const clientEmail = page.getByLabel(/email/i).first();
+    if (await clientEmail.isVisible().catch(() => false)) {
+      await clientEmail.fill("dogfood-owner@example.com");
+    }
+    const phone = page.getByLabel(/^phone/i).first();
+    if (await phone.isVisible().catch(() => false)) {
+      await phone.fill("(555) 010-7788");
+    }
+    const smsConsent = page.getByLabel(/text|sms/i).first();
+    if (await smsConsent.isVisible().catch(() => false)) {
+      await smsConsent.check().catch(() => {});
+    }
+    await shot(page, "new-client-filled");
+    await page
+      .getByRole("button", { name: /save|create client|add client/i })
+      .first()
+      .click();
+    await page.waitForTimeout(1500);
+    await shot(page, "client-created");
+  }
+
+  // Patient: dedicated /patients/new page with a client-search combobox.
+  await page.goto("/patients/new", { waitUntil: "networkidle" });
+  await page.fill(
+    'input[placeholder="Search clients by name or email..."]',
+    "Riley"
+  );
+  await page.waitForTimeout(1000);
+  await page.getByText(/riley bennett/i).first().click();
+  await page.fill("#name", "Juniper");
+  await page.selectOption("#species", "canine");
+  await page.fill("#breed", "Golden Retriever");
+  await shot(page, "new-patient-filled");
+  await page.getByRole("button", { name: /create patient/i }).click();
+  await page.waitForTimeout(2000);
+  await shot(page, "patient-created");
+
+  // Appointment: patient search + slot select, submit is "Save".
+  await page.goto("/schedule", { waitUntil: "networkidle" });
+  await page.getByRole("button", { name: /new appointment/i }).first().click();
+  await page.waitForTimeout(800);
+  await page.fill('input[placeholder="Search patients..."]', "Juniper");
+  await page.waitForTimeout(1000);
+  await page.getByText(/juniper/i).first().click();
+  await page.waitForTimeout(500);
+  await shot(page, "new-appointment-filled");
+  await page.getByRole("button", { name: /^save$/i }).click();
+  await page.waitForTimeout(2000);
+  await shot(page, "appointment-created");
+
+  await page.goto("/whiteboard", { waitUntil: "networkidle" });
+  await page.waitForTimeout(1200);
+  await shot(page, "whiteboard");
+});
+
+const JUNIPER_ID = process.env.DOGFOOD_PATIENT_ID ?? "";
+
+test("Dogfood C: check-in, vitals, SOAP, problem, Rx warning, lab", async ({ page }) => {
+  test.setTimeout(300_000);
+  await login(page);
+
+  // Check in the appointment from the schedule.
+  await page.goto("/schedule", { waitUntil: "networkidle" });
+  await page.waitForTimeout(1200);
+  const apptBlock = page.getByText(/juniper/i).first();
+  if (await apptBlock.isVisible().catch(() => false)) {
+    await apptBlock.click();
+    await page.waitForTimeout(800);
+    const checkIn = page.getByRole("button", { name: /check in/i }).first();
+    if (await checkIn.isVisible().catch(() => false)) {
+      await checkIn.click();
+      await page.waitForTimeout(1200);
+    }
+    await shot(page, "checked-in");
+  }
+  await page.goto("/whiteboard", { waitUntil: "networkidle" });
+  await page.waitForTimeout(1200);
+  await shot(page, "whiteboard-with-patient");
+
+  // Vitals on the patient chart.
+  await page.goto(`/patients/${JUNIPER_ID}`, { waitUntil: "networkidle" });
+  await page.getByRole("button", { name: /^vitals$/i }).first().click().catch(async () => {
+    await page.getByText(/^Vitals$/).first().click();
+  });
+  await page.waitForTimeout(800);
+  await page.locator('div:has(> label:has-text("Temp (C)")) input').fill("38.4");
+  await page.locator('div:has(> label:has-text("HR (bpm)")) input').fill("92");
+  await page.locator('div:has(> label:has-text("Weight (kg)")) input').fill("28.5").catch(() => {});
+  await shot(page, "vitals-filled");
+  await page.getByRole("button", { name: /record vitals/i }).click();
+  await page.waitForTimeout(1500);
+  await shot(page, "vitals-recorded");
+
+  // SOAP note (rich-text editors, one per S/O/A/P section).
+  await page.goto(`/records/new-soap/${JUNIPER_ID}`, { waitUntil: "networkidle" });
+  await page.waitForTimeout(1500);
+  const editors = page.locator('[contenteditable="true"]');
+  const soapText = [
+    "Owner reports Juniper has been scratching her left ear for three days.",
+    "T 38.4C, HR 92. Left ear canal erythematous with dark discharge. Right ear clean.",
+    "Otitis externa, left ear. R/O Malassezia vs bacterial.",
+    "Ear cytology today. Start topical treatment. Recheck in 14 days.",
+  ];
+  const editorCount = await editors.count();
+  for (let i = 0; i < Math.min(editorCount, 4); i++) {
+    await editors.nth(i).click();
+    await editors.nth(i).fill(soapText[i]!);
+  }
+  await shot(page, "soap-filled");
+  await page.getByRole("button", { name: /^save/i }).first().click();
+  await page.waitForTimeout(2000);
+  await shot(page, "soap-saved");
+
+  // Problem, prescription (allergy warning), lab on the records page.
+  await page.goto("/records", { waitUntil: "networkidle" });
+  await page.fill('input[placeholder="Search patients by name..."]', "Juniper");
+  await page.waitForTimeout(1000);
+  await page.getByText(/juniper/i).first().click();
+  await page.waitForTimeout(800);
+
+  await page.getByRole("button", { name: /problems/i }).first().click();
+  await page.waitForTimeout(500);
+  const addProblem = page.getByRole("button", { name: /add problem/i }).first();
+  if (await addProblem.isVisible().catch(() => false)) {
+    await addProblem.click();
+    await page.waitForTimeout(400);
+  }
+  await page.getByPlaceholder("e.g. Chronic otitis").fill("Otitis externa (left)");
+  await shot(page, "problem-filled");
+  await page.getByRole("button", { name: /add problem|save/i }).last().click();
+  await page.waitForTimeout(1200);
+
+  await page.getByRole("button", { name: /prescriptions/i }).first().click();
+  await page.waitForTimeout(500);
+  const newRx = page.getByRole("button", { name: /new prescription/i }).first();
+  if (await newRx.isVisible().catch(() => false)) {
+    await newRx.click();
+    await page.waitForTimeout(400);
+  }
+  await page.getByPlaceholder("e.g. Carprofen").fill("Penicillin");
+  await page.getByPlaceholder("e.g. 75 mg").fill("250 mg");
+  await page.getByPlaceholder("e.g. Every 12 hours").fill("Every 12 hours");
+  await page.getByPlaceholder("e.g. 30").fill("7");
+  await page.waitForTimeout(1500);
+  await shot(page, "rx-allergy-warning");
+  await page.getByRole("button", { name: /save prescription/i }).click();
+  await page.waitForTimeout(1500);
+  await shot(page, "rx-saved");
+
+  await page.getByRole("button", { name: /lab results/i }).first().click();
+  await page.waitForTimeout(500);
+  const newLab = page.getByRole("button", { name: /new lab|add lab|record result/i }).first();
+  if (await newLab.isVisible().catch(() => false)) {
+    await newLab.click();
+    await page.waitForTimeout(400);
+  }
+  await page.getByPlaceholder("e.g. CBC").fill("Ear cytology");
+  const labValue = page.getByPlaceholder("e.g. 12.5");
+  if (await labValue.isVisible().catch(() => false)) await labValue.fill("1");
+  await shot(page, "lab-filled");
+  await page.getByRole("button", { name: /save|record/i }).last().click();
+  await page.waitForTimeout(1500);
+  await shot(page, "lab-saved");
+});
+
+test("Dogfood C2: prescription with allergy warning + lab", async ({ page }) => {
+  test.setTimeout(240_000);
+  await login(page);
+
+  await page.goto("/records", { waitUntil: "networkidle" });
+  await page.fill('input[placeholder="Search patients by name..."]', "Juniper");
+  await page.waitForTimeout(1000);
+  await page.getByText(/juniper/i).first().click();
+  await page.waitForTimeout(800);
+
+  await page.getByRole("button", { name: /prescriptions/i }).first().click();
+  await page.waitForTimeout(500);
+  const newRx = page.getByRole("button", { name: /new prescription/i }).first();
+  if (await newRx.isVisible().catch(() => false)) {
+    await newRx.click();
+    await page.waitForTimeout(400);
+  }
+  await page.getByPlaceholder("e.g. Carprofen").fill("Penicillin");
+  await page.getByPlaceholder("e.g. 75 mg").fill("250 mg");
+  await page.getByPlaceholder("e.g. Every 12 hours").fill("Every 12 hours");
+  await page.getByPlaceholder("e.g. 30").fill("7");
+  await page.waitForTimeout(1800);
+  await shot(page, "rx-allergy-warning");
+  // A severe-allergy match blocks saving until the clinician acknowledges.
+  await page
+    .locator('label:has-text("Clinician reviewed") input')
+    .check();
+  await page.waitForTimeout(400);
+  await page.getByRole("button", { name: /save prescription/i }).click();
+  await page.waitForTimeout(1800);
+  await shot(page, "rx-saved");
+
+  await page.getByRole("button", { name: /lab results/i }).first().click();
+  await page.waitForTimeout(500);
+  const newLab = page
+    .getByRole("button", { name: /new lab|add lab|record result/i })
+    .first();
+  if (await newLab.isVisible().catch(() => false)) {
+    await newLab.click();
+    await page.waitForTimeout(400);
+  }
+  await page.getByPlaceholder("e.g. CBC").fill("Ear cytology");
+  const labValue = page.getByPlaceholder("e.g. 12.5");
+  if (await labValue.isVisible().catch(() => false)) await labValue.fill("1");
+  await shot(page, "lab-filled");
+  await page.getByRole("button", { name: /save|record/i }).last().click();
+  await page.waitForTimeout(1800);
+  await shot(page, "lab-saved");
+});

--- a/e2e/dogfood.spec.ts
+++ b/e2e/dogfood.spec.ts
@@ -330,7 +330,7 @@ test("Dogfood C2: prescription with allergy warning + lab", async ({ page }) => 
   // A severe-allergy match blocks saving until the clinician acknowledges.
   await page
     .locator('label:has-text("Clinician reviewed") input')
-    .check();
+    .check({ force: true });
   await page.waitForTimeout(400);
   await page.getByRole("button", { name: /save prescription/i }).click();
   await page.waitForTimeout(1800);


### PR DESCRIPTION
## Summary
Overnight Phase 5 dogfood on a freshly registered practice caught a real race on the very first signup: **finishing the onboarding wizard didn't stick**. `completeOnboarding` and `setJourneyProgress` (fired moments apart) both did select → spread → update on the whole `practices.settings` JSON, so the cursor write clobbered the completion write (`journeyStepId: "allSet"` present, `onboardingCompletedAt` missing).

- All `practices.settings` writers now patch atomically in-database: top-level merges via `settings || patch`, nested onboarding-state merges via `jsonb_set(..., state || patch)`, key removal via `settings - 'key'` — completeOnboarding, setJourneyProgress, setTourStatus, dismissSetup, clearDemoData, reseedDemoData.
- Missing/deleted practices still surface NOT_FOUND via guarded updates (zero rows), matching `updatePractice`'s existing pattern; safety test updated accordingly.
- Adds `e2e/dogfood.spec.ts`, the §6 "run the clinic for a day" driver (local-only, env-parameterized, example-domain defaults; excluded from CI which has no dev server/seed).

## Verification
- `tsc --noEmit` clean; full vitest suite green: 220 files / 1,948 tests.
- Dogfood re-verified after fix: fresh practice reaches `trialing` with demo data; wizard completion persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)