### PR TITLE
fix(billing): create Connect accounts with controller params (OPENVPM-48)

### DIFF
--- a/apps/web/lib/__tests__/stripe-connect-account.test.ts
+++ b/apps/web/lib/__tests__/stripe-connect-account.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const accountsCreate = vi.fn(async () => ({ id: "acct_test" }));
+const accountsCreate = vi.fn(async (_params: Record<string, unknown>) => ({
+  id: "acct_test",
+}));
 
 vi.mock("stripe", () => ({
   default: vi.fn(() => ({
@@ -26,7 +28,7 @@ describe("createConnectAccount", () => {
     });
 
     expect(accountsCreate).toHaveBeenCalledTimes(1);
-    const params = accountsCreate.mock.calls[0]![0] as Record<string, unknown>;
+    const params = accountsCreate.mock.calls[0]![0];
 
     // The platform profile is the Stripe-manages-losses configuration;
     // legacy `type: "express"` (platform-liable) is rejected under it.

--- a/apps/web/lib/__tests__/stripe-connect-account.test.ts
+++ b/apps/web/lib/__tests__/stripe-connect-account.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const accountsCreate = vi.fn(async () => ({ id: "acct_test" }));
+
+vi.mock("stripe", () => ({
+  default: vi.fn(() => ({
+    accounts: { create: accountsCreate },
+  })),
+}));
+
+vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_unit");
+
+const { createConnectAccount } = await import("../stripe");
+
+beforeEach(() => {
+  accountsCreate.mockClear();
+});
+
+describe("createConnectAccount", () => {
+  it("creates a controller-based account where Stripe manages losses", async () => {
+    await createConnectAccount({
+      practiceId: "practice-1",
+      email: "clinic@example.com",
+      country: "us",
+      businessName: "Neighborhood Vet",
+    });
+
+    expect(accountsCreate).toHaveBeenCalledTimes(1);
+    const params = accountsCreate.mock.calls[0]![0] as Record<string, unknown>;
+
+    // The platform profile is the Stripe-manages-losses configuration;
+    // legacy `type: "express"` (platform-liable) is rejected under it.
+    expect(params.type).toBeUndefined();
+    expect(params.controller).toEqual({
+      losses: { payments: "stripe" },
+      fees: { payer: "account" },
+      stripe_dashboard: { type: "express" },
+      requirement_collection: "stripe",
+    });
+    expect(params.country).toBe("US");
+    expect(params.capabilities).toEqual({
+      card_payments: { requested: true },
+      transfers: { requested: true },
+    });
+    expect(params.metadata).toMatchObject({ practiceId: "practice-1" });
+  });
+});

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -179,7 +179,17 @@ export async function createConnectAccount(data: {
   if (!stripe) return null;
 
   return stripe.accounts.create({
-    type: "express",
+    // Controller-based account matching our completed platform profile:
+    // Stripe carries negative-balance liability and ongoing compliance, the
+    // clinic pays standard Stripe processing fees, onboarding and dashboard
+    // are Stripe-hosted (Express). Legacy `type: "express"` is the
+    // platform-liable configuration and Stripe rejects it under this profile.
+    controller: {
+      losses: { payments: "stripe" },
+      fees: { payer: "account" },
+      stripe_dashboard: { type: "express" },
+      requirement_collection: "stripe",
+    },
     country: (data.country ?? "US").toUpperCase(),
     email: checkoutCustomerEmail(data.email),
     capabilities: {


### PR DESCRIPTION
## Why
Creating live connected accounts failed with Stripe's "You must complete your platform profile" error. The platform's completed Connect profile is the Stripe-manages-losses configuration, but `createConnectAccount` used legacy `type: "express"` — the platform-liable configuration — which Stripe rejects under that profile.

## What
- `stripe.accounts.create` now uses controller params matching the platform profile: `losses.payments=stripe`, `fees.payer=account`, `stripe_dashboard.type=express`, `requirement_collection=stripe`. No top-level `type`.
- Unit test asserting the params.

Everything downstream is unchanged: Stripe-hosted onboarding links, Express dashboard login links, `account.updated` sync, direct charges on the connected account.

## Tests
`pnpm vitest run lib/__tests__/stripe-connect-account.test.ts server/__tests__/billing-refunds.test.ts` — all passing, plus live click-through verification after deploy.

Jira: OPENVPM-48

🤖 Generated with [Claude Code](https://claude.com/claude-code)