### PR TITLE
feat(import): add Shepherd as a migration source preset (OPENVPM-39)

### DIFF
--- a/apps/web/lib/import/sources.ts
+++ b/apps/web/lib/import/sources.ts
@@ -7,7 +7,7 @@
  */
 
 export interface MigrationSource {
-  id: "avimark" | "cornerstone" | "ezyvet" | "other";
+  id: "avimark" | "cornerstone" | "ezyvet" | "shepherd" | "other";
   name: string;
   /** How to get CSV exports out of that system, in one breath. */
   exportHint: string;
@@ -31,6 +31,12 @@ export const MIGRATION_SOURCES: MigrationSource[] = [
     name: "ezyVet",
     exportHint:
       "In ezyVet, open the Records dashboard, search Contacts and Animals, and use Export to download CSV files.",
+  },
+  {
+    id: "shepherd",
+    name: "Shepherd",
+    exportHint:
+      "In Shepherd, use Reports to export your client and patient lists as CSV. For your full records, ask Shepherd support for your data export. Shepherd is cloud based, so support sends the files.",
   },
   {
     id: "other",

--- a/docs/migrating-to-openvpm.md
+++ b/docs/migrating-to-openvpm.md
@@ -29,6 +29,7 @@ Headers are matched loosely (case, spaces, and underscores do not matter) and co
 - **AVImark**: Information Search → pull Clients and Patients → Results → Export → save as CSV. Vaccine history exports the same way from medical history. Your Covetrus rep can also produce full exports.
 - **Cornerstone**: Reports → Client report and Patient report → save to CSV. IDEXX support can pull complete exports on request.
 - **ezyVet**: Records dashboard → search Contacts and Animals → Export to CSV.
+- **Shepherd**: Reports → export client and patient lists as CSV. For your full record set, ask Shepherd support for your data export; Shepherd is cloud based, so support sends the files.
 - **Anything else**: any spreadsheet saved as CSV works. When in doubt, send us a sample row and we will confirm the mapping.
 
 ## Import order (it matters)


### PR DESCRIPTION
## Why
Clinics moving to OpenVPM from Shepherd had no preset in the importer's "Coming from" picker, so they got no export guidance. The importer itself is source-agnostic.

## What
- `shepherd` preset in `MIGRATION_SOURCES` with a plain-language export hint (Reports → CSV, or ask Shepherd support for a full data export).
- Shepherd export path documented in `docs/migrating-to-openvpm.md`.

Pure data/docs change — no importer behavior change. `pnpm vitest run lib/import` green.

Jira: OPENVPM-39

🤖 Generated with [Claude Code](https://claude.com/claude-code)