### PR TITLE
docs: public-voice conventions for PRs, commits, and issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,3 +37,7 @@ clinics it serves, not as an internal changelog:
   or request ids, dashboard links, account identifiers.
 - Who asked, why now, and other context with names belongs in the private
   tracker (Jira) — link the ticket key instead.
+- Product roadmap and decision records stay out of the repo. Internal
+  journals, launch checklists, call notes, and strategy write-ups live in the
+  private tracker. The exception is community-facing material that materially
+  betters the open-source project (ROADMAP.md, user docs, runbooks).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,17 @@ Quick rules (full detail in the manual):
 - Sign every comment with your role: `[agent:eng|qa|gtm|ops|design]`.
 - **Never** delete issues, bulk-transition, or move a `risk:*` ticket to *Done* —
   those need a human.
+
+## Public voice — PRs, commits, and issues
+
+This is a public open-source repo. Pull request descriptions, commit messages,
+and GitHub issues are community-facing. Write them for the project and the
+clinics it serves, not as an internal changelog:
+
+- Frame every change by the problem it solves for people using OpenVPM.
+- No customer, prospect, or partner names. No team-member names or first-person
+  founder references ("X promised", "X asked for").
+- No internal specifics: deals, conversations and their dates, production log
+  or request ids, dashboard links, account identifiers.
+- Who asked, why now, and other context with names belongs in the private
+  tracker (Jira) — link the ticket key instead.


### PR DESCRIPTION
## Why
This is a public repo, and pull requests, commit messages, and issues are community-facing. They should read like open-source contributions: framed by the problem solved, free of names and internal specifics.

## What
- New "Public voice" section in `CLAUDE.md`: frame changes by the problem they solve; no customer/partner/team names; no internal specifics (deals, conversation dates, log ids); context with names lives in the private tracker, linked by ticket key.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)