### PR TITLE
polish(onboarding): deep tour with real content, agent finale, docked checklist

### DIFF
--- a/apps/web/app/(dashboard)/billing/new/page.tsx
+++ b/apps/web/app/(dashboard)/billing/new/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/common/empty-state";
 import { toast } from "sonner";
+import { ServicePicker } from "@/components/billing/service-picker";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
 import { formatCurrency } from "@/lib/locale/format";
 import {
@@ -472,23 +473,16 @@ function NewInvoiceForm() {
             ) : null}
             <div className="grid grid-cols-12 gap-2">
               <div className="col-span-4">
-                <select
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                <ServicePicker
+                  services={serviceOptions}
                   value={selectedServiceId}
-                  onChange={(e) => handleServiceSelect(e.target.value)}
+                  onSelect={handleServiceSelect}
                   disabled={
                     servicesQuery.isLoading ||
                     !!servicesQuery.error ||
                     servicesMissing
                   }
-                >
-                  <option value="">Select a service...</option>
-                  {serviceOptions.map((service) => (
-                    <option key={service.id} value={service.id}>
-                      {service.name} - ${service.defaultPrice}
-                    </option>
-                  ))}
-                </select>
+                />
               </div>
               <div className="col-span-3">
                 <Input

--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -150,6 +150,14 @@ export default function BillingPage() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
   const limit = 25;
+
+  // Deep link: /billing?expand=<invoiceId> opens that invoice's detail (the
+  // welcome tour uses this to walk into a real invoice). After mount so the
+  // server render stays stable.
+  useEffect(() => {
+    const expand = new URLSearchParams(window.location.search).get("expand");
+    if (expand) setExpandedId(expand);
+  }, []);
 
   const tab = STATUS_TABS[activeTab];
   const statusFilter = tab.isEstimate ? undefined : tab.value;
