### PR TITLE
Activation funnel: signup → activated → subscribed instrumentation + security page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,7 @@ CRON_HEARTBEAT_BILLING_LIFECYCLE_URL=
 CRON_HEARTBEAT_WELLNESS_BILLING_URL=
 CRON_HEARTBEAT_RATE_LIMIT_CLEANUP_URL=
 CRON_HEARTBEAT_AUTH_CLEANUP_URL=
+CRON_HEARTBEAT_ACTIVATION_DIGEST_URL=
 
 # Ops alerting — failures in background jobs (reminders, backups, webhook
 # delivery) post here (Slack-style incoming webhook). Required for hosted

--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -7,6 +7,7 @@ import {
   Clock,
   CheckCircle,
   AlertTriangle,
+  TrendingUp,
 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { EmptyState } from "@/components/common/empty-state";
@@ -38,6 +39,10 @@ function formatDate(d: Date | string | null, timeZone?: string | null) {
   }
 }
 
+function formatPct(rate: number) {
+  return `${Math.round(rate * 100)}%`;
+}
+
 const statusStyles: Record<string, string> = {
   active: "bg-green-100 text-green-700",
   trialing: "bg-blue-100 text-blue-700",
@@ -51,6 +56,8 @@ export default function AdminPage() {
     trpc.admin.overview.useQuery(undefined, {
       retry: false,
     });
+  const { data: funnel, error: funnelError } =
+    trpc.admin.activationFunnel.useQuery({ days: 30 }, { retry: false });
 
   if (error?.data?.code === "FORBIDDEN") {
     return (
@@ -121,6 +128,51 @@ export default function AdminPage() {
             </div>
           );
         })}
+      </div>
+
+      {/* Trial funnel */}
+      <div className="mt-6 rounded-lg border border-border bg-card p-5">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <TrendingUp className="h-4 w-4" />
+          <span className="text-sm">Trial funnel (30 days)</span>
+        </div>
+        {funnel ? (
+          <>
+            <div className="mt-3 grid gap-4 sm:grid-cols-3">
+              <div>
+                <p className="text-sm text-muted-foreground">Signups</p>
+                <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
+                  {funnel.totals.signups}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Activated</p>
+                <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
+                  {funnel.totals.activated}
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    {formatPct(funnel.totals.activationRate)}
+                  </span>
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Subscribed</p>
+                <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
+                  {funnel.totals.subscribed}
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    {formatPct(funnel.totals.conversionRate)}
+                  </span>
+                </p>
+              </div>
+            </div>
+            <p className="mt-3 text-xs text-muted-foreground">
+              Activated = added a real client and booked a real visit
+            </p>
+          </>
+        ) : (
+          <p className="mt-3 text-sm text-muted-foreground">
+            {funnelError ? "Could not load the funnel." : "Loading funnel..."}
+          </p>
+        )}
       </div>
 
       {/* Practices table */}

--- a/apps/web/app/api/cron/activation-digest/route.test.ts
+++ b/apps/web/app/api/cron/activation-digest/route.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ActivationFunnel } from "@/lib/admin/activation-funnel";
+
+const mocks = vi.hoisted(() => ({
+  db: {},
+  alertOps: vi.fn(async () => undefined),
+  cronAuthError: vi.fn(() => null),
+  reportCronHeartbeat: vi.fn(async () => undefined),
+  sendEmail: vi.fn(async () => ({ success: true, id: "email_123" })),
+  computeActivationFunnel: vi.fn(),
+}));
+
+vi.mock("@openpims/db/client", () => ({
+  db: mocks.db,
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  cronAuthError: mocks.cronAuthError,
+}));
+
+vi.mock("@/lib/cron-heartbeat", () => ({
+  reportCronHeartbeat: mocks.reportCronHeartbeat,
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendEmail: mocks.sendEmail,
+}));
+
+vi.mock("@/lib/alerts", () => ({
+  alertOps: mocks.alertOps,
+}));
+
+vi.mock("@/lib/admin/activation-funnel", () => ({
+  computeActivationFunnel: mocks.computeActivationFunnel,
+}));
+
+const { GET } = await import("./route");
+
+function funnel(days: number, totals: Partial<ActivationFunnel["totals"]> = {}): ActivationFunnel {
+  return {
+    days,
+    weeks: [],
+    totals: {
+      signups: 5,
+      activated: 2,
+      subscribed: 1,
+      activationRate: 0.4,
+      conversionRate: 0.2,
+      ...totals,
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe("activation digest cron", () => {
+  it("requires cron authorization before computing anything", async () => {
+    mocks.cronAuthError.mockReturnValueOnce(
+      new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }) as never
+    );
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/activation-digest")
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.computeActivationFunnel).not.toHaveBeenCalled();
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+    expect(mocks.reportCronHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it("skips sending when no platform admin emails are configured", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "");
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/activation-digest")
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      recipients: 0,
+      sent: 0,
+      failed: 0,
+    });
+    expect(mocks.computeActivationFunnel).not.toHaveBeenCalled();
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
+      job: "activation-digest",
+      status: "ok",
+      detail: "No platform admin emails configured; digest skipped",
+      metrics: { recipients: 0, sent: 0, failed: 0 },
+    });
+  });
+
+  it("emails the 7-day and 30-day funnel to every platform admin", async () => {
+    vi.stubEnv(
+      "PLATFORM_ADMIN_EMAILS",
+      "founder@openvpm.com, ops@openvpm.com"
+    );
+    mocks.computeActivationFunnel.mockImplementation(
+      async (_db: unknown, days: number) => funnel(days)
+    );
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/activation-digest")
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      recipients: 2,
+      sent: 2,
+      failed: 0,
+    });
+    expect(mocks.computeActivationFunnel).toHaveBeenCalledWith(mocks.db, 7);
+    expect(mocks.computeActivationFunnel).toHaveBeenCalledWith(mocks.db, 30);
+    expect(mocks.sendEmail).toHaveBeenCalledTimes(2);
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "founder@openvpm.com",
+        subject: "OpenVPM trial funnel: 5 signups, 2 activated this week",
+        html: expect.stringContaining("Past 30 days"),
+      })
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "ops@openvpm.com" })
+    );
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
+      job: "activation-digest",
+      status: "ok",
+      detail: "2 sent, 0 failed",
+      metrics: { recipients: 2, sent: 2, failed: 0 },
+    });
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+
+  it("counts send failures, alerts ops, and reports a degraded heartbeat", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "founder@openvpm.com");
+    mocks.computeActivationFunnel.mockImplementation(
+      async (_db: unknown, days: number) => funnel(days)
+    );
+    mocks.sendEmail.mockResolvedValueOnce({
+      success: false,
+      error: "Provider down",
+    } as never);
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/activation-digest")
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      recipients: 1,
+      sent: 0,
+      failed: 1,
+    });
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Activation digest had send failures",
+      "1 of 1 digest emails failed to send."
+    );
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
+      job: "activation-digest",
+      status: "degraded",
+      detail: "0 sent, 1 failed",
+      metrics: { recipients: 1, sent: 0, failed: 1 },
+    });
+  });
+
+  it("never throws when the funnel query fails; it alerts ops instead", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "founder@openvpm.com");
+    mocks.computeActivationFunnel.mockRejectedValue(
+      new Error("relation practices does not exist")
+    );
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/activation-digest")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Activation digest failed",
+    });
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Activation digest cron failed",
+      "relation practices does not exist"
+    );
+    expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith({
+      job: "activation-digest",
+      status: "failed",
+      detail: "relation practices does not exist",
+    });
+  });
+});

