### PR TITLE
polish(tour): coachmark dodges floating UI it would cover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md
+
+Instructions for Claude Code agents working in this repo.
+
+## Project management — Jira (OpenVPM)
+
+We run the OpenVPM build lifecycle on Jira. **Agents coordinate through the board:
+read your queue there, and record your work there.**
+
+- **Board:** `get-talky.atlassian.net`, project key **`OPENVPM`** (via the Atlassian MCP).
+- **Before working the board or picking up a ticket, read
+  [`docs/agents/jira-operating-manual.md`](docs/agents/jira-operating-manual.md)** —
+  it defines the workflow states, the label vocabulary, the Golden Ticket template,
+  the comment protocol, and the guardrails.
+
+Quick rules (full detail in the manual):
+
+- **Your queue:** `project = OPENVPM AND status = "To Do" AND labels = agent-ready ORDER BY priority DESC`
+- **Pick up** → move to *In Progress*, comment `[agent:<role>] plan: …`. WIP = 1 per agent.
+- **Finish** → move to *In Review*, check the acceptance-criteria boxes, comment
+  `[agent:<role>] done: … · PR: <url> · tests: <evidence>`.
+- **Stuck** → move to *Blocked*, comment `[blocked] waiting on: … · @Evan`.
+- Sign every comment with your role: `[agent:eng|qa|gtm|ops|design]`.
+- **Never** delete issues, bulk-transition, or move a `risk:*` ticket to *Done* —
+  those need a human.

--- a/apps/web/components/tour/coachmark.tsx
+++ b/apps/web/components/tour/coachmark.tsx
@@ -1,11 +1,84 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { TourStep } from "./tour-steps";
 
 const CARD_W = 320;
