### PR TITLE
polish(billing): one-product checkout, plan page simplification, provisioning kill-switch

### DIFF
--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1173,6 +1173,7 @@ function redirectToClientPaymentUrl(url: unknown) {
 
 function BillingTab() {
   const utils = trpc.useUtils();
+  const [showAllPlans, setShowAllPlans] = useState(false);
   const {
     data,
     isLoading,
@@ -1289,154 +1290,179 @@ function BillingTab() {
   const daysLeft = trialCalendarDaysLeft(data.trialEndsAt, data.timezone) ?? 0;
   const currentPlan = data.plans.find((p) => p.tier === data.tier);
   const showReadOnlyNotice = !data.hasFullAccess;
+  const perLocation = data.locationUnitPriceMonthlyUsd;
+  const multiLocation = data.locationCount > 1;
+  const priceSentence = multiLocation
+    ? `$${perLocation} a month for each of your ${data.locationCount} locations (about $${data.estimatedMonthlyBase} a month)`
+    : `$${perLocation} a month for your location`;
+  // Only surface the sync note when something actually needs attention.
+  const showSyncNote =
+    data.billingSyncStatus &&
+    (data.billingSyncStatus.status === "error" ||
+      data.billingSyncStatus.status === "legacy");
 
   return (
     <div className="space-y-6">
-      <div className="grid gap-6 xl:grid-cols-2">
-        {/* Current status */}
-        <div className="rounded-lg border border-border bg-card p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-muted-foreground">Current plan</p>
-              <h3 className="font-heading text-xl font-semibold">
+      {/* One clear plan card: what you have, what it costs, what is included. */}
+      <div className="rounded-lg border border-border bg-card p-6">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="text-sm text-muted-foreground">Your plan</p>
+            <div className="flex items-center gap-3">
+              <h3 className="font-heading text-2xl font-semibold">
                 {currentPlan?.name ?? data.tier}
               </h3>
-            </div>
-            <span
-              className={cn(
-                "rounded-full px-3 py-1 text-xs font-medium capitalize",
-                data.billingStatus === "active" &&
-                  "bg-green-100 text-green-700",
-                data.billingStatus === "trialing" &&
-                  "bg-blue-100 text-blue-700",
-                data.billingStatus === "past_due" && "bg-red-100 text-red-700",
-                (data.billingStatus === "canceled" ||
-                  data.billingStatus === "none") &&
-                  "bg-gray-100 text-gray-600",
-              )}
-            >
-              {data.billingStatus.replace("_", " ")}
-            </span>
-          </div>
-          {showReadOnlyNotice && (
-            <div className="mt-4 flex gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-              <p>
-                Cloud is in read-only mode. You can view records, manage
-                billing, and export data; writes resume when your trial or
-                subscription is active.
-              </p>
-            </div>
-          )}
-          {data.billingStatus === "trialing" && (
-            <p className="mt-3 text-sm text-muted-foreground">
-              You&apos;re on a free trial with full Cloud access —{" "}
-              <span className="font-medium text-foreground">
-                {daysLeft} days left
+              <span
+                className={cn(
+                  "rounded-full px-3 py-1 text-xs font-medium capitalize",
+                  data.billingStatus === "active" &&
+                    "bg-green-100 text-green-700",
+                  data.billingStatus === "trialing" &&
+                    "bg-blue-100 text-blue-700",
+                  data.billingStatus === "past_due" &&
+                    "bg-red-100 text-red-700",
+                  (data.billingStatus === "canceled" ||
+                    data.billingStatus === "none") &&
+                    "bg-gray-100 text-gray-600",
+                )}
+              >
+                {data.billingStatus === "trialing"
+                  ? `Trial · ${daysLeft} days left`
+                  : data.billingStatus.replace("_", " ")}
               </span>
-              . Subscribe below to keep your features after it ends.
-            </p>
-          )}
-          {data.billingStatus === "past_due" && (
-            <p className="mt-3 text-sm text-red-600">
-              Your last payment failed. Update your payment method to restore
-              write access.
-            </p>
-          )}
-          {/* Billing summary: locations + seats + this month's metered usage */}
-          <div className="mt-4 grid gap-3 border-t border-border pt-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
-            <div>
-              <p className="text-muted-foreground">Locations</p>
-              <p className="font-medium">
-                {data.locationCount} x ${data.locationUnitPriceMonthlyUsd}/mo
-              </p>
-            </div>
-            <div>
-              <p className="text-muted-foreground">Staff</p>
-              <p className="font-medium">
-                {data.billableSeatCount}
-                {data.seatUnitPriceMonthlyUsd > 0
-                  ? ` x $${data.seatUnitPriceMonthlyUsd}/mo`
-                  : " (unlimited, included)"}
-              </p>
-            </div>
-            <div>
-              <p className="text-muted-foreground">Base estimate</p>
-              <p className="font-medium">${data.estimatedMonthlyBase}/mo</p>
-            </div>
-            <div>
-              <p className="text-muted-foreground">SMS this month</p>
-              <p className="font-medium">
-                {data.usage.sms}
-                {currentPlan?.includedSmsPerMonth != null
-                  ? ` / ${currentPlan.includedSmsPerMonth} included`
-                  : ""}
-              </p>
-            </div>
-            <div>
-              <p className="text-muted-foreground">AI actions this month</p>
-              <p className="font-medium">
-                {data.usage.aiRuns}
-                {currentPlan?.includedAiRunsPerMonth != null
-                  ? ` / ${currentPlan.includedAiRunsPerMonth.toLocaleString()} included`
-                  : ""}
-              </p>
             </div>
           </div>
-          {data.billingSyncStatus && (
-            <div
-              className={cn(
-                "mt-4 rounded-md border p-3 text-xs",
-                data.billingSyncStatus.status === "error"
-                  ? "border-red-200 bg-red-50 text-red-700"
-                  : data.billingSyncStatus.status === "legacy"
-                    ? "border-amber-200 bg-amber-50 text-amber-800"
-                    : "border-border bg-muted/30 text-muted-foreground",
-              )}
-            >
-              <span className="font-medium">Billing sync: </span>
-              {data.billingSyncStatus.message}
-            </div>
-          )}
-          {data.hasBillingAccount && (
-            <Button
-              variant="outline"
-              className="mt-4"
-              disabled={portal.isPending}
-              onClick={() => portal.mutate()}
-            >
-              {portal.isPending ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <CreditCard className="mr-2 h-4 w-4" />
-              )}
-              Manage billing
-            </Button>
-          )}
+          <div className="flex flex-wrap gap-2">
+            {data.hasBillingAccount ? (
+              <Button
+                variant="outline"
+                disabled={portal.isPending}
+                onClick={() => portal.mutate()}
+              >
+                {portal.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <CreditCard className="mr-2 h-4 w-4" />
+                )}
+                Manage billing
+              </Button>
+            ) : (
+              <Button
+                disabled={checkout.isPending}
+                onClick={() => checkout.mutate({ tier: "cloud" })}
+              >
+                {checkout.isPending ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <CreditCard className="mr-2 h-4 w-4" />
+                )}
+                Subscribe
+              </Button>
+            )}
+          </div>
         </div>
 
-        <ClientPaymentProcessingSection
-          data={paymentAccount.data}
-          isLoading={paymentAccount.isLoading}
-          error={paymentAccount.error?.message}
-          setupPending={setupPaymentAccount.isPending}
-          refreshPending={refreshPaymentAccount.isPending}
-          dashboardPending={openPaymentAccountDashboard.isPending}
-          onSetup={() => setupPaymentAccount.mutate()}
-          onRefresh={() => refreshPaymentAccount.mutate()}
-          onDashboard={() => openPaymentAccountDashboard.mutate()}
-        />
+        <p className="mt-4 max-w-2xl text-sm text-muted-foreground">
+          {data.billingStatus === "trialing" ? (
+            <>
+              Your free trial has{" "}
+              <span className="font-medium text-foreground">
+                {daysLeft} days
+              </span>{" "}
+              left. After that, {currentPlan?.name ?? "Cloud"} is {priceSentence}
+              . Unlimited staff, and everything you see today stays on.
+            </>
+          ) : (
+            <>
+              {currentPlan?.name ?? "Cloud"} is {priceSentence}. Unlimited
+              staff, everything included.
+            </>
+          )}
+        </p>
+
+        {(currentPlan?.includedSmsPerMonth != null ||
+          currentPlan?.includedAiRunsPerMonth != null) && (
+          <p className="mt-2 text-sm text-muted-foreground">
+            This month:{" "}
+            <span className="font-medium text-foreground">
+              {data.usage.sms}
+            </span>{" "}
+            of {currentPlan?.includedSmsPerMonth?.toLocaleString()} included
+            texts ·{" "}
+            <span className="font-medium text-foreground">
+              {data.usage.aiRuns}
+            </span>{" "}
+            of {currentPlan?.includedAiRunsPerMonth?.toLocaleString()} included
+            AI actions
+          </p>
+        )}
+
+        {showReadOnlyNotice && (
+          <div className="mt-4 flex gap-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>
+              Cloud is in read-only mode. You can view records, manage billing,
+              and export data; writes resume when your trial or subscription is
+              active.
+            </p>
+          </div>
+        )}
+        {data.billingStatus === "past_due" && (
+          <p className="mt-3 text-sm text-red-600">
+            Your last payment failed. Update your payment method to restore
+            write access.
+          </p>
+        )}
+        {showSyncNote && (
+          <div
+            className={cn(
+              "mt-4 rounded-md border p-3 text-xs",
+              data.billingSyncStatus!.status === "error"
+                ? "border-red-200 bg-red-50 text-red-700"
+                : "border-amber-200 bg-amber-50 text-amber-800",
+            )}
+          >
+            <span className="font-medium">Billing sync: </span>
+            {data.billingSyncStatus!.message}
+          </div>
+        )}
       </div>
 
-      <PlanGrid
-        plans={data.plans}
-        currentTier={data.tier}
-        enforced
-        onChoose={(tier) => checkout.mutate({ tier })}
-        busyTier={
-          checkout.isPending ? (checkout.variables?.tier ?? null) : null
-        }
+      <ClientPaymentProcessingSection
+        data={paymentAccount.data}
+        isLoading={paymentAccount.isLoading}
+        error={paymentAccount.error?.message}
+        setupPending={setupPaymentAccount.isPending}
+        refreshPending={refreshPaymentAccount.isPending}
+        dashboardPending={openPaymentAccountDashboard.isPending}
+        onSetup={() => setupPaymentAccount.mutate()}
+        onRefresh={() => refreshPaymentAccount.mutate()}
+        onDashboard={() => openPaymentAccountDashboard.mutate()}
       />
+
+      {/* Plan comparison is reference material, collapsed by default. */}
+      <div>
+        <button
+          type="button"
+          className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+          onClick={() => setShowAllPlans((v) => !v)}
+        >
+          {showAllPlans ? "Hide plan comparison" : "Compare all plans"}
+        </button>
+        {showAllPlans && (
+          <div className="mt-4">
+            <PlanGrid
+              plans={data.plans}
+              currentTier={data.tier}
+              enforced
+              onChoose={(tier) => checkout.mutate({ tier })}
+              busyTier={
+                checkout.isPending ? (checkout.variables?.tier ?? null) : null
+              }
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/lib/billing/__tests__/subscription-sync.test.ts
+++ b/apps/web/lib/billing/__tests__/subscription-sync.test.ts
@@ -55,6 +55,21 @@ describe("billing sync practice scoping", () => {
     expect(syncState).toContain("{ locationCount: 0, billableSeatCount: 0 }");
   });
 
+  it("attaches missing metered overage items idempotently during sync", () => {
+    const syncState = source.slice(
+      source.indexOf("export async function syncPracticeSubscriptionQuantities"),
+      source.length
+    );
+
+    // Checkout carries only the base price; sync adds the metered items and
+    // must never duplicate ones that already exist on the subscription.
+    expect(syncState).toContain("cloudMeteredPriceIds()");
+    expect(syncState).toMatch(
+      /meteredPriceId &&\s*!items\.some\(\(item\) => item\.price\?\.id === meteredPriceId\)/
+    );
+    expect(syncState).toContain("stripe.subscriptionItems.create({");
+  });
+
   it("resolves Stripe price IDs through trim-aware billing helpers", () => {
     const syncState = source.slice(
       source.indexOf("export async function syncPracticeSubscriptionQuantities"),

--- a/apps/web/lib/billing/subscription-sync.ts
+++ b/apps/web/lib/billing/subscription-sync.ts
@@ -7,6 +7,7 @@ import {
   STRIPE_PRICE_CLOUD_LEGACY_ENV,
   billingEnforced,
   cloudCheckoutPriceIds,
+  cloudMeteredPriceIds,
   estimatedCloudBaseMonthlyUsd,
   stripePriceIdFromEnv,
 } from "./plans";
@@ -189,7 +190,7 @@ export async function syncPracticeSubscriptionQuantities(opts: {
       return state;
     }
 
-    const updates = [
+    const updates: Promise<unknown>[] = [
       stripe.subscriptionItems.update(locationItem.id, {
         quantity: counts.locationCount,
       }),
@@ -200,6 +201,25 @@ export async function syncPracticeSubscriptionQuantities(opts: {
           quantity: counts.billableSeatCount,
         })
       );
+    }
+
+    // Checkout shows only the per-location price (one clean product for the
+    // clinic); the metered overage items (AI + SMS) are attached here after
+    // the subscription exists. Idempotent: only add what is missing, so this
+    // also self-heals subscriptions created before overage prices existed.
+    const { aiOveragePriceId, smsOveragePriceId } = cloudMeteredPriceIds();
+    for (const meteredPriceId of [aiOveragePriceId, smsOveragePriceId]) {
+      if (
+        meteredPriceId &&
+        !items.some((item) => item.price?.id === meteredPriceId)
+      ) {
+        updates.push(
+          stripe.subscriptionItems.create({
+            subscription: subscriptionId,
+            price: meteredPriceId,
+          })
+        );
+      }
     }
     await Promise.all(updates);
 

--- a/apps/web/server/__tests__/auth-router.test.ts
+++ b/apps/web/server/__tests__/auth-router.test.ts
@@ -478,12 +478,11 @@ describe("auth router input validation", () => {
     expect(practiceInsert).not.toHaveProperty("billingStatus");
     expect(practiceInsert).not.toHaveProperty("trialEndsAt");
 
+    // Checkout shows one clean product: the metered overage items are added
+    // to the subscription server-side after creation, never at checkout.
     expect(mocks.createSubscriptionCheckoutSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        lineItems: [
-          { priceId: "price_location", quantity: 1 },
-          { priceId: "price_sms", metered: true },
-        ],
+        lineItems: [{ priceId: "price_location", quantity: 1 }],
         practiceId: "practice-1",
         customerEmail: "owner@example.com",
         trialPeriodDays: 14,

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -145,6 +145,30 @@ beforeEach(() => {
   vi.clearAllMocks();
   delete process.env.NEXT_PUBLIC_APP_URL;
   delete process.env.NEXTAUTH_URL;
+  // The platform kill-switch is on for behavior tests; the gate itself is
+  // covered in "messaging provisioning kill-switch".
+  vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+});
+
+describe("messaging provisioning kill-switch", () => {
+  it("blocks number search and provisioning until ops enables it", async () => {
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "");
+    const { db, select } = createDb();
+
+    await expect(
+      callerWithDb(db).provisionNumber({ locationId: LOCATION_ID, mode: "host" })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("almost ready"),
+    });
+    await expect(
+      callerWithDb(db).searchNumbers({ areaCode: "212" })
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    // No DB reads and no Telnyx calls happen while the switch is off.
+    expect(select).not.toHaveBeenCalled();
+    expect(mocks.searchAvailableNumbers).not.toHaveBeenCalled();
+  });
 });
 
 describe("messaging location target safety", () => {

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -205,21 +205,10 @@ export const authRouter = createRouter({
           });
         }
 
-        const { aiOveragePriceId, smsOveragePriceId } =
-          cloudMeteredPriceIds();
+        // Checkout shows the single per-location price so the clinic sees one
+        // clean product; the metered overage items (AI + SMS) are attached to
+        // the subscription server-side after creation (subscription sync).
         hostedCheckoutLineItems = [{ priceId: locationPriceId, quantity: 1 }];
-        if (aiOveragePriceId) {
-          hostedCheckoutLineItems.push({
-            priceId: aiOveragePriceId,
-            metered: true,
-          });
-        }
-        if (smsOveragePriceId) {
-          hostedCheckoutLineItems.push({
-            priceId: smsOveragePriceId,
-            metered: true,
-          });
-        }
       }
 
       const passwordHash = await hash(input.password, PASSWORD_HASH_COST);

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -102,6 +102,23 @@ async function assertActivePractice(ctx: {
   }
 }
 
+/**
+ * Platform kill-switch for number provisioning. Numbers cost real money and
+ * cannot send until the platform's carrier registration (10DLC) is approved,
+ * so provisioning stays off until ops flips MESSAGING_PROVISIONING_ENABLED.
+ * The Telnyx key alone being present must not open the purchase path.
+ */
+function assertProvisioningEnabled(): void {
+  const flag = process.env.MESSAGING_PROVISIONING_ENABLED?.trim().toLowerCase();
+  if (flag !== "true" && flag !== "1") {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Texting setup is almost ready. We are finishing carrier registration; check back soon.",
+    });
+  }
+}
+
 function telnyxWebhookUrl(): string {
   const rawBase = configuredWebhookBaseUrl();
   if (!rawBase) {
@@ -350,6 +367,7 @@ export const messagingRouter = createRouter({
       })
     )
     .query(async ({ ctx, input }) => {
+      assertProvisioningEnabled();
       await assertActivePractice(ctx);
       try {
         return await searchAvailableNumbers(input);
@@ -409,6 +427,7 @@ export const messagingRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
+      assertProvisioningEnabled();
       await assertActivePractice(ctx);
       const [loc] = await ctx.db
         .select({ id: locations.id, name: locations.name, phone: locations.phone })

--- a/apps/web/server/routers/subscription.ts
+++ b/apps/web/server/routers/subscription.ts
@@ -161,16 +161,15 @@ export const subscriptionRouter = createRouter({
         new Date(practice.trialEndsAt).getTime() > Date.now()
           ? practice.trialEndsAt
           : null;
-      // Per-location licensed item, plus the metered overage items (AI + SMS)
-      // when configured. Metered items carry no quantity; Stripe meters them.
-      const { aiOveragePriceId, smsOveragePriceId } = cloudMeteredPriceIds();
+      // Checkout carries only the per-location licensed item so the clinic
+      // sees one clean product. The metered overage items (AI + SMS) are
+      // attached to the subscription server-side after creation
+      // (syncPracticeSubscriptionQuantities), not shown at checkout.
       const lineItems: Array<{
         priceId: string;
         quantity?: number;
         metered?: boolean;
       }> = [{ priceId: locationPriceId, quantity: counts.locationCount }];
-      if (aiOveragePriceId) lineItems.push({ priceId: aiOveragePriceId, metered: true });
-      if (smsOveragePriceId) lineItems.push({ priceId: smsOveragePriceId, metered: true });
       const customerEmail =
         billingContactEmail(practice.email) ??
         billingContactEmail(ctx.session.user.email);


### PR DESCRIPTION
## From Evan's walkthrough pass (billing group)

**1. Stripe Checkout shows one product.** The two metered overage prices made checkout read "OpenVPM Cloud and 2 more" with three identical names (screenshot in session). Checkout now carries only the $79 per-location price; `syncPracticeSubscriptionQuantities` attaches the missing metered items right after the subscription exists — idempotent, so existing subscriptions self-heal on their next sync.

**2. Plan & Billing, simplified.** One plan card: name + trial chip, one plain sentence ("Your free trial has 11 days left. After that, Cloud is $79 a month for your location."), one usage line, one primary CTA. Sync chatter only appears when it needs attention. The three-tier grid is collapsed behind "Compare all plans". Verified on :3007, screenshot posted in session.

**3. Texting provisioning kill-switch.** `MESSAGING_PROVISIONING_ENABLED` gates number search + provisioning: numbers cost money and can't send until carrier registration is approved, so the purchase path stays closed (friendly copy) until ops flips the flag. Keeps trialing practices from buying dead numbers once `TELNYX_API_KEY` lands on prod.

Tests: checkout line-item expectations, sync source assertions, kill-switch gate. Suite + tsc green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)