@@ -783,7 +791,7 @@ function InvoiceRow({
       </tr>
       {isExpanded && (
         <tr className="border-b border-border last:border-0">
-          <td colSpan={9} className="bg-muted/20 px-8 py-4">
+          <td colSpan={9} className="bg-muted/20 px-8 py-4" data-tour="invoice-detail">
             {detail.isLoading ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/web/components/billing/service-picker.tsx
+++ b/apps/web/components/billing/service-picker.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronsUpDown, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface ServicePickerService {
+  id: string;
+  name: string;
+  category?: string | null;
+  defaultPrice: string;
+}
+
+/**
+ * Type-ahead service picker for charge capture. Front-desk speed is the whole
+ * game (see the PIMS research in the ledger): one search box over the whole
+ * service list, prefix matches ranked first, category and price visible on
+ * every row, and a full keyboard flow (arrows + Enter, Escape closes).
+ * Replaces the plain <select>, which stops scaling past a few dozen services.
+ */
+export function ServicePicker({
+  services,
+  value,
+  onSelect,
+  disabled,
+}: {
+  services: ServicePickerService[];
+  value: string;
+  onSelect: (serviceId: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const selected = services.find((s) => s.id === value) ?? null;
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return services;
+    const starts: ServicePickerService[] = [];
+    const contains: ServicePickerService[] = [];
+    for (const s of services) {
+      const name = s.name.toLowerCase();
+      const category = s.category?.toLowerCase() ?? "";
+      if (name.startsWith(q)) starts.push(s);
+      else if (name.includes(q) || category.includes(q)) contains.push(s);
+    }
+    return [...starts, ...contains];
+  }, [services, query]);
+
+  // Close on any click outside the control.
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+        setQuery("");
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  useEffect(() => {
+    setHighlight(0);
+  }, [query, open]);
+
+  // Keep the highlighted row in view while arrowing through results.
+  useEffect(() => {
+    const el = listRef.current?.querySelector<HTMLElement>(
+      `[data-index="${highlight}"]`
+    );
+    el?.scrollIntoView({ block: "nearest" });
+  }, [highlight]);
+
+  function choose(service: ServicePickerService) {
+    onSelect(service.id);
+    setOpen(false);
+    setQuery("");
+  }
+
+  function onKeyDown(event: React.KeyboardEvent) {
+    if (!open && (event.key === "ArrowDown" || event.key === "Enter")) {
+      setOpen(true);
+      event.preventDefault();
+      return;
+    }
+    if (!open) return;
+    if (event.key === "ArrowDown") {
+      setHighlight((h) => Math.min(h + 1, results.length - 1));
+      event.preventDefault();
+    } else if (event.key === "ArrowUp") {
+      setHighlight((h) => Math.max(h - 1, 0));
+      event.preventDefault();
+    } else if (event.key === "Enter") {
+      const service = results[highlight];
+      if (service) choose(service);
+      event.preventDefault();
+    } else if (event.key === "Escape") {
+      setOpen(false);
+      setQuery("");
+      event.preventDefault();
+    }
+  }
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => {
+          setOpen((v) => !v);
+          // Focus lands in the search box so typing starts immediately.
+          setTimeout(() => inputRef.current?.focus(), 0);
+        }}
+        onKeyDown={onKeyDown}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className={cn(
+          "flex h-10 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-2 text-left text-sm",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          !selected && "text-muted-foreground"
+        )}
+      >
+        <span className="truncate">
+          {selected ? selected.name : "Search services..."}
+        </span>
+        <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+      </button>
+
+      {open && (
+        <div className="absolute z-30 mt-1 w-full min-w-[320px] rounded-md border border-border bg-popover shadow-lg">
+          <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+            <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={onKeyDown}
+              placeholder="Type a service name..."
+              aria-label="Search services"
+              className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            />
+          </div>
+          <div ref={listRef} role="listbox" className="max-h-64 overflow-y-auto p-1">
+            {results.length === 0 ? (
+              <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+                No services match &quot;{query}&quot;.
+              </p>
+            ) : (
+              results.map((service, index) => (
+                <button
+                  key={service.id}
+                  type="button"
+                  role="option"
+                  aria-selected={service.id === value}
+                  data-index={index}
+                  onMouseEnter={() => setHighlight(index)}
+                  onClick={() => choose(service)}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-sm px-2 py-2 text-left text-sm",
+                    index === highlight && "bg-accent"
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "flex h-4 w-4 shrink-0 items-center justify-center",
+                      service.id === value ? "text-primary" : "text-transparent"
+                    )}
+                  >
+                    <Check className="h-4 w-4" />
+                  </span>
+                  <span className="min-w-0 flex-1 truncate font-medium">
+                    {service.name}
+                  </span>
+                  {service.category ? (
+                    <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                      {service.category}
+                    </span>
+                  ) : null}
+                  <span className="shrink-0 tabular-nums text-muted-foreground">
+                    ${service.defaultPrice}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/dashboard/activation-checklist.tsx
+++ b/apps/web/components/dashboard/activation-checklist.tsx
@@ -13,7 +13,6 @@ import {
 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { cn } from "@/lib/utils";
-import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { useTour } from "@/components/tour/tour-provider";
@@ -184,146 +183,137 @@ export function ActivationChecklist() {
 
   if (allDone) {
     return (
-      <Card className="relative flex items-center gap-4 border-primary/20 bg-gradient-to-br from-primary/10 via-card to-card p-5">
-        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary text-primary-foreground">
-          <PartyPopper className="h-5 w-5" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <p className="font-heading text-base font-semibold">
-            You&apos;re all set 🎉
-          </p>
-          <p className="text-sm text-muted-foreground">
-            Every setup step is done — {practiceName} is ready to run.
-          </p>
+      <div className="fixed bottom-4 right-4 z-[70] hidden w-[340px] sm:block">
+        <div className="flex items-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-900 p-4 text-zinc-50 shadow-2xl shadow-black/30">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-emerald-500 text-zinc-950">
+            <PartyPopper className="h-4 w-4" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="font-heading text-sm font-semibold">
+              You&apos;re all set 🎉
+            </p>
+            <p className="text-xs text-zinc-400">
+              {practiceName} is ready to run.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={dontShowAgain}
+            className="text-xs font-medium text-zinc-400 transition-colors hover:text-zinc-100"
+          >
+            Dismiss
+          </button>
         </div>
-        <Button variant="ghost" size="sm" onClick={dontShowAgain}>
-          Dismiss
-        </Button>
-      </Card>
+      </div>
     );
   }
 
+  // Docked launcher: a compact dark card pinned bottom-right, out of the way
+  // of the day's real work but always one glance from the next setup win.
   return (
-    <Card className="relative p-5 sm:p-6">
-      <button
-        type="button"
-        onClick={snooze}
-        aria-label="Hide for now"
-        title="Hide for now"
-        className="absolute right-3 top-3 rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-      >
-        <X className="h-4 w-4" />
-      </button>
+    <div className="fixed bottom-4 right-4 z-[70] hidden w-[340px] sm:block">
+      <div className="relative rounded-2xl border border-zinc-800 bg-zinc-900 p-4 text-zinc-50 shadow-2xl shadow-black/30">
+        <button
+          type="button"
+          onClick={snooze}
+          aria-label="Hide for now"
+          title="Hide for now"
+          className="absolute right-3 top-3 rounded-md p-1 text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-200"
+        >
+          <X className="h-4 w-4" />
+        </button>
 
-      <div className="flex items-center gap-3">
-        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-          <Sparkles className="h-5 w-5" />
-        </span>
-        <div>
-          <p className="font-heading text-base font-semibold">
-            Get {practiceName} running
-          </p>
-          <p className="text-sm text-muted-foreground">
-            {doneCount} of {total} complete
-          </p>
+        <div className="flex items-center gap-2.5 pr-6">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-emerald-500/15 text-emerald-400">
+            <Sparkles className="h-4 w-4" />
+          </span>
+          <div className="min-w-0">
+            <p className="truncate font-heading text-sm font-semibold">
+              Get {practiceName} running
+            </p>
+            <p className="text-xs text-zinc-400">
+              {doneCount} of {total} done
+            </p>
+          </div>
         </div>
-      </div>
 
-      <Progress value={pct} className="mt-4" />
+        <Progress
+          value={pct}
+          className="mt-3 h-1.5 bg-zinc-800 [&>div]:bg-emerald-500"
+        />
 
-      <div className="mt-4 grid gap-2">
-        {milestones.map((m) => {
-          const inner = (
-            <div
-              className={cn(
-                "group flex items-center gap-3 rounded-lg border px-4 py-3 transition-colors",
-                m.done
-                  ? "border-transparent bg-muted/40"
-                  : "border-border bg-card hover:border-primary/40 hover:bg-accent"
-              )}
-            >
-              <span
+        <div className="mt-3 max-h-[45vh] space-y-1 overflow-y-auto">
+          {milestones.map((m) => {
+            const inner = (
+              <div
                 className={cn(
-                  "flex h-6 w-6 shrink-0 items-center justify-center rounded-full border transition-colors",
-                  m.done
-                    ? "border-primary bg-primary text-primary-foreground"
-                    : "border-muted-foreground/30 text-transparent group-hover:border-primary"
+                  "group flex items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors",
+                  m.done ? "opacity-60" : "hover:bg-zinc-800"
                 )}
+                title={m.hint}
               >
-                <Check className="h-3.5 w-3.5" />
-              </span>
-              <div className="min-w-0 flex-1">
+                <span
+                  className={cn(
+                    "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border transition-colors",
+                    m.done
+                      ? "border-emerald-500 bg-emerald-500 text-zinc-950"
+                      : "border-zinc-600 text-transparent group-hover:border-emerald-400"
+                  )}
+                >
+                  <Check className="h-3 w-3" />
+                </span>
                 <p
                   className={cn(
-                    "text-sm font-medium",
-                    m.done && "text-muted-foreground line-through"
+                    "min-w-0 flex-1 truncate text-[13px] font-medium",
+                    m.done && "text-zinc-400 line-through"
                   )}
                 >
                   {m.label}
                 </p>
                 {!m.done ? (
-                  <p className="text-xs text-muted-foreground">{m.hint}</p>
+                  <ArrowRight className="h-3.5 w-3.5 shrink-0 text-zinc-500 transition-transform group-hover:translate-x-0.5 group-hover:text-emerald-400" />
                 ) : null}
               </div>
-              {!m.done ? (
-                <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-primary" />
-              ) : null}
-            </div>
-          );
-
-          if (m.href) {
-            return (
-              <Link key={m.key} href={m.href} className="block">
-                {inner}
-              </Link>
             );
-          }
-          return (
-            <button
-              key={m.key}
-              type="button"
-              onClick={m.onClick}
-              className="block w-full text-left"
-            >
-              {inner}
-            </button>
-          );
-        })}
-      </div>
 
-      <div className="mt-4 flex justify-end">
-        <button
-          type="button"
-          onClick={dontShowAgain}
-          className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-        >
-          Don&apos;t show this again
-        </button>
+            if (m.href) {
+              return (
+                <Link key={m.key} href={m.href} className="block">
+                  {inner}
+                </Link>
+              );
+            }
+            return (
+              <button
+                key={m.key}
+                type="button"
+                onClick={m.onClick}
+                className="block w-full text-left"
+              >
+                {inner}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mt-3 flex justify-end border-t border-zinc-800 pt-2.5">
+          <button
+            type="button"
+            onClick={dontShowAgain}
+            className="text-xs font-medium text-zinc-500 transition-colors hover:text-zinc-200"
+          >
+            Don&apos;t show this again
+          </button>
+        </div>
       </div>
-    </Card>
+    </div>
   );
 }
 
 function ActivationChecklistLoading() {
-  return (
-    <Card className="p-5 sm:p-6">
-      <div className="animate-pulse">
-        <div className="flex items-center gap-3">
-          <div className="h-9 w-9 rounded-lg bg-muted" />
-          <div className="space-y-2">
-            <div className="h-4 w-48 rounded bg-muted" />
-            <div className="h-3 w-24 rounded bg-muted" />
-          </div>
-        </div>
-        <div className="mt-4 h-2 rounded-full bg-muted" />
-        <div className="mt-4 grid gap-2">
-          {Array.from({ length: 4 }).map((_, index) => (
-            <div key={index} className="h-14 rounded-lg border bg-muted/40" />
-          ))}
-        </div>
-      </div>
-    </Card>
-  );
+  // The docked card simply appears once its data is ready; a floating
+  // skeleton in the corner would only draw the eye to nothing.
+  return null;
 }
 
 function ActivationChecklistError({
@@ -334,21 +324,22 @@ function ActivationChecklistError({
   onRetry: () => void;
 }) {
   return (
-    <Card className="border-destructive/30 bg-destructive/5 p-5">
-      <div className="flex items-start gap-3">
-        <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-destructive/10 text-destructive">
-          <AlertTriangle className="h-5 w-5" />
-        </span>
+    <div className="fixed bottom-4 right-4 z-[70] hidden w-[340px] sm:block">
+      <div className="flex items-start gap-3 rounded-2xl border border-zinc-800 bg-zinc-900 p-4 text-zinc-50 shadow-2xl shadow-black/30">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
         <div className="min-w-0 flex-1">
-          <p className="font-heading text-base font-semibold">
-            Setup checklist could not load
-          </p>
-          <p className="mt-1 text-sm text-muted-foreground">{message}</p>
-          <Button variant="outline" size="sm" onClick={onRetry} className="mt-3">
+          <p className="text-sm font-semibold">Setup checklist could not load</p>
+          <p className="mt-1 text-xs text-zinc-400">{message}</p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRetry}
+            className="mt-2 border-zinc-700 bg-transparent text-zinc-100 hover:bg-zinc-800"
+          >
             Retry
           </Button>
         </div>
       </div>
-    </Card>
+    </div>
   );
 }

--- a/apps/web/components/tour/tour-provider.tsx
+++ b/apps/web/components/tour/tour-provider.tsx
@@ -13,7 +13,7 @@ import { useSession } from "next-auth/react";
 import { trpc } from "@/lib/trpc";
 import type { GuideId } from "@/lib/welcome/cards";
 import { markGuideCompleted } from "@/lib/welcome/local-state";
-import { TOUR_STEPS } from "./tour-steps";
+import { buildTourSteps } from "./tour-steps";
 import {
   buildGuideSteps,
   type GuideContext,
@@ -68,6 +68,16 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
     enabled: isAdmin,
   });
   const setTourStatus = trpc.settings.setTourStatus.useMutation();
+  // Context for the deep tour (real chart, real bill, live agent finale).
+  // Both queries are cached app-wide, so this adds no extra traffic.
+  const welcomeCtx = trpc.settings.welcomeContext.useQuery(undefined, {
+    enabled: isAdmin,
+    staleTime: 5 * 60_000,
+  });
+  const agentStatus = trpc.agent.status.useQuery(undefined, {
+    enabled: isAdmin,
+    staleTime: 5 * 60_000,
+  });
 
   // null = no guide running; otherwise the active recipe + step cursor.
   const [run, setRun] = useState<ActiveRun | null>(null);
@@ -110,9 +120,21 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
     (recipe: GuideId = "tour", ctx: GuideContext = {}) => {
       if (recipe === "tour") {
         if (!isAdmin) return;
-        prefetchSteps(TOUR_STEPS);
-        setRun({ recipe, steps: TOUR_STEPS, index: 0 });
-        persist("in_progress", TOUR_STEPS[0]!.id);
+        // Context-aware: with sample data the tour walks into a real chart
+        // and a real bill, and ends on the AI helper answering a question.
+        // Callers may pass context; anything missing fills from the cached
+        // welcome context so every entry point gets the deep tour.
+        const steps = buildTourSteps({
+          demoPatientName:
+            ctx.demoPatientName ?? welcomeCtx.data?.demoPatientName,
+          demoPatientId: welcomeCtx.data?.demoPatientId,
+          demoInvoiceId: welcomeCtx.data?.demoInvoiceId,
+          agentConfigured:
+            ctx.agentConfigured ?? agentStatus.data?.configured,
+        });
+        prefetchSteps(steps);
+        setRun({ recipe, steps, index: 0 });
+        persist("in_progress", steps[0]!.id);
         return;
       }
       const steps = buildGuideSteps(recipe, ctx);
@@ -120,7 +142,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
       prefetchSteps(steps);
       setRun({ recipe, steps, index: 0 });
     },
-    [isAdmin, persist, prefetchSteps]
+    [isAdmin, persist, prefetchSteps, welcomeCtx.data, agentStatus.data]
   );
 
   // Start ONLY on an explicit ?tour=start deep-link. Onboarding is opt-in: a
@@ -128,6 +150,9 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
   // welcome surface and activation checklist invoke start() on demand instead.
   useEffect(() => {
     if (autoStarted.current || run !== null || !isAdmin) return;
+    // Wait for the tour context to settle so the deep-link never races into
+    // the shallow fallback steps (fetch errors still start the fallback).
+    if (welcomeCtx.isLoading || agentStatus.isLoading) return;
     const wantStart =
       typeof window !== "undefined" &&
       new URLSearchParams(window.location.search).get("tour") === "start";
@@ -137,7 +162,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
       start();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAdmin, stateQuery.data, pathname, run]);
+  }, [isAdmin, stateQuery.data, pathname, run, welcomeCtx.isLoading, agentStatus.isLoading]);
 
   const step = run ? run.steps[run.index] ?? null : null;
 

--- a/apps/web/components/tour/tour-steps.ts
+++ b/apps/web/components/tour/tour-steps.ts
@@ -4,9 +4,14 @@
  * the sidebar nav links keeps anchors stable across route changes; steps without
  * an anchor render as a centered card.
  *
- * Voice: simple, fourth-grade, warm, no em dashes. Lead with the value: you own
- * your data and real AI tools are built in.
+ * The tour is context-aware: when the workspace has sample data we walk into a
+ * real chart and a real bill instead of pointing at empty tabs, and the finale
+ * is the AI helper answering a real question. Voice: simple, fourth-grade,
+ * warm, no em dashes. Lead with the value: you own your data and real AI tools
+ * are built in.
  */
+import { GUIDE_SIGNALS } from "./guide-signals";
+
 export interface TourStep {
   id: string;
   /** Route to navigate to before showing this step. */
@@ -15,53 +20,101 @@ export interface TourStep {
   anchor?: string;
   title: string;
   body: string;
+  /** Guide signal that auto-advances past this step (never blocks Next). */
+  advanceOn?: string;
 }
 
-export const TOUR_STEPS: TourStep[] = [
-  {
-    id: "welcome",
-    route: "/",
-    title: "Welcome to OpenVPM",
-    body: "This is your practice. We added a few sample pets so it feels real while you look around.",
-  },
-  {
-    id: "schedule",
-    route: "/schedule",
-    anchor: "nav-/schedule",
-    title: "Your day, at a glance",
-    body: "Book visits and check pets in from one simple calendar.",
-  },
-  {
-    id: "records",
-    route: "/records",
-    anchor: "nav-/records",
-    title: "Every pet's full story",
-    body: "Notes, shots, meds, and labs all live in one place.",
-  },
-  {
-    id: "billing",
-    route: "/billing",
-    anchor: "nav-/billing",
-    title: "Bill in one click",
-    body: "Turn a visit into a bill and take payment online.",
-  },
-  {
-    id: "agent",
-    route: "/agent",
-    anchor: "nav-/agent",
-    title: "Your AI helper",
-    body: "Ask it about your pets and your data and it does the work. You will get to try it in a minute.",
-  },
-  {
-    id: "ownership",
-    route: "/",
-    title: "Your data is yours",
-    body: "You own everything here. Export it any time, and connect by API when you are ready.",
-  },
-  {
-    id: "finish",
-    route: "/",
-    title: "You're all set",
-    body: "That was the quick look. Your clinic is ready to go. Your data stays yours, and the AI helper is here whenever you need it.",
-  },
-];
+export const AGENT_TOUR_QUESTION = "Which pets are overdue for vaccines?";
+
+export interface TourContext {
+  /** First demo patient's name, e.g. "Biscuit", when demo data is present. */
+  demoPatientName?: string | null;
+  /** First demo patient's id, for walking into a real chart. */
+  demoPatientId?: string | null;
+  /** A live sample invoice id, for walking into a real bill. */
+  demoInvoiceId?: string | null;
+  /** False when the AI agent has no platform key; the tour never blocks. */
+  agentConfigured?: boolean;
+}
+
+export function buildTourSteps(ctx: TourContext = {}): TourStep[] {
+  const patientName = ctx.demoPatientName ?? null;
+  const agentReady = ctx.agentConfigured ?? false;
+
+  const steps: TourStep[] = [
+    {
+      id: "welcome",
+      route: "/",
+      title: "Welcome to OpenVPM",
+      body: "This is your practice. We added a few sample pets so it feels real while you look around.",
+    },
+    {
+      id: "schedule",
+      route: "/schedule",
+      anchor: "schedule-calendar",
+      title: "Your day, at a glance",
+      body: patientName
+        ? `Every visit lives here. ${patientName} is already booked, so you can see a real day. Click any open slot to book a visit.`
+        : "Book visits and check pets in from one simple calendar. Click any open slot to book a visit.",
+    },
+  ];
+
+  if (ctx.demoPatientId) {
+    steps.push({
+      id: "patient-chart",
+      route: `/patients/${ctx.demoPatientId}`,
+      title: "Every pet's full story",
+      body: `This is ${patientName ?? "a sample pet"}'s chart. Notes, shots, meds, and labs all live on one page. The tabs go deeper when you need them.`,
+    });
+  } else {
+    steps.push({
+      id: "records",
+      route: "/records",
+      anchor: "nav-/records",
+      title: "Every pet's full story",
+      body: "Notes, shots, meds, and labs all live in one place.",
+    });
+  }
+
+  if (ctx.demoInvoiceId) {
+    steps.push({
+      id: "invoice",
+      route: `/billing?expand=${ctx.demoInvoiceId}`,
+      anchor: "invoice-detail",
+      title: "Bill in one click",
+      body: "Here is a real bill, already itemized. A visit becomes a bill in one click, and clients can pay online.",
+    });
+  } else {
+    steps.push({
+      id: "billing",
+      route: "/billing",
+      anchor: "nav-/billing",
+      title: "Bill in one click",
+      body: "Turn a visit into a bill and take payment online.",
+    });
+  }
+
+  steps.push(
+    {
+      id: "agent",
+      route: `/agent?ask=${encodeURIComponent(AGENT_TOUR_QUESTION)}`,
+      anchor: "agent-input",
+      title: "Now meet your AI helper",
+      body: agentReady
+        ? "We typed a real question for you. Press send and watch it check every chart in seconds."
+        : "Ask about your pets and your data in plain words, right here. Your AI helper turns on once your workspace key is set.",
+      advanceOn: agentReady ? GUIDE_SIGNALS.agentRunSucceeded : undefined,
+    },
+    {
+      id: "finish",
+      route: "/",
+      title: "You're all set",
+      body: "That was your clinic: the day sheet, the charts, the bills, and your AI helper. Your data is always yours. Export it any time.",
+    }
+  );
+
+  return steps;
+}
+
+/** Context-free steps, used for prefetch fallbacks and tests. */
+export const TOUR_STEPS: TourStep[] = buildTourSteps();

--- a/apps/web/lib/__tests__/billing-ui.test.ts
+++ b/apps/web/lib/__tests__/billing-ui.test.ts
@@ -122,7 +122,10 @@ describe("billing invoice form UX", () => {
     expect(source).toContain("servicesQuery.isLoading");
     expect(source).toContain("const servicesMissing =");
     expect(source).toContain("const serviceOptions =");
-    expect(source).toContain("serviceOptions.map((service)");
+    // The plain select gave way to the searchable picker (service-picker-ui
+    // tests cover its behavior); the page still feeds it the guarded options.
+    expect(source).toContain("<ServicePicker");
+    expect(source).toContain("services={serviceOptions}");
     expect(source).toContain("serviceOptions.find((s) => s.id === serviceId)");
     expect(source).toContain(
       "serviceOptions.find((s) => s.id === selectedServiceId)"

--- a/apps/web/lib/__tests__/service-picker-ui.test.ts
+++ b/apps/web/lib/__tests__/service-picker-ui.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Source-level UI-state assertions for the searchable service picker
+ * (charge capture), mirroring consult-companion-ui.test.ts.
+ */
+
+describe("service picker UI states", () => {
+  const picker = readFileSync("components/billing/service-picker.tsx", "utf8");
+  const newInvoicePage = readFileSync(
+    "app/(dashboard)/billing/new/page.tsx",
+    "utf8"
+  );
+
+  it("replaces the plain select on the new-invoice page", () => {
+    expect(newInvoicePage).toContain(
+      'import { ServicePicker } from "@/components/billing/service-picker"'
+    );
+    expect(newInvoicePage).toContain("<ServicePicker");
+    expect(newInvoicePage).not.toContain("Select a service...");
+  });
+
+  it("ranks prefix matches first and searches categories too", () => {
+    expect(picker).toContain("name.startsWith(q)");
+    expect(picker).toContain("category.includes(q)");
+    expect(picker).toMatch(/\[\.\.\.starts, \.\.\.contains\]/);
+  });
+
+  it("supports a full keyboard flow", () => {
+    for (const key of ["ArrowDown", "ArrowUp", "Enter", "Escape"]) {
+      expect(picker).toContain(`"${key}"`);
+    }
+    expect(picker).toContain('role="listbox"');
+    expect(picker).toContain('role="option"');
+  });
+
+  it("shows category and price on every row", () => {
+    expect(picker).toContain("service.category");
+    expect(picker).toContain("${service.defaultPrice}");
+    expect(picker).toContain("tabular-nums");
+  });
+
+  it("keeps picker copy free of em dashes", () => {
+    expect(picker).not.toContain("—");
+  });
+});

--- a/apps/web/server/__tests__/settings-welcome-context.test.ts
+++ b/apps/web/server/__tests__/settings-welcome-context.test.ts
@@ -70,7 +70,7 @@ describe("settings.welcomeContext", () => {
     const { db } = createDb([
       [practiceRow(demoSettings)],
       [{ id: DEMO_CLIENT_ID, firstName: "Jordan", lastName: "Avery" }],
-      [{ name: "Biscuit" }],
+      [{ id: DEMO_PATIENT_ID, name: "Biscuit" }],
     ]);
 
     const result = await callerWithRole(db, "front_desk").welcomeContext();
@@ -83,6 +83,9 @@ describe("settings.welcomeContext", () => {
         lastName: "Avery",
       },
       demoPatientName: "Biscuit",
+      demoPatientId: DEMO_PATIENT_ID,
+      // The fixture has no invoiceIds, so the tour's bill step falls back.
+      demoInvoiceId: null,
     });
   });
 

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -869,20 +869,40 @@ export const settingsRouter = createRouter({
     }
 
     let demoPatientName: string | null = null;
-    const demoPatientId = demo?.patientIds?.[0];
-    if (demoPatientId) {
+    let demoPatientId: string | null = null;
+    const candidatePatientId = demo?.patientIds?.[0];
+    if (candidatePatientId) {
       const [row] = await ctx.db
-        .select({ name: patients.name })
+        .select({ id: patients.id, name: patients.name })
         .from(patients)
         .where(
           and(
-            eq(patients.id, demoPatientId),
+            eq(patients.id, candidatePatientId),
             eq(patients.practiceId, ctx.practiceId),
             isNull(patients.deletedAt)
           )
         )
         .limit(1);
       demoPatientName = row?.name ?? null;
+      demoPatientId = row?.id ?? null;
+    }
+
+    // A live sample invoice lets the welcome tour open a real bill.
+    let demoInvoiceId: string | null = null;
+    const candidateInvoiceId = demo?.invoiceIds?.[0];
+    if (candidateInvoiceId) {
+      const [row] = await ctx.db
+        .select({ id: invoices.id })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.id, candidateInvoiceId),
+            eq(invoices.practiceId, ctx.practiceId),
+            isNull(invoices.deletedAt)
+          )
+        )
+        .limit(1);
+      demoInvoiceId = row?.id ?? null;
     }
 
     return {
@@ -890,6 +910,8 @@ export const settingsRouter = createRouter({
       hasDemoData: !!demo,
       portalClient,
       demoPatientName,
+      demoPatientId,
+      demoInvoiceId,
     };
   }),
 


### PR DESCRIPTION
## From Evan's walkthrough pass (onboarding group)

**1. The tour now shows real things.** With sample data present it opens the demo patient's actual chart, expands a real itemized invoice (`/billing?expand=<id>` deep link + anchor), and **ends on the AI helper** with the question pre-typed — auto-advancing when the agent answers. Simple, approachable copy throughout; shallow fallback preserved when sample data is gone. This also answers "the agent should be brought up more": it is now the tour's finale.

**2. Checklist docked bottom-right.** The "Get {clinic} running" card is now an Intercom-style dark widget: compact one-line bubbles, thin progress bar, hover hints, same snooze / "Don't show this again" behavior. Hidden on phones.

Plumbing: `settings.welcomeContext` now returns validated `demoPatientId` + `demoInvoiceId`; the tour provider fills context from cached queries so every entry point gets the deep tour, and the `?tour=start` deep link waits for context instead of racing into the fallback.

Suite 2,103 green, tsc clean. Screenshots posted in session (docked checklist + real-bill tour step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)