--- a/apps/web/app/api/cron/activation-digest/route.ts
+++ b/apps/web/app/api/cron/activation-digest/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+import { db } from "@openpims/db/client";
+import { cronAuthError } from "@/lib/cron-auth";
+import { sendEmail } from "@/lib/email";
+import { alertOps } from "@/lib/alerts";
+import { reportCronHeartbeat } from "@/lib/cron-heartbeat";
+import { platformAdminEmails } from "@/lib/platform-admin";
+import {
+  computeActivationFunnel,
+  type ActivationFunnel,
+} from "@/lib/admin/activation-funnel";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+// Weekly trial-funnel digest for the founder/operators: signups -> activated
+// -> subscribed for the past 7 and 30 days, emailed to PLATFORM_ADMIN_EMAILS.
+// Reporting only — it must never 500-loop, so failures alert ops and still
+// return a non-throwing response.
+export async function GET(request: Request) {
+  const authError = cronAuthError(request);
+  if (authError) return authError;
+
+  try {
+    const recipients = platformAdminEmails();
+    if (recipients.length === 0) {
+      await reportCronHeartbeat({
+        job: "activation-digest",
+        status: "ok",
+        detail: "No platform admin emails configured; digest skipped",
+        metrics: { recipients: 0, sent: 0, failed: 0 },
+      });
+      return NextResponse.json({ recipients: 0, sent: 0, failed: 0 });
+    }
+
+    const [week, month] = await Promise.all([
+      computeActivationFunnel(db, 7),
+      computeActivationFunnel(db, 30),
+    ]);
+
+    const subject = `OpenVPM trial funnel: ${week.totals.signups} signups, ${week.totals.activated} activated this week`;
+    const html = digestHtml(week, month);
+
+    let sent = 0;
+    let failed = 0;
+    for (const to of recipients) {
+      const result = await sendEmail({ to, subject, html });
+      if (result.success) {
+        sent++;
+      } else {
+        failed++;
+      }
+    }
+
+    if (failed > 0) {
+      void alertOps(
+        "Activation digest had send failures",
+        `${failed} of ${recipients.length} digest emails failed to send.`
+      );
+    }
+
+    await reportCronHeartbeat({
+      job: "activation-digest",
+      status: failed > 0 ? "degraded" : "ok",
+      detail: `${sent} sent, ${failed} failed`,
+      metrics: { recipients: recipients.length, sent, failed },
+    });
+
+    return NextResponse.json({ recipients: recipients.length, sent, failed });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    void alertOps("Activation digest cron failed", message);
+    await reportCronHeartbeat({
+      job: "activation-digest",
+      status: "failed",
+      detail: message,
+    });
+    // Deliberately not a 5xx: a broken digest should alert ops, not retry-loop.
+    return NextResponse.json({ ok: false, error: "Activation digest failed" });
+  }
+}
+
+function pct(rate: number): string {
+  return `${Math.round(rate * 100)}%`;
+}
+
+function funnelSection(title: string, funnel: ActivationFunnel): string {
+  const { signups, activated, subscribed, activationRate, conversionRate } =
+    funnel.totals;
+  return `<h2 style="margin:24px 0 8px;font-size:16px;color:#111827;">${title}</h2>
+<table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
+  <tr style="text-align:left;color:#6b7280;font-size:13px;">
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Signups</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Activated</th>
+    <th style="padding:4px 0;font-weight:500;">Subscribed</th>
+  </tr>
+  <tr style="font-size:20px;color:#111827;font-weight:600;">
+    <td style="padding:2px 12px 2px 0;">${signups}</td>
+    <td style="padding:2px 12px 2px 0;">${activated} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(activationRate)}</span></td>
+    <td style="padding:2px 0;">${subscribed} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(conversionRate)}</span></td>
+  </tr>
+</table>`;
+}
+
+function digestHtml(week: ActivationFunnel, month: ActivationFunnel): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OpenVPM trial funnel</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f5;">
+    <tr>
+      <td align="center" style="padding:24px 16px;">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background-color:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+          <tr>
+            <td style="background-color:#0d9488;padding:24px 32px;">
+              <h1 style="margin:0;color:#ffffff;font-size:22px;font-weight:600;letter-spacing:-0.01em;">OpenVPM trial funnel</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:32px;">
+              ${funnelSection("Past 7 days", week)}
+              ${funnelSection("Past 30 days", month)}
+              <p style="margin:24px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Activated = added a real client and booked a real visit. Subscribed = billing is active. Demo data never counts.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px;background-color:#f9fafb;border-top:1px solid #e5e7eb;">
+              <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.5;">Weekly digest from the OpenVPM activation cron. Full detail is on the platform admin page.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -21,6 +21,22 @@ describe("admin UI", () => {
     expect(source).not.toContain("if (isLoading || !data)");
   });
 
