### PR TITLE
fix(billing): connected accounts get the full Stripe Dashboard (OPENVPM-48)

### DIFF
--- a/apps/web/lib/__tests__/stripe-connect-account.test.ts
+++ b/apps/web/lib/__tests__/stripe-connect-account.test.ts
@@ -36,7 +36,7 @@ describe("createConnectAccount", () => {
     expect(params.controller).toEqual({
       losses: { payments: "stripe" },
       fees: { payer: "account" },
-      stripe_dashboard: { type: "express" },
+      stripe_dashboard: { type: "full" },
       requirement_collection: "stripe",
     });
     expect(params.country).toBe("US");

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -181,13 +181,15 @@ export async function createConnectAccount(data: {
   return stripe.accounts.create({
     // Controller-based account matching our completed platform profile:
     // Stripe carries negative-balance liability and ongoing compliance, the
-    // clinic pays standard Stripe processing fees, onboarding and dashboard
-    // are Stripe-hosted (Express). Legacy `type: "express"` is the
-    // platform-liable configuration and Stripe rejects it under this profile.
+    // clinic pays standard Stripe processing fees, and onboarding is
+    // Stripe-hosted. The dashboard must be "full" — Stripe requires platform
+    // fee-collection and loss liability for the Express dashboard, so under
+    // this profile the clinic gets its own full Stripe Dashboard (which also
+    // fits the promise that practices own their Stripe account outright).
     controller: {
       losses: { payments: "stripe" },
       fees: { payer: "account" },
-      stripe_dashboard: { type: "express" },
+      stripe_dashboard: { type: "full" },
       requirement_collection: "stripe",
     },
     country: (data.country ?? "US").toUpperCase(),

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -832,21 +832,16 @@ export const billingRouter = createRouter({
 
       try {
         const link = await createConnectLoginLink(existing.stripeAccountId);
-        if (!isSafeCheckoutRedirectUrl(link?.url)) {
-          throw new TRPCError({
-            code: "SERVICE_UNAVAILABLE",
-            message: "Stripe dashboard is unavailable.",
-          });
+        if (isSafeCheckoutRedirectUrl(link?.url)) {
+          return { url: link!.url };
         }
-        return { url: link.url };
       } catch (err) {
-        if (err instanceof TRPCError) throw err;
-        console.error("[Stripe Connect] dashboard link failed", err);
-        throw new TRPCError({
-          code: "SERVICE_UNAVAILABLE",
-          message: "Stripe dashboard is unavailable.",
-        });
+        // Login links only exist for Express-dashboard accounts. Accounts
+        // with the full Stripe Dashboard sign in to Stripe directly, so fall
+        // through to the standard dashboard URL.
+        console.warn("[Stripe Connect] no login link for account", err);
       }
+      return { url: "https://dashboard.stripe.com/login" };
     }),
 
   listInvoices: protectedProcedure


### PR DESCRIPTION
## Why
Live account creation surfaced a follow-up constraint: Stripe only allows the simplified Express dashboard when the platform collects fees and carries loss liability. Under the Stripe-manages-losses configuration, connected accounts must use the full Stripe Dashboard.

## What
- `controller.stripe_dashboard.type` changes from `express` to `full`. Practices get their own complete Stripe Dashboard, which fits clinics owning their Stripe account outright.
- "Open Stripe dashboard" now falls back to the standard Stripe sign-in page — login links exist only for Express-dashboard accounts.

## Tests
`pnpm vitest run lib/__tests__/stripe-connect-account.test.ts server/__tests__/billing-refunds.test.ts` — all passing; `tsc --noEmit` clean. Live click-through verification after deploy.

Jira: OPENVPM-48

🤖 Generated with [Claude Code](https://claude.com/claude-code)