### PR TITLE
Guide engine: named walkthrough recipes + welcome context (groundwork)

### DIFF
--- a/apps/web/app/(dashboard)/agent/page.tsx
+++ b/apps/web/app/(dashboard)/agent/page.tsx
@@ -18,6 +18,10 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/common/empty-state";
 import {
+  emitGuideSignal,
+  GUIDE_SIGNALS,
+} from "@/components/tour/guide-signals";
+import {
   AGENT_INSTRUCTION_MAX_LENGTH,
   isAgentInstructionValid,
 } from "@/lib/agent/policy";
@@ -77,6 +81,7 @@ export default function AgentPage() {
 }
 
 function AgentRunner() {
+  const router = useRouter();
   const status = trpc.agent.status.useQuery();
   const run = trpc.agent.run.useMutation();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -85,6 +90,20 @@ function AgentRunner() {
   const idRef = useRef(0);
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const prefilled = useRef(false);
+
+  // One-shot ?ask= prefill (guides deep-link here with a ready question).
+  // The param is stripped right away so a refresh will not re-fill.
+  useEffect(() => {
+    if (prefilled.current || typeof window === "undefined") return;
+    prefilled.current = true;
+    const ask = new URLSearchParams(window.location.search).get("ask");
+    if (ask?.trim()) {
+      setInstruction(ask.trim().slice(0, AGENT_INSTRUCTION_MAX_LENGTH));
+      router.replace("/agent");
+      textareaRef.current?.focus();
+    }
+  }, [router]);
 
   const statusMissing = !status.isLoading && !status.error && !status.data;
   const verifiedAgentStatus =
@@ -150,6 +169,7 @@ function AgentRunner() {
               toolCalls: data.toolCalls,
             },
           ]);