+  it("shows the trial funnel tile with counts, rates, and the plain hint", () => {
+    expect(source).toContain(
+      "trpc.admin.activationFunnel.useQuery({ days: 30 }, { retry: false })"
+    );
+    expect(source).toContain("Trial funnel (30 days)");
+    expect(source).toContain("{funnel.totals.signups}");
+    expect(source).toContain("{funnel.totals.activated}");
+    expect(source).toContain("{funnel.totals.subscribed}");
+    expect(source).toContain("formatPct(funnel.totals.activationRate)");
+    expect(source).toContain("formatPct(funnel.totals.conversionRate)");
+    expect(source).toContain(
+      "Activated = added a real client and booked a real visit"
+    );
+    expect(source).toContain("Could not load the funnel.");
+  });
+
   it("renders practice dates in each practice timezone", () => {
     expect(source).toContain(
       "function formatDate(d: Date | string | null, timeZone?: string | null)"

--- a/apps/web/lib/__tests__/cron-schedule.test.ts
+++ b/apps/web/lib/__tests__/cron-schedule.test.ts
@@ -17,6 +17,7 @@ describe("Vercel cron schedule", () => {
         "/api/cron/wellness-billing",
         "/api/cron/rate-limit-cleanup",
         "/api/cron/auth-cleanup",
+        "/api/cron/activation-digest",
       ])
     );
   });

