### PR TITLE
perf(whiteboard): poll the board every 30s instead of 5s

### DIFF
--- a/apps/web/app/(dashboard)/whiteboard/page.tsx
+++ b/apps/web/app/(dashboard)/whiteboard/page.tsx
@@ -534,7 +534,7 @@ export default function WhiteboardPage() {
     isLoading,
     error,
   } = trpc.whiteboard.getActive.useQuery(undefined, {
-    refetchInterval: 5000,
+    refetchInterval: 30000,
   });
   const settingsQuery = trpc.whiteboard.settings.useQuery();
   const practiceSettings = settingsQuery.data;


### PR DESCRIPTION
## Problem

The whiteboard page refetches active appointments every 5 seconds. A single open tab generates roughly 17,000 requests per day, and clinics typically leave the whiteboard up on a front-desk screen all day. That is constant, unnecessary load on the server (and on serverless deployments it translates directly into function invocations).

## Change

Raise the `refetchInterval` for `whiteboard.getActive` from 5s to 30s. Status changes still show up well within the cadence the board is used at, and load drops ~6x per open tab.

## Tests

`vitest run server/__tests__/whiteboard.test.ts lib/__tests__/whiteboard-ui.test.ts` — 19/19 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)