### PR TITLE
fix(onboarding): return to guided setup after Stripe checkout

### DIFF
--- a/apps/web/components/onboarding/journey-overlay.tsx
+++ b/apps/web/components/onboarding/journey-overlay.tsx
@@ -124,6 +124,26 @@ export function OnboardingJourneyProvider({
     setIndex(resumeIndex);
   }, [isAdmin, resumeIndex]);
 
+  // Returning from Stripe Checkout during setup: ?setup=resume reopens the
+  // journey at the saved step (the card step persisted "allSet" before the
+  // redirect), instead of stranding the admin wherever Stripe landed them.
+  useEffect(() => {
+    if (opened.current || index !== null || !isAdmin) return;
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("setup") !== "resume") return;
+    if (!onboardingState.data) return; // wait for the saved cursor
+    opened.current = true;
+    params.delete("setup");
+    const rest = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname + (rest ? `?${rest}` : "")
+    );
+    setIndex(resumeIndex);
+  }, [isAdmin, index, onboardingState.data, resumeIndex]);
+
   useEffect(() => {
     if (opened.current || index !== null || !isAdmin) return;
     // In "welcome" first-run mode the Polaroid guide surface owns the

--- a/apps/web/components/onboarding/steps/add-a-card.tsx
+++ b/apps/web/components/onboarding/steps/add-a-card.tsx
@@ -40,7 +40,11 @@ export function AddACardStep({
     try {
       // Resume at the closing step when Stripe sends the user back.
       await setJourneyProgress.mutateAsync({ stepId: "allSet" });
-      const result = await createCheckout.mutateAsync({ tier: "cloud" });
+      const result = await createCheckout.mutateAsync({
+        tier: "cloud",
+        // Stripe sends the admin back into the guided setup, not billing.
+        returnTo: "setup",
+      });
       const url = result?.url;
       if (!url || !isSafeCheckoutRedirectUrl(url)) {
         toast.error("Checkout is unavailable right now. Please try again.");

--- a/apps/web/server/routers/subscription.ts
+++ b/apps/web/server/routers/subscription.ts
@@ -126,7 +126,14 @@ export const subscriptionRouter = createRouter({
 
   /** Start a Stripe Checkout for the self-serve Cloud plan. */
   createCheckout: adminProcedure
-    .input(z.object({ tier: z.enum(["cloud"]).default("cloud") }))
+    .input(
+      z.object({
+        tier: z.enum(["cloud"]).default("cloud"),
+        // Where Stripe sends the admin back: the billing page (default) or
+        // the guided setup, which resumes where they left off.
+        returnTo: z.enum(["settings", "setup"]).default("settings"),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       const plan = PLANS[input.tier];
       const { locationPriceId } = cloudCheckoutPriceIds();
@@ -180,8 +187,14 @@ export const subscriptionRouter = createRouter({
         customerEmail,
         trialEnd: activeTrialEnd,
         trialPeriodDays: activeTrialEnd || practice.trialEndsAt ? undefined : TRIAL_DAYS,
-        successUrl: `${base}/settings?tab=billing&checkout=success`,
-        cancelUrl: `${base}/settings?tab=billing&checkout=cancelled`,
+        successUrl:
+          input.returnTo === "setup"
+            ? `${base}/?setup=resume&checkout=success`
+            : `${base}/settings?tab=billing&checkout=success`,
+        cancelUrl:
+          input.returnTo === "setup"
+            ? `${base}/?setup=resume&checkout=cancelled`
+            : `${base}/settings?tab=billing&checkout=cancelled`,
       });
       const checkoutUrl = result?.url;
       if (!isSafeCheckoutRedirectUrl(checkoutUrl)) {


### PR DESCRIPTION
From Evan's staging walkthrough: entering a card during guided setup returned to the billing page instead of onboarding. Checkout now carries returnTo=setup from the card step; Stripe returns to /?setup=resume and the journey reopens at the saved step (allSet). Suite + tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)