--- a/apps/web/lib/admin/activation-funnel.ts
+++ b/apps/web/lib/admin/activation-funnel.ts
@@ -1,0 +1,140 @@
+import { sql } from "drizzle-orm";
+import type { Database } from "@openpims/db/client";
+import { withSystem } from "@/lib/tenant-db";
+
+/**
+ * Trial activation funnel, DERIVED from existing data (no schema changes).
+ *
+ * - signup: a practice created inside the window (soft-deleted excluded).
+ * - activated: the practice has at least one real (non-demo) client AND at
+ *   least one real (non-demo) appointment created after signup. Demo rows are
+ *   the ids recorded in practices.settings -> 'demoData' when sample data is
+ *   seeded, so they never count toward activation.
+ * - subscribed: billingStatus = 'active' (a 'trialing' practice is still in
+ *   the trial, not converted).
+ *
+ * Shared by the platform-admin tRPC query and the weekly digest cron so both
+ * always report the same numbers.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface ActivationFunnelWeek {
+  /** ISO date (YYYY-MM-DD) of the Monday the week starts on. */
+  weekStart: string;
+  signups: number;
+  activated: number;
+  subscribed: number;
+}
+
+export interface ActivationFunnelTotals {
+  signups: number;
+  activated: number;
+  subscribed: number;
+  /** activated / signups; 0 when there are no signups. */
+  activationRate: number;
+  /** subscribed / signups; 0 when there are no signups. */
+  conversionRate: number;
+}
+
+export interface ActivationFunnel {
+  days: number;
+  weeks: ActivationFunnelWeek[];
+  totals: ActivationFunnelTotals;
+}
+
+/** Rate guarded against divide-by-zero: no signups means a 0 rate, not NaN. */
+export function funnelRate(part: number, whole: number): number {
+  return whole > 0 ? part / whole : 0;
+}
+
+interface FunnelRow {
+  weekStart: string;
+  signups: number | string;
+  activated: number | string;
+  subscribed: number | string;
+}
+
+function rowsFromExecute<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  const rows = (result as { rows?: unknown[] } | null)?.rows;
+  return Array.isArray(rows) ? (rows as T[]) : [];
+}
+
+export async function computeActivationFunnel(
+  db: Database,
+  days: number
+): Promise<ActivationFunnel> {
+  const windowStart = new Date(Date.now() - days * DAY_MS).toISOString();
+
+  // Cross-tenant read → system context (RLS bypass), same as the admin
+  // overview. One grouped aggregate query — no per-practice N+1.
+  const result = await withSystem(db, (tx) =>
+    tx.execute(sql`
+      with signups as (
+        select
+          p.id,
+          p.created_at,
+          p.billing_status,
+          date_trunc('week', p.created_at) as week_start,
+          coalesce(p.settings -> 'demoData' -> 'clientIds', '[]'::jsonb)
+            as demo_client_ids,
+          coalesce(p.settings -> 'demoData' -> 'appointmentIds', '[]'::jsonb)
+            as demo_appointment_ids
+        from practices p
+        where p.deleted_at is null
+          and p.created_at >= ${windowStart}::timestamptz
+      )
+      select
+        to_char(s.week_start, 'YYYY-MM-DD') as "weekStart",
+        count(*)::int as "signups",
+        count(*) filter (
+          where exists (
+            select 1
+            from clients c
+            where c.practice_id = s.id
+              and c.deleted_at is null
+              and c.created_at >= s.created_at
+              and not (s.demo_client_ids @> to_jsonb(c.id::text))
+          )
+          and exists (
+            select 1
+            from appointments a
+            where a.practice_id = s.id
+              and a.deleted_at is null
+              and a.created_at >= s.created_at
+              and not (s.demo_appointment_ids @> to_jsonb(a.id::text))
+          )
+        )::int as "activated",
+        count(*) filter (where s.billing_status = 'active')::int as "subscribed"
+      from signups s
+      group by s.week_start
+      order by s.week_start
+    `)
+  );
+
+  const weeks: ActivationFunnelWeek[] = rowsFromExecute<FunnelRow>(result).map(
+    (row) => ({
+      weekStart: String(row.weekStart),
+      signups: Number(row.signups) || 0,
+      activated: Number(row.activated) || 0,
+      subscribed: Number(row.subscribed) || 0,
+    })
+  );
+
+  const signups = weeks.reduce((sum, week) => sum + week.signups, 0);
+  const activated = weeks.reduce((sum, week) => sum + week.activated, 0);
+  const subscribed = weeks.reduce((sum, week) => sum + week.subscribed, 0);
+
+  return {
+    days,
+    weeks,
+    totals: {
+      signups,
+      activated,
+      subscribed,
+      activationRate: funnelRate(activated, signups),
+      conversionRate: funnelRate(subscribed, signups),
+    },
+  };
+}