+          emitGuideSignal(GUIDE_SIGNALS.agentRunSucceeded);
         },
         onError: (err) => {
           setMessages((prev) => [
@@ -291,7 +311,10 @@ function AgentRunner() {
 
       {/* Composer */}
       <div className="mt-3 shrink-0">
-        <div className="rounded-2xl border border-border bg-card p-2 shadow-sm focus-within:border-primary/40">
+        <div
+          data-tour="agent-input"
+          className="rounded-2xl border border-border bg-card p-2 shadow-sm focus-within:border-primary/40"
+        >
           <textarea
             ref={textareaRef}
             value={instruction}

--- a/apps/web/app/(dashboard)/clients/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/clients/[id]/page.tsx
@@ -26,6 +26,10 @@ import { trpc } from "@/lib/trpc";
 import { EmptyState } from "@/components/common/empty-state";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  emitGuideSignal,
+  GUIDE_SIGNALS,
+} from "@/components/tour/guide-signals";
 import { toast } from "sonner";
 import { useCurrencyFormatter } from "@/lib/locale/useCurrency";
 import {
@@ -153,6 +157,7 @@ export default function ClientDetailPage() {
         `${window.location.origin}${portalPath}`
       );
       toast.success("Portal link copied");
+      emitGuideSignal(GUIDE_SIGNALS.portalLinkCopied);
     } catch {
       toast.error("Could not copy portal link");
     }
@@ -218,7 +223,10 @@ export default function ClientDetailPage() {
         </div>
       </div>
 
-      <div className="mt-6 rounded-lg border border-border bg-card p-6">
+      <div
+        data-tour="client-portal-link"
+        className="mt-6 rounded-lg border border-border bg-card p-6"
+      >
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <h3 className="font-heading text-lg font-semibold">

--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -1951,7 +1951,8 @@ export default function SchedulePage() {
         </div>
       </div>
 
-      {/* Error */}
+      {/* Calendar area (the "your day" guide spotlights this region) */}
+      <div data-tour="schedule-calendar">
       {scheduleError || scheduleMissing ? (
         <div className="mt-4 rounded-lg border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
           {scheduleError?.message ?? "Unable to load schedule. Please retry."}
@@ -2055,6 +2056,7 @@ export default function SchedulePage() {
           onAppointmentClick={setSelectedAppointment}
         />
       )}
+      </div>
 
       {/* Detail popover */}
       {selectedAppointmentFromList &&

--- a/apps/web/app/(dashboard)/whiteboard/page.tsx
+++ b/apps/web/app/(dashboard)/whiteboard/page.tsx
@@ -639,6 +639,8 @@ export default function WhiteboardPage() {
         </div>
       </div>
 
+      {/* Board area (the "your day" guide spotlights this region) */}
+      <div data-tour="whiteboard-board">
       {pageError || pageMissing ? (
         <div className="mt-4 rounded-lg border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
           {pageError?.message ?? "Unable to load whiteboard. Please retry."}
@@ -719,6 +721,7 @@ export default function WhiteboardPage() {
           }}
         />
       )}
+      </div>
 
       {/* Detail modal */}
       {selectedAppointmentFromList &&

--- a/apps/web/components/tour/guide-recipes.ts
+++ b/apps/web/components/tour/guide-recipes.ts
@@ -1,0 +1,125 @@
+/**
+ * Named guide recipes: short walkthroughs the welcome surface (and the
+ * sidebar Guides entry) can launch through the shared coachmark engine in
+ * tour-provider. The classic value tour is the "tour" recipe; the others are
+ * the "first win" guides, built at start time from a small context object so
+ * routes and copy can use live data (the demo client, the demo patient) and
+ * degrade gracefully once demo data is cleared.
+ *
+ * Voice: simple, fourth-grade, warm, no em dashes. Benefits first.
+ */
+
+import type { GuideId } from "@/lib/welcome/cards";
+import { GUIDE_SIGNALS } from "./guide-signals";
+import { TOUR_STEPS, type TourStep } from "./tour-steps";
+
+export interface GuideStep extends TourStep {
+  /**
+   * Guide signal that auto-advances past this step (see guide-signals.ts).
+   * The Next button still works, so a step never blocks on the signal.
+   */
+  advanceOn?: string;
+}
+
+export interface GuideContext {
+  /** Target client for the portal guide (demo client, else first real one). */
+  portalClient?: { id: string; firstName: string } | null;
+  /** First demo patient's name, e.g. "Biscuit", when demo data is present. */
+  demoPatientName?: string | null;
+  /** False when the AI agent has no platform key; the guide never blocks. */
+  agentConfigured?: boolean;
+}
+
+export const AGENT_GUIDE_QUESTION = "Which pets are overdue for vaccines?";
+
+export function buildGuideSteps(
+  recipe: GuideId,
+  ctx: GuideContext = {}
+): GuideStep[] {
+  switch (recipe) {
+    case "tour":
+      return TOUR_STEPS;
+
+    case "ask-ai": {
+      const ready = ctx.agentConfigured !== false;
+      return [
+        {
+          id: "ask",
+          route: `/agent?ask=${encodeURIComponent(AGENT_GUIDE_QUESTION)}`,
+          anchor: "agent-input",
+          title: "Ask about a pet",
+          body: ready
+            ? "Your question is ready to go. Press send and watch the AI check every chart for you."
+            : "Your AI helper turns on once your workspace key is set. Here is where you will ask it questions in plain words.",
+          advanceOn: ready ? GUIDE_SIGNALS.agentRunSucceeded : undefined,
+        },
+        {
+          id: "done",
+          title: "That easy",
+          body: "The AI just read your charts so you did not have to. Ask it anything about your clinic, any time.",
+        },
+      ];
+    }
+
+    case "your-day": {
+      const patient = ctx.demoPatientName;
+      return [
+        {
+          id: "schedule",
+          route: "/schedule",
+          anchor: "schedule-calendar",
+          title: "Your day sheet",
+          body: patient
+            ? `Every booked visit lives here. ${patient} is already on today's schedule.`
+            : "Every booked visit lives here, day by day. Click any open slot to book one.",
+        },
+        {
+          id: "whiteboard",
+          route: "/whiteboard",
+          anchor: "whiteboard-board",
+          title: "Who is here right now",
+          body: "When a pet checks in, the whole team sees it here. No sticky notes, no shouting down the hall.",
+        },
+        {
+          id: "done",
+          title: "That is your whole day",
+          body: "Front desk to exam room on one screen. Book a visit, check the pet in, and everyone stays in the loop.",
+        },
+      ];
+    }
+
+    case "client-portal": {
+      if (!ctx.portalClient) {
+        return [
+          {
+            id: "empty",
+            route: "/clients",
+            title: "Every client gets a portal",
+            body: "Add your first client and they get their own private link right away. Pet parents can see visits and bills without calling you.",
+          },
+        ];
+      }
+      const first = ctx.portalClient.firstName;
+      return [
+        {
+          id: "copy",
+          route: `/clients/${ctx.portalClient.id}`,
+          anchor: "client-portal-link",
+          title: "A private link for every client",
+          body: `${first} has a private portal link. Copy it here, then share it by text or email.`,
+          advanceOn: GUIDE_SIGNALS.portalLinkCopied,
+        },
+        {
+          id: "done",
+          title: "Fewer calls for you",
+          body: `Open the link to see what ${first} sees: pets, visits, and bills. Clients help themselves, and your phone rings less.`,
+        },
+      ];
+    }
+
+    case "calendar-feed":
+      // Ships with the calendar subscribe button (its anchor does not exist
+      // yet). An empty recipe makes start() a safe no-op until then.
+      return [];
+  }
+}

--- a/apps/web/components/tour/guide-signals.ts
+++ b/apps/web/components/tour/guide-signals.ts
@@ -1,0 +1,29 @@
+/**
+ * One-way signals from product code into an active guide. A page that
+ * completes a guide-relevant action (an agent run succeeds, a portal link is
+ * copied) emits a named signal; the tour provider auto-advances any active
+ * guide step that declared it via `advanceOn`. Emissions are no-ops when no
+ * guide is listening, so call sites stay one-liners with zero coupling.
+ */
+
+export const GUIDE_SIGNAL_EVENT = "ovpm:guide-signal";
+
+export const GUIDE_SIGNALS = {
+  agentRunSucceeded: "agent-run-succeeded",
+  portalLinkCopied: "portal-link-copied",
+  calendarUrlCopied: "calendar-url-copied",
+} as const;
+
+export type GuideSignal = (typeof GUIDE_SIGNALS)[keyof typeof GUIDE_SIGNALS];
+
+export function emitGuideSignal(name: GuideSignal): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent(GUIDE_SIGNAL_EVENT, { detail: { name } })
+  );
+}
+
+export function guideSignalName(event: Event): string | null {
+  const detail = (event as CustomEvent<{ name?: unknown }>).detail;
+  return typeof detail?.name === "string" ? detail.name : null;
+}

--- a/apps/web/components/tour/tour-provider.tsx
+++ b/apps/web/components/tour/tour-provider.tsx
@@ -11,23 +11,44 @@ import {
 import { useRouter, usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { trpc } from "@/lib/trpc";
+import type { GuideId } from "@/lib/welcome/cards";
+import { markGuideCompleted } from "@/lib/welcome/local-state";
 import { TOUR_STEPS } from "./tour-steps";
+import {
+  buildGuideSteps,
+  type GuideContext,
+  type GuideStep,
+} from "./guide-recipes";
+import { GUIDE_SIGNAL_EVENT, guideSignalName } from "./guide-signals";
 import { useAnchorRect } from "./use-tour-anchor";
 import { Coachmark } from "./coachmark";
 
 interface TourContextValue {
-  /** Manually (re)start the tour from the beginning. */
-  start: () => void;
+  /**
+   * Start a guide from its first step. No recipe id = the classic value tour
+   * (admin-only, persisted server-side). Named guides are open to all staff
+   * and record completion per user on this device.
+   */
+  start: (recipe?: GuideId, ctx?: GuideContext) => void;
   isActive: boolean;
+  /** Which guide is running, or null. */
+  activeGuide: GuideId | null;
 }
 
 const TourContext = createContext<TourContextValue>({
   start: () => {},
   isActive: false,
+  activeGuide: null,
 });
 
 export function useTour() {
   return useContext(TourContext);
+}
+
+interface ActiveRun {
+  recipe: GuideId;
+  steps: GuideStep[];
+  index: number;
 }
 
 export function TourProvider({ children }: { children: React.ReactNode }) {
@@ -36,6 +57,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
   const { data: session, status } = useSession();
   const isAdmin =
     status === "authenticated" && session?.user?.role === "admin";
+  const userId = session?.user?.id ?? null;
 
   const utils = trpc.useUtils();
   const stateQuery = trpc.settings.getOnboardingState.useQuery(undefined, {
@@ -43,11 +65,13 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
   });
   const setTourStatus = trpc.settings.setTourStatus.useMutation();
 
-  // null = tour inactive; otherwise the active step index.
-  const [index, setIndex] = useState<number | null>(null);
+  // null = no guide running; otherwise the active recipe + step cursor.
+  const [run, setRun] = useState<ActiveRun | null>(null);
   // Auto-start runs at most once per mount, so finishing/skipping never relaunches.
   const autoStarted = useRef(false);
 
+  // Server persistence exists only for the classic tour; named guides record
+  // completion in per-user local state instead (viewers cannot mutate).
   const persist = useCallback(
     (status: "in_progress" | "completed" | "skipped", stepId?: string) => {
       if (!isAdmin) return;
@@ -67,18 +91,26 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
     [isAdmin, setTourStatus, utils]
   );
 
-  const start = useCallback(() => {
-    if (!isAdmin) return;
-
-    setIndex(0);
-    persist("in_progress", TOUR_STEPS[0]!.id);
-  }, [isAdmin, persist]);
+  const start = useCallback(
+    (recipe: GuideId = "tour", ctx: GuideContext = {}) => {
+      if (recipe === "tour") {
+        if (!isAdmin) return;
+        setRun({ recipe, steps: TOUR_STEPS, index: 0 });
+        persist("in_progress", TOUR_STEPS[0]!.id);
+        return;
+      }
+      const steps = buildGuideSteps(recipe, ctx);
+      if (steps.length === 0) return;
+      setRun({ recipe, steps, index: 0 });
+    },
+    [isAdmin, persist]
+  );
 
   // Start ONLY on an explicit ?tour=start deep-link. Onboarding is opt-in: a
   // not-yet-started workspace is no longer auto-nagged into the tour — the
-  // welcome panel and activation checklist invoke start() on demand instead.
+  // welcome surface and activation checklist invoke start() on demand instead.
   useEffect(() => {
-    if (autoStarted.current || index !== null || !isAdmin) return;
+    if (autoStarted.current || run !== null || !isAdmin) return;
     const wantStart =
       typeof window !== "undefined" &&
       new URLSearchParams(window.location.search).get("tour") === "start";
@@ -88,51 +120,72 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
       start();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAdmin, stateQuery.data, pathname, index]);
+  }, [isAdmin, stateQuery.data, pathname, run]);
 
-  const step = index !== null ? TOUR_STEPS[index] : null;
+  const step = run ? run.steps[run.index] ?? null : null;
 
-  // Navigate to the step's route when the step changes.
+  // Navigate to the step's route when the step changes. Routes may carry a
+  // one-shot query string (e.g. /agent?ask=...); compare on the path only.
   useEffect(() => {
     if (!step?.route) return;
-    if (pathname !== step.route) router.push(step.route);
+    const routePath = step.route.split("?")[0]!;
+    if (pathname !== routePath) router.push(step.route);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [index]);
-
-  const rect = useAnchorRect(step?.anchor, index);
-
-  const total = TOUR_STEPS.length;
+  }, [run?.index, run?.recipe]);
 
   const onNext = useCallback(() => {
-    setIndex((i) => {
-      if (i === null) return i;
-      if (i >= total - 1) {
-        persist("completed");
+    setRun((r) => {
+      if (!r) return r;
+      if (r.index >= r.steps.length - 1) {
+        if (r.recipe === "tour") persist("completed");
+        else markGuideCompleted(userId, r.recipe);
         return null;
       }
-      persist("in_progress", TOUR_STEPS[i + 1]!.id);
-      return i + 1;
+      if (r.recipe === "tour") persist("in_progress", r.steps[r.index + 1]!.id);
+      return { ...r, index: r.index + 1 };
     });
-  }, [persist, total]);
+  }, [persist, userId]);
 
   const onBack = useCallback(
-    () => setIndex((i) => (i && i > 0 ? i - 1 : i)),
+    () =>
+      setRun((r) => (r && r.index > 0 ? { ...r, index: r.index - 1 } : r)),
     []
   );
 
   const onSkip = useCallback(() => {
-    persist("skipped");
-    setIndex(null);
+    setRun((r) => {
+      if (r?.recipe === "tour") persist("skipped");
+      return null;
+    });
   }, [persist]);
 
+  // Auto-advance the active step when product code emits its signal (e.g. an
+  // agent run succeeded, a portal link was copied). Next still works, so a
+  // missing signal never strands anyone.
+  const advanceOn = step?.advanceOn;
+  useEffect(() => {
+    if (!advanceOn || typeof window === "undefined") return;
+    const onSignal = (event: Event) => {
+      if (guideSignalName(event) === advanceOn) onNext();
+    };
+    window.addEventListener(GUIDE_SIGNAL_EVENT, onSignal);
+    return () => window.removeEventListener(GUIDE_SIGNAL_EVENT, onSignal);
+  }, [advanceOn, onNext]);
+
+  const rect = useAnchorRect(step?.anchor, run?.index);
+
+  const total = run?.steps.length ?? 0;
+
   return (
-    <TourContext.Provider value={{ start, isActive: index !== null }}>
+    <TourContext.Provider
+      value={{ start, isActive: run !== null, activeGuide: run?.recipe ?? null }}
+    >
       {children}
-      {step ? (
+      {run && step ? (
         <Coachmark
           rect={step.anchor ? rect : null}
           step={step}
-          index={index!}
+          index={run.index}
           total={total}
           onNext={onNext}
           onBack={onBack}

--- a/apps/web/lib/__tests__/guide-recipes.test.ts
+++ b/apps/web/lib/__tests__/guide-recipes.test.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_GUIDE_QUESTION,
+  buildGuideSteps,
+  type GuideContext,
+} from "@/components/tour/guide-recipes";
+import { GUIDE_SIGNALS } from "@/components/tour/guide-signals";
+import type { GuideId } from "../welcome/cards";
+
+const ALL_GUIDES: GuideId[] = [
+  "tour",
+  "ask-ai",
+  "your-day",
+  "client-portal",
+  "calendar-feed",
+];
+
+/**
+ * Where each spotlight anchor must exist as a literal data-tour attribute.
+ * This test is the drift guard: renaming or removing an anchored element
+ * without updating the recipe fails here instead of silently degrading the
+ * guide to a centered card.
+ */
+const ANCHOR_SOURCES: Record<string, string> = {
+  "agent-input": "app/(dashboard)/agent/page.tsx",
+  "schedule-calendar": "app/(dashboard)/schedule/page.tsx",
+  "whiteboard-board": "app/(dashboard)/whiteboard/page.tsx",
+  "client-portal-link": "app/(dashboard)/clients/[id]/page.tsx",
+  "calendar-subscribe": "components/schedule/calendar-subscribe.tsx",
+};
+
+const RICH_CONTEXT: GuideContext = {
+  portalClient: { id: "client-1", firstName: "Jordan" },
+  demoPatientName: "Biscuit",
+  agentConfigured: true,
+};
+
+function allSteps(ctx: GuideContext) {
+  return ALL_GUIDES.flatMap((id) => buildGuideSteps(id, ctx));
+}
+
+describe("guide recipes", () => {
+  it("every recipe anchor exists as a data-tour attribute in its source", () => {
+    for (const step of allSteps(RICH_CONTEXT)) {
+      if (!step.anchor) continue;
+      if (step.anchor.startsWith("nav-")) {
+        // Sidebar nav anchors are emitted dynamically per nav item.
+        const sidebar = readFileSync("components/layout/sidebar.tsx", "utf8");
+        expect(sidebar).toContain("data-tour={`nav-${");
+        continue;
+      }
+      const source = ANCHOR_SOURCES[step.anchor];
+      expect(
+        source,
+        `anchor "${step.anchor}" has no source mapping in ANCHOR_SOURCES`
+      ).toBeTruthy();
+      const file = readFileSync(source!, "utf8");
+      expect(
+        file,
+        `expected ${source} to contain data-tour="${step.anchor}"`
+      ).toContain(`data-tour="${step.anchor}"`);
+    }
+  });
+
+  it("ask-ai deep-links the prefilled question and advances on a successful run", () => {
+    const steps = buildGuideSteps("ask-ai", RICH_CONTEXT);
+    expect(steps[0]!.route).toBe(
+      `/agent?ask=${encodeURIComponent(AGENT_GUIDE_QUESTION)}`
+    );
+    expect(steps[0]!.advanceOn).toBe(GUIDE_SIGNALS.agentRunSucceeded);
+    expect(steps.length).toBeGreaterThan(1);
+  });
+
+  it("ask-ai never blocks when the agent is not configured", () => {
+    const steps = buildGuideSteps("ask-ai", {
+      ...RICH_CONTEXT,
+      agentConfigured: false,
+    });
+    expect(steps[0]!.advanceOn).toBeUndefined();
+    expect(steps[0]!.body).toContain("turns on once");
+  });
+
+  it("your-day names the demo patient when present and stays generic otherwise", () => {
+    const withDemo = buildGuideSteps("your-day", RICH_CONTEXT);
+    expect(withDemo[0]!.body).toContain("Biscuit");
+    const without = buildGuideSteps("your-day", {});
+    expect(without[0]!.body).not.toContain("Biscuit");
+    expect(without.map((s) => s.route)).toContain("/whiteboard");
+  });
+
+  it("client-portal routes to the target client and advances on copy", () => {
+    const steps = buildGuideSteps("client-portal", RICH_CONTEXT);
+    expect(steps[0]!.route).toBe("/clients/client-1");
+    expect(steps[0]!.advanceOn).toBe(GUIDE_SIGNALS.portalLinkCopied);
+    expect(steps[0]!.body).toContain("Jordan");
+  });
+
+  it("client-portal degrades to a single pointer when there is no client", () => {
+    const steps = buildGuideSteps("client-portal", { portalClient: null });
+    expect(steps).toHaveLength(1);
+    expect(steps[0]!.route).toBe("/clients");
+    expect(steps[0]!.advanceOn).toBeUndefined();
+  });
+
+  it("calendar-feed stays a no-op until the subscribe button ships", () => {
+    expect(buildGuideSteps("calendar-feed", RICH_CONTEXT)).toEqual([]);
+  });
+
+  it("keeps guide copy in voice: no em or en dashes", () => {
+    for (const step of [
+      ...allSteps(RICH_CONTEXT),
+      ...allSteps({}),
+      ...allSteps({ agentConfigured: false }),
+    ]) {
+      expect(step.title).not.toMatch(/[—–]/);
+      expect(step.body).not.toMatch(/[—–]/);
+    }
+  });
+});

--- a/apps/web/lib/__tests__/welcome-cards.test.ts
+++ b/apps/web/lib/__tests__/welcome-cards.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  canRunAgentGuideRole,
+  visibleWelcomeCards,
+} from "../welcome/cards";
+
+describe("welcome card visibility", () => {
+  it("shows all four cards to roles that can run the agent", () => {
+    for (const role of ["admin", "veterinarian"]) {
+      const cards = visibleWelcomeCards({ role });
+      expect(cards).toEqual([
+        "ask-ai",
+        "your-day",
+        "client-portal",
+        "calendar-feed",
+      ]);
+    }
+  });
+
+  it("hides the AI card for roles without agent access", () => {
+    for (const role of ["front_desk", "technician", "viewer"]) {
+      const cards = visibleWelcomeCards({ role });
+      expect(cards).toEqual(["your-day", "client-portal", "calendar-feed"]);
+      expect(cards).not.toContain("ask-ai");
+    }
+  });
+
+  it("treats a missing role as no agent access", () => {
+    expect(visibleWelcomeCards({ role: null })).toEqual([
+      "your-day",
+      "client-portal",
+      "calendar-feed",
+    ]);
+    expect(visibleWelcomeCards({})).toEqual([
+      "your-day",
+      "client-portal",
+      "calendar-feed",
+    ]);
+  });
+
+  it("matches the agent page's own role gate", () => {
+    // agent/page.tsx canRunAgentRole: admin | veterinarian only.
+    expect(canRunAgentGuideRole("admin")).toBe(true);
+    expect(canRunAgentGuideRole("veterinarian")).toBe(true);
+    expect(canRunAgentGuideRole("technician")).toBe(false);
+    expect(canRunAgentGuideRole("front_desk")).toBe(false);
+    expect(canRunAgentGuideRole("viewer")).toBe(false);
+    expect(canRunAgentGuideRole(undefined)).toBe(false);
+  });
+});

--- a/apps/web/lib/welcome/cards.ts
+++ b/apps/web/lib/welcome/cards.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure derivation of which welcome guide cards a user can see. Kept free of
+ * React so the role matrix is unit-testable.
+ *
+ * "tour" is the classic value tour (admin-only, persisted server-side); the
+ * other guides are the welcome walkthroughs, open to every staff role. The
+ * AI guide is the exception: the agent itself is admin + veterinarian only
+ * (agentProcedure), so the card hides for roles that could never run it.
+ */
+
+export type GuideId =
+  | "tour"
+  | "ask-ai"
+  | "your-day"
+  | "client-portal"
+  | "calendar-feed";
+
+/** Cards shown on the welcome surface, in display order. */
+export type WelcomeCardId = Exclude<GuideId, "tour">;
+
+export function canRunAgentGuideRole(role?: string | null): boolean {
+  return role === "admin" || role === "veterinarian";
+}
+
+export function visibleWelcomeCards(opts: {
+  role?: string | null;
+}): WelcomeCardId[] {
+  const cards: WelcomeCardId[] = [];
+  if (canRunAgentGuideRole(opts.role)) {
+    cards.push("ask-ai");
+  }
+  cards.push("your-day", "client-portal", "calendar-feed");
+  return cards;
+}

--- a/apps/web/lib/welcome/local-state.ts
+++ b/apps/web/lib/welcome/local-state.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-user welcome + guide progress, stored in localStorage.
+ *
+ * Why localStorage and not the server: the users table has no per-user prefs
+ * column, and the tRPC layer blocks ALL mutations for the viewer role, so a
+ * server write would silently fail for viewers. Welcome-seen is low stakes
+ * (re-showing once per device is fine, and guides are re-entrant from the
+ * sidebar). Upgrade path if this ever needs to roam: a users.ui_state jsonb
+ * column plus a protectedProcedure that also allows viewers.
+ */
+
+import type { GuideId } from "./cards";
+
+const KEY_PREFIX = "ovpm.welcome.v1.";
+
+export interface WelcomeLocalState {
+  /** ISO timestamp of the first time this user saw (or skipped) the welcome. */
+  seenAt?: string;
+  guides?: Partial<Record<GuideId, "completed">>;
+}
+
+function storageKey(userId: string): string {
+  return `${KEY_PREFIX}${userId}`;
+}
+
+export function readWelcomeState(
+  userId: string | null | undefined
+): WelcomeLocalState {
+  if (!userId || typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(storageKey(userId));
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    return parsed as WelcomeLocalState;
+  } catch {
+    return {};
+  }
+}
+
+function writeWelcomeState(userId: string, state: WelcomeLocalState): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKey(userId), JSON.stringify(state));
+  } catch {
+    // Storage full or blocked; the welcome may show again on this device.
+  }
+}
+
+export function markWelcomeSeen(userId: string | null | undefined): void {
+  if (!userId) return;
+  const state = readWelcomeState(userId);
+  if (state.seenAt) return;
+  writeWelcomeState(userId, { ...state, seenAt: new Date().toISOString() });
+}
+
+export function markGuideCompleted(
+  userId: string | null | undefined,
+  guide: GuideId
+): void {
+  if (!userId) return;
+  const state = readWelcomeState(userId);
+  writeWelcomeState(userId, {
+    ...state,
+    guides: { ...state.guides, [guide]: "completed" },
+  });
+}
+
+export function isGuideCompleted(
+  userId: string | null | undefined,
+  guide: GuideId
+): boolean {
+  return readWelcomeState(userId).guides?.[guide] === "completed";
+}

--- a/apps/web/server/__tests__/settings-welcome-context.test.ts
+++ b/apps/web/server/__tests__/settings-welcome-context.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/billing/subscription-sync", () => ({
+  syncPracticeSubscriptionQuantities: vi.fn(async () => ({
+    status: "ok",
+    message: "synced",
+    updatedAt: new Date("2026-07-08T00:00:00Z").toISOString(),
+    locationCount: 1,
+    billableSeatCount: 1,
+  })),
+}));
+
+const { settingsRouter } = await import("../routers/settings");
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+const DEMO_CLIENT_ID = "00000000-0000-0000-0000-000000000010";
+const DEMO_PATIENT_ID = "00000000-0000-0000-0000-000000000011";
+
+function callerWithRole(db: Record<string, unknown>, role: string) {
+  const session = {
+    user: {
+      id: USER_ID,
+      email: "staff@example.com",
+      name: "Staff",
+      role,
+      practiceId: PRACTICE_ID,
+    },
+  };
+  return settingsRouter.createCaller({ db, session } as never);
+}
+
+/** Sequenced select mock: each select() call consumes the next result set. */
+function createDb(selectResults: unknown[][]) {
+  const remaining = [...selectResults];
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn(async () => remaining.shift() ?? []),
+      })),
+    })),
+  }));
+  const db: Record<string, unknown> = {
+    transaction: async (fn: (tx: unknown) => unknown) => fn(db),
+    execute: vi.fn(async () => undefined),
+    select,
+  };
+  return { db, select };
+}
+
+const practiceRow = (settings: Record<string, unknown>) => ({
+  name: "Aspen Creek Animal Hospital",
+  settings,
+});
+
+const demoSettings = {
+  demoData: {
+    clientIds: [DEMO_CLIENT_ID],
+    patientIds: [DEMO_PATIENT_ID],
+    appointmentIds: [],
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("settings.welcomeContext", () => {
+  it("returns the live demo client and patient for a fresh trial", async () => {
+    const { db } = createDb([
+      [practiceRow(demoSettings)],
+      [{ id: DEMO_CLIENT_ID, firstName: "Jordan", lastName: "Avery" }],
+      [{ name: "Biscuit" }],
+    ]);
+
+    const result = await callerWithRole(db, "front_desk").welcomeContext();
+    expect(result).toEqual({
+      practiceName: "Aspen Creek Animal Hospital",
+      hasDemoData: true,
+      portalClient: {
+        id: DEMO_CLIENT_ID,
+        firstName: "Jordan",
+        lastName: "Avery",
+      },
+      demoPatientName: "Biscuit",
+    });
+  });
+
+  it("falls back to the first real client once demo rows are gone", async () => {
+    const { db } = createDb([
+      [practiceRow(demoSettings)],
+      [], // demo client soft-deleted
+      [{ id: "real-1", firstName: "Riley", lastName: "Bennett" }],
+      [], // demo patient soft-deleted
+    ]);
+
+    const result = await callerWithRole(db, "admin").welcomeContext();
+    expect(result.portalClient).toEqual({
+      id: "real-1",
+      firstName: "Riley",
+      lastName: "Bennett",
+    });
+    expect(result.demoPatientName).toBeNull();
+    expect(result.hasDemoData).toBe(true);
+  });
+
+  it("returns nulls for an empty practice with no demo data", async () => {
+    const { db } = createDb([
+      [practiceRow({})],
+      [], // fallback client lookup finds nobody
+    ]);
+
+    const result = await callerWithRole(db, "technician").welcomeContext();
+    expect(result.portalClient).toBeNull();
+    expect(result.demoPatientName).toBeNull();
+    expect(result.hasDemoData).toBe(false);
+  });
+
+  it("is readable by the viewer role (queries are not role-gated)", async () => {
+    const { db } = createDb([[practiceRow({})], []]);
+    await expect(
+      callerWithRole(db, "viewer").welcomeContext()
+    ).resolves.toMatchObject({
+      practiceName: "Aspen Creek Animal Hospital",
+    });
+  });
+
+  it("404s when the practice is missing or deleted", async () => {
+    const { db } = createDb([[]]);
+    await expect(
+      callerWithRole(db, "admin").welcomeContext()
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -807,6 +807,92 @@ export const settingsRouter = createRouter({
     };
   }),
 
+  /**
+   * Data the welcome guides need, readable by ANY authenticated role (the
+   * welcome surface greets invited staff too, unlike the admin-only wizard).
+   * Prefers the seeded demo client/patient while they are alive, then falls
+   * back to the practice's first real client so guides degrade gracefully
+   * after demo data is cleared.
+   */
+  welcomeContext: protectedProcedure.query(async ({ ctx }) => {
+    const [practice] = await ctx.db
+      .select({ name: practices.name, settings: practices.settings })
+      .from(practices)
+      .where(activePracticeWhere(ctx.practiceId))
+      .limit(1);
+    if (!practice) {
+      throw practiceNotFound();
+    }
+    const settings = (practice.settings ?? {}) as PracticeSettings;
+    const demo = settings.demoData;
+
+    let portalClient: {
+      id: string;
+      firstName: string;
+      lastName: string;
+    } | null = null;
+    const demoClientId = demo?.clientIds?.[0];
+    if (demoClientId) {
+      const [row] = await ctx.db
+        .select({
+          id: clients.id,
+          firstName: clients.firstName,
+          lastName: clients.lastName,
+        })
+        .from(clients)
+        .where(
+          and(
+            eq(clients.id, demoClientId),
+            eq(clients.practiceId, ctx.practiceId),
+            isNull(clients.deletedAt)
+          )
+        )
+        .limit(1);
+      portalClient = row ?? null;
+    }
+    if (!portalClient) {
+      const [row] = await ctx.db
+        .select({
+          id: clients.id,
+          firstName: clients.firstName,
+          lastName: clients.lastName,
+        })
+        .from(clients)
+        .where(
+          and(
+            eq(clients.practiceId, ctx.practiceId),
+            isNull(clients.deletedAt)
+          )
+        )
+        .limit(1);
+      portalClient = row ?? null;
+    }
+
+    let demoPatientName: string | null = null;
+    const demoPatientId = demo?.patientIds?.[0];
+    if (demoPatientId) {
+      const [row] = await ctx.db
+        .select({ name: patients.name })
+        .from(patients)
+        .where(
+          and(
+            eq(patients.id, demoPatientId),
+            eq(patients.practiceId, ctx.practiceId),
+            isNull(patients.deletedAt)
+          )
+        )
+        .limit(1);
+      demoPatientName = row?.name ?? null;
+    }
+
+    return {
+      practiceName: practice.name,
+      hasDemoData: !!demo,
+      portalClient,
+      demoPatientName,
+    };
+  }),
+
   /** Mark onboarding complete. */
   completeOnboarding: adminProcedure.mutation(async ({ ctx }) => {
     const [updated] = await ctx.db


### PR DESCRIPTION
Part 1 of the value-first welcome experience (plan: Polaroid guide cards for new trials). This PR is invisible groundwork; no user-facing behavior changes.

## What
- **Tour engine → guide recipes**: `start(recipeId, ctx)` runs short named walkthroughs (`ask-ai`, `your-day`, `client-portal`) through the existing coachmark/anchor machinery. The classic value tour is unchanged (admin-only, server-persisted). Named guides are open to every staff role and record completion per user in localStorage (the viewer role cannot run mutations, so server state is not an option).
- **Guide signals**: one-way window events from product code (`agent-run-succeeded`, `portal-link-copied`) auto-advance a matching active guide step. Next always works, so a guide can never strand anyone.
- **Anchors**: `data-tour` attributes on the agent composer, schedule calendar, whiteboard board, and client portal card. A drift-guard test pins every recipe anchor to its source file.
- **Agent `?ask=` prefill**: one-shot query param fills the composer and is stripped immediately (mirrors the `?tour=start` pattern).
- **`settings.welcomeContext`** (protectedProcedure, any role): practice name, demo-data presence, the portal guide's target client (live demo client first, then first real client), and the demo patient name. This is how guides degrade gracefully after demo data is cleared.

## Tests
- `welcome-cards.test.ts`: card visibility role matrix (front desk 3 cards, vet 4, viewer 3)
- `guide-recipes.test.ts`: recipe behaviors, no-dash copy voice, anchor drift guard
- `settings-welcome-context.test.ts`: demo → real-client fallback → empty, viewer readable, 404
- Full suite: **223 files / 1,966 tests green**; type-check + build green

Next up: PR 2 = ICS calendar subscription feed (the `calendar-feed` recipe is an intentional no-op until its subscribe button ships), PR 3 = the Polaroid welcome surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)