+const CARD_H = 260; // placement estimate, matches the viewport clamp below
+const GAP = 16;
+
+interface Box {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+function overlaps(a: Box, b: Box): boolean {
+  return (
+    a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top
+  );
+}
+
+/**
+ * Do-it steps open floating UI right next to their anchor (the calendar
+ * popover, for one), and the card at z-70 would sit on top of the thing it
+ * just asked the user to open. Watch the body for Radix popper portals and
+ * hand back a position clear of both the popper and the anchor.
+ */
+function useDodgeFloatingUi(
+  base: { left: number; top: number } | null,
+  anchor: DOMRect | null
+): { left: number; top: number } | null {
+  const [dodged, setDodged] = useState<{ left: number; top: number } | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (!base || !anchor || typeof document === "undefined") {
+      setDodged(null);
+      return;
+    }
+    const compute = () => {
+      const poppers = Array.from(
+        document.querySelectorAll("[data-radix-popper-content-wrapper]")
+      ).map((el) => el.getBoundingClientRect());
+      const card: Box = {
+        left: base.left,
+        top: base.top,
+        right: base.left + CARD_W,
+        bottom: base.top + CARD_H,
+      };
+      const hit = poppers.find((p) => p.width > 0 && overlaps(card, p));
+      if (!hit) {
+        setDodged(null);
+        return;
+      }
+      // Try fully left of the popper + anchor; otherwise drop below them.
+      const unionLeft = Math.min(hit.left, anchor.left);
+      const leftOf = unionLeft - CARD_W - GAP;
+      if (leftOf >= GAP) {
+        setDodged({ left: leftOf, top: base.top });
+        return;
+      }
+      const unionBottom = Math.max(hit.bottom, anchor.bottom);
+      setDodged({
+        left: Math.max(GAP, Math.min(base.left, window.innerWidth - CARD_W - GAP)),
+        top: Math.min(unionBottom + GAP, window.innerHeight - CARD_H - GAP),
+      });
+    };
+    compute();
+    // Radix portals mount and unmount directly under <body>.
+    const mo = new MutationObserver(compute);
+    mo.observe(document.body, { childList: true });
+    return () => mo.disconnect();
+  }, [base?.left, base?.top, anchor]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return dodged;
+}
 
 interface CoachmarkProps {
   /** Anchor rect to spotlight, or null for a centered card. */
@@ -30,16 +103,19 @@ export function Coachmark({
   const isCentered = !rect;
   const isLast = index === total - 1;
 
-  let cardStyle: React.CSSProperties | undefined;
+  let basePosition: { left: number; top: number } | null = null;
   if (rect && typeof window !== "undefined") {
     const spaceRight = window.innerWidth - rect.right;
     const left =
       spaceRight > CARD_W + 32
-        ? rect.right + 16
-        : Math.max(16, rect.left - CARD_W - 16);
-    const top = Math.min(Math.max(rect.top, 16), window.innerHeight - 260);
-    cardStyle = { left, top };
+        ? rect.right + GAP
+        : Math.max(GAP, rect.left - CARD_W - GAP);
+    const top = Math.min(Math.max(rect.top, GAP), window.innerHeight - CARD_H);
+    basePosition = { left, top };
   }
+  const dodged = useDodgeFloatingUi(basePosition, rect);
+  const cardStyle: React.CSSProperties | undefined =
+    dodged ?? basePosition ?? undefined;
 
   return (
     <>
@@ -62,7 +138,7 @@ export function Coachmark({
         role="dialog"
         aria-label={step.title}
         className={cn(
-          "fixed z-[70] w-80 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-xl",
+          "fixed z-[70] w-80 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-xl transition-[left,top] duration-200",
           isCentered && "left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
         )}
         style={cardStyle}

--- a/docs/agents/jira-operating-manual.md
+++ b/docs/agents/jira-operating-manual.md
@@ -1,0 +1,154 @@
+# OpenVPM — Agent Operating Manual (Jira)
+
+**Read this before you touch Jira.** Jira is the agent team's shared brain and
+control plane: the queue of what to do, the record of what happened, and the
+coordination layer that keeps multiple agents from colliding. Treat every issue
+as durable shared memory — the next agent (or Evan) only knows what the issue says.
+
+The governing principle: **the ticket is the quality ceiling.** Your output is
+capped by the quality of the ticket that triggered it. A ticket with real
+acceptance criteria, the right file paths, and a test plan lands close to
+production on the first pass. A one-line ticket produces one-line-quality work.
+
+---
+
+## The board
+
+- **Site:** `get-talky.atlassian.net`
+- **Project:** OpenVPM — **key `OPENVPM`**
+- **Type:** team-managed **Software**. Hierarchy: **Epic → Story / Task / Bug → Sub-task**.
+- **Access:** the Atlassian MCP (`mcp__claude_ai_Atlassian__*`). The MCP writes as
+  **Evan's account**, so your identity lives in **labels + comment signatures**
+  (see Attribution). Cloud id: `88265351-683a-47a9-910c-6183509bbfa3`.
+
+## Issue types
+
+| Type | Use for | Who creates it |
+|------|---------|----------------|
+| **Epic** | A lifecycle workstream / theme (see Epic spine below). | Humans, or agents *after asking*. |
+| **Story** | A user-facing feature or capability. | Anyone. |
+| **Task** | Engineering/ops work with no direct user story. | Anyone. |
+| **Bug** | A defect. | Anyone. |
+| **Sub-task** | A slice of a Story/Task an agent finishes in one sitting. | The owning agent. |
+
+Every actionable Story/Task/Bug is attached to an Epic and filled out with the
+**Golden Ticket template** below.
+
+## Workflow — the state machine
+
+```
+Proposed ──▶ To Do ──▶ In Progress ──▶ In Review ──▶ Done
+                            │
+                            └──▶ Blocked ──▶ (back to In Progress / To Do)
+```
+
+| State | Meaning | Entry rule |
+|-------|---------|-----------|
+| **Proposed** | An idea an agent surfaced. **Not approved. Do not start.** | Agent proposes; a human triages it to To Do. |
+| **To Do** | Triaged and spec'd — Definition of Ready is met. | Safe for an agent to pick up. |
+| **In Progress** | Exactly one agent owns it right now. | WIP limit = **1 In Progress per agent**. |
+| **In Review** | Work done, PR open, acceptance criteria checked. | The **human-approval gate**. |
+| **Blocked** | Waiting on a dependency, a decision, or an external clock. | Must have a `[blocked]` comment saying what it waits on. |
+| **Done** | Merged/shipped **and** verified. | A **human** moves any `risk:*` ticket to Done. |
+
+## Your queue (JQL recipes)
+
+- **Ready for an agent to pick up:**
+  `project = OPENVPM AND status = "To Do" AND labels = agent-ready ORDER BY priority DESC`
+- **What I'm currently holding:**
+  `project = OPENVPM AND status = "In Progress"`
+- **Needs a human decision:**
+  `project = OPENVPM AND labels = needs-human`
+- **Stuck / waiting:**
+  `project = OPENVPM AND status = Blocked`
+- **A whole workstream:**
+  `project = OPENVPM AND parent = OPENVPM-<epic-number>`
+
+## Attribution & the comment protocol (the message bus)
+
+Because every agent writes as Evan's account, **identity lives in an `owner:*`
+label + a signed comment prefix.** Comments are the audit trail; write them as if
+the next agent has zero context.
+
+- **On pickup** → move to *In Progress*, comment:
+  `[agent:eng] plan: <2–4 bullets; name the files/modules you'll touch>`
+- **As you go** → comment decisions and findings. Future agents replay this.
+- **On finish** → move to *In Review*, check every Acceptance Criteria box in the
+  description, comment:
+  `[agent:eng] done: <what changed> · PR: <url> · tests: <command/screen/evidence>`
+- **When stuck** → move to *Blocked*, comment:
+  `[blocked] waiting on: <thing> · @Evan`
+- **Signatures:** `[agent:eng]` `[agent:qa]` `[agent:gtm]` `[agent:ops]` `[agent:design]`.
+
+## Labels — controlled vocabulary (do not invent new namespaces)
+
+| Namespace | Values | Purpose |
+|-----------|--------|---------|
+| `area:*` | billing, onboarding, consult, comms, sms, scheduling, records, infra, marketing | What part of the product. |
+| `owner:*` | eng, qa, gtm, ops, design | Which agent role owns it (routing). |
+| `stage:*` | launch, testing, scale | Lifecycle phase. |
+| `risk:*` | prod, money, security, data | High blast radius — **escalate, never auto-close.** |
+| _(flags)_ | `agent-ready`, `needs-human` | `agent-ready` = safe to auto-pick-up. `needs-human` = a human must decide. |
+
+## Guardrails
+
+- **WIP = 1** In Progress per agent. Finish or Block before picking up the next.
+- **`risk:*` tickets:** do the work and move to *In Review*, but only a **human**
+  moves them to *Done*. Never auto-close anything touching prod, money, security, or data.
+- **No destructive moves:** never delete issues, never bulk-transition, never edit
+  another agent's comments.
+- **One PR per ticket.** Link the PR in the *In Review* comment.
+- **Missing spec?** If Acceptance Criteria or Definition of Ready is absent or
+  ambiguous, do **not** guess — move it back to *To Do*/*Proposed* and comment
+  `needs spec: <what's unclear>`.
+
+---
+
+## The Golden Ticket template
+
+Paste this into the **description** of every actionable Story / Task / Bug. This
+template is the single highest-leverage thing in this manual.
+
+```markdown
+## Context / Why
+<1–3 sentences: the user-facing problem or goal. Link the plan/memory/PR.>
+
+## Scope
+- In scope: …
+- Out of scope: …
+
+## Acceptance criteria  (the Definition of Done — check these on finish)
+- [ ] …
+- [ ] …
+
+## Technical notes
+- Repo / branch: …
+- Files / modules likely involved: `path/to/file.ts`
+- Prior art / related PRs: #NN
+- Constraints: RLS · migrations · env / feature flags · billing · demo-mode
+
+## Test / verification plan
+<How we'll know it works: a command, a screen to check, an e2e spec.>
+
+## Definition of Ready  (must all be true before → In Progress)
+- [ ] Acceptance criteria are testable
+- [ ] Entry-point files identified
+- [ ] Dependencies / blockers noted
+
+## Links
+Epic: OPENVPM-NN · Depends on: OPENVPM-NN · Plan/memory: …
+```
+
+---
+
+## Epic spine (the lifecycle)
+
+The build lifecycle lives in six standing Epics. Attach new work to the right one.
+
+1. **Launch / Go-Live** — everything gating paid production (maps to the Gate
+   A/B/C plan: money & comms plumbing, hardening, core vet functionality).
+2. **Early Testing & Dogfood** — beta.openvpm.com, restore drills, security review.
+3. **Scale** — multi-tenant performance, reliability, cost, observability.
+4. **Ops & Incidents** — production incidents, on-call, runbooks.
+5. **Growth & GTM** — marketing, onboarding funnel, activation.
+6. **Bugs & Quality** — defects and quality debt not tied to a feature Epic.


### PR DESCRIPTION
Found while verifying #65 live on beta: the calendar-feed guide spotlights **Add to your calendar**, the user opens the popover, and the coachmark card (`z-[70]`) sits directly on top of it, covering the **Turn on the calendar link** button it just asked for. Playwright could not even click through it, and a human sees the guide camping on the content.

Fix: the card observes `document.body` for Radix popper portals (`[data-radix-popper-content-wrapper]`). When its footprint overlaps one, it repositions clear of the popper + anchor union (left of both, or below when there is no room) and glides there with a 200ms transition. When the popper closes it returns to its normal spot.

Verified live on beta together with the #65 checks (screenshots on the thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)