### PR TITLE
fix(auth): full document navigation after signup, not router.push

### DIFF
--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -79,10 +79,11 @@ function RegisterPageInner() {
         redirect: false,
       });
       if (result?.ok) {
-        // Land on the dashboard; the "Make it yours" setup wizard auto-opens
-        // there for new admins (hosted and self-host alike).
-        router.push("/");
-        router.refresh();
+        // Full document navigation, NOT router.push: the logo link prefetched
+        // "/" while logged out, so the router cache holds a redirect to
+        // /login for up to 30s and push would replay it, bouncing brand-new
+        // accounts to the login page right after signup.
+        window.location.assign("/");
       } else {
         toast.success("Account created. Please sign in.");
         router.push("/login");

--- a/apps/web/lib/__tests__/signup-billing-ui.test.ts
+++ b/apps/web/lib/__tests__/signup-billing-ui.test.ts
@@ -50,7 +50,10 @@ describe("signup billing copy", () => {
     expect(registerSource).toContain(
       "if (!isSafeCheckoutRedirectUrl(data.checkoutUrl))"
     );
-    // New signups land on the dashboard, where the setup wizard auto-opens.
-    expect(registerSource).toContain('router.push("/")');
+    // New signups land on the dashboard via a FULL document navigation: the
+    // logo link prefetches "/" while logged out, so the router cache holds a
+    // redirect to /login and router.push would bounce fresh accounts there.
+    expect(registerSource).toContain('window.location.assign("/")');
+    expect(registerSource).not.toContain('router.push("/");');
   });
 });


### PR DESCRIPTION
Gate B dogfood finding, reproduced 3/3 on beta and present on prod.

**Bug:** register succeeds, signIn succeeds (callback 200, session cookie valid), yet the user lands on /login. Network trace showed no 401 and no fallback toast: the bounce is the Next.js router cache. The register page's logo is `<Link href="/">`, which prefetches `/` while logged out; the middleware's redirect-to-/login gets cached, and `router.push("/")` after signIn replays it. Humans usually dodge it because the prefetch entry expires in ~30s and typing the form takes longer, which is why this survived manual walkthroughs.

**Fix:** cross the auth boundary with `window.location.assign("/")` (full document load, no router cache). Fallback path to /login unchanged. Source-level drift guard added to `signup-billing-ui.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)