### PR TITLE
feat(admin): platform admin can extend a practice trial (OPENVPM-38)

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   ShieldAlert,
   Building2,
@@ -52,12 +53,21 @@ const statusStyles: Record<string, string> = {
 };
 
 export default function AdminPage() {
+  const utils = trpc.useUtils();
   const { data, isLoading, error, refetch } =
     trpc.admin.overview.useQuery(undefined, {
       retry: false,
     });
   const { data: funnel, error: funnelError } =
     trpc.admin.activationFunnel.useQuery({ days: 30 }, { retry: false });
+  const [extendTrialError, setExtendTrialError] = useState<string | null>(null);
+  const extendTrial = trpc.admin.extendTrial.useMutation({
+    onSuccess: () => {
+      setExtendTrialError(null);
+      utils.admin.overview.invalidate();
+    },
+    onError: (err) => setExtendTrialError(err.message),
+  });
 
   if (error?.data?.code === "FORBIDDEN") {
     return (
@@ -176,6 +186,11 @@ export default function AdminPage() {
       </div>
 
       {/* Practices table */}
+      {extendTrialError && (
+        <div className="mt-6 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          Could not extend the trial: {extendTrialError}
+        </div>
+      )}
       <div className="mt-8 overflow-x-auto rounded-lg border border-border">
         <table className="w-full text-sm">
           <thead>
@@ -208,7 +223,22 @@ export default function AdminPage() {
                   </span>
                 </td>
                 <td className="px-4 py-2.5 text-muted-foreground">
-                  {formatDate(p.trialEndsAt, p.timezone)}
+                  <span className="inline-flex items-center gap-2">
+                    {formatDate(p.trialEndsAt, p.timezone)}
+                    {p.billingStatus === "trialing" && (
+                      <button
+                        type="button"
+                        title="Give this trial 14 more days"
+                        disabled={extendTrial.isPending}
+                        onClick={() =>
+                          extendTrial.mutate({ practiceId: p.id, days: 14 })
+                        }
+                        className="rounded border border-border px-1.5 py-0.5 text-xs font-medium text-foreground hover:bg-muted disabled:opacity-50"
+                      >
+                        +14d
+                      </button>
+                    )}
+                  </span>
                 </td>
                 <td className="px-4 py-2.5 text-right tabular-nums">{p.locationCount}</td>
                 <td className="px-4 py-2.5 text-right tabular-nums">{p.userCount}</td>

--- a/apps/web/server/__tests__/admin-extend-trial.test.ts
+++ b/apps/web/server/__tests__/admin-extend-trial.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const selectResults: unknown[][] = [];
+  const select = vi.fn(() => {
+    const result = selectResults.shift() ?? [];
+    const builder = {
+      from: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      orderBy: vi.fn(async () => result),
+      groupBy: vi.fn(async () => result),
+      limit: vi.fn(async () => result),
+    };
+    return builder;
+  });
+  const updateSet = vi.fn();
+  const update = vi.fn(() => ({
+    set: vi.fn((values: unknown) => {
+      updateSet(values);
+      return { where: vi.fn(async () => undefined) };
+    }),
+  }));
+  const db = { select, update };
+
+  return {
+    db,
+    selectResults,
+    update,
+    updateSet,
+    withTenant: vi.fn(
+      async (
+        database: unknown,
+        _practiceId: string,
+        fn: (tx: unknown) => Promise<unknown>
+      ) => fn(database)
+    ),
+    withSystem: vi.fn(
+      async (database: unknown, fn: (tx: unknown) => Promise<unknown>) =>
+        fn(database)
+    ),
+  };
+});
+
+vi.mock("@openpims/db/client", () => ({
+  db: mocks.db,
+}));
+
+vi.mock("@/lib/tenant-db", () => ({
+  withTenant: mocks.withTenant,
+  withSystem: mocks.withSystem,
+}));
+
+const { adminRouter } = await import("../routers/admin");
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function caller(email = "ops@example.com") {
+  return adminRouter.createCaller({
+    db: mocks.db,
+    session: {
+      user: {
+        id: USER_ID,
+        email,
+        name: "Ops",
+        role: "admin",
+        practiceId: PRACTICE_ID,
+      },
+    },
+  } as never);
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+  mocks.selectResults.length = 0;
+});
+
+describe("admin extendTrial", () => {
+  it("extends an active trial from its current end date", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    const currentEnd = new Date(Date.now() + 3 * DAY_MS);
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        billingStatus: "trialing",
+        trialEndsAt: currentEnd,
+      },
+    ]);
+
+    const result = await caller().extendTrial({
+      practiceId: PRACTICE_ID,
+      days: 14,
+    });
+
+    expect(result.trialEndsAt.getTime()).toBe(
+      currentEnd.getTime() + 14 * DAY_MS
+    );
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ trialEndsAt: result.trialEndsAt })
+    );
+    expect(mocks.withSystem).toHaveBeenCalled();
+  });
+
+  it("revives a lapsed trial by extending from now", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    const lapsedEnd = new Date(Date.now() - 10 * DAY_MS);
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        billingStatus: "trialing",
+        trialEndsAt: lapsedEnd,
+      },
+    ]);
+
+    const before = Date.now();
+    const result = await caller().extendTrial({
+      practiceId: PRACTICE_ID,
+      days: 14,
+    });
+    const after = Date.now();
+
+    expect(result.trialEndsAt.getTime()).toBeGreaterThanOrEqual(
+      before + 14 * DAY_MS
+    );
+    expect(result.trialEndsAt.getTime()).toBeLessThanOrEqual(
+      after + 14 * DAY_MS
+    );
+  });
+
+  it("rejects non-trialing practices", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.selectResults.push([
+      {
+        id: PRACTICE_ID,
+        billingStatus: "active",
+        trialEndsAt: null,
+      },
+    ]);
+
+    await expect(
+      caller().extendTrial({ practiceId: PRACTICE_ID, days: 14 })
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown practices", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.selectResults.push([]);
+
+    await expect(
+      caller().extendTrial({ practiceId: PRACTICE_ID, days: 14 })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("rejects callers outside the platform admin allowlist", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+
+    await expect(
+      caller("someone@clinic.example.com").extendTrial({
+        practiceId: PRACTICE_ID,
+        days: 14,
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { isNull, sql, desc } from "drizzle-orm";
+import { and, eq, isNull, sql, desc } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure } from "../trpc";
 import { db } from "@openpims/db/client";
@@ -120,6 +120,60 @@ export const adminRouter = createRouter({
     };
     })
   ),
+
+  /**
+   * Platform-operator tooling: give a trialing practice more time. Extends
+   * from the later of now / the current trial end, so a lapsed no-card trial
+   * comes back to life. Paid, past-due, and canceled practices are managed in
+   * Stripe, never here.
+   */
+  extendTrial: platformAdminProcedure
+    .input(
+      z.object({
+        practiceId: z.string().uuid(),
+        days: z.number().int().min(1).max(90),
+      })
+    )
+    .mutation(async ({ input }) =>
+      withSystem(db, async (tx) => {
+        const [practice] = await tx
+          .select({
+            id: practices.id,
+            billingStatus: practices.billingStatus,
+            trialEndsAt: practices.trialEndsAt,
+          })
+          .from(practices)
+          .where(
+            and(eq(practices.id, input.practiceId), isNull(practices.deletedAt))
+          )
+          .limit(1);
+
+        if (!practice) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Practice not found." });
+        }
+        if (practice.billingStatus !== "trialing") {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Only trialing practices can be extended. Paid and canceled practices are managed through Stripe.",
+          });
+        }
+
+        const now = Date.now();
+        const base =
+          practice.trialEndsAt && practice.trialEndsAt.getTime() > now
+            ? practice.trialEndsAt.getTime()
+            : now;
+        const trialEndsAt = new Date(base + input.days * 24 * 60 * 60 * 1000);
+
+        await tx
+          .update(practices)
+          .set({ trialEndsAt, updatedAt: new Date() })
+          .where(eq(practices.id, input.practiceId));
+
+        return { practiceId: input.practiceId, trialEndsAt };
+      })
+    ),
 
   /**
    * Trial funnel: signups -> activated -> subscribed, derived from existing

--- a/apps/web/server/trpc.ts
+++ b/apps/web/server/trpc.ts
@@ -113,6 +113,10 @@ const HOSTED_READ_ONLY_MUTATION_ALLOWLIST = new Set([
   "settings.requestAccountDeletion",
   "subscription.createCheckout",
   "subscription.openBillingPortal",
+  // Platform-operator tooling must keep working even when the operator's own
+  // practice trial has lapsed; the procedure itself gates on the
+  // PLATFORM_ADMIN_EMAILS allowlist.
+  "admin.extendTrial",
 ]);
 
 function practiceNotFound(): TRPCError {


### PR DESCRIPTION
## Why
Trials sometimes need more time than the default 14 days. Clinics piloting OpenVPM often onboard slowly, and until now `trial_ends_at` was only written at signup or by the Stripe subscription webhook, so giving a practice more time meant direct database access.

## What
- `admin.extendTrial({practiceId, days})` — platform-operator tRPC mutation gated by the PLATFORM_ADMIN_EMAILS allowlist. Trialing practices only; extends from the later of now / the current trial end, so a lapsed trial regains access. Paid, past-due, and canceled practices stay Stripe-managed and are rejected.
- `/admin` practices table: a **+14d** button next to the trial end date for trialing practices; failures surface inline instead of being swallowed.
- The mutation is exempt from the hosted read-only guard (which gates on the caller's own practice) so the tool works regardless of the operator practice's billing state; authorization remains the platform-admin allowlist.
- Tests: extend-from-future, revive-lapsed, non-trialing rejection, unknown practice, non-admin FORBIDDEN.

No migration (column exists). No billing-status writes.

## Tests
`pnpm vitest run server/__tests__/admin-extend-trial.test.ts server/__tests__/admin-overview.test.ts server/__tests__/admin-activation-funnel.test.ts` — all passing.

Jira: OPENVPM-38

🤖 Generated with [Claude Code](https://claude.com/claude-code)