### PR TITLE
Fix: legal pages public in auth middleware

### DIFF
--- a/apps/web/lib/__tests__/legal-pages.test.ts
+++ b/apps/web/lib/__tests__/legal-pages.test.ts
@@ -24,4 +24,9 @@ describe("legal pages", () => {
     expect(register).toContain('href="/legal/privacy"');
     expect(portal).toContain('href="/legal/privacy"');
   });
+
+  it("keeps legal pages public in the auth middleware", () => {
+    const middleware = readFileSync("middleware.ts", "utf8");
+    expect(middleware).toContain('"/legal",');
+  });
 });

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -9,6 +9,7 @@ const PUBLIC_PATH_PREFIXES = [
   "/api",
   "/api-docs",
   "/forgot-password",
+  "/legal",
   "/login",
   "/portal",
   "/register",


### PR DESCRIPTION
Prod smoke after #44 deployed: /legal/terms 307-redirected to /login because the middleware public-path allowlist lacked /legal. One-line fix + test pinning it. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)