### PR TITLE
fix(schedule): concurrent appointments side by side + doctor lanes (OPENVPM-35)

### DIFF
--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -52,6 +52,10 @@ import {
   isAppointmentRecurrenceIntervalInputValid,
   isAppointmentRecurrenceOccurrencesInputValid,
 } from "@/lib/scheduling/appointment-policy";
+import {
+  layoutOverlaps,
+  type OverlapPosition,
+} from "@/lib/scheduling/overlap-layout";
 
 // --- Constants ---
 
@@ -195,6 +199,54 @@ function sortAppointments(appointments: Appointment[]): Appointment[] {
     (a, b) =>
       new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
   );
+}
+
+/** Side-by-side columns for concurrent appointments (never stacked). */
+function buildOverlapLayout(
+  appointments: Appointment[]
+): Map<string, OverlapPosition> {
+  return layoutOverlaps(
+    appointments.map((appt) => ({
+      id: appt.id,
+      startMs: new Date(appt.startTime).getTime(),
+      endMs: new Date(appt.endTime).getTime(),
+    }))
+  );
+}
+
+/**
+ * One lane per doctor for the day view, derived from the day's own
+ * appointments (works even when the only provider is the practice admin).
+ * Unassigned appointments (tech work like nail trims) share a Team lane.
+ */
+function buildDayLanes(
+  appointments: Appointment[]
+): { key: string; label: string; appointments: Appointment[] }[] {
+  const byDoctor = new Map<string, { label: string; appointments: Appointment[] }>();
+  for (const appt of appointments) {
+    const key = appt.doctorId ?? "team";
+    const existing = byDoctor.get(key);
+    if (existing) {
+      existing.appointments.push(appt);
+    } else {
+      byDoctor.set(key, {
+        label: appt.doctorId ? appt.doctorName ?? "Doctor" : "Team",
+        appointments: [appt],
+      });
+    }
+  }
+  const lanes = [...byDoctor.entries()].map(([key, lane]) => ({
+    key,
+    label: lane.label,
+    appointments: lane.appointments,
+  }));
+  // Doctors alphabetically, the shared Team lane last.
+  lanes.sort((a, b) => {
+    if (a.key === "team") return 1;
+    if (b.key === "team") return -1;
+    return a.label.localeCompare(b.label);
+  });
+  return lanes;
 }
 
 function formatToolbarDate(date: Date, view: CalendarView): string {
@@ -348,24 +400,32 @@ function AppointmentBlock({
   appointment,
   timeZone,
   onClick,
+  position,
 }: {
   appointment: Appointment;
   timeZone?: string | null;
   onClick: () => void;
+  position?: OverlapPosition;
 }) {
   const start = new Date(appointment.startTime);
   const end = new Date(appointment.endTime);
   const { top, height } = getAppointmentLayout(start, end, timeZone);
   const bgColor = getAppointmentColor(appointment);
+  // Concurrent appointments split the column width; a lone appointment
+  // keeps the old full-width look.
+  const widthPct = 100 / (position?.columns ?? 1);
+  const leftPct = (position?.column ?? 0) * widthPct;
 
   return (
     <button
       type="button"
       onClick={onClick}
-      className="absolute left-1 right-1 rounded-md px-2 py-1 text-left text-xs overflow-hidden cursor-pointer transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1"
+      className="absolute rounded-md px-2 py-1 text-left text-xs overflow-hidden cursor-pointer transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1"
       style={{
         top,
         height,
+        left: `calc(${leftPct}% + 3px)`,
+        width: `calc(${widthPct}% - 6px)`,
         backgroundColor: `${bgColor}20`,
         borderLeft: `3px solid ${bgColor}`,
       }}
@@ -399,61 +459,125 @@ function DayCalendar({
   onSlotClick?: (y: number) => void;
   onAppointmentClick: (appointment: Appointment) => void;
 }) {
+  // A real clinic day: one lane per doctor (plus a Team lane for
+  // unassigned/tech work). With one provider or none it stays the single
+  // clean column it always was.
+  const lanes = buildDayLanes(appointments);
+  const showLanes = lanes.length > 1;
+
+  const laneColumn = (laneAppointments: Appointment[], key: string) => {
+    const layout = buildOverlapLayout(laneAppointments);
+    return (
+      <div
+        key={key}
+        className={cn(
+          "relative flex-1 border-l border-border",
+          onSlotClick && "cursor-pointer"
+        )}
+        style={{ height: CALENDAR_HEIGHT, minWidth: showLanes ? 160 : undefined }}
+        onClick={(e) => {
+          if (!onSlotClick) return;
+          if ((e.target as HTMLElement).closest("button")) return;
+          const rect = e.currentTarget.getBoundingClientRect();
+          onSlotClick(e.clientY - rect.top);
+        }}
+      >
+        <GridLines />
+
+        {showNowLine && (
+          <div
+            className="absolute left-0 right-0 z-10 flex items-center"
+            style={{ top: nowTop }}
+          >
+            <div className="h-2.5 w-2.5 rounded-full bg-red-500 -ml-1" />
+            <div className="flex-1 border-t-2 border-red-500" />
+          </div>
+        )}
+
+        {laneAppointments.map((appt) => (
+          <AppointmentBlock
+            key={appt.id}
+            appointment={appt}
+            timeZone={timeZone}
+            onClick={() => onAppointmentClick(appt)}
+            position={layout.get(appt.id)}
+          />
+        ))}
+      </div>
+    );
+  };
+
   return (
     <div className="mt-4 overflow-hidden rounded-lg border border-border bg-card">
-      <div className="flex overflow-auto" style={{ maxHeight: "calc(100vh - 220px)" }}>
-        <TimeSlots />
-
+      <div className="overflow-x-auto">
         <div
-          className={cn(
-            "relative flex-1 border-l border-border",
-            onSlotClick && "cursor-pointer"
-          )}
-          style={{ height: CALENDAR_HEIGHT }}
-          onClick={(e) => {
-            if (!onSlotClick) return;
-            if ((e.target as HTMLElement).closest("button")) return;
-            const rect = e.currentTarget.getBoundingClientRect();
-            onSlotClick(e.clientY - rect.top);
+          style={{
+            minWidth: showLanes ? 64 + lanes.length * 160 : undefined,
           }}
         >
-          <GridLines />
-
-          {showNowLine && (
-            <div
-              className="absolute left-0 right-0 z-10 flex items-center"
-              style={{ top: nowTop }}
-            >
-              <div className="h-2.5 w-2.5 rounded-full bg-red-500 -ml-1" />
-              <div className="flex-1 border-t-2 border-red-500" />
+          {showLanes && (
+            <div className="flex border-b border-border bg-muted/30">
+              <div className="w-16 shrink-0" />
+              {lanes.map((lane) => (
+                <div
+                  key={lane.key}
+                  className="flex-1 border-l border-border px-3 py-2"
+                  style={{ minWidth: 160 }}
+                >
+                  <p className="truncate text-sm font-medium">{lane.label}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {lane.appointments.length} appointment
+                    {lane.appointments.length !== 1 ? "s" : ""}
+                  </p>
+                </div>
+              ))}
             </div>
           )}
 
-          {appointments.length > 0 ? (
-            appointments.map((appt) => (
-              <AppointmentBlock
-                key={appt.id}
-                appointment={appt}
-                timeZone={timeZone}
-                onClick={() => onAppointmentClick(appt)}
-              />
-            ))
-          ) : (
-            <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-              <div className="text-center">
-                <Calendar className="mx-auto h-8 w-8 text-muted-foreground/40" />
-                <p className="mt-2 text-sm text-muted-foreground">
-                  No appointments for this day
-                </p>
+          <div
+            className="flex overflow-y-auto"
+            style={{ maxHeight: "calc(100vh - 220px)" }}
+          >
+            <TimeSlots />
+
+            {appointments.length > 0 ? (
+              showLanes ? (
+                lanes.map((lane) => laneColumn(lane.appointments, lane.key))
+              ) : (
+                laneColumn(appointments, "all")
+              )
+            ) : (
+              <div
+                className={cn(
+                  "relative flex-1 border-l border-border",
+                  onSlotClick && "cursor-pointer"
+                )}
+                style={{ height: CALENDAR_HEIGHT }}
+                onClick={(e) => {
+                  if (!onSlotClick) return;
+                  const rect = e.currentTarget.getBoundingClientRect();
+                  onSlotClick(e.clientY - rect.top);
+                }}
+              >
+                <GridLines />
+                <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                  <div className="text-center">
+                    <Calendar className="mx-auto h-8 w-8 text-muted-foreground/40" />
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      No appointments for this day
+                    </p>
+                  </div>
+                </div>
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </div>
 
       {appointments.length > 0 && (
         <div className="border-t border-border px-4 py-2 text-xs text-muted-foreground">
           {appointments.length} appointment{appointments.length !== 1 ? "s" : ""}
+          {showLanes && ` · ${lanes.length} lanes`}
         </div>
       )}
     </div>
@@ -530,6 +654,7 @@ function WeekCalendar({
                 const key = toISODate(day);
                 const isToday = key === todayKey;
                 const dayAppointments = sortAppointments(appointmentsByDate[key] ?? []);
+                const dayLayout = buildOverlapLayout(dayAppointments);
 
                 return (
                   <div
@@ -562,6 +687,7 @@ function WeekCalendar({
                         appointment={appt}
                         timeZone={timeZone}
                         onClick={() => onAppointmentClick(appt)}
+                        position={dayLayout.get(appt.id)}
                       />
                     ))}
                   </div>

--- a/apps/web/lib/onboarding/defaults.ts
+++ b/apps/web/lib/onboarding/defaults.ts
@@ -187,13 +187,19 @@ export async function seedDemoData(
   const wellnessTypeId = typeByName("Wellness Exam");
   const vaccineTypeId = typeByName("Vaccination");
   const sickTypeId = typeByName("Sick Visit");
+  const recheckTypeId = typeByName("Recheck / Follow-up");
   const doctorId = owner?.id ?? null;
   const room1 = seededRooms[0]?.id ?? null;
   const room2 = seededRooms[1]?.id ?? room1;
 
-  // Build appointments for today inside business hours (clinic local time), plus
-  // one in the future. Hours render 8-18 on the Schedule, so 9:00 / 11:30 / 14:00
-  // all show up. A mix of statuses makes the day look real.
+  // Build a day of appointments inside business hours (clinic local time),
+  // plus one in the future. Hours render 8-18 on the Schedule. The shape
+  // follows how a real clinic day is staggered (docs/agents/
+  // vet-workflow-research.md §6): morning wellness anchors, a same-day sick
+  // visit, short vaccine/recheck slots, one doctor-less tech appointment
+  // (nail trims and boosters run without a doctor, and it shows the Team
+  // lane), and one deliberate mid-afternoon overlap so the side-by-side
+  // rendering is visible. A mix of statuses makes the day look real.
   const todayAt = (hour: number, minute: number) => {
     const d = new Date();
     d.setHours(hour, minute, 0, 0);
@@ -207,6 +213,9 @@ export async function seedDemoData(
     status: "scheduled" | "confirmed" | "checked_in" | "in_exam";
     typeId: string | null;
     roomId: string | null;
+    /** Omit for the owner; pass null for tech work with no doctor. */
+    doctor?: string | null;
+    notes?: string;
   }) => ({
     practiceId: opts.practiceId,
     clientId: insertedClients[opts2.clientIdx]!.id,
@@ -215,14 +224,16 @@ export async function seedDemoData(
     endTime: new Date(opts2.start.getTime() + opts2.durationMin * 60 * 1000),
     status: opts2.status,
     typeId: opts2.typeId,
-    doctorId,
+    doctorId: opts2.doctor === undefined ? doctorId : opts2.doctor,
     roomId: opts2.roomId,
+    notes: opts2.notes,
   });
 
   const futureStart = new Date(Date.now() + 26 * 60 * 60 * 1000);
   const insertedAppts = await db
     .insert(appointments)
     .values([
+      // Keep this first: the wellness SOAP note below links to it.
       mkAppt({
         clientIdx: 0,
         patientIdx: 0,
@@ -231,6 +242,28 @@ export async function seedDemoData(
         status: "checked_in",
         typeId: wellnessTypeId,
         roomId: room1,
+      }),
+      mkAppt({
+        clientIdx: 1,
+        patientIdx: 1,
+        start: todayAt(10, 0),
+        durationMin: 30,
+        status: "in_exam",
+        typeId: sickTypeId,
+        roomId: room2,
+        notes: "Less active this week. Owner worried.",
+      }),
+      // Tech work runs without a doctor: this renders in the Team lane.
+      mkAppt({
+        clientIdx: 2,
+        patientIdx: 2,
+        start: todayAt(10, 0),
+        durationMin: 15,
+        status: "confirmed",
+        typeId: vaccineTypeId,
+        roomId: room1,
+        doctor: null,
+        notes: "Booster with the tech. Nail trim if time allows.",
       }),
       mkAppt({
         clientIdx: 1,
@@ -249,6 +282,27 @@ export async function seedDemoData(
         status: "scheduled",
         typeId: sickTypeId,
         roomId: room1,
+      }),
+      // Deliberate overlap with the 2:00: concurrent blocks render side by
+      // side, never stacked.
+      mkAppt({
+        clientIdx: 0,
+        patientIdx: 0,
+        start: todayAt(14, 15),
+        durationMin: 15,
+        status: "scheduled",
+        typeId: vaccineTypeId,
+        roomId: room2,
+      }),
+      mkAppt({
+        clientIdx: 1,
+        patientIdx: 1,
+        start: todayAt(15, 30),
+        durationMin: 15,
+        status: "scheduled",
+        typeId: recheckTypeId,
+        roomId: room1,
+        notes: "Quick look at the teeth after starting dental care.",
       }),
       mkAppt({
         clientIdx: 0,

--- a/apps/web/lib/scheduling/__tests__/overlap-layout.test.ts
+++ b/apps/web/lib/scheduling/__tests__/overlap-layout.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { layoutOverlaps } from "../overlap-layout";
+
+const at = (minutes: number) => minutes * 60_000;
+
+function item(id: string, startMin: number, endMin: number) {
+  return { id, startMs: at(startMin), endMs: at(endMin) };
+}
+
+describe("layoutOverlaps", () => {
+  it("gives non-overlapping items the full width", () => {
+    const layout = layoutOverlaps([item("a", 0, 30), item("b", 30, 60)]);
+    expect(layout.get("a")).toEqual({ column: 0, columns: 1 });
+    expect(layout.get("b")).toEqual({ column: 0, columns: 1 });
+  });
+
+  it("splits two concurrent items side by side (the Biscuit bug)", () => {
+    const layout = layoutOverlaps([item("a", 0, 30), item("b", 0, 30)]);
+    expect(layout.get("a")).toEqual({ column: 0, columns: 2 });
+    expect(layout.get("b")).toEqual({ column: 1, columns: 2 });
+  });
+
+  it("splits partial overlaps too", () => {
+    const layout = layoutOverlaps([item("a", 0, 45), item("b", 30, 60)]);
+    expect(layout.get("a")).toEqual({ column: 0, columns: 2 });
+    expect(layout.get("b")).toEqual({ column: 1, columns: 2 });
+  });
+
+  it("reuses a column once it frees up inside a cluster", () => {
+    // Longer blocks claim the first column, so b (0-60) takes column 0 and
+    // a (0-30) column 1. When c (30-60) starts, a's column is free again:
+    // the cluster stays at two columns.
+    const layout = layoutOverlaps([
+      item("a", 0, 30),
+      item("b", 0, 60),
+      item("c", 30, 60),
+    ]);
+    expect(layout.get("b")).toEqual({ column: 0, columns: 2 });
+    expect(layout.get("a")).toEqual({ column: 1, columns: 2 });
+    expect(layout.get("c")).toEqual({ column: 1, columns: 2 });
+  });
+
+  it("shares the widest column count across a connected chain", () => {
+    // Three-deep overlap at the peak: everyone in the cluster renders at
+    // one-third width so edges line up.
+    const layout = layoutOverlaps([
+      item("a", 0, 60),
+      item("b", 10, 40),
+      item("c", 20, 50),
+    ]);
+    expect(layout.get("a")!.columns).toBe(3);
+    expect(layout.get("b")!.columns).toBe(3);
+    expect(layout.get("c")!.columns).toBe(3);
+    const columns = ["a", "b", "c"].map((id) => layout.get(id)!.column);
+    expect(new Set(columns).size).toBe(3);
+  });
+
+  it("starts a fresh cluster after a gap", () => {
+    const layout = layoutOverlaps([
+      item("a", 0, 30),
+      item("b", 0, 30),
+      item("c", 60, 90),
+    ]);
+    expect(layout.get("c")).toEqual({ column: 0, columns: 1 });
+  });
+
+  it("treats back-to-back items as non-overlapping", () => {
+    const layout = layoutOverlaps([item("a", 0, 30), item("b", 30, 60)]);
+    expect(layout.get("a")!.columns).toBe(1);
+    expect(layout.get("b")!.columns).toBe(1);
+  });
+
+  it("handles zero-duration items without dividing by zero", () => {
+    const layout = layoutOverlaps([item("a", 0, 0), item("b", 0, 30)]);
+    expect(layout.get("a")!.columns).toBe(2);
+    expect(layout.get("b")!.columns).toBe(2);
+  });
+
+  it("is deterministic for identical times", () => {
+    const layout = layoutOverlaps([item("b", 0, 30), item("a", 0, 30)]);
+    expect(layout.get("a")).toEqual({ column: 0, columns: 2 });
+    expect(layout.get("b")).toEqual({ column: 1, columns: 2 });
+  });
+});

--- a/apps/web/lib/scheduling/overlap-layout.ts
+++ b/apps/web/lib/scheduling/overlap-layout.ts
@@ -1,0 +1,73 @@
+/**
+ * Column layout for concurrent calendar blocks. Appointments that overlap in
+ * time get split side by side instead of stacking on top of each other:
+ * items are grouped into clusters (connected chains of overlap), each item
+ * takes the first column that is free at its start time, and every item in a
+ * cluster shares the cluster's column count so widths line up.
+ */
+
+export type OverlapInput = {
+  id: string;
+  startMs: number;
+  endMs: number;
+};
+
+export type OverlapPosition = {
+  /** 0-based column inside the cluster. */
+  column: number;
+  /** Total columns in the cluster (divide the width by this). */
+  columns: number;
+};
+
+export function layoutOverlaps(
+  items: OverlapInput[]
+): Map<string, OverlapPosition> {
+  const result = new Map<string, OverlapPosition>();
+
+  const sorted = [...items]
+    .map((item) => ({
+      ...item,
+      // Zero/negative durations still occupy a sliver so they cluster.
+      endMs: Math.max(item.endMs, item.startMs + 1),
+    }))
+    .sort(
+      (a, b) =>
+        a.startMs - b.startMs || b.endMs - a.endMs || a.id.localeCompare(b.id)
+    );
+
+  let cluster: { id: string; column: number }[] = [];
+  let columnEnds: number[] = [];
+  let clusterEnd = -Infinity;
+
+  const closeCluster = () => {
+    for (const member of cluster) {
+      result.set(member.id, {
+        column: member.column,
+        columns: columnEnds.length,
+      });
+    }
+    cluster = [];
+    columnEnds = [];
+    clusterEnd = -Infinity;
+  };
+
+  for (const item of sorted) {
+    if (cluster.length > 0 && item.startMs >= clusterEnd) {
+      closeCluster();
+    }
+
+    let column = columnEnds.findIndex((end) => end <= item.startMs);
+    if (column === -1) {
+      column = columnEnds.length;
+      columnEnds.push(item.endMs);
+    } else {
+      columnEnds[column] = item.endMs;
+    }
+
+    cluster.push({ id: item.id, column });
+    clusterEnd = Math.max(clusterEnd, item.endMs);
+  }
+  closeCluster();
+
+  return result;
+}


### PR DESCRIPTION
## What

The day calendar now looks like a real clinic day. Fixes the "Biscuit" bug where two concurrent appointments rendered stacked on top of each other with the text colliding.

Grounded in the OPENVPM-32 research (`docs/agents/vet-workflow-research.md` §6): provider columns + a tech lane, type color as the primary channel, deliberate staggering.

## Changes

**Overlap engine** — `lib/scheduling/overlap-layout.ts`, a pure function: clusters appointments whose times intersect (connected chains), assigns each the first free column, and shares the cluster's column count so widths line up. Longer blocks claim earlier columns; ties break deterministically. 9 unit tests (side-by-side split, partial overlap, column reuse, chain width sharing, cluster reset after gaps, zero-duration safety, determinism).

**Day view lanes** — when more than one provider has appointments that day, the day view renders a lane per doctor (alphabetical) plus a **Team** lane for doctor-less appointments (tech work: boosters, nail trims), with a header row showing name + count. Lanes derive from the day's own appointments rather than the veterinarian list, so it also works for admin-run trial practices. Single-provider days keep the exact single-column look we had. Header and lanes share one horizontal scroller so they can't desync.

**Week view** — the same overlap layout applies per day column (the bug reproduced there too).

**Demo day** — the hosted-trial seed (`lib/onboarding/defaults.ts`) now builds a realistic staggered day: 9:00 wellness (checked in), 10:00 sick visit (in exam) concurrent with a 10:00 doctor-less tech booster (Team lane), 11:30 vaccine, 14:00 sick + 14:15 vaccine (deliberate overlap → side-by-side), 15:30 recheck, plus the future booking. Mixed statuses, notes on a few.

## Verification

- `tsc --noEmit` clean; full unit suite green (2,122 tests / 238 files), including the 9 new layout tests.
- Visual check pending: local Docker would not start on this machine today (daemon hangs at startup; survived a clean quit + relaunch), so no local screenshot. The trial demo seed intentionally creates both an overlap pair and a Team lane, so signing up a fresh trial on the preview deploy shows all of it on the Schedule day view immediately.

Jira: OPENVPM-35 · Research: PR #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)