### PR TITLE
fix(ui): widen the global search bar (OPENVPM-31)

### DIFF
--- a/apps/web/components/common/command-search.tsx
+++ b/apps/web/components/common/command-search.tsx
@@ -168,7 +168,7 @@ export function CommandSearch({
       aria-modal="true"
     >
       <div className="fixed inset-0 bg-black/50" onClick={onClose} />
-      <div className="relative w-full max-w-lg rounded-lg border border-border bg-background shadow-elevated">
+      <div className="relative mx-4 w-full max-w-2xl rounded-lg border border-border bg-background shadow-elevated">
         <Command className="flex flex-col" shouldFilter={!hasQuery}>
           <div className="flex items-center border-b border-border px-3">
             {isSearching ? (

--- a/apps/web/components/layout/__tests__/responsive-shell.test.ts
+++ b/apps/web/components/layout/__tests__/responsive-shell.test.ts
@@ -19,8 +19,11 @@ describe("responsive dashboard shell", () => {
     expect(source).toContain('aria-label="Open navigation"');
     expect(source).toContain("lg:hidden");
     expect(source).toContain('aria-label="Open search"');
+    // The search label and the shortcut hint stay hidden on phones; the
+    // trigger only takes its comfortable search-bar width from sm up.
     expect(source).toContain('className="hidden sm:inline"');
-    expect(source).toContain('className="ml-2 hidden');
+    expect(source).toContain('className="ml-auto hidden');
+    expect(source).toContain("sm:w-64");
   });
 
   it("keeps top bar labels and quick-create actions aligned with app roles", () => {

--- a/apps/web/components/layout/top-bar.tsx
+++ b/apps/web/components/layout/top-bar.tsx
@@ -133,11 +133,11 @@ export function TopBar({
           type="button"
           onClick={onSearchOpen}
           aria-label="Open search"
-          className="flex h-9 items-center gap-2 rounded-md border border-input bg-background px-2 text-sm text-muted-foreground transition-colors hover:bg-accent sm:px-3"
+          className="flex h-9 items-center gap-2 rounded-md border border-input bg-background px-2 text-sm text-muted-foreground transition-colors hover:bg-accent sm:w-64 sm:px-3 md:w-80"
         >
-          <Search className="h-4 w-4" />
+          <Search className="h-4 w-4 shrink-0" />
           <span className="hidden sm:inline">Search...</span>
-          <kbd className="ml-2 hidden rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium md:inline">
+          <kbd className="ml-auto hidden rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium md:inline">
             ⌘K
           </kbd>
         </button>


### PR DESCRIPTION
## What

The top global search read as a small button (icon + "Search..." + ⌘K, shrink-to-content). Widen it so it looks and feels like a real search bar.

## Changes

- **Top-bar trigger** (`components/layout/top-bar.tsx`): comfortable search-bar width on desktop — `sm:w-64` (256px), `md:w-80` (320px) — with the ⌘K hint floated to the right edge (`ml-auto`). Below `sm` it stays icon-only and compact, so mobile/tablet don't get crushed.
- **Command palette** (`components/common/command-search.tsx`): widened from `max-w-lg` (512px) to `max-w-2xl` (672px) so the input you actually type in is roomier, plus `mx-4` side gutters so it never touches the edges on narrow screens.

## Verification

- Responsive-shell unit test updated to assert the new width class and the floated hint while keeping the phone-compact intent (label + shortcut hidden below `sm`). Test green; `tsc` clean.
- Built a static Tailwind mock of the top bar at 1280 / 700 / 380px to confirm: desktop shows the full-width bar with ⌘K right-aligned, tablet keeps the bar width while the page title truncates, phone collapses to the icon-only button. (Local Docker + the browser extension were both unavailable on this machine today, so no in-app screenshot; the change is CSS-only width classes.)

Jira: OPENVPM-31

🤖 Generated with [Claude Code](https://claude.com/claude-code)