### PR TITLE
polish(copy): conversion moments in voice, no em dashes

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -14,7 +14,7 @@ import { isValidEmail } from "@/lib/utils";
 const DEMO_ROLES = [
   {
     label: "Admin",
-    description: "Full access — everything a practice owner sees",
+    description: "Full access. Everything a practice owner sees.",
     email: "admin@neighborhoodvet.example.com",
     password: "password123",
   },

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -14,7 +14,7 @@ const dmSans = DM_Sans({
 });
 
 export const metadata: Metadata = {
-  title: "OpenVPM — Open-Source Veterinary Practice Management",
+  title: "OpenVPM: Open-Source Veterinary Practice Management",
   description:
     "The first modern, open-source, API-first practice management system built for the veterinary community. Beautiful, fast, and free.",
   icons: {

--- a/apps/web/components/layout/trial-badge.tsx
+++ b/apps/web/components/layout/trial-badge.tsx
@@ -83,7 +83,7 @@ export function TrialBadge() {
         className="inline-flex items-center gap-1.5 rounded-full border border-destructive/30 bg-destructive/10 px-3 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/20"
       >
         <Clock className="h-3.5 w-3.5" />
-        Trial ended — read-only · Reactivate
+        Trial ended, read only · Turn it back on
       </Link>
     );
   }

--- a/apps/web/components/onboarding/steps/set-up-texting.tsx
+++ b/apps/web/components/onboarding/steps/set-up-texting.tsx
@@ -84,7 +84,7 @@ export function SetUpTextingStep({
                 <p className="text-xs text-slate-500">
                   {isActive
                     ? "Texting is active."
-                    : "Number set up. Carrier registration is pending — sending turns on once it's approved."}
+                    : "Number set up. Carrier registration is pending. Sending turns on once it's approved."}
                 </p>
               </div>
             ) : (

--- a/packages/email/src/templates/TrialEndingEmail.tsx
+++ b/packages/email/src/templates/TrialEndingEmail.tsx
@@ -30,15 +30,15 @@ export function TrialEndingEmail({
   return (
     <EmailLayout
       brand={brand}
-      preview={`Your OpenVPM trial ends ${whenLabel} — add billing to keep your data`}
+      preview={`Your OpenVPM trial ends ${whenLabel}. Add a card and nothing changes.`}
       unsubscribeUrl={unsubscribeUrl}
     >
       <Heading>Your trial ends {whenLabel}</Heading>
       <Paragraph>
         Hi {practiceName}, your OpenVPM trial ends on{" "}
-        <strong>{trialEndDate}</strong>. Add billing now to keep running without
-        interruption — your schedule, records, and everything you&apos;ve set up
-        stay exactly as they are.
+        <strong>{trialEndDate}</strong>. Add a card now and nothing changes.
+        Your schedule, your records, and everything you&apos;ve set up stay
+        exactly as they are.
       </Paragraph>
 
       <InfoCard tone="warning">
@@ -54,8 +54,8 @@ export function TrialEndingEmail({
       </Section>
 
       <Paragraph muted>
-        If your trial lapses, your workspace simply becomes read-only — nothing
-        is deleted, and you can reactivate anytime by adding billing.
+        If your trial lapses, your workspace simply becomes read only. Nothing
+        is deleted, and you can turn it back on anytime by adding a card.
       </Paragraph>
     </EmailLayout>
   );

--- a/packages/email/src/templates/WelcomeEmail.tsx
+++ b/packages/email/src/templates/WelcomeEmail.tsx
@@ -15,7 +15,7 @@ export interface WelcomeEmailProps {
 
 const STEPS = [
   "Take the 60-second tour of the schedule, records, and billing.",
-  "Make it yours — add your logo, accent color, and invite your team.",
+  "Make it yours: add your logo, accent color, and invite your team.",
   "Ask the AI assistant something, like “which pets are overdue for vaccines?”",
 ];
 


### PR DESCRIPTION
Gate B item 5: conversion copy pass on the trial-to-paid moments.

- Lapsed pill: "Trial ended — read-only · Reactivate" → "Trial ended, read only · Turn it back on" (warmer action, no em dash)
- TrialEndingEmail: preview + body now lead with the reassurance ("Add a card now and nothing changes"), lapse line loses the em dash
- WelcomeEmail step, set-up-texting pending note, demo-role description, app `<title>`: em dashes removed per the voice deck
- Checked and left alone (already in voice): trialing pill, Plan & Billing trial paragraph, add-a-card step, the #65 all-done offer
- Table "—" empty-value placeholders untouched (typography, not prose)

Suite: 2,113 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)