### PR TITLE
docs(help): public help docs v1 from the in-app guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ That's the bar we're building to.
 |-----------|----------|----------------|
 | ![Dashboard](docs/screenshots/dashboard.png) | ![Schedule](docs/screenshots/schedule.png) | ![Patient](docs/screenshots/patient.png) |
 
+## Help & Guides
+
+Short, plain-language guides live in [docs/help](docs/help/README.md): getting started, the day sheet, the AI helper, client portals, calendar sync, and owning your data. Switching from another PIMS? Start with [Migrating to OpenVPM](docs/migrating-to-openvpm.md).
+
 ## Features
 
 ### Phase 1 — Foundation (Implemented)

--- a/docs/help/README.md
+++ b/docs/help/README.md
@@ -1,0 +1,35 @@
+# OpenVPM Help
+
+Short guides for running your clinic on OpenVPM. Each one takes a minute or
+two. The same walkthroughs live inside the app: open **Settings** and click
+**Guides** to see them with your own data.
+
+## Getting started
+
+- [Getting started](getting-started.md). A quick look at the whole app: your
+  day, every pet's story, one-click billing, and the AI helper.
+- [Switching from another system](../migrating-to-openvpm.md). Bring your
+  clients, pets, and vaccine history over from AVImark, Cornerstone, ezyVet,
+  or any CSV export. Every import shows a dry run first.
+
+## Daily work
+
+- [Your day sheet](your-day.md). Book visits, check pets in, and keep the
+  whole team on the same page.
+- [Ask the AI about a pet](ask-the-ai.md). Stop digging through charts. Just
+  ask in plain words.
+
+## For your clients
+
+- [Give every client a portal](client-portal.md). Pet parents see visits and
+  bills without calling you.
+
+## Your schedule and your data
+
+- [See your schedule in your own calendar](calendar-feed.md). Google, Apple,
+  or Outlook. It stays up to date on its own.
+- [Your data: export, backup, and import](your-data.md). You own everything
+  here. Take it with you any time.
+
+Need help with something these pages do not cover? Email
+[hello@openvpm.com](mailto:hello@openvpm.com) and a real person will answer.

--- a/docs/help/ask-the-ai.md
+++ b/docs/help/ask-the-ai.md
@@ -1,0 +1,38 @@
+# Ask the AI About a Pet
+
+Stop digging through charts. Just ask.
+
+## How it works
+
+Open **Agent** and type a question in plain words, like:
+
+- "Which pets are overdue for vaccines?"
+- "When was Biscuit's last visit?"
+- "Which invoices are still unpaid this month?"
+
+Press send. The AI reads your charts so you do not have to, and answers with
+your clinic's real data. It only sees your practice's data, never anyone
+else's.
+
+## What it is good at
+
+- Finding pets that need something: overdue shots, missed rechecks.
+- Pulling up a pet's history without clicking through tabs.
+- Answering questions about your day, your bills, and your records.
+
+## A note on trust
+
+The AI helper reads your data to answer questions. It does not write records
+on its own. When it helps draft something, like a visit note, a person always
+reviews and saves it.
+
+## If the AI helper is off
+
+Your AI helper turns on once your workspace key is set. On OpenVPM Cloud it
+is ready out of the box. Self-hosting? Add your AI key in the environment
+settings and the Agent page lights up.
+
+## See it with your own data
+
+Open **Settings**, click **Guides**, and pick "Ask the AI about a pet." It
+takes about 1 minute.

--- a/docs/help/calendar-feed.md
+++ b/docs/help/calendar-feed.md
@@ -1,0 +1,44 @@
+# See Your Schedule in Your Own Calendar
+
+Your clinic's day, right inside Google, Apple, or Outlook. New visits show up
+in your own calendar without any extra work. Set it and forget it.
+
+## Get your calendar link
+
+1. Open **Schedule**.
+2. Click the **subscribe** button to get your calendar link.
+3. Copy the link.
+
+The link is private to your practice. Anyone with the link can see your
+schedule, so share it only with your team.
+
+## Paste it into your calendar
+
+**Google Calendar**
+
+1. On a computer, open Google Calendar.
+2. Next to "Other calendars," click the plus sign, then **From URL**.
+3. Paste the link and click **Add calendar**.
+
+**Apple Calendar**
+
+1. Open Calendar on your Mac.
+2. Choose **File → New Calendar Subscription**.
+3. Paste the link and click **Subscribe**.
+
+**Outlook**
+
+1. Open Outlook's calendar view.
+2. Choose **Add calendar → Subscribe from web**.
+3. Paste the link and give it a name.
+
+## It stays up to date on its own
+
+Book or change a visit in OpenVPM and your calendar picks it up
+automatically. Calendar apps refresh on their own schedule, so a new visit
+can take a little while to appear.
+
+## See it with your own data
+
+Open **Settings**, click **Guides**, and pick "See your schedule in your own
+calendar." It takes about 1 minute.

--- a/docs/help/client-portal.md
+++ b/docs/help/client-portal.md
@@ -1,0 +1,30 @@
+# Give Every Client a Portal
+
+Pet parents see visits and bills without calling you. Clients help
+themselves, and your phone rings less.
+
+## Every client gets a private link
+
+Add a client and they get their own private portal link right away. There is
+nothing to set up and no password for them to forget.
+
+## Share the link
+
+1. Open **Clients** and pick a client.
+2. Find the portal link on their page and click copy.
+3. Share it by text or email.
+
+## What clients see
+
+Open the link yourself to see what they see:
+
+- Their pets
+- Upcoming and past visits
+- Bills, and a way to pay online
+
+They see only their own family's information. Nothing else.
+
+## See it with your own data
+
+Open **Settings**, click **Guides**, and pick "Give clients their own
+portal." It takes about 1 minute.

