### PR TITLE
Patients: record and remove allergies from the chart

### DIFF
--- a/apps/web/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/patients/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
   Loader2,
   Plus,
   Receipt,
+  X,
 } from "lucide-react";
 import { toast } from "sonner";
 import Link from "next/link";
@@ -353,6 +354,60 @@ export default function PatientDetailPage() {
     });
   }
 
+  // Allergies: recorded here feed the alert bar, prescription safety
+  // warnings, the portal, and PDF summaries.
+  const [showAllergyForm, setShowAllergyForm] = useState(false);
+  const [allergyName, setAllergyName] = useState("");
+  const [allergySeverity, setAllergySeverity] = useState<
+    "mild" | "moderate" | "severe"
+  >("moderate");
+  const [allergyReaction, setAllergyReaction] = useState("");
+  const addAllergy = trpc.patients.addAllergy.useMutation({
+    onSuccess: () => {
+      toast.success("Allergy recorded");
+      utils.patients.getById.invalidate({ id: params.id });
+      setAllergyName("");
+      setAllergyReaction("");
+      setAllergySeverity("moderate");
+      setShowAllergyForm(false);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+  const removeAllergy = trpc.patients.removeAllergy.useMutation({
+    onSuccess: () => {
+      toast.success("Allergy removed");
+      utils.patients.getById.invalidate({ id: params.id });
+    },
+    onError: (err) => toast.error(err.message),
+  });
+  const canSubmitAllergy =
+    canManagePatientDetail &&
+    allergyName.trim().length > 0 &&
+    !addAllergy.isPending;
+
+  function handleAddAllergy(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmitAllergy || !patient) return;
+    addAllergy.mutate({
+      patientId: patient.id,
+      allergen: allergyName.trim(),
+      severity: allergySeverity,
+      reaction: allergyReaction.trim() || undefined,
+    });
+  }
+
+  function handleRemoveAllergy(allergy: { id: string; allergen: string }) {
+    if (!patient || removeAllergy.isPending) return;
+    if (
+      !window.confirm(
+        `Remove the "${allergy.allergen}" allergy? Prescription safety checks will stop warning about it.`
+      )
+    ) {
+      return;
+    }
+    removeAllergy.mutate({ patientId: patient.id, id: allergy.id });
+  }
+
   const loadError = error ?? recordsSettingsError;
   const isPageLoading = !loadError && (isLoading || recordsSettingsLoading);
 
@@ -601,17 +656,18 @@ export default function PatientDetailPage() {
       </div>
 
       {/* Allergy Alert Bar */}
-      {patient.allergies && patient.allergies.length > 0 && (
+      {patient.allergies && patient.allergies.length > 0 ? (
         <div className="mt-4 flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950/30">
           <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-red-600 dark:text-red-400" />
-          <div>
+          <div className="min-w-0 flex-1">
             <p className="text-sm font-semibold text-red-800 dark:text-red-300">
               Allergies
             </p>
-            <div className="mt-1 flex flex-wrap gap-2">
+            <div className="mt-1 flex flex-wrap items-center gap-2">
               {patient.allergies.map((allergy) => (
                 <span
                   key={allergy.id}
+                  title={allergy.reaction ?? undefined}
                   className={cn(
                     "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
                     allergy.severity === "severe"
@@ -627,12 +683,76 @@ export default function PatientDetailPage() {
                       severe
                     </span>
                   ) : null}
+                  {canManagePatientDetail ? (
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveAllergy(allergy)}
+                      disabled={removeAllergy.isPending}
+                      aria-label={`Remove ${allergy.allergen} allergy`}
+                      className="ml-1 rounded-full p-0.5 opacity-60 transition-opacity hover:opacity-100 disabled:cursor-not-allowed"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  ) : null}
                 </span>
               ))}
+              {canManagePatientDetail && !showAllergyForm ? (
+                <button
+                  type="button"
+                  onClick={() => setShowAllergyForm(true)}
+                  className="inline-flex items-center gap-1 rounded-full border border-dashed border-red-300 px-2.5 py-0.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-950"
+                >
+                  <Plus className="h-3 w-3" />
+                  Add
+                </button>
+              ) : null}
             </div>
+            {showAllergyForm ? (
+              <AllergyForm
+                allergyName={allergyName}
+                setAllergyName={setAllergyName}
+                allergySeverity={allergySeverity}
+                setAllergySeverity={setAllergySeverity}
+                allergyReaction={allergyReaction}
+                setAllergyReaction={setAllergyReaction}
+                canSubmit={canSubmitAllergy}
+                isPending={addAllergy.isPending}
+                onSubmit={handleAddAllergy}
+                onCancel={() => setShowAllergyForm(false)}
+              />
+            ) : null}
           </div>
         </div>
-      )}
+      ) : canManagePatientDetail ? (
+        <div className="mt-4 rounded-lg border border-border bg-muted/30 px-4 py-3">
+          {showAllergyForm ? (
+            <AllergyForm
+              allergyName={allergyName}
+              setAllergyName={setAllergyName}
+              allergySeverity={allergySeverity}
+              setAllergySeverity={setAllergySeverity}
+              allergyReaction={allergyReaction}
+              setAllergyReaction={setAllergyReaction}
+              canSubmit={canSubmitAllergy}
+              isPending={addAllergy.isPending}
+              onSubmit={handleAddAllergy}
+              onCancel={() => setShowAllergyForm(false)}
+            />
+          ) : (
+            <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+              <span>No known allergies recorded.</span>
+              <button
+                type="button"
+                onClick={() => setShowAllergyForm(true)}
+                className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                Add allergy
+              </button>
+            </div>
+          )}
+        </div>
+      ) : null}
 
       {/* Tab Navigation */}
       <div className="mt-6 border-b border-border">
@@ -1507,5 +1627,104 @@ function InvoicesTab({ patientId }: { patientId: string }) {
         </tbody>
       </table>
     </div>
+  );
+}
+
+function AllergyForm({
+  allergyName,
+  setAllergyName,
+  allergySeverity,
+  setAllergySeverity,
+  allergyReaction,
+  setAllergyReaction,
+  canSubmit,
+  isPending,
+  onSubmit,
+  onCancel,
+}: {
+  allergyName: string;
+  setAllergyName: (v: string) => void;
+  allergySeverity: "mild" | "moderate" | "severe";
+  setAllergySeverity: (v: "mild" | "moderate" | "severe") => void;
+  allergyReaction: string;
+  setAllergyReaction: (v: string) => void;
+  canSubmit: boolean;
+  isPending: boolean;
+  onSubmit: (e: React.FormEvent) => void;
+  onCancel: () => void;
+}) {
+  return (
+    <form onSubmit={onSubmit} className="mt-3 flex flex-wrap items-end gap-2">
+      <div className="w-full sm:w-44">
+        <label
+          htmlFor="allergy-allergen"
+          className="mb-1 block text-xs font-medium text-muted-foreground"
+        >
+          Allergen
+        </label>
+        <input
+          id="allergy-allergen"
+          type="text"
+          value={allergyName}
+          maxLength={255}
+          required
+          placeholder="Penicillin"
+          onChange={(event) => setAllergyName(event.target.value)}
+          className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+        />
+      </div>
+      <div>
+        <label
+          htmlFor="allergy-severity"
+          className="mb-1 block text-xs font-medium text-muted-foreground"
+        >
+          Severity
+        </label>
+        <select
+          id="allergy-severity"
+          value={allergySeverity}
+          onChange={(event) =>
+            setAllergySeverity(
+              event.target.value as "mild" | "moderate" | "severe"
+            )
+          }
+          className="rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+        >
+          <option value="mild">Mild</option>
+          <option value="moderate">Moderate</option>
+          <option value="severe">Severe</option>
+        </select>
+      </div>
+      <div className="w-full sm:w-56">
+        <label
+          htmlFor="allergy-reaction"
+          className="mb-1 block text-xs font-medium text-muted-foreground"
+        >
+          Reaction (optional)
+        </label>
+        <input
+          id="allergy-reaction"
+          type="text"
+          value={allergyReaction}
+          maxLength={2000}
+          placeholder="Facial swelling"
+          onChange={(event) => setAllergyReaction(event.target.value)}
+          className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <Button type="submit" size="sm" disabled={!canSubmit}>
+          {isPending ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          {isPending ? "Saving..." : "Save allergy"}
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </form>
   );
 }

--- a/apps/web/lib/__tests__/patient-detail-ui.test.ts
+++ b/apps/web/lib/__tests__/patient-detail-ui.test.ts
@@ -292,4 +292,26 @@ describe("patient detail UI states", () => {
     expect(source).toContain("weightKg: weightKg.trim()");
     expect(source).toContain('toast.success("Weight recorded")');
   });
+
+  it("lets staff manage allergies from the alert bar, gated and confirmed", () => {
+    const source = readFileSync("app/(dashboard)/patients/[id]/page.tsx", "utf8");
+    // Add + remove both refresh the same getById payload the bar renders from.
+    expect(source).toContain("trpc.patients.addAllergy.useMutation");
+    expect(source).toContain("trpc.patients.removeAllergy.useMutation");
+    const invalidations = source.match(
+      /utils\.patients\.getById\.invalidate\(\{ id: params\.id \}\)/g
+    );
+    expect(invalidations && invalidations.length).toBeGreaterThanOrEqual(3);
+    // Removal is destructive to safety checks; it must be confirmed and
+    // both controls stay behind the same role gate as the server.
+    expect(source).toContain("window.confirm(");
+    expect(source).toContain(
+      "Prescription safety checks will stop warning about it."
+    );
+    expect(source).toContain("{canManagePatientDetail && !showAllergyForm ?");
+    expect(source).toContain("allergen: allergyName.trim()");
+    // Read-only roles still see the alert bar but never the empty-state
+    // add strip (it renders null for them).
+    expect(source).toContain(") : canManagePatientDetail ? (");
+  });
 });

--- a/apps/web/server/__tests__/patients-safety.test.ts
+++ b/apps/web/server/__tests__/patients-safety.test.ts
@@ -30,6 +30,7 @@ const MERGE_PATIENT_ID = "00000000-0000-0000-0000-000000000004";
 const OTHER_CLIENT_ID = "00000000-0000-0000-0000-000000000005";
 const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000006";
 const WAITLIST_ID = "00000000-0000-0000-0000-000000000007";
+const ALLERGY_ID = "00000000-0000-0000-0000-000000000008";
 
 function callerWithDb(db: Record<string, unknown>, role = "admin") {
   const session = {
@@ -458,6 +459,66 @@ describe("patients mutation safety", () => {
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("keeps allergy removal restricted to non-viewer staff roles", async () => {
+    const { db, select, updateSet } = createDb();
+
+    await expect(
+      callerWithDb(db, "viewer").removeAllergy({
+        patientId: PATIENT_ID,
+        id: ALLERGY_ID,
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("soft deletes allergies for tenant-owned patients only", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [[{ id: PATIENT_ID }]],
+      updatedRows: [{ id: ALLERGY_ID }],
+    });
+
+    await expect(
+      callerWithDb(db, "front_desk").removeAllergy({
+        patientId: PATIENT_ID,
+        id: ALLERGY_ID,
+      })
+    ).resolves.toEqual({ ok: true });
+
+    // Soft delete: the row is retired via deletedAt, never hard-deleted.
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ deletedAt: expect.any(Date) })
+    );
+  });
+
+  it("404s allergy removal when the patient is not tenant-owned", async () => {
+    const { db, updateSet } = createDb({ selectResults: [[]] });
+
+    await expect(
+      callerWithDb(db).removeAllergy({
+        patientId: PATIENT_ID,
+        id: ALLERGY_ID,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("404s allergy removal when the row is missing or already removed", async () => {
+    const { db } = createDb({
+      selectResults: [[{ id: PATIENT_ID }]],
+      updatedRows: [],
+    });
+
+    await expect(
+      callerWithDb(db).removeAllergy({
+        patientId: PATIENT_ID,
+        id: ALLERGY_ID,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 
   it("rejects stale or cross-tenant patient updates", async () => {

--- a/apps/web/server/routers/patients.ts
+++ b/apps/web/server/routers/patients.ts
@@ -569,6 +569,36 @@ export const patientsRouter = createRouter({
       return allergy!;
     }),
 
+  /**
+   * Soft delete: the row keeps its history (the Rx safety log may reference
+   * it) but stops feeding the alert bar, prescription checks, and portal.
+   */
+  removeAllergy: patientManagerProcedure
+    .input(
+      z.object({
+        patientId: z.string().uuid(),
+        id: z.string().uuid(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertPatientBelongsToPractice(ctx.db, ctx.practiceId, input.patientId);
+      const [removed] = await ctx.db
+        .update(patientAllergies)
+        .set({ deletedAt: new Date() })
+        .where(
+          and(
+            eq(patientAllergies.id, input.id),
+            eq(patientAllergies.patientId, input.patientId),
+            isNull(patientAllergies.deletedAt)
+          )
+        )
+        .returning({ id: patientAllergies.id });
+      if (!removed) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Allergy not found" });
+      }
+      return { ok: true };
+    }),
+
   merge: protectedProcedure
     .use(requireRole("admin"))
     .input(


### PR DESCRIPTION
Closes the top safety gap from the overnight dogfood: the prescription allergy warning fires correctly, but staff had **no UI to record the allergy that triggers it** (`patients.addAllergy` existed server-side only), and no way to remove a mistaken entry.

## What
- **`patients.removeAllergy`** (same roles as add: admin/vet/tech/front desk; viewers blocked): tenant-asserted **soft delete** — the row keeps its history but stops feeding the alert bar, Rx safety checks, portal, and PDFs. 404 on missing/already-removed/cross-tenant rows.
- **Managed Allergy Alert Bar** on the patient chart: per-pill ✕ with an explicit confirm ("Prescription safety checks will stop warning about it."), inline add form (allergen, severity, optional reaction shown as pill tooltip), and a neutral "No known allergies · Add allergy" strip when the list is empty (managers only; read-only roles see nothing new).
- Both mutations invalidate `patients.getById` — the same payload the Rx check and portal read.

## Verified live
Add → remove round trip on the dogfood patient with the seeded penicillin case (screenshots in session log): pills render with severity colors, confirm guard works, toasts fire.

## Tests
- `patients-safety`: viewer FORBIDDEN, soft-delete assertion, tenant 404, missing-row 404
- `patient-detail-ui`: mutation wiring, confirm guard, role gating, invalidation count
- Suite: 1,971 green; typecheck + targeted runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)