### PR TITLE
PIMS migration tooling: source-aware imports + vaccine history

### DIFF
--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -83,6 +83,7 @@ import {
   IMPORT_CSV_MAX_BYTES,
   isImportCsvSizeValid,
 } from "@/lib/import/policy";
+import { MIGRATION_SOURCES } from "@/lib/import/sources";
 import {
   AUTH_PASSWORD_MAX_LENGTH,
   AUTH_PASSWORD_MIN_LENGTH,
@@ -2662,14 +2663,27 @@ type ImportPreview = {
   willInsert: number;
   duplicates?: number;
   unmatchedClient?: number;
+  unmatchedPatient?: number;
   errors: string[];
 };
+type ImportMode = "clients" | "patients" | "vaccinations";
 const IMPORT_CSV_SIZE_MESSAGE = "CSV imports must be 5 MB or less.";
+const IMPORT_COLUMN_HINTS: Record<ImportMode, string> = {
+  clients:
+    "Expected columns: firstName, lastName, email, phone, address, city, state, zip",
+  patients:
+    "Expected columns: clientEmail, name, species, breed, sex, dob, color, microchipNumber",
+  vaccinations:
+    "Expected columns: clientEmail, patientName, vaccineName, dateGiven, nextDueDate, lotNumber, manufacturer",
+};
 
 // ── Data Tab ─────────────────────────────────────────────────
 function DataTab() {
   const [exportingType, setExportingType] = useState<string | null>(null);
-  const [importMode, setImportMode] = useState<"clients" | "patients" | null>(null);
+  const [importMode, setImportMode] = useState<ImportMode | null>(null);
+  const [migrationSource, setMigrationSource] = useState<
+    (typeof MIGRATION_SOURCES)[number]["id"] | null
+  >(null);
   const [csvText, setCsvText] = useState("");
   const [csvFileName, setCsvFileName] = useState("");
   const [importPreview, setImportPreview] = useState<ImportPreview | null>(null);
@@ -2796,6 +2810,31 @@ function DataTab() {
       setCsvText("");
       setCsvFileName("");
       toast.success("Patients imported");
+    },
+    onError: (err) => {
+      toast.error(err.message);
+    },
+  });
+  const importVaccinationsCsv = trpc.data.importVaccinationsCsv.useMutation({
+    onSuccess: (data) => {
+      if ("dryRun" in data && data.dryRun) {
+        setImportPreview({
+          total: data.total,
+          willInsert: data.willInsert,
+          duplicates: data.duplicates,
+          unmatchedPatient: data.unmatchedPatient,
+          errors: data.errors,
+        });
+        setImportResult(null);
+        toast.success("Vaccination CSV checked");
+        return;
+      }
+
+      setImportResult({ imported: data.imported ?? 0, errors: data.errors });
+      setImportPreview(null);
+      setCsvText("");
+      setCsvFileName("");
+      toast.success("Vaccine history imported");
     },
     onError: (err) => {
       toast.error(err.message);
@@ -3031,8 +3070,10 @@ function DataTab() {
         setCsvText(text);
         if (importMode === "clients") {
           importClientsCsv.mutate({ csv: text, dryRun: true });
-        } else {
+        } else if (importMode === "patients") {
           importPatientsCsv.mutate({ csv: text, dryRun: true });
+        } else {
+          importVaccinationsCsv.mutate({ csv: text, dryRun: true });
         }
       };
       reader.onerror = () => {
@@ -3041,7 +3082,7 @@ function DataTab() {
       };
       reader.readAsText(file);
     },
-    [importClientsCsv, importMode, importPatientsCsv]
+    [importClientsCsv, importMode, importPatientsCsv, importVaccinationsCsv]
   );
 
   const handleDrop = useCallback(
@@ -3064,12 +3105,24 @@ function DataTab() {
     }
     if (importMode === "clients") {
       importClientsCsv.mutate({ csv: csvText, dryRun: false });
-    } else {
+    } else if (importMode === "patients") {
       importPatientsCsv.mutate({ csv: csvText, dryRun: false });
+    } else {
+      importVaccinationsCsv.mutate({ csv: csvText, dryRun: false });
     }
-  }, [csvText, importMode, importPreview, importClientsCsv, importPatientsCsv]);
+  }, [
+    csvText,
+    importMode,
+    importPreview,
+    importClientsCsv,
+    importPatientsCsv,
+    importVaccinationsCsv,
+  ]);
 
-  const isImportPending = importClientsCsv.isPending || importPatientsCsv.isPending;
+  const isImportPending =
+    importClientsCsv.isPending ||
+    importPatientsCsv.isPending ||
+    importVaccinationsCsv.isPending;
   const canRestoreBackup =
     Boolean(backupPayload) &&
     Boolean(backupSummary) &&
@@ -3482,49 +3535,82 @@ function DataTab() {
       <div>
         <h3 className="text-sm font-semibold mb-1">Import Data</h3>
         <p className="text-sm text-muted-foreground mb-4">
-          Upload a CSV file to check for parser errors, duplicates, and missing
-          owner matches before importing.
+          Moving from another system? Import clients first, then patients,
+          then vaccine history. Every file is dry-run first so you see
+          duplicates and missing matches before anything is saved. Common
+          column names from AVImark, Cornerstone, and ezyVet exports are
+          understood automatically.
         </p>
 
+        {/* Where the data is coming from (export instructions per source) */}
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <span className="text-xs font-medium text-muted-foreground">
+            Coming from:
+          </span>
+          {MIGRATION_SOURCES.map((source) => (
+            <button
+              key={source.id}
+              type="button"
+              onClick={() =>
+                setMigrationSource(
+                  migrationSource === source.id ? null : source.id
+                )
+              }
+              className={cn(
+                "rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
+                migrationSource === source.id
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border text-muted-foreground hover:border-primary/50"
+              )}
+            >
+              {source.name}
+            </button>
+          ))}
+        </div>
+        {migrationSource ? (
+          <p className="mb-4 max-w-2xl rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+            {
+              MIGRATION_SOURCES.find((s) => s.id === migrationSource)!
+                .exportHint
+            }
+          </p>
+        ) : null}
+
         {/* Import mode selector */}