--- a/docs/help/getting-started.md
+++ b/docs/help/getting-started.md
@@ -1,0 +1,43 @@
+# Getting Started with OpenVPM
+
+Welcome! This is the quick look at your new practice. When you first sign in,
+OpenVPM adds a few sample pets so the app feels real while you look around.
+You can remove them any time in **Settings → Data → Remove sample data**.
+
+## Your day, at a glance
+
+**Schedule** is your day sheet. Book visits and check pets in from one simple
+calendar. Click any open slot to book a visit.
+
+## Every pet's full story
+
+**Records** keeps notes, shots, meds, and labs in one place. Open any patient
+to see their whole story: medical records, appointments, weight history,
+vitals, vaccinations, and invoices, all on one chart.
+
+## Bill in one click
+
+**Billing** turns a visit into a bill. Add the services, send it, and take
+payment online. No retyping, no paper chase.
+
+## Your AI helper
+
+**Agent** is your AI helper. Ask it about your pets and your data in plain
+words, and it does the work. Try asking: "Which pets are overdue for
+vaccines?"
+
+## Your data is yours
+
+You own everything here. Export it any time from **Settings → Data**, and
+connect by API when you are ready. See
+[Your data: export, backup, and import](your-data.md).
+
+## Keep exploring
+
+- [Your day sheet](your-day.md)
+- [Ask the AI about a pet](ask-the-ai.md)
+- [Give every client a portal](client-portal.md)
+- [See your schedule in your own calendar](calendar-feed.md)
+
+Every guide here also runs inside the app with your own data: open
+**Settings** and click **Guides**.

--- a/docs/help/your-data.md
+++ b/docs/help/your-data.md
@@ -1,0 +1,42 @@
+# Your Data: Export, Backup, and Import
+
+You own everything here. Export it any time. No lock-in, period.
+
+Everything on this page lives in one place: **Settings → Data**.
+
+## Export your data
+
+- **CSV exports.** Download your clients, patients, appointments, or
+  invoices as simple spreadsheet files.
+- **Full backup.** Download your whole practice as one file: every client,
+  pet, note, shot, lab, bill, and payment. Click **Export Full Backup** and
+  keep the file somewhere safe.
+
+On OpenVPM Cloud we also take a full backup of your practice every night and
+store it encrypted, separate from the live database.
+
+## Import your data
+
+Switching from another system? Bring your clients, pets, and vaccine history
+with you. Imports run in a strict order (clients, then patients, then
+vaccines) and every import shows a **dry run** first, so you see exactly what
+will happen before anything is saved. Imports never overwrite your records;
+they only add.
+
+The full step-by-step playbook, including how to export from AVImark,
+Cornerstone, and ezyVet, is here:
+[Switching to OpenVPM](../migrating-to-openvpm.md).
+
+## Restore a backup
+
+A full backup can be restored into a fresh practice. It rebuilds the whole
+clinic: records, bills, history, everything. Restores check the file first,
+never overwrite, and only add rows that do not already exist.
+
+If you ever need this, we run it with you. The technical runbook is
+[here](../backup-restore-runbook.md).
+
+## Sample data
+
+New practices start with a few sample pets so the app feels real on day one.
+When you are ready for real work: **Settings → Data → Remove sample data**.

--- a/docs/help/your-day.md
+++ b/docs/help/your-day.md
@@ -1,0 +1,31 @@
+# Your Day Sheet
+
+Front desk to exam room on one screen. Book a visit, check the pet in, and
+everyone stays in the loop.
+
+## The schedule
+
+Open **Schedule**. Every booked visit lives here, day by day.
+
+- Click any open slot to book a visit.
+- Pick the client, the pet, and the visit type. Done.
+- Use the arrows at the top to move between days.
+
+## Who is here right now
+
+Open **Whiteboard**. When a pet checks in, the whole team sees it here. No
+sticky notes, no shouting down the hall.
+
+- Check a pet in from the schedule and it appears on the whiteboard.
+- Move pets through the visit: waiting, in exam, ready to go home.
+- Everyone at the clinic sees the same board, live.
+
+## That is your whole day
+
+Book a visit on the schedule. Check the pet in. Watch the whiteboard. When
+the visit is done, turn it into a bill with one click from **Billing**.
+
+## See it with your own data
+
+Open **Settings**, click **Guides**, and pick "See your day at a glance."
+The app walks you through these screens live. It takes about 2 minutes.


### PR DESCRIPTION
## What

Help docs v1 (Day 2 trust block): the in-app guided walkthroughs and the migration playbook, extracted into short public docs under `docs/help/`, written in the product voice (fourth grade, no em dashes, benefits first).

- `docs/help/README.md` index, linked from the root README under a new "Help & Guides" section
- One page per welcome guide: getting started, your day sheet, ask the AI, client portal, calendar feed
- `your-data.md`: exports, nightly cloud backups, imports (links the migration playbook), restore, sample data
- Every page points back to the live in-app version (Settings → Guides)

Docs only, no app code. Note: `your-data.md` links to `docs/backup-restore-runbook.md` from #58, so merge #58 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)