### PR TITLE
fix(backup): make real backup files restorable + first restore drill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ WEBSITE-BUILD-PROMPT.md
 .vercel
 docs/screenshots/audit/
 test-results/
+playwright-report/
 CAVSG_AI_Innovator_Survey_COMPLETED.docx
 package-lock.json
 

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import {
   backupKey,
+  coerceRowDates,
   PRACTICE_EXPORT_SECRET_REPLACEMENTS,
   PRACTICE_EXPORT_SYSTEM_EXCLUSIONS,
   PRACTICE_EXPORT_SECTIONS,
@@ -10,6 +11,7 @@ import {
   summarizePracticeExport,
   validatePracticeExportRestore,
 } from "../export";
+import { patients } from "@openpims/db";
 import {
   PRACTICE_BACKUP_JSON_MAX_BYTES,
   isPracticeBackupJsonSizeValid,
@@ -314,6 +316,58 @@ describe("restorePracticeData", () => {
       restorePracticeData(db as never, "target-practice", backup)
     ).rejects.toThrow("Backup contains invalid restore data");
     expect(inserted).toEqual([]);
+  });
+
+  it("coerces JSON timestamp strings into Dates before insert", async () => {
+    // A real backup file round-trips through JSON, so every timestamp is an
+    // ISO string; pg timestamp columns reject those (value.toISOString crash).
+    const backup = {
+      ...emptyBackup(),
+      clients: [
+        {
+          id: "client-1",
+          practiceId: "source-practice",
+          createdAt: "2026-07-01T12:00:00.000Z",
+          updatedAt: "2026-07-02T12:00:00.000Z",
+        },
+      ],
+      patients: [
+        {
+          id: "patient-1",
+          practiceId: "source-practice",
+          clientId: "client-1",
+          createdAt: "2026-07-01T12:00:00.000Z",
+          dob: "2020-05-01",
+        },
+      ],
+    };
+    const { db, inserted } = restoreDb();
+
+    await restorePracticeData(db as never, "target-practice", backup);
+    const restoredRows = inserted.flatMap(({ rows }) => rows);
+    const client = restoredRows.find((row) => row.id === "client-1");
+    const patient = restoredRows.find((row) => row.id === "patient-1");
+
+    expect(client?.createdAt).toBeInstanceOf(Date);
+    expect(client?.updatedAt).toBeInstanceOf(Date);
+    expect((client?.createdAt as Date).toISOString()).toBe(
+      "2026-07-01T12:00:00.000Z"
+    );
+    expect(patient?.createdAt).toBeInstanceOf(Date);
+    // String-mode date columns (calendar dates) stay strings.
+    expect(patient?.dob).toBe("2020-05-01");
+  });
+
+  it("leaves null, absent, and unparseable timestamp values unchanged", () => {
+    const rows = coerceRowDates(patients, [
+      { id: "patient-1", createdAt: null, deletedAt: undefined },
+      { id: "patient-2", createdAt: "not-a-date" },
+      { id: "patient-3", createdAt: new Date("2026-07-01T12:00:00.000Z") },
+    ]);
+
+    expect(rows[0].createdAt).toBeNull();
+    expect(rows[1].createdAt).toBe("not-a-date");
+    expect(rows[2].createdAt).toBeInstanceOf(Date);
   });
 
   it("wraps direct restore helper calls in a database transaction when available", async () => {

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -1,4 +1,4 @@
-import { eq, and, isNull, inArray, sql } from "drizzle-orm";
+import { eq, and, isNull, inArray, sql, getTableColumns } from "drizzle-orm";
 import type { Database } from "@openpims/db/client";
 import { redactSecrets } from "@/lib/audit";
 import {
@@ -460,6 +460,30 @@ async function tenantParentChildRows(
     );
 }
 
+/**
+ * Backups round-trip through JSON, so timestamp values arrive as ISO strings
+ * while the drizzle timestamp columns expect Date objects on insert. Coerce
+ * per-table so a real backup file is directly restorable.
+ */
+export function coerceRowDates(table: any, rows: Row[]): Row[] {
+  const dateColumns = Object.entries(getTableColumns(table))
+    .filter(([, column]) => (column as { dataType?: string }).dataType === "date")
+    .map(([name]) => name);
+  if (dateColumns.length === 0) return rows;
+
+  return rows.map((row) => {
+    const coerced = { ...row };
+    for (const name of dateColumns) {
+      const value = coerced[name];
+      if (typeof value === "string") {
+        const parsed = new Date(value);
+        if (!Number.isNaN(parsed.getTime())) coerced[name] = parsed;
+      }
+    }
+    return coerced;
+  });
+}
+
 async function restoreRows(
   db: Database,
   table: any,
@@ -468,7 +492,10 @@ async function restoreRows(
   opts: { practiceId?: string } = {}
 ): Promise<number> {
   if (rows.length === 0) return 0;
-  const sanitizedRows = sanitizePracticeExportRows(section, rows);
+  const sanitizedRows = coerceRowDates(
+    table,
+    sanitizePracticeExportRows(section, rows)
+  );
   const values = opts.practiceId
     ? withPracticeId(sanitizedRows, opts.practiceId)
     : sanitizedRows;

--- a/docs/backup-restore-runbook.md
+++ b/docs/backup-restore-runbook.md
@@ -1,0 +1,128 @@
+# Backup and Restore Runbook
+
+OpenVPM Cloud takes a full backup of every practice every day. This runbook
+covers what is in those backups, how to restore one, and the drill log that
+proves the whole path works.
+
+## What gets backed up
+
+- **When:** daily at 3:00 AM UTC (`/api/cron/backup`, see `apps/web/vercel.json`).
+- **Where:** object storage, one file per practice per day:
+  `backups/{practiceId}/{YYYY-MM-DD}.json` (date in the practice's timezone).
+- **What:** every practice-owned table, active rows only. That includes the
+  full clinical record (SOAP notes, clinical notes, vitals, vaccinations,
+  labs, procedures, prescriptions, problem lists, cases, treatment plans,
+  controlled-substance log), clients and patients, scheduling, billing
+  (invoices, items, payments, adjustments, claims), inventory, staff, and the
+  audit log. The canonical section list is `PRACTICE_EXPORT_SECTIONS` in
+  `apps/web/lib/backup/export.ts`.
+- **What is left out on purpose:** billing meter records, Stripe state,
+  rate-limit buckets, sessions, and expiring tokens
+  (`PRACTICE_EXPORT_SYSTEM_EXCLUSIONS` documents each reason). The `practices`
+  row itself is not exported; a restore targets an existing practice.
+- **Secrets are sanitized on export:** user password hashes are replaced with
+  a placeholder (restored staff must reset their passwords), client portal
+  tokens are cleared, API keys are disabled, webhook secrets are replaced and
+  webhooks arrive deactivated.
+- **File binaries are not in the JSON.** The `files` section holds the
+  database rows that point at object-storage keys. Object storage is
+  independent of the database, so a database loss does not touch the file
+  binaries and restored rows point at them correctly.
+
+Admins can also download the identical payload on demand:
+**Settings → Data → Export Full Backup**.
+
+## Restore runbook (database loss)
+
+Scenario: the database is gone or a practice's data must be rebuilt from a
+snapshot. Wall-clock times from the 2026-07-10 drill are in brackets.
+
+1. **Stand up a database with the current schema** (skip if the database is
+   fine and you are only rebuilding one practice):
+
+   ```sh
+   cd packages/db
+   DATABASE_URL=<target> pnpm run db:migrate   # [~2s]
+   DATABASE_URL=<target> pnpm run db:rls       # [~1s]
+   ```
+
+2. **Fetch the practice's latest backup** from object storage. There is no
+   in-product download of stored snapshots yet, so pull it with any S3
+   client using the deployment's `S3_*` credentials:
+
+   ```
+   GET {S3_ENDPOINT}/{S3_BUCKET}/backups/{practiceId}/{YYYY-MM-DD}.json
+   ```
+
+   (An admin's on-demand **Export Full Backup** file works the same way if
+   you have one from before the incident.)
+
+3. **Register a fresh practice** on the app and log in as its admin. [~4s]
+
+4. **Remove the sample data.** New practices are seeded with sample pets so
+   the first minutes feel real, and the restore refuses any practice that
+   already has clients, patients, appointments, or invoices.
+   **Settings → Data → Remove sample data.**
+
+5. **Restore:** **Settings → Data → Restore Full Backup → Choose Backup
+   JSON.** The dry run happens automatically and shows verified row counts
+   without writing anything. [~2s] Check the fresh-practice confirmation,
+   then **Restore into Fresh Practice**. [under 1s for a small clinic]
+
+6. **Verify:** client list, one patient chart (vaccinations tab), one
+   invoice. Row counts in the success box should match the dry-run counts.
+
+7. **After-restore hygiene** (by design, see sanitization above):
+   - Staff accounts exist but need password resets.
+   - Webhooks are disabled with placeholder secrets; re-enable after rotating.
+   - API keys are disabled; issue new ones.
+   - Reconnect payment processing (Stripe state is not replayed).
+
+The restore is transactional and additive: it validates sections and
+cross-references first, inserts everything in one transaction, and skips rows
+that already exist. Backups up to 50 MB of JSON are accepted.
+
+## Repeatable drill
+
+`e2e/restore-drill.spec.ts` automates the whole runbook against a scratch
+database and is skipped unless `RESTORE_DRILL_BACKUP` is set:
+
+```sh
+# scratch DB + dev server pointed at it, then:
+RESTORE_DRILL_BACKUP=/path/to/backup.json \
+PLAYWRIGHT_BASE_URL=http://localhost:3009 \
+pnpm exec playwright test e2e/restore-drill.spec.ts
+```
+
+It registers a practice, removes sample data, uploads the backup, checks the
+dry run, restores, and verifies restored clients and a patient chart in the
+UI, printing phase timings at the end.
+
+## Drill log
+
+### 2026-07-10 (first drill)
+
+- **Scenario:** simulated total database loss. Fresh Postgres database,
+  schema from the migration chain, RLS applied, brand-new practice via the
+  real registration flow, restore through the Settings UI.
+- **Source backup:** the daily cron's real output for a working practice
+  (Aspen Creek Animal Hospital, 113 rows across 17 sections, 49.5 KB JSON).
+  Cron swept 7 practices in about 1 second.
+- **Result: PASS.** All 113 of 113 rows restored. Database-level counts
+  matched the export section by section, and the restored patient chart
+  (including imported vaccine history) rendered correctly.
+- **Timings:** register 4.2s, upload + dry run 1.7s, live restore 0.4s.
+  Whole drill including browser startup: 26s.
+- **Found and fixed a release blocker:** restores of real backup files
+  crashed (`value.toISOString is not a function`). Backups round-trip through
+  JSON so timestamps arrive as strings, but the insert path expected `Date`
+  objects. The export/download side was always fine; only restore was
+  affected. Fixed in `coerceRowDates` (`apps/web/lib/backup/export.ts`) with
+  a regression test, and this drill now guards the whole path.
+- **Runbook step discovered:** seeded sample data blocks the fresh-practice
+  restore. Documented above (step 4); a clearer in-product hint on the
+  restore error is a candidate follow-up.
+- **Known gap:** no in-product way to list or download the stored daily
+  snapshots; retrieval is a manual S3 pull (step 2). Candidate follow-up.
+- **Known gap:** file binaries exist only in object storage. Fine for
+  database loss; object-storage loss is not covered by these backups.

--- a/e2e/restore-drill.spec.ts
+++ b/e2e/restore-drill.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Restore drill (run manually, not in CI): registers a fresh practice on a
+ * fresh database and restores a real practice backup through the Settings UI,
+ * timing each phase. Point PLAYWRIGHT_BASE_URL at a dev server whose
+ * DATABASE_URL is an empty, freshly-migrated database, and set
+ * RESTORE_DRILL_BACKUP to the backup JSON path.
+ *
+ *   RESTORE_DRILL_BACKUP=/path/to/backup.json \
+ *   PLAYWRIGHT_BASE_URL=http://localhost:3009 \
+ *   pnpm exec playwright test e2e/restore-drill.spec.ts
+ */
+
+const backupPath = process.env.RESTORE_DRILL_BACKUP ?? "";
+const shotDir = process.env.RESTORE_DRILL_SHOTS ?? "restore-drill-shots";
+const drillEmail = `drill-admin-${Date.now()}@openpims.dev`;
+const drillPassword = "DrillRestore123!";
+
+function shot(name: string): string {
+  return path.join(shotDir, name);
+}
+
+test.describe("Restore drill", () => {
+  test.skip(!backupPath, "Set RESTORE_DRILL_BACKUP to run the drill");
+
+  test("fresh practice restores a real backup through the UI", async ({ page }) => {
+    test.setTimeout(180_000);
+    const timings: Record<string, number> = {};
+
+    // Keep the first-login welcome overlay closed for the drill: report the
+    // welcome as already seen for any user id (it is keyed per user).
+    await page.addInitScript(() => {
+      const realGetItem = Storage.prototype.getItem;
+      Storage.prototype.getItem = function (key: string) {
+        if (typeof key === "string" && key.startsWith("ovpm.welcome.v1.")) {
+          return JSON.stringify({ seenAt: "2026-01-01T00:00:00.000Z" });
+        }
+        return realGetItem.call(this, key);
+      };
+    });
+
+    // Phase 1: register a fresh practice on the empty database.
+    let t = Date.now();
+    await page.goto("/register");
+    await page.getByLabel(/practice name/i).fill("Restore Drill Clinic");
+    await page.getByLabel(/work email/i).fill(drillEmail);
+    await page.getByLabel(/password/i).fill(drillPassword);
+    await page.getByRole("button", { name: /create workspace/i }).click();
+    await expect(page).toHaveURL(
+      (url) => url.pathname === "/" || url.pathname.startsWith("/login"),
+      { timeout: 45_000 }
+    );
+    if (page.url().includes("/login")) {
+      await page.getByLabel(/email/i).fill(drillEmail);
+      await page.getByLabel(/password/i).fill(drillPassword);
+      await page.getByRole("button", { name: /sign in/i }).click();
+      await expect(page).toHaveURL((url) => url.pathname === "/", {
+        timeout: 30_000,
+      });
+    }
+    timings.registerMs = Date.now() - t;
+    await page.screenshot({ path: shot("01-fresh-practice.png"), fullPage: false });
+
+    // Dismiss the first-login welcome overlay whenever it appears (it can
+    // auto-open again on a fresh page load).
+    const dismissWelcome = async () => {
+      const dialog = page.getByRole("dialog", { name: /welcome to openvpm/i });
+      if (await dialog.isVisible({ timeout: 8_000 }).catch(() => false)) {
+        await dialog.getByRole("button", { name: /skip for now/i }).click();
+        await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+      }
+    };
+    await dismissWelcome();
+
+    // Phase 2: Settings → Data → upload backup → automatic dry run.
+    t = Date.now();
+    await page.goto("/settings");
+    await dismissWelcome();
+    await page.getByRole("button", { name: /^data$/i }).click();
+    await expect(
+      page.getByRole("heading", { name: /restore full backup/i })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // New practices are seeded with sample pets, and the restore requires an
+    // empty practice — remove the sample data first (part of the runbook).
+    await page.getByRole("button", { name: /remove sample data/i }).click();
+    await expect(page.getByText(/sample data removed/i)).toBeVisible({
+      timeout: 20_000,
+    });
+
+    await page.setInputFiles('input[type="file"][accept*="json"]', backupPath);
+    await expect(page.getByText("Verified", { exact: true })).toBeVisible({
+      timeout: 30_000,
+    });
+    timings.dryRunMs = Date.now() - t;
+    await expect(page.getByText(/rows detected/i)).toBeVisible();
+    await page
+      .getByRole("heading", { name: /restore full backup/i })
+      .scrollIntoViewIfNeeded();
+    await page.screenshot({ path: shot("02-dry-run-verified.png"), fullPage: true });
+
+    // Phase 3: confirm fresh practice and run the live restore.
+    await page
+      .getByRole("checkbox", {
+        name: /I confirm this practice has no live clients/i,
+      })
+      .click();
+    await expect(
+      page.getByRole("button", { name: /restore into fresh practice/i })
+    ).toBeEnabled({ timeout: 10_000 });
+    t = Date.now();
+    await page
+      .getByRole("button", { name: /restore into fresh practice/i })
+      .click();
+    await expect(page.getByText(/^Restored [\d,]+ rows$/).first()).toBeVisible({
+      timeout: 60_000,
+    });
+    timings.restoreMs = Date.now() - t;
+    const restoredText = await page
+      .getByText(/^Restored [\d,]+ rows$/)
+      .first()
+      .textContent();
+    await page.screenshot({ path: shot("03-restore-complete.png"), fullPage: true });
+
+    // Phase 4: verify the clinic's data is really back, using rows from the
+    // backup itself so the drill works with any practice's backup file.
+    const backup = JSON.parse(readFileSync(backupPath, "utf8")) as {
+      clients: { firstName: string; lastName: string }[];
+      patients: { id: string; name: string }[];
+    };
+    const firstClient = backup.clients[0];
+    const firstPatient = backup.patients[0];
+
+    await page.goto("/clients");
+    await expect(
+      page
+        .getByText(new RegExp(`${firstClient.firstName}\\s+${firstClient.lastName}`, "i"))
+        .first()
+    ).toBeVisible({ timeout: 20_000 });
+    await page.screenshot({ path: shot("04-clients-restored.png"), fullPage: false });
+
+    await page.goto(`/patients/${firstPatient.id}`);
+    await expect(
+      page.getByText(new RegExp(firstPatient.name, "i")).first()
+    ).toBeVisible({ timeout: 20_000 });
+    await page.screenshot({ path: shot("05-patient-chart.png"), fullPage: true });
+
+    console.log("RESTORE_DRILL_RESULT", JSON.stringify({ ...timings, restoredText }));
+  });
+});


### PR DESCRIPTION
## What

The first **restore drill** (Day 2 trust block): simulated total database loss, then restored a real practice backup through the actual product flow (register → remove sample data → Settings → Data → Restore Full Backup). The drill caught a release blocker and this PR fixes it.

## The bug the drill caught (P1)

Restoring any real backup file crashed with `value.toISOString is not a function` (tRPC 500). Backups round-trip through JSON, so timestamps arrive as ISO strings, but the insert path handed those strings to pg timestamp columns. Export and download always worked; **restore was broken end to end**, including on prod. Unit tests never saw it because they stub the DB.

**Fix:** `coerceRowDates` in `apps/web/lib/backup/export.ts` converts ISO strings back to `Date` for each table's date-mode columns before insert. String-mode calendar dates (like `patients.dob`), nulls, and unparseable values pass through untouched. Regression tests included.

## Drill result (2026-07-10): PASS

| Phase | Time |
|---|---|
| Backup cron, 7 practices | ~1s |
| Fresh DB: migrations + RLS | ~3s |
| Register fresh practice | 4.2s |
| Upload + automatic dry run | 1.7s |
| **Live restore, 113 rows** | **0.4s** |

- 113/113 rows restored; DB counts matched the export section by section
- Restored patient chart (imported vaccine history included) renders correctly
- Runbook step surfaced: new practices are seeded with sample pets, so **Remove sample data** must run before a restore (documented)

## Also in this PR

- `e2e/restore-drill.spec.ts`: repeatable, env-gated drill harness (skipped unless `RESTORE_DRILL_BACKUP` is set; CI does not run Playwright)
- `docs/backup-restore-runbook.md`: backup contents, restore runbook, after-restore hygiene (password resets, webhook/API-key rotation), known gaps (no in-product download of stored snapshots; file binaries live only in object storage), drill log
- `.gitignore`: `playwright-report/`

Suite: 230 files / 2,030 tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)