### PR TITLE
feat(onboarding): show the inbox in the walkthrough with seeded messages (OPENVPM-28)

### DIFF
--- a/apps/web/app/(dashboard)/inbox/page.tsx
+++ b/apps/web/app/(dashboard)/inbox/page.tsx
@@ -648,6 +648,7 @@ export default function InboxPage() {
       <div className="flex flex-1 rounded-lg border border-border bg-card overflow-hidden min-h-0">
         {/* Left panel - list */}
         <div
+          data-tour="inbox-list"
           className={cn(
             "w-full flex-col border-border shrink-0 md:flex md:w-80 md:border-r",
             selectedClientId || selectedUnmatched || newMessageMode

--- a/apps/web/components/tour/tour-steps.ts
+++ b/apps/web/components/tour/tour-steps.ts
@@ -100,6 +100,14 @@ export function buildTourSteps(ctx: TourContext = {}): TourStep[] {
   }
 
   steps.push({
+    id: "inbox",
+    route: "/inbox",
+    anchor: "inbox-list",
+    title: "Talk to clients, all in one place",
+    body: "Text clients from your own number, or send and receive email, right here. We added a few messages so you can see how it feels.",
+  });
+
+  steps.push({
     id: "agent",
     route: `/agent?ask=${encodeURIComponent(AGENT_TOUR_QUESTION)}`,
     anchor: "agent-input",

--- a/apps/web/lib/__tests__/guide-recipes.test.ts
+++ b/apps/web/lib/__tests__/guide-recipes.test.ts
@@ -31,6 +31,7 @@ const ANCHOR_SOURCES: Record<string, string> = {
   "whiteboard-board": "app/(dashboard)/whiteboard/page.tsx",
   "client-portal-link": "app/(dashboard)/clients/[id]/page.tsx",
   "calendar-subscribe": "components/schedule/calendar-subscribe.tsx",
+  "inbox-list": "app/(dashboard)/inbox/page.tsx",
 };
 
 const RICH_CONTEXT: GuideContext = {

--- a/apps/web/lib/onboarding/defaults.ts
+++ b/apps/web/lib/onboarding/defaults.ts
@@ -13,6 +13,7 @@ import {
   problemList,
   invoices,
   invoiceItems,
+  communications,
 } from "@openpims/db";
 
 /**
@@ -120,6 +121,7 @@ export interface DemoDataIds {
   problemIds: string[];
   invoiceIds: string[];
   invoiceItemIds: string[];
+  communicationIds: string[];
 }
 
 /**
@@ -420,6 +422,41 @@ export async function seedDemoData(
     serviceNames: ["Wellness Exam", "Nail Trim"],
   });
 
+  // A few inbound messages so the Inbox has real conversations to show in the
+  // walkthrough. Inbound + status not "read" + no readAt renders as unread.
+  const insertedComms = await db
+    .insert(communications)
+    .values([
+      {
+        practiceId: opts.practiceId,
+        clientId: insertedClients[0]!.id,
+        channel: "sms" as const,
+        direction: "inbound" as const,
+        content:
+          "Hi! Is Biscuit due for anything at his visit tomorrow? Want to make sure we do it all in one trip.",
+        status: "delivered" as const,
+      },
+      {
+        practiceId: opts.practiceId,
+        clientId: insertedClients[1]!.id,
+        channel: "email" as const,
+        direction: "inbound" as const,
+        subject: "Luna's recent invoice",
+        content:
+          "Thanks for seeing Luna. Quick question about the invoice you sent, can I pay online?",
+        status: "delivered" as const,
+      },
+      {
+        practiceId: opts.practiceId,
+        clientId: insertedClients[2]!.id,
+        channel: "sms" as const,
+        direction: "inbound" as const,
+        content: "Can I get a copy of Mango's records for our new groomer?",
+        status: "delivered" as const,
+      },
+    ])
+    .returning({ id: communications.id });
+
   return {
     clientIds: insertedClients.map((c) => c.id),
     patientIds: insertedPatients.map((p) => p.id),
@@ -429,5 +466,6 @@ export async function seedDemoData(
     problemIds: insertedProblems.map((p) => p.id),
     invoiceIds,
     invoiceItemIds,
+    communicationIds: insertedComms.map((c) => c.id),
   };
 }

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -19,6 +19,7 @@ import {
   problemList,
   invoices,
   invoiceItems,
+  communications,
   products,
   locations,
   locationMessaging,
@@ -244,6 +245,7 @@ interface PracticeSettings {
     problemIds?: string[];
     invoiceIds?: string[];
     invoiceItemIds?: string[];
+    communicationIds?: string[];
   };
   onboardingDraft?: {
     logoName?: string;
@@ -1034,6 +1036,17 @@ export const settingsRouter = createRouter({
       const now = new Date();
       // Soft-delete the clinical and billing records first, then the
       // appointments/patients/clients they hang off of.
+      if (demo.communicationIds?.length) {
+        await ctx.db
+          .update(communications)
+          .set({ deletedAt: now })
+          .where(
+            and(
+              eq(communications.practiceId, ctx.practiceId),
+              inArray(communications.id, demo.communicationIds)
+            )
+          );
+      }
       if (demo.invoiceItemIds?.length) {
         await ctx.db
           .update(invoiceItems)


### PR DESCRIPTION
## What

The build half of OPENVPM-28: the onboarding walkthrough now includes the **Inbox**, so new clinics see the low-friction hook (text/email clients from your own number) during the tour.

The ideate half (email-as-standalone-tool + auto-tagging taxonomy/routing) was posted as a proposal on the Jira ticket for Evan **before** this build, per the ticket. None of that ships here.

## Changes

- **Tour step** (`components/tour/tour-steps.ts`): a new `inbox` step after Billing, before the AI helper. Routes to `/inbox`, spotlights the conversation list, copy: "Text clients from your own number, or send and receive email, right here. We added a few messages so you can see how it feels." (fourth-grade voice, no em/en dashes per the guide voice test).
- **Anchor** (`app/(dashboard)/inbox/page.tsx`): `data-tour="inbox-list"` on the conversation-list panel, plus the matching entry in the guide drift-guard test's `ANCHOR_SOURCES`.
- **Seeded demo messages** (`lib/onboarding/defaults.ts`): `seedDemoData` now inserts 3 inbound messages tied to the demo clients — Biscuit's owner asking about tomorrow's visit (SMS), Luna's owner asking to pay the invoice online (email), Mango's owner requesting records (SMS). Inbound + unread, so the inbox reads as a live conversation list. Plumbed through `DemoDataIds`.
- **Cleanup** (`server/routers/settings.ts`): `clearDemoData` soft-deletes the seeded communications alongside the other demo records; `PracticeSettings.demoData` gains `communicationIds`.

## Verification

- `tsc` clean; full unit suite green (2,113 tests / 237 files), including the guide anchor drift-guard (new `inbox-list` mapping), the tour voice/dash guard, and the demo-data admin-safety tests.
- No migration (uses the existing `communications` table). Demo seed runs on hosted-trial signup, so the step lands on real messages on the Vercel preview.

Jira: OPENVPM-28 (proposal comment posted there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)