--- a/apps/web/lib/cron-heartbeat.ts
+++ b/apps/web/lib/cron-heartbeat.ts
@@ -11,6 +11,7 @@ export const CRON_HEARTBEAT_JOBS = [
   "wellness-billing",
   "rate-limit-cleanup",
   "auth-cleanup",
+  "activation-digest",
 ] as const;
 
 export type CronHeartbeatJob = (typeof CRON_HEARTBEAT_JOBS)[number];

--- a/apps/web/server/__tests__/admin-activation-funnel.test.ts
+++ b/apps/web/server/__tests__/admin-activation-funnel.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const executeResults: unknown[][] = [];
+  const execute = vi.fn(async () => executeResults.shift() ?? []);
+  const db = { execute };
+
+  return {
+    db,
+    execute,
+    executeResults,
+    withTenant: vi.fn(
+      async (
+        database: unknown,
+        _practiceId: string,
+        fn: (tx: unknown) => Promise<unknown>
+      ) => fn(database)
+    ),
+    withSystem: vi.fn(
+      async (database: unknown, fn: (tx: unknown) => Promise<unknown>) =>
+        fn(database)
+    ),
+  };
+});
+
+vi.mock("@openpims/db/client", () => ({
+  db: mocks.db,
+}));
+
+vi.mock("@/lib/tenant-db", () => ({
+  withTenant: mocks.withTenant,
+  withSystem: mocks.withSystem,
+}));
+
+const { adminRouter } = await import("../routers/admin");
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+
+function caller(email = "ops@example.com") {
+  return adminRouter.createCaller({
+    db: mocks.db,
+    session: {
+      user: {
+        id: USER_ID,
+        email,
+        name: "Ops",
+        role: "admin",
+        practiceId: PRACTICE_ID,
+      },
+    },
+  } as never);
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+  mocks.executeResults.length = 0;
+});
+
+describe("admin activation funnel", () => {
+  it("rejects non-platform-admin callers with FORBIDDEN", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+
+    await expect(
+      caller("clinic-admin@example.com").activationFunnel({ days: 30 })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
+  it("sums weekly rows and computes activation and conversion rates", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.executeResults.push([
+      { weekStart: "2026-06-15", signups: 4, activated: 2, subscribed: 1 },
+      { weekStart: "2026-06-22", signups: 6, activated: 3, subscribed: 2 },
+    ]);
+
+    const result = await caller().activationFunnel({ days: 30 });
+
+    expect(result.days).toBe(30);
+    expect(result.weeks).toEqual([
+      { weekStart: "2026-06-15", signups: 4, activated: 2, subscribed: 1 },
+      { weekStart: "2026-06-22", signups: 6, activated: 3, subscribed: 2 },
+    ]);
+    expect(result.totals).toEqual({
+      signups: 10,
+      activated: 5,
+      subscribed: 3,
+      activationRate: 0.5,
+      conversionRate: 0.3,
+    });
+    expect(mocks.withSystem).toHaveBeenCalledWith(
+      mocks.db,
+      expect.any(Function)
+    );
+  });
+
+  it("defaults to a 30-day window when no input is given", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.executeResults.push([]);
+
+    const result = await caller().activationFunnel();
+
+    expect(result.days).toBe(30);
+  });
+
+  it("returns zero rates instead of dividing by zero when there are no signups", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.executeResults.push([]);
+
+    const result = await caller().activationFunnel({ days: 7 });
+
+    expect(result.totals).toEqual({
+      signups: 0,
+      activated: 0,
+      subscribed: 0,
+      activationRate: 0,
+      conversionRate: 0,
+    });
+  });
+
+  it("coerces string counts from the driver into numbers", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.executeResults.push([
+      { weekStart: "2026-06-29", signups: "2", activated: "1", subscribed: "0" },
+    ]);
+
+    const result = await caller().activationFunnel({ days: 30 });
+
+    expect(result.totals.signups).toBe(2);
+    expect(result.totals.activated).toBe(1);
+    expect(result.totals.activationRate).toBe(0.5);
+  });
+
+  it("excludes demo rows and soft-deleted data in the funnel SQL", () => {
+    const source = readFileSync("lib/admin/activation-funnel.ts", "utf8");
+
+    // Demo ids seeded into practices.settings.demoData never count.
+    expect(source).toContain("p.settings -> 'demoData' -> 'clientIds'");
+    expect(source).toContain("p.settings -> 'demoData' -> 'appointmentIds'");
+    expect(source).toContain("not (s.demo_client_ids @> to_jsonb(c.id::text))");
+    expect(source).toContain(
+      "not (s.demo_appointment_ids @> to_jsonb(a.id::text))"
+    );
+
+    // Soft-deleted practices, clients, and appointments are excluded.
+    expect(source).toContain("p.deleted_at is null");
+    expect(source).toContain("c.deleted_at is null");
+    expect(source).toContain("a.deleted_at is null");
+
+    // Activation only counts rows created after the practice signed up.
+    expect(source).toContain("c.created_at >= s.created_at");
+    expect(source).toContain("a.created_at >= s.created_at");
+
+    // Subscribed means an active subscription, not a running trial.
+    expect(source).toContain("where s.billing_status = 'active'");
+
+    // Weekly grouping via date_trunc — a grouped aggregate, not a per-practice N+1.
+    expect(source).toContain("date_trunc('week', p.created_at)");
+  });
+});

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -1,9 +1,11 @@
+import { z } from "zod";
 import { isNull, sql, desc } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure } from "../trpc";
 import { db } from "@openpims/db/client";
 import { practices, users, clients, patients, locations } from "@openpims/db";
 import { isPlatformAdmin } from "@/lib/platform-admin";
