### PR TITLE
CI: skip Vercel preview builds that ship nothing

### DIFF
--- a/apps/web/scripts/vercel-ignore-build.sh
+++ b/apps/web/scripts/vercel-ignore-build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Vercel Ignored Build Step for the projects deployed from apps/web.
+# Exit 0 skips the build; exit 1 lets it proceed.
+#
+# - Production deployments always build.
+# - The public demo deployment (NEXT_PUBLIC_DEMO_MODE=true) tracks
+#   production only; its preview builds are skipped as duplicates.
+# - Preview builds are skipped when nothing that ships in the web app
+#   changed. turbo-ignore walks the workspace graph, so pushes that only
+#   touch docs, e2e specs, or infra stop producing throwaway builds.
+
+set -u
+
+if [ "${VERCEL_ENV:-}" = "production" ]; then
+  exit 1
+fi
+
+if [ "${NEXT_PUBLIC_DEMO_MODE:-}" = "true" ]; then
+  exit 0
+fi
+case "${VERCEL_PROJECT_PRODUCTION_URL:-}" in
+  demo.*) exit 0 ;;
+esac
+
+# turbo-ignore exits 0 when @openpims/web and its workspace dependencies
+# are unchanged since the last deployment (falling back to the parent
+# commit). Any failure falls through to building, never to skipping.
+npx --yes turbo-ignore "@openpims/web" || exit 1
+exit 0

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -4,6 +4,7 @@
   "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
   "buildCommand": "pnpm build",
   "outputDirectory": ".next",
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh",
   "crons": [
     {
       "path": "/api/cron/reminders",


### PR DESCRIPTION
## Why

Self-hosters and contributors deploying from this monorepo to Vercel get a build for every push, even when the push only touches docs, e2e specs, or infrastructure files. On multi-project setups (a production app and a demo built from the same directory) that doubles again. Wasted builds cost money and slow the deploy queue for everyone running this repo.

## What changed

`apps/web/vercel.json` gains an `ignoreCommand` backed by a small script:

- Production deployments always build.
- Deployments configured as demo mirrors (`NEXT_PUBLIC_DEMO_MODE=true`, or a `demo.*` production URL) skip preview builds entirely; they track production only.
- Other preview builds run `turbo-ignore @openpims/web`, which walks the workspace graph and skips the build when neither the app nor its workspace dependencies changed since the last deployment.
- Every failure mode falls through to building, never to skipping.

## Testing

- `bash -n` on the script.
- This PR's own preview exercises the path: it touches `apps/web`, so the preview builds; after merge, a docs-only push should show its preview deployments as skipped in Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)