### PR TITLE
brand(logo): unify on the white-paw-on-teal mark (OPENVPM-30)

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -9,6 +9,7 @@ import {
   isAuthEmailLengthValid,
 } from "@/lib/auth-input-policy";
 import { AUTH_PASSWORD_MAX_LENGTH } from "@/lib/auth-password-policy";
+import { PawMark } from "@/components/brand/paw-mark";
 import { isValidEmail } from "@/lib/utils";
 
 const DEMO_ROLES = [
@@ -111,6 +112,9 @@ function LoginPageInner() {
     <div className="flex min-h-screen items-center justify-center bg-surface p-4">
       <div className="w-full max-w-md rounded-lg border border-border bg-card p-8">
         <div className="mb-6 text-center">
+          <span className="mx-auto mb-3 flex h-11 w-11 items-center justify-center rounded-xl bg-primary text-primary-foreground">
+            <PawMark className="h-6 w-6" />
+          </span>
           <h1 className="font-heading text-2xl font-bold text-foreground">
             OpenVPM
           </h1>

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -19,6 +19,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { FormField } from "@/components/ui/form-field";
+import { PawMark } from "@/components/brand/paw-mark";
 import { cn, initials, isValidEmail } from "@/lib/utils";
 import { trpc } from "@/lib/trpc";
 import { toast } from "sonner";
@@ -148,7 +149,7 @@ function RegisterPageInner() {
             className="inline-flex items-center gap-2 text-sm font-medium text-slate-600 hover:text-primary"
           >
             <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-              <PawPrint className="h-4 w-4" />
+              <PawMark className="h-4 w-4" />
             </span>
             OpenVPM {cloudIntent ? "Cloud" : ""}
           </Link>

--- a/apps/web/app/capture/layout.tsx
+++ b/apps/web/app/capture/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { PawMark } from "@/components/brand/paw-mark";
 
 export const metadata: Metadata = {
   title: "Add Photos - OpenVPM",
@@ -21,7 +22,7 @@ export default function CaptureLayout({
         <div className="mx-auto max-w-lg px-4 py-3 flex items-center gap-3">
           <div className="flex items-center gap-2">
             <div className="h-8 w-8 rounded-lg bg-teal-600 flex items-center justify-center">
-              <span className="text-white font-bold text-sm">OP</span>
+              <PawMark className="h-4 w-4 text-white" />
             </div>
             <div>
               <span className="font-semibold text-gray-900 text-sm">

--- a/apps/web/app/portal/layout.tsx
+++ b/apps/web/app/portal/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { PawMark } from "@/components/brand/paw-mark";
 
 export const metadata: Metadata = {
   title: "Pet Portal - OpenVPM",
@@ -16,7 +17,7 @@ export default function PortalLayout({
         <div className="mx-auto max-w-4xl px-4 py-3 flex items-center gap-3">
           <div className="flex items-center gap-2">
             <div className="h-8 w-8 rounded-lg bg-teal-600 flex items-center justify-center">
-              <span className="text-white font-bold text-sm">OP</span>
+              <PawMark className="h-4 w-4 text-white" />
             </div>
             <div>
               <span className="font-semibold text-gray-900 text-sm">OpenVPM</span>

--- a/apps/web/app/sign/layout.tsx
+++ b/apps/web/app/sign/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { PawMark } from "@/components/brand/paw-mark";
 
 export const metadata: Metadata = {
   title: "Sign Consent - OpenVPM",
@@ -21,7 +22,7 @@ export default function SignLayout({
         <div className="mx-auto max-w-lg px-4 py-3 flex items-center gap-3">
           <div className="flex items-center gap-2">
             <div className="h-8 w-8 rounded-lg bg-teal-600 flex items-center justify-center">
-              <span className="text-white font-bold text-sm">OP</span>
+              <PawMark className="h-4 w-4 text-white" />
             </div>
             <div>
               <span className="font-semibold text-gray-900 text-sm">

--- a/apps/web/components/brand/paw-mark.tsx
+++ b/apps/web/components/brand/paw-mark.tsx
@@ -1,0 +1,48 @@
+/**
+ * The OpenVPM brand mark: a paw print. This is the single source for the
+ * in-app logo so every surface (sidebar, e-sign / capture headers) renders
+ * the same shape. The geometry matches `public/logo.svg` and
+ * `public/favicon.svg`. No "use client" so it works in server components too.
+ *
+ * `PawMark` draws just the paw in `currentColor`; `BrandBadge` is the full
+ * lockup (white paw on a teal rounded square) used wherever the brand appears
+ * on its own.
+ */
+
+export function PawMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <ellipse cx="12" cy="16" rx="4.5" ry="3.5" />
+      <ellipse cx="6" cy="9" rx="2" ry="2.5" />
+      <ellipse cx="9.5" cy="4.5" rx="1.7" ry="2.2" />
+      <ellipse cx="14.5" cy="4.5" rx="1.7" ry="2.2" />
+      <ellipse cx="18" cy="9" rx="2" ry="2.5" />
+    </svg>
+  );
+}
+
+/** White paw on the brand teal, rounded square. `size` sets the square. */
+export function BrandBadge({
+  className,
+  pawClassName = "h-4 w-4",
+}: {
+  className?: string;
+  pawClassName?: string;
+}) {
+  return (
+    <div
+      className={
+        "flex items-center justify-center rounded-lg bg-primary text-primary-foreground " +
+        (className ?? "h-8 w-8")
+      }
+    >
+      <PawMark className={pawClassName} />
+    </div>
+  );
+}

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -24,24 +24,7 @@ import {
   ChevronRight,
   LogOut,
 } from "lucide-react";
-
-function PawMark({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      className={className}
-      fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg"
-      aria-hidden="true"
-    >
-      <ellipse cx="12" cy="16" rx="4.5" ry="3.5" />
-      <ellipse cx="6" cy="9" rx="2" ry="2.5" />
-      <ellipse cx="9.5" cy="4.5" rx="1.7" ry="2.2" />
-      <ellipse cx="14.5" cy="4.5" rx="1.7" ry="2.2" />
-      <ellipse cx="18" cy="9" rx="2" ry="2.5" />
-    </svg>
-  );
-}
+import { PawMark } from "@/components/brand/paw-mark";
 
 type UserRole = "admin" | "veterinarian" | "technician" | "front_desk" | "viewer";
 


### PR DESCRIPTION
## What

Standardize on **the white paw print on teal** everywhere a brand mark renders, and remove the off-brand stragglers (teal squares showing "OP" text, and one generic lucide paw).

## Audit (surfaces checked)

| Surface | Before | After |
|---|---|---|
| Sidebar nav | local paw copy | shared `PawMark` |
| E-sign / consent no-login header | teal square **"OP"** | paw mark |
| Photo-capture no-login header | teal square **"OP"** | paw mark |
| Client portal header | teal square **"OP"** | paw mark |
| Register brand lockup | lucide `PawPrint` (generic) | brand `PawMark` |
| Login header | text only, no mark | brand badge (matches register) |
| PDF record summary | drawn paw on teal | ✓ already consistent (OPENVPM-29) |
| `public/logo.svg` | paw on teal | ✓ canonical |
| `public/favicon.svg` | paw on teal | ✓ already consistent |
| Transactional email | practice name on brand teal | left as-is (see note) |

**Canonical asset:** the paw geometry now lives once in `components/brand/paw-mark.tsx` (`PawMark` + a `BrandBadge` lockup), matching `public/logo.svg` and `public/favicon.svg`. @Evan — confirm this existing mark is the intended canonical one.

**Email note:** transactional emails are sent on behalf of the *practice* and already use the brand teal header with the clinic's own name. Reliably rendering the paw *image* in email needs a hosted PNG (inline SVG is stripped by Gmail; images are blocked-by-default until the recipient loads them), which is a real asset decision rather than a code change — flagging it for you rather than shipping something that renders inconsistently across mail clients.

## Verification

`tsc` clean; full unit suite green (2,113 tests). No stray `"OP"` badges remain (grep-verified). The paw geometry is identical to the shipped favicon/logo and the live sidebar mark, so the swapped surfaces render the same shape. Visual confirmation on preview (local Docker/browser were unavailable on this machine today).

Jira: OPENVPM-30

🤖 Generated with [Claude Code](https://claude.com/claude-code)