### PR TITLE
No-card trial becomes the default hosted signup

### DIFF
--- a/apps/web/lib/billing/plans.ts
+++ b/apps/web/lib/billing/plans.ts
@@ -243,13 +243,15 @@ export function planHasFeature(tier: string | null | undefined, feature: Feature
 export const TRIAL_DAYS = 14;
 
 /**
- * Whether hosted signups start a card-free trial. When true, a new practice is
- * granted a `trialing` window at signup with NO Stripe subscription — the user
- * lands straight in the product and only enters card details to convert. When
- * false (legacy), signup redirects to card-collected Stripe Checkout first.
+ * Whether hosted signups start a card-free trial. This is the DEFAULT: a new
+ * practice is granted a `trialing` window at signup with NO Stripe
+ * subscription — the user lands straight in the product and only enters card
+ * details to convert. Set HOSTED_NO_CARD_TRIAL=false to reinstate the legacy
+ * card-collected Stripe Checkout wall at signup (kept as a reversible lever
+ * while we gather conversion data).
  */
 export function noCardTrialEnabled(): boolean {
-  return envFlagEnabled("HOSTED_NO_CARD_TRIAL");
+  return process.env.HOSTED_NO_CARD_TRIAL?.trim().toLowerCase() !== "false";
 }
 
 /** The trial-end timestamp for a trial starting now (or at `from`). */

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -15,7 +15,7 @@ This boundary is intentional. Do not add hosted-only requirements to the self-ho
 - `Try the Live Demo` -> `${NEXT_PUBLIC_DEMO_URL}/login`
 - `Self-host OpenVPM` -> `/install` and GitHub
 
-Cloud signup creates a practice, a primary location, the owner admin user, default configuration, and hosted first-run demo data. With `HOSTED_NO_CARD_TRIAL=true`, signup grants a 14-day trial immediately with no card and the clinic lands in the product (adding a card converts to paid); email verification is a soft prompt, not a login gate.
+Cloud signup creates a practice, a primary location, the owner admin user, default configuration, and hosted first-run demo data. By default, signup grants a 14-day trial immediately with no card and the clinic lands in the product (adding a card converts to paid); email verification is a soft prompt, not a login gate. Set `HOSTED_NO_CARD_TRIAL=false` to reinstate the legacy card-collected checkout wall at signup.
 
 Set the marketing deployment envs to:
 


### PR DESCRIPTION
Flips the default: hosted signup grants the 14-day card-free trial without needing `HOSTED_NO_CARD_TRIAL=true` set. The flag stays as the reversal lever (`=false` restores the card-collected checkout wall) so the posture can change as conversion data comes in. Doc updated. Full suite green: 220 files / 1,949 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)