### PR TITLE
polish(onboarding): return to Polaroids between guides, let the AI answer land

### DIFF
--- a/apps/web/app/(dashboard)/agent/page.tsx
+++ b/apps/web/app/(dashboard)/agent/page.tsx
@@ -117,6 +117,19 @@ function AgentRunner() {
   const submitDisabled =
     !canRun || !isAgentInstructionValid(instruction) || run.isPending;
   const hasConversation = messages.length > 0;
+  const lastReplyId = [...messages]
+    .reverse()
+    .find((m) => m.role === "assistant" && !m.isError)?.id;
+
+  // Signal the tour AFTER the reply is committed to the DOM so its next step
+  // can spotlight the answer. Firing from onSuccess ran before render, and
+  // the tour moved on from a reply that was not on screen yet.
+  const signaledReplyId = useRef<number | null>(null);
+  useEffect(() => {
+    if (lastReplyId == null || signaledReplyId.current === lastReplyId) return;
+    signaledReplyId.current = lastReplyId;
+    emitGuideSignal(GUIDE_SIGNALS.agentRunSucceeded);
+  }, [lastReplyId]);
 
   useEffect(() => {
     if (!canRun && allowWrites) {
@@ -169,7 +182,6 @@ function AgentRunner() {
               toolCalls: data.toolCalls,
             },
           ]);
-          emitGuideSignal(GUIDE_SIGNALS.agentRunSucceeded);
         },
         onError: (err) => {
           setMessages((prev) => [
@@ -301,9 +313,16 @@ function AgentRunner() {
           </div>
         ) : (
           <div className="space-y-4 pb-2">
-            {messages.map((m) => (
-              <MessageBubble key={m.id} message={m} />
-            ))}
+            {messages.map((m) =>
+              m.id === lastReplyId ? (
+                // The tour's reply beat spotlights the newest good answer.
+                <div key={m.id} data-tour="agent-reply">
+                  <MessageBubble message={m} />
+                </div>
+              ) : (
+                <MessageBubble key={m.id} message={m} />
+              )
+            )}
             {run.isPending ? <TypingIndicator /> : null}
           </div>
         )}

--- a/apps/web/components/tour/coachmark.tsx
+++ b/apps/web/components/tour/coachmark.tsx
@@ -99,8 +99,14 @@ export function Coachmark({
                 Back
               </Button>
             ) : null}
-            <Button size="sm" onClick={onNext}>
-              {isLast ? "Finish" : "Next"}
+            {/* On do-it steps (advanceOn) the page owns the primary action,
+                so the button reads as the way past, not the way forward. */}
+            <Button
+              size="sm"
+              variant={!isLast && step.advanceOn ? "ghost" : "default"}
+              onClick={onNext}
+            >
+              {isLast ? "Finish" : step.advanceOn ? "Skip this step" : "Next"}
             </Button>
           </div>
         </div>

--- a/apps/web/components/tour/guide-recipes.ts
+++ b/apps/web/components/tour/guide-recipes.ts
@@ -55,6 +55,9 @@ export function buildGuideSteps(
         },
         {
           id: "done",
+          // Spotlight the real answer so the win lands. requiresAnchor lets
+          // the guide end quietly if the user never pressed send.
+          ...(ready ? { anchor: "agent-reply", requiresAnchor: true } : {}),
           title: "That easy",
           body: "The AI just read your charts so you did not have to. Ask it anything about your clinic, any time.",
         },

--- a/apps/web/components/tour/tour-provider.tsx
+++ b/apps/web/components/tour/tour-provider.tsx
@@ -24,8 +24,23 @@ import {
   GUIDE_SIGNAL_EVENT,
   guideSignalName,
 } from "./guide-signals";
-import { useAnchorRect } from "./use-tour-anchor";
+import { findTourAnchor, useAnchorRect } from "./use-tour-anchor";
 import { Coachmark } from "./coachmark";
+
+/**
+ * Walk from `from` in direction `dir`, passing over steps whose required
+ * anchor is not in the DOM right now (e.g. the AI reply beat when the user
+ * skipped sending). Can return -1 or steps.length when nothing is showable.
+ */
+function nextShowable(steps: GuideStep[], from: number, dir: 1 | -1): number {
+  let i = from;
+  while (i >= 0 && i < steps.length) {
+    const s = steps[i]!;
+    if (s.requiresAnchor && s.anchor && !findTourAnchor(s.anchor)) i += dir;
+    else break;
+  }
+  return i;
+}
 
 interface TourContextValue {
   /**
@@ -178,7 +193,8 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
   const onNext = useCallback(() => {
     setRun((r) => {
       if (!r) return r;
-      if (r.index >= r.steps.length - 1) {
+      const next = nextShowable(r.steps, r.index + 1, 1);
+      if (next >= r.steps.length) {
         if (r.recipe === "tour") {
           persist("completed");
         } else {
@@ -189,10 +205,10 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
       }
       // Navigate WITH the step change (not as a trailing effect) so rapid
       // Next clicks always land on the newest step's route.
-      const nextStep = r.steps[r.index + 1]!;
+      const nextStep = r.steps[next]!;
       if (nextStep.route) router.push(nextStep.route);
       if (r.recipe === "tour") persist("in_progress", nextStep.id);
-      return { ...r, index: r.index + 1 };
+      return { ...r, index: next };
     });
   }, [persist, router, userId]);
 
@@ -200,9 +216,11 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
     () =>
       setRun((r) => {
         if (!r || r.index <= 0) return r;
-        const prevStep = r.steps[r.index - 1]!;
+        const prev = nextShowable(r.steps, r.index - 1, -1);
+        if (prev < 0) return r;
+        const prevStep = r.steps[prev]!;
         if (prevStep.route) router.push(prevStep.route);
-        return { ...r, index: r.index - 1 };
+        return { ...r, index: prev };
       }),
     [router]
   );

--- a/apps/web/components/tour/tour-steps.ts
+++ b/apps/web/components/tour/tour-steps.ts
@@ -18,6 +18,11 @@ export interface TourStep {
   route?: string;
   /** `data-tour` value of the element to spotlight. Absent = centered card. */
   anchor?: string;
+  /**
+   * Only visit this step while its anchor is in the DOM; Next and Back pass
+   * over it otherwise (e.g. the AI reply beat when nothing was ever sent).
+   */
+  requiresAnchor?: boolean;
   title: string;
   body: string;
   /** Guide signal that auto-advances past this step (never blocks Next). */
@@ -94,24 +99,36 @@ export function buildTourSteps(ctx: TourContext = {}): TourStep[] {
     });
   }
 
-  steps.push(
-    {
-      id: "agent",
-      route: `/agent?ask=${encodeURIComponent(AGENT_TOUR_QUESTION)}`,
-      anchor: "agent-input",
-      title: "Now meet your AI helper",
-      body: agentReady
-        ? "We typed a real question for you. Press send and watch it check every chart in seconds."
-        : "Ask about your pets and your data in plain words, right here. Your AI helper turns on once your workspace key is set.",
-      advanceOn: agentReady ? GUIDE_SIGNALS.agentRunSucceeded : undefined,
-    },
-    {
-      id: "finish",
-      route: "/",
-      title: "You're all set",
-      body: "That was your clinic: the day sheet, the charts, the bills, and your AI helper. Your data is always yours. Export it any time.",
-    }
-  );
+  steps.push({
+    id: "agent",
+    route: `/agent?ask=${encodeURIComponent(AGENT_TOUR_QUESTION)}`,
+    anchor: "agent-input",
+    title: "Now meet your AI helper",
+    body: agentReady
+      ? "We typed a real question for you. Press send and watch it check every chart in seconds."
+      : "Ask about your pets and your data in plain words, right here. Your AI helper turns on once your workspace key is set.",
+    advanceOn: agentReady ? GUIDE_SIGNALS.agentRunSucceeded : undefined,
+  });
+
+  // The payoff beat: stay on the answer and spotlight it. Without this the
+  // finish step navigated home the moment the reply landed, so nobody ever
+  // read what the AI wrote.
+  if (agentReady) {
+    steps.push({
+      id: "agent-reply",
+      anchor: "agent-reply",
+      requiresAnchor: true,
+      title: "There is your answer",
+      body: "The AI read your charts and answered in plain words. Take a moment and read it. You can ask anything like this, any time.",
+    });
+  }
+
+  steps.push({
+    id: "finish",
+    route: "/",
+    title: "You're all set",
+    body: "That was your clinic: the day sheet, the charts, the bills, and your AI helper. Your data is always yours. Export it any time.",
+  });
 
   return steps;
 }

--- a/apps/web/components/welcome/welcome-copy.ts
+++ b/apps/web/components/welcome/welcome-copy.ts
@@ -17,9 +17,9 @@ export const WELCOME_COPY = {
   reopenHint: "You can come back any time from Guides in the sidebar.",
   setupInstead: "Set up my clinic instead",
   doneBadge: "Done",
-  firstWin: {
-    title: "That was your first win!",
-    body: "Ready to make OpenVPM yours? Add your logo, your team, and your real clients.",
+  allDone: {
+    title: "You tried them all!",
+    body: "That was every guide. Ready to make OpenVPM yours? Add your logo, your team, and your real clients.",
     accept: "Make it mine",
     later: "Later",
   },

--- a/apps/web/components/welcome/welcome-provider.tsx
+++ b/apps/web/components/welcome/welcome-provider.tsx
@@ -18,7 +18,11 @@ import {
   visibleWelcomeCards,
   type WelcomeCardId,
 } from "@/lib/welcome/cards";
-import { markWelcomeSeen, readWelcomeState } from "@/lib/welcome/local-state";
+import {
+  markSetupOffered,
+  markWelcomeSeen,
+  readWelcomeState,
+} from "@/lib/welcome/local-state";
 import { firstRunMode } from "@/lib/welcome/first-run";
 import { useTour } from "@/components/tour/tour-provider";
 import { useOnboardingJourney } from "@/components/onboarding/journey-overlay";
@@ -84,7 +88,7 @@ export function WelcomeProvider({ children }: { children: React.ReactNode }) {
   });
 
   const [open, setOpen] = useState(false);
-  const [firstWinOpen, setFirstWinOpen] = useState(false);
+  const [setupOfferOpen, setSetupOfferOpen] = useState(false);
   // Auto-open decides at most once per mount; finishing/skipping never re-nags.
   const autoDecided = useRef(false);
   // Captured at mount: the ?guides=1 strip below rewrites the URL, which
@@ -94,7 +98,7 @@ export function WelcomeProvider({ children }: { children: React.ReactNode }) {
   // Manual open (sidebar Guides) works regardless of first-run mode.
   const openWelcome = useCallback(() => {
     if (!authed) return;
-    setFirstWinOpen(false);
+    setSetupOfferOpen(false);
     setOpen(true);
   }, [authed]);
 
@@ -144,26 +148,32 @@ export function WelcomeProvider({ children }: { children: React.ReactNode }) {
     router,
   ]);
 
-  // After a guide finishes: admins mid-onboarding get the wizard offer on
-  // their first win; everyone else returns to the cards to pick another.
+  // After a guide finishes, return to the cards so the next one is one click
+  // away. Only when an admin mid-onboarding has tried every visible card do
+  // we offer setup, once; the docked checklist keeps a standing path to it.
   useEffect(() => {
     if (typeof window === "undefined") return;
     const onCompleted = (event: Event) => {
       const recipe = guideCompletedRecipe(event);
       if (!recipe || recipe === "tour") return;
-      const completedGuides = Object.keys(
-        readWelcomeState(userId).guides ?? {}
-      ).filter((g) => g !== "tour");
-      const firstWin =
+      const state = readWelcomeState(userId);
+      const done = new Set(Object.keys(state.guides ?? {}));
+      const allDone = visibleWelcomeCards({ role }).every((c) => done.has(c));
+      const offerSetup =
         isAdmin &&
         onboardingStatus.data?.completedAt == null &&
-        completedGuides.length <= 1;
-      if (firstWin) setFirstWinOpen(true);
-      else setOpen(true);
+        allDone &&
+        !state.setupOfferedAt;
+      if (offerSetup) {
+        markSetupOffered(userId);
+        setSetupOfferOpen(true);
+      } else {
+        setOpen(true);
+      }
     };
     window.addEventListener(GUIDE_COMPLETED_EVENT, onCompleted);
     return () => window.removeEventListener(GUIDE_COMPLETED_EVENT, onCompleted);
-  }, [isAdmin, onboardingStatus.data, userId]);
+  }, [isAdmin, onboardingStatus.data, userId, role]);
 
   const startGuide = useCallback(
     (card: WelcomeCardId, ctx: GuideContext) => {
@@ -219,14 +229,14 @@ export function WelcomeProvider({ children }: { children: React.ReactNode }) {
           onSetupInstead={setupInstead}
         />
       ) : null}
-      {firstWinOpen ? (
-        <FirstWinOffer
+      {setupOfferOpen ? (
+        <SetupOffer
           onAccept={() => {
-            setFirstWinOpen(false);
+            setSetupOfferOpen(false);
             openJourney();
           }}
           onLater={() => {
-            setFirstWinOpen(false);
+            setSetupOfferOpen(false);
             setOpen(true);
           }}
         />
@@ -249,7 +259,7 @@ function resolveVariant(): WelcomeVariant {
     : "vignette";
 }
 
-function FirstWinOffer({
+function SetupOffer({
   onAccept,
   onLater,
 }: {
@@ -260,24 +270,24 @@ function FirstWinOffer({
     <div className="fixed inset-0 z-[85] flex items-center justify-center bg-slate-900/50 p-4">
       <div
         role="dialog"
-        aria-label={WELCOME_COPY.firstWin.title}
+        aria-label={WELCOME_COPY.allDone.title}
         className="w-full max-w-sm rounded-xl border border-border bg-card p-6 text-center shadow-xl"
       >
         <span className="mx-auto flex h-11 w-11 items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
           <PartyPopper className="h-5 w-5" aria-hidden="true" />
         </span>
         <h2 className="mt-3 font-heading text-lg font-semibold">
-          {WELCOME_COPY.firstWin.title}
+          {WELCOME_COPY.allDone.title}
         </h2>
         <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
-          {WELCOME_COPY.firstWin.body}
+          {WELCOME_COPY.allDone.body}
         </p>
         <div className="mt-5 flex items-center justify-center gap-2">
           <Button variant="ghost" size="sm" onClick={onLater}>
-            {WELCOME_COPY.firstWin.later}
+            {WELCOME_COPY.allDone.later}
           </Button>
           <Button size="sm" onClick={onAccept}>
-            {WELCOME_COPY.firstWin.accept}
+            {WELCOME_COPY.allDone.accept}
           </Button>
         </div>
       </div>

--- a/apps/web/lib/__tests__/guide-recipes.test.ts
+++ b/apps/web/lib/__tests__/guide-recipes.test.ts
@@ -6,6 +6,7 @@ import {
   type GuideContext,
 } from "@/components/tour/guide-recipes";
 import { GUIDE_SIGNALS } from "@/components/tour/guide-signals";
+import { buildTourSteps } from "@/components/tour/tour-steps";
 import type { GuideId } from "../welcome/cards";
 
 const ALL_GUIDES: GuideId[] = [
@@ -24,6 +25,8 @@ const ALL_GUIDES: GuideId[] = [
  */
 const ANCHOR_SOURCES: Record<string, string> = {
   "agent-input": "app/(dashboard)/agent/page.tsx",
+  "agent-reply": "app/(dashboard)/agent/page.tsx",
+  "invoice-detail": "app/(dashboard)/billing/page.tsx",
   "schedule-calendar": "app/(dashboard)/schedule/page.tsx",
   "whiteboard-board": "app/(dashboard)/whiteboard/page.tsx",
   "client-portal-link": "app/(dashboard)/clients/[id]/page.tsx",
@@ -36,8 +39,21 @@ const RICH_CONTEXT: GuideContext = {
   agentConfigured: true,
 };
 
+const DEEP_TOUR_CONTEXT = {
+  demoPatientName: "Biscuit",
+  demoPatientId: "patient-1",
+  demoInvoiceId: "invoice-1",
+  agentConfigured: true,
+};
+
 function allSteps(ctx: GuideContext) {
-  return ALL_GUIDES.flatMap((id) => buildGuideSteps(id, ctx));
+  return [
+    ...ALL_GUIDES.flatMap((id) => buildGuideSteps(id, ctx)),
+    ...buildTourSteps({
+      ...DEEP_TOUR_CONTEXT,
+      agentConfigured: ctx.agentConfigured === true,
+    }),
+  ];
 }
 
 describe("guide recipes", () => {
@@ -79,6 +95,34 @@ describe("guide recipes", () => {
     });
     expect(steps[0]!.advanceOn).toBeUndefined();
     expect(steps[0]!.body).toContain("turns on once");
+    // No reply to spotlight either, so the closing step stays centered.
+    expect(steps[1]!.anchor).toBeUndefined();
+  });
+
+  it("ask-ai spotlights the real answer on its closing step", () => {
+    const steps = buildGuideSteps("ask-ai", RICH_CONTEXT);
+    const done = steps[steps.length - 1]!;
+    expect(done.anchor).toBe("agent-reply");
+    // If the user never pressed send there is no reply; the guide must end
+    // without bragging about an answer that does not exist.
+    expect(done.requiresAnchor).toBe(true);
+  });
+
+  it("the deep tour stays on the AI answer before finishing", () => {
+    const steps = buildTourSteps(DEEP_TOUR_CONTEXT);
+    const ids = steps.map((s) => s.id);
+    expect(ids.indexOf("agent-reply")).toBe(ids.indexOf("agent") + 1);
+    expect(ids.indexOf("finish")).toBe(ids.indexOf("agent-reply") + 1);
+    const reply = steps.find((s) => s.id === "agent-reply")!;
+    expect(reply.route).toBeUndefined(); // stays on /agent with the answer
+    expect(reply.anchor).toBe("agent-reply");
+    expect(reply.requiresAnchor).toBe(true);
+    // Without a configured agent there is no answer to stay on.
+    const shallow = buildTourSteps({
+      ...DEEP_TOUR_CONTEXT,
+      agentConfigured: false,
+    });
+    expect(shallow.map((s) => s.id)).not.toContain("agent-reply");
   });
 
   it("your-day names the demo patient when present and stays generic otherwise", () => {

--- a/apps/web/lib/__tests__/welcome-ui-states.test.ts
+++ b/apps/web/lib/__tests__/welcome-ui-states.test.ts
@@ -90,6 +90,18 @@ describe("welcome surface UI states", () => {
     expect(settingsSource).toContain("onClick={openWelcome}");
   });
 
+  it("returns to the cards after every guide; setup waits for the last one", () => {
+    // Evan's walkthrough note: finishing one Polaroid should land back on
+    // the Polaroids, not in the setup wizard. The Make-it-mine offer fires
+    // only when every visible card is done, and only once per user/device.
+    expect(providerSource).toContain(
+      'visibleWelcomeCards({ role }).every((c) => done.has(c))'
+    );
+    expect(providerSource).toContain("!state.setupOfferedAt");
+    expect(providerSource).toContain("markSetupOffered(userId)");
+    expect(copySource).toContain("Make it mine");
+  });
+
   it("keeps the copy deck in voice: no em or en dashes", () => {
     expect(copySource).not.toMatch(/[—–]/);
   });

--- a/apps/web/lib/welcome/local-state.ts
+++ b/apps/web/lib/welcome/local-state.ts
@@ -17,6 +17,8 @@ export interface WelcomeLocalState {
   /** ISO timestamp of the first time this user saw (or skipped) the welcome. */
   seenAt?: string;
   guides?: Partial<Record<GuideId, "completed">>;
+  /** ISO timestamp of the one-time setup offer shown after the last guide. */
+  setupOfferedAt?: string;
 }
 
 function storageKey(userId: string): string {
@@ -63,6 +65,16 @@ export function markGuideCompleted(
   writeWelcomeState(userId, {
     ...state,
     guides: { ...state.guides, [guide]: "completed" },
+  });
+}
+
+export function markSetupOffered(userId: string | null | undefined): void {
+  if (!userId) return;
+  const state = readWelcomeState(userId);
+  if (state.setupOfferedAt) return;
+  writeWelcomeState(userId, {
+    ...state,
+    setupOfferedAt: new Date().toISOString(),
   });
 }
 


### PR DESCRIPTION
## Walkthrough notes (Evan's staging pass)

**1. Back to the Polaroids between guides.** Finishing one guide used to jump straight to the "Make it mine" setup offer. Now every guide returns to the welcome cards so the next one is one click away. The setup offer fires only after the LAST visible card is done, once per user per device. The docked activation checklist keeps a standing path to setup the whole time.

**2. The AI answer now lands.** The tour's finale auto-advanced to the finish step (routed to `/`) the moment the agent replied, navigating the user away from the answer they just asked for. Now:
- A new **reply beat** stays on `/agent` and spotlights the actual answer bubble (`data-tour="agent-reply"` on the newest good reply).
- The success signal fires **after the reply is committed to the DOM** (moved from mutation `onSuccess` to an effect keyed on the last reply id), so the spotlight always finds it.
- The ask-ai guide's closing step spotlights the answer the same way instead of dimming it behind a centered card.
- New `requiresAnchor` step flag: Next/Back pass over a step whose anchor is not on the page, so skipping send never shows "there is your answer" over nothing.

**3. Do-the-thing steps read that way.** When a step waits on a real action (press send, copy the link), the coachmark button is now a ghost "Skip this step" instead of a primary "Next", making the page action the obvious way forward.

## Tests
- `guide-recipes.test.ts`: drift guard now also covers the deep tour's anchors (incl. `agent-reply`, `invoice-detail`); new assertions for the reply beat ordering and the not-configured fallbacks.
- `welcome-ui-states.test.ts`: asserts return-to-cards + all-done-only setup offer + once guard.
- Full suite: **2,113 green**, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)