-        <div className="flex gap-2 mb-4">
-          <Button
-            variant={importMode === "clients" ? "default" : "outline"}
-            size="sm"
-            onClick={() => {
-              setImportMode("clients");
-              setCsvText("");
-              setCsvFileName("");
-              setImportPreview(null);
-              setImportResult(null);
-            }}
-          >
-            <Upload className="mr-2 h-4 w-4" />
-            Import Clients
-          </Button>
-          <Button
-            variant={importMode === "patients" ? "default" : "outline"}
-            size="sm"
-            onClick={() => {
-              setImportMode("patients");
-              setCsvText("");
-              setCsvFileName("");
-              setImportPreview(null);
-              setImportResult(null);
-            }}
-          >
-            <Upload className="mr-2 h-4 w-4" />
-            Import Patients
-          </Button>
+        <div className="flex flex-wrap gap-2 mb-4">
+          {(
+            [
+              { mode: "clients" as const, label: "1. Import Clients" },
+              { mode: "patients" as const, label: "2. Import Patients" },
+              {
+                mode: "vaccinations" as const,
+                label: "3. Import Vaccine History",
+              },
+            ]
+          ).map(({ mode, label }) => (
+            <Button
+              key={mode}
+              variant={importMode === mode ? "default" : "outline"}
+              size="sm"
+              onClick={() => {
+                setImportMode(mode);
+                setCsvText("");
+                setCsvFileName("");
+                setImportPreview(null);
+                setImportResult(null);
+              }}
+            >
+              <Upload className="mr-2 h-4 w-4" />
+              {label}
+            </Button>
+          ))}
         </div>
 
         {importMode && (
           <div className="max-w-2xl space-y-4">
             {/* Expected columns hint */}
             <p className="text-xs text-muted-foreground">
-              {importMode === "clients"
-                ? "Expected columns: firstName, lastName, email, phone, address, city, state, zip"
-                : "Expected columns: clientEmail, name, species, breed, sex, dob, color, microchipNumber"}
+              {IMPORT_COLUMN_HINTS[importMode]}
             </p>
 
             {/* Drop zone */}
@@ -3602,6 +3688,12 @@ function DataTab() {
                       <ImportStat
                         label="Missing owners"
                         value={importPreview.unmatchedClient ?? 0}
+                      />
+                    )}
+                    {importMode === "vaccinations" && (
+                      <ImportStat
+                        label="Missing pets"
+                        value={importPreview.unmatchedPatient ?? 0}
                       />
                     )}
                     <ImportStat

--- a/apps/web/lib/csv/__tests__/import.test.ts
+++ b/apps/web/lib/csv/__tests__/import.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { parseCsv, normalizeKey } from "../parse";
-import { csvToClientRecords, csvToPatientRecords } from "../import";
+import {
+  csvToClientRecords,
+  csvToPatientRecords,
+  csvToVaccinationRecords,
+} from "../import";
 
 describe("parseCsv", () => {
   it("parses headers and rows", () => {
@@ -97,6 +101,110 @@ describe("csvToPatientRecords", () => {
       'clientEmail,name,species\n"owner@example.com,Rex,canine'
     );
 
+    expect(records).toEqual([]);
+    expect(errors).toEqual(["CSV has an unterminated quoted field."]);
+  });
+
+  it("reads real-export headers and values (migration aliases)", () => {
+    // AVImark-style export: friendly headers, dog/cat species, MN sex,
+    // US-format birthday. All should normalize without hand-editing.
+    const csv =
+      "Owner Email,Pet Name,Species,Gender,Birthday,Microchip\n" +
+      "jane@x.com,Rex,Dog,MN,3/5/2019,985112004\n" +
+      "jane@x.com,Tweety,Bird,F,2020-01-15,";
+    const { records, errors } = csvToPatientRecords(csv);
+    expect(errors).toEqual([]);
+    expect(records[0]).toMatchObject({
+      clientEmail: "jane@x.com",
+      name: "Rex",
+      species: "canine",
+      sex: "male_neutered",
+      dob: "2019-03-05",
+      microchipNumber: "985112004",
+    });
+    expect(records[1]).toMatchObject({
+      name: "Tweety",
+      species: "avian",
+      sex: "female",
+      dob: "2020-01-15",
+    });
+  });
+
+  it("passes unreadable DOBs through so the router reports them precisely", () => {
+    const csv = "clientEmail,name,species,dob\njane@x.com,Rex,canine,last spring";
+    const { records } = csvToPatientRecords(csv);
+    expect(records[0]!.dob).toBe("last spring");
+  });
+});
+
+describe("csvToClientRecords migration aliases", () => {
+  it("reads owner-style headers from real exports", () => {
+    const csv =
+      "Owner First Name,Surname,Email Address,Cell Phone,Street Address,Town,Province,Postal Code\n" +
+      "Jane,Doe,jane@x.com,555-0100,1 Main St,Boise,ID,83701";
+    const { records, errors } = csvToClientRecords(csv);
+    expect(errors).toEqual([]);
+    expect(records[0]).toEqual({
+      firstName: "Jane",
+      lastName: "Doe",
+      email: "jane@x.com",
+      phone: "555-0100",
+      address: "1 Main St",
+      city: "Boise",
+      state: "ID",
+      zip: "83701",
+    });
+  });
+});
+
+describe("csvToVaccinationRecords", () => {
+  it("maps vaccine history rows with alias headers and US dates", () => {
+    const csv =
+      "Owner Email,Pet Name,Vaccine,Date Given,Due Date,Lot,Manufacturer\n" +
+      "jane@x.com,Rex,Rabies 3yr,10/4/2024,10/4/2027,RB-771,Zoetis";
+    const { records, errors } = csvToVaccinationRecords(csv);
+    expect(errors).toEqual([]);
+    expect(records[0]).toEqual({
+      clientEmail: "jane@x.com",
+      patientName: "Rex",
+      vaccineName: "Rabies 3yr",
+      administeredAt: "2024-10-04",
+      nextDueDate: "2027-10-04",
+      lotNumber: "RB-771",
+      manufacturer: "Zoetis",
+    });
+  });
+
+  it("requires an owner email, pet name, vaccine, and readable date given", () => {
+    const csv =
+      "clientEmail,patientName,vaccineName,dateGiven\n" +
+      ",Rex,Rabies,10/4/2024\n" +
+      "jane@x.com,,Rabies,10/4/2024\n" +
+      "jane@x.com,Rex,,10/4/2024\n" +
+      "jane@x.com,Rex,Rabies,someday";
+    const { records, errors } = csvToVaccinationRecords(csv);
+    expect(records).toEqual([]);
+    expect(errors).toHaveLength(4);
+    expect(errors[0]).toMatch(/Row 1: clientEmail is required/);
+    expect(errors[1]).toMatch(/Row 2: patientName is required/);
+    expect(errors[2]).toMatch(/Row 3: vaccineName is required/);
+    expect(errors[3]).toMatch(/Row 4: dateGiven must be a date/);
+  });
+
+  it("imports a row without its due date when only the due date is unreadable", () => {
+    const csv =
+      "clientEmail,patientName,vaccineName,dateGiven,nextDueDate\n" +
+      "jane@x.com,Rex,DHPP,2024-06-01,when due";
+    const { records, errors } = csvToVaccinationRecords(csv);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.nextDueDate).toBeUndefined();
+    expect(errors[0]).toMatch(/nextDueDate could not be read/);
+  });
+
+  it("does not map vaccination records from malformed quoted CSV", () => {
+    const { records, errors } = csvToVaccinationRecords(
+      'clientEmail,patientName,vaccineName,dateGiven\n"jane@x.com,Rex'
+    );
     expect(records).toEqual([]);
     expect(errors).toEqual(["CSV has an unterminated quoted field."]);
   });

--- a/apps/web/lib/csv/import.ts
+++ b/apps/web/lib/csv/import.ts
@@ -1,10 +1,18 @@
 import { parseCsv, normalizeRow } from "./parse";
+import {
+  normalizeDateValue,
+  normalizeSexValue,
+  normalizeSpeciesValue,
+} from "@/lib/import/normalize";
 
 /**
  * Map parsed CSV rows into the record shapes the data router's import
  * mutations expect. Header matching is normalized (case/spacing/underscore
- * insensitive). Returns valid records plus per-row errors so a partial import
- * can proceed and report what it skipped. Pure — no I/O.
+ * insensitive) and each field accepts the aliases that real PIMS exports
+ * use (AVImark, Cornerstone, ezyVet, plain spreadsheets), so a clinic's
+ * export usually imports without hand-editing headers. Returns valid
+ * records plus per-row errors so a partial import can proceed and report
+ * what it skipped. Pure — no I/O.
  */
 
 export interface ClientImportRecord {
@@ -29,17 +37,75 @@ export interface PatientImportRecord {
   microchipNumber?: string;
 }
 
+export interface VaccinationImportRecord {
+  clientEmail: string;
+  patientName: string;
+  vaccineName: string;
+  administeredAt: string;
+  nextDueDate?: string;
+  lotNumber?: string;
+  manufacturer?: string;
+}
+
 export interface ParseResult<T> {
   records: T[];
   errors: string[];
 }
 
 const SPECIES = ["canine", "feline", "avian", "rabbit", "reptile", "equine", "other"];
-const SEXES = ["male", "female", "male_neutered", "female_spayed"];
+
+/**
+ * Normalized-header aliases per field (see parse.ts normalizeKey: lowercase,
+ * strip non-alphanumerics). First match wins, so put our canonical export
+ * headers first — a round-trip of our own export must always import.
+ */
+const CLIENT_ALIASES: Record<keyof ClientImportRecord, string[]> = {
+  firstName: ["firstname", "first", "clientfirstname", "ownerfirstname", "fname", "givenname"],
+  lastName: ["lastname", "last", "surname", "clientlastname", "ownerlastname", "lname", "familyname"],
+  email: ["email", "emailaddress", "clientemail", "owneremail", "email1"],
+  phone: ["phone", "phonenumber", "homephone", "cellphone", "mobilephone", "mobile", "phone1", "contactnumber"],
+  address: ["address", "address1", "streetaddress", "addressline1", "street"],
+  city: ["city", "town"],
+  state: ["state", "province", "region"],
+  zip: ["zip", "zipcode", "postalcode", "postcode"],
+};
+
+const PATIENT_ALIASES: Record<keyof PatientImportRecord, string[]> = {
+  clientEmail: ["clientemail", "owneremail", "email", "emailaddress"],
+  name: ["name", "patientname", "petname", "patient", "pet", "animalname"],
+  species: ["species", "speciesdescription", "kind", "animaltype"],
+  breed: ["breed", "breeddescription"],
+  sex: ["sex", "gender"],
+  dob: ["dob", "dateofbirth", "birthday", "birthdate", "born"],
+  color: ["color", "colour", "markings"],
+  microchipNumber: ["microchipnumber", "microchip", "chipnumber", "microchipid", "chipid"],
+};
+
+const VACCINATION_ALIASES: Record<keyof VaccinationImportRecord, string[]> = {
+  clientEmail: ["clientemail", "owneremail", "email", "emailaddress"],
+  patientName: ["patientname", "name", "petname", "patient", "pet", "animalname"],
+  vaccineName: ["vaccinename", "vaccine", "vaccination", "description", "treatment"],
+  administeredAt: ["administeredat", "dategiven", "givendate", "givenon", "date", "vaccinationdate", "administered", "dateadministered"],
+  nextDueDate: ["nextduedate", "duedate", "nextdue", "due", "dueon", "expires", "expirationdate"],
+  lotNumber: ["lotnumber", "lot", "serialnumber", "serial"],
+  manufacturer: ["manufacturer", "maker", "brand", "producer"],
+};
 
 function opt(v: string | undefined): string | undefined {
   const t = v?.trim();
   return t ? t : undefined;
+}
+
+/** First non-empty value among a field's normalized-header aliases. */
+function fromAliases(
+  row: Record<string, string>,
+  aliases: string[]
+): string | undefined {
+  for (const key of aliases) {
+    const value = opt(row[key]);
+    if (value) return value;
+  }
+  return undefined;
 }
 
 export function csvToClientRecords(csv: string): ParseResult<ClientImportRecord> {
@@ -53,8 +119,8 @@ export function csvToClientRecords(csv: string): ParseResult<ClientImportRecord>
 
   rows.forEach((raw, i) => {
     const r = normalizeRow(raw);
-    const firstName = opt(r.firstname);
-    const lastName = opt(r.lastname);
+    const firstName = fromAliases(r, CLIENT_ALIASES.firstName);
+    const lastName = fromAliases(r, CLIENT_ALIASES.lastName);
     if (!firstName || !lastName) {
       errors.push(`Row ${i + 1}: firstName and lastName are required.`);
       return;
@@ -62,12 +128,12 @@ export function csvToClientRecords(csv: string): ParseResult<ClientImportRecord>
     records.push({
       firstName,
       lastName,
-      email: opt(r.email),
-      phone: opt(r.phone),
-      address: opt(r.address),
-      city: opt(r.city),
-      state: opt(r.state),
-      zip: opt(r.zip),
+      email: fromAliases(r, CLIENT_ALIASES.email),
+      phone: fromAliases(r, CLIENT_ALIASES.phone),
+      address: fromAliases(r, CLIENT_ALIASES.address),
+      city: fromAliases(r, CLIENT_ALIASES.city),
+      state: fromAliases(r, CLIENT_ALIASES.state),
+      zip: fromAliases(r, CLIENT_ALIASES.zip),
     });
   });
 
@@ -85,9 +151,10 @@ export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecor
 
   rows.forEach((raw, i) => {
     const r = normalizeRow(raw);
-    const clientEmail = opt(r.clientemail) ?? opt(r.email);
-    const name = opt(r.name) ?? opt(r.patientname);
-    const species = opt(r.species)?.toLowerCase();
+    const clientEmail = fromAliases(r, PATIENT_ALIASES.clientEmail);
+    const name = fromAliases(r, PATIENT_ALIASES.name);
+    const speciesRaw = fromAliases(r, PATIENT_ALIASES.species);
+    const species = normalizeSpeciesValue(speciesRaw);
 
     if (!clientEmail) {
       errors.push(`Row ${i + 1}: clientEmail is required to link the pet to an owner.`);
@@ -97,23 +164,89 @@ export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecor
       errors.push(`Row ${i + 1}: name is required.`);
       return;
     }
-    if (!species || !SPECIES.includes(species)) {
+    if (!species) {
       errors.push(
-        `Row ${i + 1}: species must be one of ${SPECIES.join(", ")} (got "${species ?? ""}").`
+        `Row ${i + 1}: species must be one of ${SPECIES.join(", ")} (got "${speciesRaw?.toLowerCase() ?? ""}").`
       );
       return;
     }
 
-    const sex = opt(r.sex)?.toLowerCase();
+    // DOB: normalize common formats; an unreadable value passes through so
+    // the router's validation reports it with the exact expected format.
+    const dobRaw = fromAliases(r, PATIENT_ALIASES.dob);
+    const dob = dobRaw ? normalizeDateValue(dobRaw) ?? dobRaw : undefined;
+
     records.push({
       clientEmail,
       name,
-      species: species as PatientImportRecord["species"],
-      breed: opt(r.breed),
-      sex: sex && SEXES.includes(sex) ? (sex as PatientImportRecord["sex"]) : undefined,
-      dob: opt(r.dob),
-      color: opt(r.color),
-      microchipNumber: opt(r.microchipnumber) ?? opt(r.microchip),
+      species,
+      breed: fromAliases(r, PATIENT_ALIASES.breed),
+      sex: normalizeSexValue(fromAliases(r, PATIENT_ALIASES.sex)),
+      dob,
+      color: fromAliases(r, PATIENT_ALIASES.color),
+      microchipNumber: fromAliases(r, PATIENT_ALIASES.microchipNumber),
+    });
+  });
+
+  return { records, errors };
+}
+
+export function csvToVaccinationRecords(
+  csv: string
+): ParseResult<VaccinationImportRecord> {
+  const { rows, errors: parseErrors } = parseCsv(csv);
+  const records: VaccinationImportRecord[] = [];
+  const errors: string[] = [...parseErrors];
+
+  if (parseErrors.length > 0) {
+    return { records, errors };
+  }
+
+  rows.forEach((raw, i) => {
+    const r = normalizeRow(raw);
+    const clientEmail = fromAliases(r, VACCINATION_ALIASES.clientEmail);
+    const patientName = fromAliases(r, VACCINATION_ALIASES.patientName);
+    const vaccineName = fromAliases(r, VACCINATION_ALIASES.vaccineName);
+    const administeredRaw = fromAliases(r, VACCINATION_ALIASES.administeredAt);
+
+    if (!clientEmail) {
+      errors.push(
+        `Row ${i + 1}: clientEmail is required to link the vaccine to a pet.`
+      );
+      return;
+    }
+    if (!patientName) {
+      errors.push(`Row ${i + 1}: patientName is required.`);
+      return;
+    }
+    if (!vaccineName) {
+      errors.push(`Row ${i + 1}: vaccineName is required.`);
+      return;
+    }
+    const administeredAt = normalizeDateValue(administeredRaw);
+    if (!administeredAt) {
+      errors.push(
+        `Row ${i + 1}: dateGiven must be a date (like 2025-10-04 or 10/4/2025), got "${administeredRaw ?? ""}".`
+      );
+      return;
+    }
+
+    const dueRaw = fromAliases(r, VACCINATION_ALIASES.nextDueDate);
+    const nextDueDate = dueRaw ? normalizeDateValue(dueRaw) ?? undefined : undefined;
+    if (dueRaw && !nextDueDate) {
+      errors.push(
+        `Row ${i + 1}: nextDueDate could not be read as a date (got "${dueRaw}"); the row imports without it.`
+      );
+    }
+
+    records.push({
+      clientEmail,
+      patientName,
+      vaccineName,
+      administeredAt,
+      nextDueDate,
+      lotNumber: fromAliases(r, VACCINATION_ALIASES.lotNumber),
+      manufacturer: fromAliases(r, VACCINATION_ALIASES.manufacturer),
     });
   });
 

--- a/apps/web/lib/import/__tests__/normalize.test.ts
+++ b/apps/web/lib/import/__tests__/normalize.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeDateValue,
+  normalizeSexValue,
+  normalizeSpeciesValue,
+} from "../normalize";
+
+const NOW = new Date("2026-07-10T12:00:00Z");
+
+describe("migration value normalizers", () => {
+  it("maps the species spellings real exports use onto our enum", () => {
+    expect(normalizeSpeciesValue("Dog")).toBe("canine");
+    expect(normalizeSpeciesValue("CANINE")).toBe("canine");
+    expect(normalizeSpeciesValue("cat")).toBe("feline");
+    expect(normalizeSpeciesValue("Kitten")).toBe("feline");
+    expect(normalizeSpeciesValue("Bird")).toBe("avian");
+    expect(normalizeSpeciesValue("bunny")).toBe("rabbit");
+    expect(normalizeSpeciesValue("Bearded  Dragon")).toBe("reptile");
+    expect(normalizeSpeciesValue("Horse")).toBe("equine");
+    expect(normalizeSpeciesValue("Ferret")).toBe("other");
+    expect(normalizeSpeciesValue("Guinea Pig")).toBe("other");
+  });
+
+  it("returns null for unrecognized species instead of guessing", () => {
+    expect(normalizeSpeciesValue("dragon")).toBeNull();
+    expect(normalizeSpeciesValue("")).toBeNull();
+    expect(normalizeSpeciesValue(undefined)).toBeNull();
+  });
+
+  it("maps sex abbreviations and phrasings onto our enum", () => {
+    expect(normalizeSexValue("M")).toBe("male");
+    expect(normalizeSexValue("f")).toBe("female");
+    expect(normalizeSexValue("MN")).toBe("male_neutered");
+    expect(normalizeSexValue("Neutered Male")).toBe("male_neutered");
+    expect(normalizeSexValue("male neutered")).toBe("male_neutered");
+    expect(normalizeSexValue("Castrated")).toBe("male_neutered");
+    expect(normalizeSexValue("FS")).toBe("female_spayed");
+    expect(normalizeSexValue("Spayed Female")).toBe("female_spayed");
+    expect(normalizeSexValue("female_spayed")).toBe("female_spayed");
+    expect(normalizeSexValue("unknown")).toBeUndefined();
+    expect(normalizeSexValue(undefined)).toBeUndefined();
+  });
+
+  it("normalizes ISO and US date formats to YYYY-MM-DD", () => {
+    expect(normalizeDateValue("2019-03-05", NOW)).toBe("2019-03-05");
+    expect(normalizeDateValue("2019-3-5", NOW)).toBe("2019-03-05");
+    expect(normalizeDateValue("3/5/2019", NOW)).toBe("2019-03-05");
+    expect(normalizeDateValue("03-05-2019", NOW)).toBe("2019-03-05");
+    expect(normalizeDateValue("3.5.2019", NOW)).toBe("2019-03-05");
+    expect(normalizeDateValue("12/31/2025", NOW)).toBe("2025-12-31");
+  });
+
+  it("resolves two-digit years into the past, never the future", () => {
+    // Birthdays and history: 3/5/19 is 2019, but 3/5/99 is 1999.
+    expect(normalizeDateValue("3/5/19", NOW)).toBe("2019-03-05");
+    expect(normalizeDateValue("3/5/26", NOW)).toBe("2026-03-05");
+    expect(normalizeDateValue("3/5/27", NOW)).toBe("1927-03-05");
+    expect(normalizeDateValue("3/5/99", NOW)).toBe("1999-03-05");
+  });
+
+  it("rejects impossible and unreadable dates", () => {
+    expect(normalizeDateValue("2026-02-30", NOW)).toBeNull();
+    expect(normalizeDateValue("13/1/2020", NOW)).toBeNull();
+    expect(normalizeDateValue("0/10/2020", NOW)).toBeNull();
+    expect(normalizeDateValue("last spring", NOW)).toBeNull();
+    expect(normalizeDateValue("", NOW)).toBeNull();
+    expect(normalizeDateValue(undefined, NOW)).toBeNull();
+  });
+});

--- a/apps/web/lib/import/normalize.ts
+++ b/apps/web/lib/import/normalize.ts
@@ -1,0 +1,160 @@
+/**
+ * Value normalizers for migration imports. Real PIMS exports (AVImark,
+ * Cornerstone, ezyVet, spreadsheets) spell species, sex, and dates a dozen
+ * ways; these map the common spellings onto OpenVPM's enums and ISO dates
+ * so clinics do not have to hand-edit their files. Pure — no I/O.
+ */
+
+export type NormalizedSpecies =
+  | "canine"
+  | "feline"
+  | "avian"
+  | "rabbit"
+  | "reptile"
+  | "equine"
+  | "other";
+
+const SPECIES_ALIASES: Record<string, NormalizedSpecies> = {
+  canine: "canine",
+  dog: "canine",
+  puppy: "canine",
+  k9: "canine",
+  feline: "feline",
+  cat: "feline",
+  kitten: "feline",
+  avian: "avian",
+  bird: "avian",
+  parrot: "avian",
+  parakeet: "avian",
+  cockatiel: "avian",
+  chicken: "avian",
+  rabbit: "rabbit",
+  bunny: "rabbit",
+  lagomorph: "rabbit",
+  reptile: "reptile",
+  lizard: "reptile",
+  snake: "reptile",
+  turtle: "reptile",
+  tortoise: "reptile",
+  gecko: "reptile",
+  iguana: "reptile",
+  "bearded dragon": "reptile",
+  equine: "equine",
+  horse: "equine",
+  pony: "equine",
+  donkey: "equine",
+  mule: "equine",
+  other: "other",
+  exotic: "other",
+  "pocket pet": "other",
+  ferret: "other",
+  "guinea pig": "other",
+  hamster: "other",
+  rat: "other",
+  mouse: "other",
+  hedgehog: "other",
+  chinchilla: "other",
+};
+
+/** Map a source species value onto our enum, or null when unrecognized. */
+export function normalizeSpeciesValue(
+  value: string | undefined
+): NormalizedSpecies | null {
+  const v = value?.trim().toLowerCase().replace(/\s+/g, " ");
+  if (!v) return null;
+  return SPECIES_ALIASES[v] ?? null;
+}
+
+export type NormalizedSex =
+  | "male"
+  | "female"
+  | "male_neutered"
+  | "female_spayed";
+
+const SEX_ALIASES: Record<string, NormalizedSex> = {
+  male: "male",
+  m: "male",
+  "male intact": "male",
+  "intact male": "male",
+  female: "female",
+  f: "female",
+  "female intact": "female",
+  "intact female": "female",
+  male_neutered: "male_neutered",
+  mn: "male_neutered",
+  nm: "male_neutered",
+  neutered: "male_neutered",
+  "neutered male": "male_neutered",
+  "male neutered": "male_neutered",
+  castrated: "male_neutered",
+  "castrated male": "male_neutered",
+  female_spayed: "female_spayed",
+  fs: "female_spayed",
+  sf: "female_spayed",
+  spayed: "female_spayed",
+  "spayed female": "female_spayed",
+  "female spayed": "female_spayed",
+};
+
+/** Map a source sex value onto our enum, or undefined when unrecognized. */
+export function normalizeSexValue(
+  value: string | undefined
+): NormalizedSex | undefined {
+  const v = value?.trim().toLowerCase().replace(/[\s/-]+/g, " ");
+  if (!v) return undefined;
+  return SEX_ALIASES[v];
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function isRealDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+  const d = new Date(Date.UTC(year, month - 1, day));
+  return (
+    d.getUTCFullYear() === year &&
+    d.getUTCMonth() === month - 1 &&
+    d.getUTCDate() === day
+  );
+}
+
+/**
+ * Normalize a source date to YYYY-MM-DD. Accepts ISO (2019-03-05) and the
+ * US formats PIMS exports actually use: 3/5/2019, 03-05-2019, 3.5.19.
+ * Two-digit years resolve to the past (birthdays and history, never the
+ * future). Returns null when the value cannot be read as a date.
+ */
+export function normalizeDateValue(
+  value: string | undefined,
+  now: Date = new Date()
+): string | null {
+  const v = value?.trim();
+  if (!v) return null;
+
+  const iso = v.match(/^(\d{4})-(\d{1,2})-(\d{1,2})(?:[T ].*)?$/);
+  if (iso) {
+    const [, y, m, d] = iso;
+    const year = Number(y);
+    const month = Number(m);
+    const day = Number(d);
+    if (!isRealDate(year, month, day)) return null;
+    return `${year}-${pad2(month)}-${pad2(day)}`;
+  }
+
+  const us = v.match(/^(\d{1,2})[/.-](\d{1,2})[/.-](\d{2}|\d{4})$/);
+  if (us) {
+    const month = Number(us[1]);
+    const day = Number(us[2]);
+    let year = Number(us[3]);
+    if (us[3]!.length === 2) {
+      const century = Math.floor(now.getUTCFullYear() / 100) * 100;
+      year += century;
+      if (year > now.getUTCFullYear()) year -= 100;
+    }
+    if (!isRealDate(year, month, day)) return null;
+    return `${year}-${pad2(month)}-${pad2(day)}`;
+  }
+
+  return null;
+}

--- a/apps/web/lib/import/sources.ts
+++ b/apps/web/lib/import/sources.ts
@@ -1,0 +1,48 @@
+/**
+ * Migration source presets: where a clinic's data is coming from and how
+ * to get it out of that system. The importers themselves are source
+ * agnostic (header aliases + value normalization in lib/csv/import.ts);
+ * these presets exist so the UI and docs can meet people where they are.
+ * Voice: fourth grade, no em dashes.
+ */
+
+export interface MigrationSource {
+  id: "avimark" | "cornerstone" | "ezyvet" | "other";
+  name: string;
+  /** How to get CSV exports out of that system, in one breath. */
+  exportHint: string;
+}
+
+export const MIGRATION_SOURCES: MigrationSource[] = [
+  {
+    id: "avimark",
+    name: "AVImark",
+    exportHint:
+      "In AVImark, use Information Search to pull Clients and Patients, then choose Results, then Export and save as CSV. Your Covetrus rep can also send full exports.",
+  },
+  {
+    id: "cornerstone",
+    name: "Cornerstone",
+    exportHint:
+      "In Cornerstone, run the Client and Patient reports under Reports, then save or print each one to CSV. IDEXX support can also pull full exports for you.",
+  },
+  {
+    id: "ezyvet",
+    name: "ezyVet",
+    exportHint:
+      "In ezyVet, open the Records dashboard, search Contacts and Animals, and use Export to download CSV files.",
+  },
+  {
+    id: "other",
+    name: "Another system or spreadsheet",
+    exportHint:
+      "Any CSV works. We read the common column names automatically, and the dry run shows exactly what will import before anything is saved.",
+  },
+];
+
+/** Import order that always works: owners first, then pets, then history. */
+export const MIGRATION_STEPS = [
+  { mode: "clients" as const, label: "1. Clients (pet owners)" },
+  { mode: "patients" as const, label: "2. Patients (pets)" },
+  { mode: "vaccinations" as const, label: "3. Vaccine history" },
+];

--- a/apps/web/server/__tests__/data-import-vaccinations.test.ts
+++ b/apps/web/server/__tests__/data-import-vaccinations.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(async () => undefined),
+}));
+
+const { IMPORT_CSV_MAX_BYTES, dataRouter } = await import("../routers/data");
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+const PATIENT_ID = "00000000-0000-0000-0000-0000000000p1";
+
+function callerWithDb(db: Record<string, unknown>, role = "admin") {
+  const session = {
+    user: {
+      id: USER_ID,
+      email: `${role}@example.com`,
+      name: "Admin",
+      role,
+      practiceId: PRACTICE_ID,
+    },
+  };
+  return dataRouter.createCaller({ db, session } as never);
+}
+
+function thenableRows(result: unknown[]) {
+  return {
+    limit: vi.fn(async () => result),
+    then: (
+      resolve: (value: unknown[]) => unknown,
+      reject?: (error: unknown) => unknown
+    ) => Promise.resolve(result).then(resolve, reject),
+  };
+}
+
+function createDb(
+  selectRows: unknown[][],
+  practiceRows: unknown[] = [{ id: PRACTICE_ID }]
+) {
+  const remainingSelects = [practiceRows, ...selectRows];
+  const select = vi.fn(() => {
+    const result = remainingSelects.shift() ?? [];
+    const rows = thenableRows(result);
+    const builder = {
+      from: vi.fn(() => builder),
+      innerJoin: vi.fn(() => builder),
+      where: vi.fn(() => rows),
+    };
+    return builder;
+  });
+
+  const insertValues = vi.fn(() => ({
+    then: (resolve: (value: undefined) => unknown) =>
+      Promise.resolve(undefined).then(resolve),
+  }));
+  const insert = vi.fn(() => ({ values: insertValues }));
+
+  const db: Record<string, unknown> = {
+    transaction: async (fn: (tx: unknown) => unknown) => fn(db),
+    execute: vi.fn(async () => undefined),
+    select,
+    insert,
+  };
+
+  return { db, insertValues, select };
+}
+
+const HEADER = "clientEmail,patientName,vaccineName,dateGiven,nextDueDate";
+const REX_ROW = "jane@x.com,Rex,Rabies 3yr,2024-10-04,2027-10-04";
+
+const patientRows = [
+  { id: PATIENT_ID, name: "Rex", clientEmail: "jane@x.com" },
+];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("vaccination history import", () => {
+  it("is admin-only", async () => {
+    const { db, select, insertValues } = createDb([]);
+    for (const role of ["front_desk", "veterinarian", "viewer"]) {
+      await expect(
+        callerWithDb(db, role).importVaccinationsCsv({
+          csv: `${HEADER}\n${REX_ROW}`,
+        })
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    }
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized CSV before any DB work", async () => {
+    const { db, select } = createDb([]);
+    await expect(
+      callerWithDb(db).importVaccinationsCsv({
+        csv: "x".repeat(IMPORT_CSV_MAX_BYTES + 1),
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("returns parse errors for malformed CSV without touching the DB", async () => {
+    const { db, select, insertValues } = createDb([]);
+    const result = await callerWithDb(db).importVaccinationsCsv({
+      csv: `${HEADER}\n"jane@x.com,Rex`,
+    });
+    expect(result).toEqual({
+      imported: 0,
+      errors: ["CSV has an unterminated quoted field."],
+    });
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("dry run reports matches, duplicates, and missing pets without inserting", async () => {
+    const existingDose = {
+      patientId: PATIENT_ID,
+      vaccineName: "Rabies 3yr",
+      administeredAt: new Date("2023-10-04T12:00:00.000Z"),
+    };
+    const { db, insertValues } = createDb([patientRows, [existingDose]]);
+
+    const result = await callerWithDb(db).importVaccinationsCsv({
+      csv: [
+        HEADER,
+        REX_ROW, // new dose
+        "jane@x.com,Rex,Rabies 3yr,2023-10-04,", // already in the DB
+        REX_ROW, // in-file duplicate
+        "jane@x.com,Ghost,DHPP,2024-01-01,", // unknown pet
+      ].join("\n"),
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      total: 4,
+      willInsert: 1,
+      duplicates: 2,
+      unmatchedPatient: 1,
+    });
+    expect(result.errors.some((e) => /No pet named "Ghost"/.test(e))).toBe(true);
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("imports doses at noon UTC of the given day, tenant-stamped", async () => {
+    const { db, insertValues } = createDb([patientRows, []]);
+
+    const result = await callerWithDb(db).importVaccinationsCsv({
+      csv: `${HEADER}\n${REX_ROW}`,
+    });
+
+    expect(result).toMatchObject({ imported: 1 });
+    expect(insertValues).toHaveBeenCalledTimes(1);
+    const rows = (
+      insertValues.mock.calls as unknown as [Array<Record<string, unknown>>][]
+    )[0]![0];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      practiceId: PRACTICE_ID,
+      patientId: PATIENT_ID,
+      vaccineName: "Rabies 3yr",
+      nextDueDate: "2027-10-04",
+      administeredBy: null,
+    });
+    expect((rows[0]!.administeredAt as Date).toISOString()).toBe(
+      "2024-10-04T12:00:00.000Z"
+    );
+  });
+
+  it("flags same-named pets under one owner instead of guessing", async () => {
+    const twins = [
+      { id: PATIENT_ID, name: "Rex", clientEmail: "jane@x.com" },
+      { id: "00000000-0000-0000-0000-0000000000p2", name: "Rex", clientEmail: "jane@x.com" },
+    ];
+    const { db, insertValues } = createDb([twins, []]);
+
+    const result = await callerWithDb(db).importVaccinationsCsv({
+      csv: `${HEADER}\n${REX_ROW}`,
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      willInsert: 0,
+      unmatchedPatient: 1,
+    });
+    expect(
+      result.errors.some((e) => /More than one pet named "Rex"/.test(e))
+    ).toBe(true);
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("matches pets case- and spacing-insensitively", async () => {
+    const { db } = createDb([
+      [{ id: PATIENT_ID, name: "Rex  Jr", clientEmail: "Jane@X.com" }],
+      [],
+    ]);
+
+    const result = await callerWithDb(db).importVaccinationsCsv({
+      csv: `${HEADER}\nJANE@x.com,rex jr,Bordetella,2024-05-05,`,
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({ dryRun: true, willInsert: 1 });
+  });
+
+  it("404s when the practice is missing or deleted", async () => {
+    const { db } = createDb([], []);
+    await expect(
+      callerWithDb(db).importVaccinationsCsv({
+        csv: `${HEADER}\n${REX_ROW}`,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/apps/web/server/routers/data.ts
+++ b/apps/web/server/routers/data.ts
@@ -11,13 +11,16 @@ import {
   invoiceItems,
   practices,
   users,
+  vaccinationRecords,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import {
   type ClientImportRecord,
   type PatientImportRecord,
+  type VaccinationImportRecord,
   csvToClientRecords,
   csvToPatientRecords,
+  csvToVaccinationRecords,
 } from "@/lib/csv/import";
 import {
   exportPracticeData,
@@ -42,6 +45,10 @@ export { IMPORT_CSV_MAX_BYTES, IMPORT_MAX_ROWS } from "@/lib/import/policy";
 
 type ClientImportRow = Omit<typeof clients.$inferInsert, "practiceId">;
 type PatientImportRow = Omit<typeof patients.$inferInsert, "practiceId">;
+type VaccinationImportRow = Omit<
+  typeof vaccinationRecords.$inferInsert,
+  "practiceId"
+>;
 type DataContext = {
   db: Database;
   practiceId: string;
@@ -79,6 +86,10 @@ const importOptionalEmail = z.preprocess(
 const importOptionalDate = z.preprocess(
   (value) => (typeof value === "string" ? value.trim() || undefined : value),
   clinicalDateInput("Date of birth").optional()
+);
+const importOptionalDueDate = z.preprocess(
+  (value) => (typeof value === "string" ? value.trim() || undefined : value),
+  clinicalDateInput("Next due date").optional()
 );
 const clientImportRecordInput = z.object({
   firstName: importRequiredText("First name", 128),
@@ -118,6 +129,21 @@ const importClientsInput = z.object({
 const importPatientsInput = z.object({
   patients: patientImportRecordsInput,
 });
+const vaccinationImportRecordInput = z.object({
+  clientEmail: z.string().trim().email().max(255),
+  patientName: importRequiredText("Patient name", 128),
+  vaccineName: importRequiredText("Vaccine name", 255),
+  administeredAt: clinicalDateInput("Date given"),
+  nextDueDate: importOptionalDueDate,
+  lotNumber: importOptionalText("Lot number", 64),
+  manufacturer: importOptionalText("Manufacturer", 128),
+});
+const vaccinationImportRecordsInput = z
+  .array(vaccinationImportRecordInput)
+  .max(
+    IMPORT_MAX_ROWS,
+    `Vaccination imports can include at most ${IMPORT_MAX_ROWS} rows.`
+  );
 const importCsvInput = z.object({
   csv: z
     .string()
@@ -295,6 +321,122 @@ function dedupePatientImport(
   });
 
   return { rows, errors, duplicates, unmatchedClient };
+}
+
+/** Key linking a vaccination row to a pet: owner email + normalized name. */
+function vaccinationPatientKey(clientEmail: string, patientName: string): string {
+  return `${normalizeImportEmail(clientEmail) ?? ""}|${normalizeImportText(patientName)}`;
+}
+
+/** Identity of an administered dose: patient + vaccine + date given. */
+function vaccinationIdentityKey(input: {
+  patientId: string;
+  vaccineName: string;
+  administeredDate: string;
+}): string {
+  return [
+    input.patientId,
+    normalizeImportText(input.vaccineName),
+    input.administeredDate,
+  ].join("|");
+}
+
+/**
+ * Historical doses import at noon UTC of the given day so the calendar
+ * date survives every clinic timezone (the exact hour was never in the
+ * source export to begin with).
+ */
+function vaccinationInstant(dateInput: string): Date {
+  return new Date(`${dateInput}T12:00:00.000Z`);
+}
+
+function dedupeVaccinationImport(
+  records: VaccinationImportRecord[],
+  patientKeyToId: Record<string, string | "ambiguous">,
+  existingDoses: Array<{
+    patientId: string;
+    vaccineName: string;
+    administeredAt: Date;
+  }>
+): {
+  rows: VaccinationImportRow[];
+  errors: string[];
+  duplicates: number;
+  unmatchedPatient: number;
+} {
+  const seen = new Set(
+    existingDoses.map((dose) =>
+      vaccinationIdentityKey({
+        patientId: dose.patientId,
+        vaccineName: dose.vaccineName,
+        administeredDate: dose.administeredAt.toISOString().slice(0, 10),
+      })
+    )
+  );
+
+  const rows: VaccinationImportRow[] = [];
+  const errors: string[] = [];
+  let duplicates = 0;
+  let unmatchedPatient = 0;
+
+  records.forEach((record, index) => {
+    const key = vaccinationPatientKey(record.clientEmail, record.patientName);
+    const patientId = patientKeyToId[key];
+    if (!patientId) {
+      unmatchedPatient++;
+      errors.push(
+        `Row ${index + 1}: No pet named "${record.patientName}" found for client "${record.clientEmail}"`
+      );
+      return;
+    }
+    if (patientId === "ambiguous") {
+      unmatchedPatient++;
+      errors.push(
+        `Row ${index + 1}: More than one pet named "${record.patientName}" belongs to "${record.clientEmail}"; add this dose by hand.`
+      );
+      return;
+    }
+
+    const identityKey = vaccinationIdentityKey({
+      patientId,
+      vaccineName: record.vaccineName,
+      administeredDate: record.administeredAt,
+    });
+    if (seen.has(identityKey)) {
+      duplicates++;
+      errors.push(
+        `Row ${index + 1}: Skipped duplicate dose "${record.vaccineName}" for "${record.patientName}".`
+      );
+      return;
+    }
+    seen.add(identityKey);
+
+    rows.push({
+      patientId,
+      vaccineName: record.vaccineName.trim(),
+      administeredAt: vaccinationInstant(record.administeredAt),
+      nextDueDate: record.nextDueDate ?? null,
+      lotNumber: record.lotNumber?.trim() || null,
+      manufacturer: record.manufacturer?.trim() || null,
+      // Historical import: no OpenVPM user administered this dose.
+      administeredBy: null,
+    });
+  });
+
+  return { rows, errors, duplicates, unmatchedPatient };
+}
+
+function parseVaccinationImportRecords(
+  records: VaccinationImportRecord[]
+): VaccinationImportRecord[] {
+  const result = vaccinationImportRecordsInput.safeParse(records);
+  if (!result.success) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Vaccination import rows contain invalid values.",
+    });
+  }
+  return result.data;
 }
 
 function parseClientImportRecords(
@@ -916,6 +1058,101 @@ export const dataRouter = createRouter({
       if (deduped.rows.length > 0) {
         await ctx.db.insert(patients).values(
           deduped.rows.map((p) => ({ ...p, practiceId: ctx.practiceId }))
+        );
+      }
+      return {
+        imported: deduped.rows.length,
+        errors: [...errors, ...deduped.errors],
+      };
+    }),
+
+  /**
+   * Vaccination history import (migration): rows link to pets by owner
+   * email + pet name, so run it AFTER clients and patients. Historical
+   * doses power reminders and the overdue-vaccine views from day one.
+   */
+  importVaccinationsCsv: adminProcedure
+    .input(importCsvInput)
+    .mutation(async ({ ctx, input }) => {
+      const { records, errors } = csvToVaccinationRecords(input.csv);
+      const validRecords = parseVaccinationImportRecords(records);
+
+      if (validRecords.length === 0 && errors.length > 0) {
+        if (input.dryRun) {
+          return {
+            dryRun: true as const,
+            total: 0,
+            willInsert: 0,
+            unmatchedPatient: 0,
+            duplicates: 0,
+            errors,
+          };
+        }
+        return { imported: 0, errors };
+      }
+
+      await assertActivePractice(ctx);
+
+      const patientRows = await ctx.db
+        .select({
+          id: patients.id,
+          name: patients.name,
+          clientEmail: clients.email,
+        })
+        .from(patients)
+        .innerJoin(clients, eq(patients.clientId, clients.id))
+        .where(
+          and(
+            eq(patients.practiceId, ctx.practiceId),
+            activePracticePredicate(ctx.practiceId),
+            isNull(patients.deletedAt),
+            isNull(clients.deletedAt)
+          )
+        );
+      const patientKeyToId: Record<string, string | "ambiguous"> = {};
+      for (const p of patientRows) {
+        if (!p.clientEmail) continue;
+        const key = vaccinationPatientKey(p.clientEmail, p.name);
+        // Two pets with the same name under one owner cannot be told apart
+        // by a CSV row; flag instead of guessing which pet got the dose.
+        patientKeyToId[key] = patientKeyToId[key] ? "ambiguous" : p.id;
+      }
+
+      const existingDoses = await ctx.db
+        .select({
+          patientId: vaccinationRecords.patientId,
+          vaccineName: vaccinationRecords.vaccineName,
+          administeredAt: vaccinationRecords.administeredAt,
+        })
+        .from(vaccinationRecords)
+        .where(
+          and(
+            eq(vaccinationRecords.practiceId, ctx.practiceId),
+            activePracticePredicate(ctx.practiceId),
+            isNull(vaccinationRecords.deletedAt)
+          )
+        );
+
+      const deduped = dedupeVaccinationImport(
+        validRecords,
+        patientKeyToId,
+        existingDoses
+      );
+
+      if (input.dryRun) {
+        return {
+          dryRun: true as const,
+          total: validRecords.length,
+          willInsert: deduped.rows.length,
+          unmatchedPatient: deduped.unmatchedPatient,
+          duplicates: deduped.duplicates,
+          errors: [...errors, ...deduped.errors],
+        };
+      }
+
+      if (deduped.rows.length > 0) {
+        await ctx.db.insert(vaccinationRecords).values(
+          deduped.rows.map((v) => ({ ...v, practiceId: ctx.practiceId }))
         );
       }
       return {

--- a/docs/migrating-to-openvpm.md
+++ b/docs/migrating-to-openvpm.md
@@ -1,0 +1,50 @@
+# Migrating to OpenVPM
+
+Switching systems is the scary part of buying a PIMS. This guide makes it boring: export three CSV files from your old system, import them in order, and your clinic is running with its own clients, pets, and vaccine history. Every import runs a **dry run first** and shows exactly what will be added, what is a duplicate, and what needs a fix, before anything is saved.
+
+On OpenVPM Cloud we will also do this **for you**: send your exports to support and we hand back a ready clinic.
+
+## What you can import today
+
+| Data | File | Links by |
+|---|---|---|
+| Clients (pet owners) | clients CSV | deduped by email |
+| Patients (pets) | patients CSV | owner's email |
+| Vaccine history | vaccinations CSV | owner's email + pet name |
+
+Vaccine history is worth the extra file: overdue-vaccine lists, reminders, and the AI assistant all light up with real answers on day one.
+
+Appointments, invoices, and full medical notes can be brought over today via a guided (white-glove) migration; a full OpenVPM backup JSON can also be restored into a fresh practice.
+
+## Column names: we speak your export's language
+
+Headers are matched loosely (case, spaces, and underscores do not matter) and common synonyms are accepted, so most exports import without editing:
+
+- **Clients**: `firstName`/`first`/`owner first name`, `lastName`/`surname`, `email`, `phone`/`cell phone`/`mobile`, `address`/`address1`/`street`, `city`, `state`/`province`, `zip`/`postal code`
+- **Patients**: `clientEmail`/`owner email`/`email` (required, links the pet to its owner), `name`/`pet name`/`patient name`, `species` (accepts `dog`, `cat`, `bird`, `bunny`, `horse`, `lizard`, and more), `breed`, `sex` (accepts `M`, `F`, `MN`, `FS`, `neutered male`, `spayed female`), `dob`/`birthday`/`date of birth` (accepts `2019-03-05` and `3/5/2019` and `3/5/19`), `color`, `microchip`
+- **Vaccinations**: `clientEmail`, `patientName`/`pet name`, `vaccine`/`vaccine name`, `date given`/`administered` (required), `next due date`/`due date`, `lot number`, `manufacturer`
+
+## Exporting from your current system
+
+- **AVImark**: Information Search → pull Clients and Patients → Results → Export → save as CSV. Vaccine history exports the same way from medical history. Your Covetrus rep can also produce full exports.
+- **Cornerstone**: Reports → Client report and Patient report → save to CSV. IDEXX support can pull complete exports on request.
+- **ezyVet**: Records dashboard → search Contacts and Animals → Export to CSV.
+- **Anything else**: any spreadsheet saved as CSV works. When in doubt, send us a sample row and we will confirm the mapping.
+
+## Import order (it matters)
+
+1. **Clients first.** Pets link to owners by email, so owners must exist before pets.
+2. **Patients second.** Rows whose owner email is not found are reported, not guessed.
+3. **Vaccinations third.** Doses link by owner email + pet name; duplicates (same pet, same vaccine, same date) are skipped automatically, so re-running a file is safe.
+
+Where: **Settings → Data → Import**, or during onboarding in the "Bring your real data" step. Each step shows a dry-run report first: rows parsed, rows that will import, duplicates, unmatched owners or pets, and per-row issues with row numbers.
+
+## Getting your data OUT of OpenVPM
+
+The door swings both ways, always: **Settings → Data → Export** gives per-entity CSVs (clients, patients, appointments, invoices) and a full JSON backup of every table, any time, no support ticket. Nightly encrypted backups run on Cloud automatically.
+
+## Limits and safety
+
+- Files up to 5 MB and 10,000 rows per import; split bigger exports.
+- Imports never overwrite existing records; they only add, and duplicates are skipped by stable keys (client email; pet identity or microchip; dose identity).
+- Everything is tenant scoped and admin only.


### PR DESCRIPTION
Step 2's switching-cost killer: a clinic leaving AVImark/Cornerstone/ezyVet can now import **clients → patients → vaccine history** from their real exports, dry-run first, without hand-editing files. Public playbook included.

## What
- **Header aliases**: every import field accepts the column names real exports use (`Owner First Name`, `Surname`, `Cell Phone`, `Pet Name`, `Gender`, `Birthday`, `Microchip`, `Date Given`, `Due Date`, …). Canonical headers stay first-priority, so our own export → import round trip is unchanged.
- **Value normalization** (`lib/import/normalize.ts`): `Dog`/`Cat`/`Bird`/`Bunny`/`Bearded Dragon` → species enum; `M`/`MN`/`FS`/`Neutered Male`/`Castrated` → sex enum; `3/5/2019`, `03-05-2019`, `3/5/19` → ISO dates (two-digit years resolve to the past — birthdays, not appointments). Unknown species still error; unreadable DOBs pass through so the router reports the precise expected format.
- **NEW `data.importVaccinationsCsv`** (admin-only, 5 MB/10k-row caps, dry-run first): links doses by owner email + pet name (case/spacing-insensitive), **flags same-named pets under one owner instead of guessing**, dedupes by patient+vaccine+date against both the DB and the file (safe to re-run), inserts historical doses at noon UTC of the given day with `administeredBy: null`. Vaccine history means overdue lists, reminders, and the AI assistant work on day one for a migrated clinic.
- **Settings → Data**: "Coming from" source chips with per-system export instructions, a numbered 3-step import order, vaccinations mode with a Missing-pets stat in the dry-run report.
- **`docs/migrating-to-openvpm.md`**: the public switching playbook (also a sales page: white-glove offer + the data-out promise).

## Tests
- `normalize.test.ts` (6), csv alias/vaccination mapping (import.test.ts now 18), `data-import-vaccinations.test.ts` (8: role gate, size gate before DB, malformed-CSV short-circuit, dry-run counts incl. duplicates + missing pets, noon-UTC tenant-stamped insert payload, ambiguous-pet flag, fuzzy match, practice 404)
- Full suite **225 files / 1,987 green**; typecheck green. Existing dedup suite passes unchanged over the alias layer.

## Note
Local Docker/Postgres died mid-session (disk full), so the scripted end-to-end UI walkthrough is prepared (AVImark-style fixture CSVs) but not yet executed; the UI reuses the existing proven dry-run→confirm flow with one added mode. Will run it when the local DB is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)