### PR TITLE
fix(tour): re-measure poppers after Radix positions them

### DIFF
--- a/apps/web/components/tour/coachmark.tsx
+++ b/apps/web/components/tour/coachmark.tsx
@@ -70,11 +70,25 @@ function useDodgeFloatingUi(
         top: Math.min(unionBottom + GAP, window.innerHeight - CARD_H - GAP),
       });
     };
-    compute();
-    // Radix portals mount and unmount directly under <body>.
-    const mo = new MutationObserver(compute);
+    // Radix mounts the portal first and positions it a frame later via a
+    // style transform (no childList mutation), so measure again shortly
+    // after any mutation or the popper is still at 0x0 when we look.
+    let active = true;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const computeSoon = () => {
+      if (!active) return;
+      compute();
+      timers.push(setTimeout(() => active && compute(), 120));
+      timers.push(setTimeout(() => active && compute(), 400));
+    };
+    computeSoon();
+    const mo = new MutationObserver(computeSoon);
     mo.observe(document.body, { childList: true });
-    return () => mo.disconnect();
+    return () => {
+      active = false;
+      timers.forEach(clearTimeout);
+      mo.disconnect();
+    };
   }, [base?.left, base?.top, anchor]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return dodged;


### PR DESCRIPTION
Follow-up to #66: the coachmark dodge never fired live because the MutationObserver only sees the portal mount (childList), while Radix applies the popper's position via a style transform one frame later — no second mutation. The overlap check ran against a 0x0 wrapper and concluded there was nothing to dodge.

Fix: after any body mutation (and once on attach), re-measure at +120ms and +400ms, guarded and cleaned up on unmount. Verified live on beta (screenshots on the thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)