+import { computeActivationFunnel } from "@/lib/admin/activation-funnel";
 import {
   CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD,
   CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD,
@@ -118,4 +120,16 @@ export const adminRouter = createRouter({
     };
     })
   ),
+
+  /**
+   * Trial funnel: signups -> activated -> subscribed, derived from existing
+   * rows (see lib/admin/activation-funnel.ts for the definitions).
+   */
+  activationFunnel: platformAdminProcedure
+    .input(
+      z
+        .object({ days: z.number().int().min(1).max(365).default(30) })
+        .optional()
+    )
+    .query(({ input }) => computeActivationFunnel(db, input?.days ?? 30)),
 });

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -32,6 +32,10 @@
     {
       "path": "/api/cron/auth-cleanup",
       "schedule": "45 4 * * *"
+    },
+    {
+      "path": "/api/cron/activation-digest",
+      "schedule": "0 13 * * 1"
     }
   ]
 }

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -226,7 +226,8 @@ set job-specific URLs (`CRON_HEARTBEAT_REMINDERS_URL`,
 `CRON_HEARTBEAT_BILLING_LIFECYCLE_URL`,
 `CRON_HEARTBEAT_WELLNESS_BILLING_URL`,
 `CRON_HEARTBEAT_RATE_LIMIT_CLEANUP_URL`,
-`CRON_HEARTBEAT_AUTH_CLEANUP_URL`) when your external monitor expects one URL
+`CRON_HEARTBEAT_AUTH_CLEANUP_URL`,
+`CRON_HEARTBEAT_ACTIVATION_DIGEST_URL`) when your external monitor expects one URL
 per scheduled job. URL templates may include `{job}` and `{status}` tokens.
 
 ## Demo Mode

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,55 @@
+# Security Overview
+
+How OpenVPM protects practice and patient data. This is a factual summary of controls that exist in the codebase today. For the vulnerability reporting process, see [SECURITY.md](../SECURITY.md) at the repo root.
+
+## Tenant isolation
+
+Every tenant-scoped table carries a `practice_id` column, and the application layer filters every query by the signed-in user's practice. Isolation is covered by dedicated tests (`apps/web/server/__tests__/tenant-scoping.test.ts` and per-router scoping tests).
+
+Behind the app-layer filters, Postgres Row-Level Security enforces the same boundary at the database:
+
+- Policies live in `packages/db/rls/enable-rls.sql` and key off an `app.current_practice_id` setting the app sets per request inside a transaction (`apps/web/lib/tenant-db.ts`).
+- Cross-tenant paths (platform admin, cron sweeps, pre-login flows) must opt in explicitly via a system context; there is no ambient bypass.
+- CI runs a dedicated `rls` job (`.github/workflows/ci.yml`) that applies the policies to a real Postgres and runs live isolation tests (`packages/db/test-rls.ts`) connected as the application role, proving one tenant cannot read another's rows.
+
+## Least-privilege database role
+
+The hosted application connects as `openpims_app`, a role with only `SELECT`, `INSERT`, `UPDATE`, and `DELETE` grants. It does not own tables, so it cannot alter schema and cannot bypass RLS. Migrations run separately on the owner connection.
+
+## Backups and restore validation
+
+A scheduled job (`apps/web/app/api/cron/backup`, daily at 03:00 UTC) exports each practice's full data set to a private S3-compatible object storage bucket, one restorable snapshot per practice per day. The export includes the complete medical record: SOAP notes, clinical notes, problem lists, lab results, prescriptions, vaccination records, vital signs, and the controlled substance log, alongside scheduling, client, inventory, and billing data (`apps/web/lib/backup/export.ts`).
+
+Restores are validated before anything is written: the backup file is checked against the expected sections and row shapes, and invalid or oversized files (over 50 MB) are rejected (`validatePracticeExportRestore`, `apps/web/lib/backup/policy.ts`). Backup failures page the operators through the ops alert webhook, and a dead-man heartbeat monitors that the job actually ran.
+
+## Rate limiting
+
+Rate limiting is durable, not in-memory. A fixed-window limiter stores counters in Postgres (`apps/web/lib/rate-limit.ts`), so limits hold across serverless instances and process restarts. Overlong keys are hashed, responses carry standard `Retry-After` and `X-RateLimit-*` headers, and a daily cron prunes expired buckets. Sensitive public surfaces such as the client portal use it on their read paths.
+
+## Security headers
+
+Every response gets a strict header set (`apps/web/lib/security-headers.js`, applied through `next.config.js` and the middleware):
+
+- `Content-Security-Policy` with `default-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`, and `upgrade-insecure-requests` in production
+- `Strict-Transport-Security` for two years with `includeSubDomains` and `preload`
+- `Permissions-Policy` denying camera, microphone, geolocation, payment, and USB
+- `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin`
+
+## Audit log
+
+Mutations are recorded to an `audit_log` table with the practice, user, IP address, action, entity, and a redacted copy of the change (`apps/web/lib/audit.ts`). Secret-like fields (passwords, tokens, keys) are stripped before storage. Audit writes are best-effort and never block or fail the underlying request.
+
+## Capability URLs
+
+Public links are capability URLs: possession of the unguessable token is the credential, and the token grants only one narrow capability.
+
+- Client portal links (`/portal/<token>`) use a unique per-client access token and expose only that client's own data.
+- The practice calendar feed (`/api/calendar/<token>`) uses a unique practice-level token that can be rotated, which invalidates every previously shared URL.
+
+## Authentication
+
+Passwords are hashed with bcrypt. All dashboard routes require an authenticated session, enforced in middleware. API keys are stored as bcrypt hashes with an indexed lookup prefix; the raw key is shown once and never persisted.
+
+## Responsible disclosure
+
+Please do not report security issues through public GitHub issues. Email **security@openvpm.com** with `[SECURITY]` in the subject line. We acknowledge reports within 48 hours and follow the 90-day coordinated disclosure process described in [SECURITY.md](../SECURITY.md).


### PR DESCRIPTION
Day 2 of the 36-hour push. The no-card trial decision finally gets data.

- **`admin.activationFunnel`** (platform-admin gated like `admin.overview`): weekly signups → activated → subscribed with rates, one grouped aggregate (demo rows excluded via `settings->demoData` ids; activated = real client AND real appointment after signup).
- **Trial funnel card** on /admin.
- **Weekly digest email** to PLATFORM_ADMIN_EMAILS: new `/api/cron/activation-digest` (Mon 13:00 UTC, CRON_SECRET-gated, fail-soft, heartbeat-registered per repo invariant).
- **`docs/security.md`**: public trust page — every claim verified against code before writing (backups described honestly as private-storage + restore-validated, not 'encrypted').

No schema changes. Suite **230 files / 2,028 green**; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)