### PR TITLE
fix(records): stack Medical Record Summary PDF header so long clinic names fit (OPENVPM-29)

### DIFF
--- a/apps/web/lib/__tests__/pdf-generation.test.ts
+++ b/apps/web/lib/__tests__/pdf-generation.test.ts
@@ -1,5 +1,45 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { generateMedicalSummaryPdf } from "../pdf";
+
+describe("medical summary header", () => {
+  const source = readFileSync("lib/pdf.ts", "utf8");
+
+  it("stacks logo, clinic name, then the title so long names cannot collide", () => {
+    const headerSection = source.slice(
+      source.indexOf("export function generateMedicalSummaryPdf"),
+      source.indexOf('sectionHeading("Patient Information")')
+    );
+    const logoAt = headerSection.indexOf("drawPawMark");
+    const nameAt = headerSection.indexOf("splitTextToSize(data.practiceName");
+    const titleAt = headerSection.indexOf('"MEDICAL RECORD SUMMARY"');
+    expect(logoAt).toBeGreaterThan(-1);
+    expect(nameAt).toBeGreaterThan(logoAt);
+    expect(titleAt).toBeGreaterThan(nameAt);
+    // The title is no longer right-aligned onto the same line as the name.
+    expect(headerSection).not.toContain('align: "right"');
+  });
+
+  it("renders with a very long clinic name without throwing", () => {
+    const doc = generateMedicalSummaryPdf({
+      practiceName:
+        "Bushwick Veterinary Clinic and Animal Wellness Center of Greater Brooklyn",
+      practiceAddress: "123 Knickerbocker Ave, Brooklyn, NY",
+      practicePhone: "(555) 000-1234",
+      patientName: "Biscuit",
+      species: "Canine",
+      clientName: "Jordan Avery",
+      allergies: [],
+      problems: [],
+      vaccinations: [{ name: "Rabies", date: "2026-05-01", nextDue: "2027-05-01" }],
+      recentNotes: [],
+      prescriptions: [],
+      generatedDate: "7/11/2026",
+    });
+    expect(doc.getNumberOfPages()).toBeGreaterThanOrEqual(1);
+    expect(doc.output("arraybuffer").byteLength).toBeGreaterThan(1000);
+  });
+});
 
 describe("pdf generation date labels", () => {
   const source = readFileSync("lib/pdf.ts", "utf8");

--- a/apps/web/lib/pdf.ts
+++ b/apps/web/lib/pdf.ts
@@ -55,6 +55,27 @@ function formatGeneratedDateUtc(): string {
   return new Date().toLocaleDateString("en-US", { timeZone: "UTC" });
 }
 
+/**
+ * Brand mark: a white paw print on a teal rounded square, drawn with
+ * primitives so PDFs need no image asset. Matches the in-app brand color.
+ */
+function drawPawMark(doc: jsPDF, x: number, y: number, size: number) {
+  const [r, g, b] = hexToRgb(COLOR_TEAL);
+  doc.setFillColor(r, g, b);
+  doc.roundedRect(x, y, size, size, size * 0.22, size * 0.22, "F");
+
+  doc.setFillColor(255, 255, 255);
+  const cx = x + size / 2;
+  const s = size / 12;
+  // Main pad
+  doc.ellipse(cx, y + 7.7 * s, 2.7 * s, 2.2 * s, "F");
+  // Four toes
+  doc.circle(cx - 3.3 * s, y + 4.7 * s, 1.15 * s, "F");
+  doc.circle(cx - 1.15 * s, y + 3.5 * s, 1.15 * s, "F");
+  doc.circle(cx + 1.15 * s, y + 3.5 * s, 1.15 * s, "F");
+  doc.circle(cx + 3.3 * s, y + 4.7 * s, 1.15 * s, "F");
+}
+
 // ---------------------------------------------------------------------------
 // 1. Invoice PDF
 // ---------------------------------------------------------------------------
@@ -445,11 +466,18 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
   }
 
   // ---- Header ---------------------------------------------------------------
+  // Stacked top to bottom (logo, clinic name, document title) so any
+  // clinic-name length fits without colliding with the title.
+  const logoSize = 12;
+  drawPawMark(doc, PAGE_MARGIN, y, logoSize);
+  y += logoSize + 8;
+
   doc.setFont(FONT, "bold");
   doc.setFontSize(20);
   setColor(doc, COLOR_TEAL);
-  doc.text(data.practiceName, PAGE_MARGIN, y);
-  y += 7;
+  const nameLines = doc.splitTextToSize(data.practiceName, CONTENT_WIDTH);
+  doc.text(nameLines, PAGE_MARGIN, y);
+  y += nameLines.length * 8;
 
   doc.setFont(FONT, "normal");
   doc.setFontSize(9);
@@ -462,16 +490,14 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
     doc.text(data.practicePhone, PAGE_MARGIN, y);
     y += 4;
   }
+  y += 4;
 
-  // Title
   doc.setFont(FONT, "bold");
   doc.setFontSize(16);
   setColor(doc, COLOR_DARK);
-  doc.text("MEDICAL RECORD SUMMARY", PAGE_WIDTH - PAGE_MARGIN, PAGE_MARGIN, {
-    align: "right",
-  });
+  doc.text("MEDICAL RECORD SUMMARY", PAGE_MARGIN, y);
 
-  y = Math.max(y, PAGE_MARGIN + 14) + 4;
+  y += 3;
   drawLine(doc, y);
   y += 8;
 


### PR DESCRIPTION
## What

The downloaded Medical Record Summary rendered the clinic name and the "MEDICAL RECORD SUMMARY" title on the same line (name left, title right-aligned), so they collided at longer clinic-name lengths.

## Fix

Stack the header vertically, top to bottom:
1. **Brand paw mark** — white paw print on a teal rounded square, drawn from jsPDF primitives (no image asset needed, so it works everywhere the PDF is generated).
2. **Clinic name** — wraps across lines via `splitTextToSize` if long, so any length fits.
3. **"MEDICAL RECORD SUMMARY"** title, left-aligned under the name.

The right-aligned same-line title is gone, so there is no longer any name length that can overlap it.

## Verification

Rendered a PDF with a deliberately long name ("Bushwick Veterinary Clinic and Animal Wellness Center of Greater Brooklyn") and inspected it: the name wraps to two lines and the title sits cleanly below, no collision. Two unit tests added: header element ordering (logo → name → title, no right-align), and a long-name render that must not throw and must produce a real document. `tsc` clean; PDF test file green.

Note: this uses a self-contained paw mark. The full cross-surface logo unification (app, email, e-sign, favicon) is OPENVPM-30 and will confirm the single canonical asset with Evan.

Jira: OPENVPM-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)