### PR TITLE
Track acquisition through the signup funnel

### DIFF
--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -34,6 +34,7 @@ import {
   isRequiredAuthTextValid,
 } from "@/lib/auth-input-policy";
 import { isSafeCheckoutRedirectUrl } from "@/lib/checkout-redirect";
+import { acquisitionFromSearchParams } from "@/lib/acquisition";
 
 export default function RegisterPage() {
   return (
@@ -53,6 +54,7 @@ function RegisterPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const cloudIntent = searchParams.get("intent") === "cloud";
+  const acquisition = acquisitionFromSearchParams(searchParams);
   const [practiceName, setPracticeName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -136,6 +138,7 @@ function RegisterPageInner() {
       email: email.trim().toLowerCase(),
       password,
       practiceName: practiceName.trim(),
+      acquisition,
     });
   }
 

--- a/apps/web/app/(auth)/verify-email/page.tsx
+++ b/apps/web/app/(auth)/verify-email/page.tsx
@@ -44,13 +44,13 @@ function ConfirmToken({ token }: { token: string }) {
       {status === "ok" && (
         <>
           <p className="mt-3 text-sm text-foreground">
-            Your email is verified. You can sign in and start your free trial.
+            Your email is verified. Your OpenVPM trial is ready.
           </p>
           <Link
-            href="/login?next=/"
+            href="/"
             className="mt-6 inline-block rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
-            Sign in and continue
+            Open OpenVPM
           </Link>
         </>
       )}
@@ -92,12 +92,12 @@ function PendingVerification({ email }: { email: string }) {
           <>
             We sent a verification link to{" "}
             <span className="font-medium text-foreground">{email}</span>. Click it
-            to activate your account and start your free trial.
+            to confirm your address. Your trial is already active.
           </>
         ) : (
           <>
-            We sent a verification link to your email. Click it to activate your
-            account and start your free trial.
+            We sent a verification link to your email. Click it to confirm your
+            address. Your trial is already active.
           </>
         )}
       </p>

--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -148,11 +148,29 @@ export default function AdminPage() {
         </div>
         {funnel ? (
           <>
-            <div className="mt-3 grid gap-4 sm:grid-cols-3">
+            <div className="mt-3 grid gap-4 sm:grid-cols-5">
               <div>
                 <p className="text-sm text-muted-foreground">Signups</p>
                 <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
                   {funnel.totals.signups}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Setup started</p>
+                <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
+                  {funnel.totals.setupStarted}
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    {formatPct(funnel.totals.setupStartRate)}
+                  </span>
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Setup complete</p>
+                <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
+                  {funnel.totals.setupCompleted}
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    {formatPct(funnel.totals.setupCompletionRate)}
+                  </span>
                 </p>
               </div>
               <div>
@@ -175,7 +193,8 @@ export default function AdminPage() {
               </div>
             </div>
             <p className="mt-3 text-xs text-muted-foreground">
-              Activated = added a real client and booked a real visit
+              Setup progress comes from the guided clinic setup. Activated = added a
+              real client and booked a real visit.
             </p>
           </>
         ) : (
@@ -198,6 +217,8 @@ export default function AdminPage() {
               <th className="px-4 py-2.5 font-medium">Practice</th>
               <th className="px-4 py-2.5 font-medium">Plan</th>
               <th className="px-4 py-2.5 font-medium">Status</th>
+              <th className="px-4 py-2.5 font-medium">Source</th>
+              <th className="px-4 py-2.5 font-medium">Setup</th>
               <th className="px-4 py-2.5 font-medium">Trial ends</th>
               <th className="px-4 py-2.5 font-medium text-right">Locations</th>
               <th className="px-4 py-2.5 font-medium text-right">Staff</th>
@@ -221,6 +242,12 @@ export default function AdminPage() {
                   >
                     {p.billingStatus.replace("_", " ")}
                   </span>
+                </td>
+                <td className="px-4 py-2.5 text-muted-foreground">
+                  {p.acquisitionSource}
+                </td>
+                <td className="px-4 py-2.5 text-muted-foreground">
+                  {p.setupStage}
                 </td>
                 <td className="px-4 py-2.5 text-muted-foreground">
                   <span className="inline-flex items-center gap-2">
@@ -253,7 +280,7 @@ export default function AdminPage() {
             ))}
             {data.practices.length === 0 && (
               <tr>
-                <td colSpan={11} className="px-4 py-8 text-center text-muted-foreground">
+                <td colSpan={13} className="px-4 py-8 text-center text-muted-foreground">
                   No practices yet.
                 </td>
               </tr>

--- a/apps/web/app/api/cron/activation-digest/route.test.ts
+++ b/apps/web/app/api/cron/activation-digest/route.test.ts
@@ -42,8 +42,12 @@ function funnel(days: number, totals: Partial<ActivationFunnel["totals"]> = {}):
     weeks: [],
     totals: {
       signups: 5,
+      setupStarted: 3,
+      setupCompleted: 2,
       activated: 2,
       subscribed: 1,
+      setupStartRate: 0.6,
+      setupCompletionRate: 0.4,
       activationRate: 0.4,
       conversionRate: 0.2,
       ...totals,

--- a/apps/web/app/api/cron/activation-digest/route.ts
+++ b/apps/web/app/api/cron/activation-digest/route.ts
@@ -13,8 +13,8 @@ import {
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
-// Weekly trial-funnel digest for the founder/operators: signups -> activated
-// -> subscribed for the past 7 and 30 days, emailed to PLATFORM_ADMIN_EMAILS.
+// Weekly trial-funnel digest for the founder/operators: signups -> setup ->
+// activated -> subscribed for the past 7 and 30 days.
 // Reporting only — it must never 500-loop, so failures alert ops and still
 // return a non-throwing response.
 export async function GET(request: Request) {
@@ -85,17 +85,30 @@ function pct(rate: number): string {
 }
 
 function funnelSection(title: string, funnel: ActivationFunnel): string {
-  const { signups, activated, subscribed, activationRate, conversionRate } =
-    funnel.totals;
+  const {
+    signups,
+    setupStarted,
+    setupCompleted,
+    activated,
+    subscribed,
+    setupStartRate,
+    setupCompletionRate,
+    activationRate,
+    conversionRate,
+  } = funnel.totals;
   return `<h2 style="margin:24px 0 8px;font-size:16px;color:#111827;">${title}</h2>
 <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;">
   <tr style="text-align:left;color:#6b7280;font-size:13px;">
     <th style="padding:4px 12px 4px 0;font-weight:500;">Signups</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Setup started</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">Setup complete</th>
     <th style="padding:4px 12px 4px 0;font-weight:500;">Activated</th>
     <th style="padding:4px 0;font-weight:500;">Subscribed</th>
   </tr>
   <tr style="font-size:20px;color:#111827;font-weight:600;">
     <td style="padding:2px 12px 2px 0;">${signups}</td>
+    <td style="padding:2px 12px 2px 0;">${setupStarted} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(setupStartRate)}</span></td>
+    <td style="padding:2px 12px 2px 0;">${setupCompleted} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(setupCompletionRate)}</span></td>
     <td style="padding:2px 12px 2px 0;">${activated} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(activationRate)}</span></td>
     <td style="padding:2px 0;">${subscribed} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(conversionRate)}</span></td>
   </tr>

--- a/apps/web/lib/__tests__/acquisition.test.ts
+++ b/apps/web/lib/__tests__/acquisition.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACQUISITION_VALUE_MAX_LENGTH,
+  acquisitionFromSearchParams,
+} from "@/lib/acquisition";
+
+describe("signup acquisition", () => {
+  it("prefers an explicit placement source and keeps campaign context", () => {
+    const params = new URLSearchParams(
+      "source=homepage_hero&utm_source=google&utm_medium=cpc&utm_campaign=vet_tools"
+    );
+    expect(acquisitionFromSearchParams(params)).toEqual({
+      source: "homepage_hero",
+      medium: "cpc",
+      campaign: "vet_tools",
+    });
+  });
+
+  it("falls back to utm_source", () => {
+    expect(
+      acquisitionFromSearchParams(new URLSearchParams("utm_source=google"))
+    ).toEqual({ source: "google", medium: undefined, campaign: undefined });
+  });
+
+  it("drops unsafe or oversized values and returns undefined when empty", () => {
+    const params = new URLSearchParams({
+      source: "<script>",
+      utm_campaign: "x".repeat(ACQUISITION_VALUE_MAX_LENGTH + 1),
+    });
+    expect(acquisitionFromSearchParams(params)).toBeUndefined();
+  });
+});

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -27,14 +27,25 @@ describe("admin UI", () => {
     );
     expect(source).toContain("Trial funnel (30 days)");
     expect(source).toContain("{funnel.totals.signups}");
+    expect(source).toContain("{funnel.totals.setupStarted}");
+    expect(source).toContain("{funnel.totals.setupCompleted}");
     expect(source).toContain("{funnel.totals.activated}");
     expect(source).toContain("{funnel.totals.subscribed}");
     expect(source).toContain("formatPct(funnel.totals.activationRate)");
+    expect(source).toContain("formatPct(funnel.totals.setupStartRate)");
+    expect(source).toContain("formatPct(funnel.totals.setupCompletionRate)");
     expect(source).toContain("formatPct(funnel.totals.conversionRate)");
     expect(source).toContain(
-      "Activated = added a real client and booked a real visit"
+      "Activated = added a"
     );
     expect(source).toContain("Could not load the funnel.");
+  });
+
+  it("shows trial source and setup stage for diagnosing individual drop-off", () => {
+    expect(source).toContain("{p.acquisitionSource}");
+    expect(source).toContain("{p.setupStage}");
+    expect(source).toContain(">Source</th>");
+    expect(source).toContain(">Setup</th>");
   });
 
   it("renders practice dates in each practice timezone", () => {

--- a/apps/web/lib/acquisition.ts
+++ b/apps/web/lib/acquisition.ts
@@ -1,0 +1,28 @@
+export const ACQUISITION_VALUE_MAX_LENGTH = 80;
+
+export interface SignupAcquisition {
+  source?: string;
+  medium?: string;
+  campaign?: string;
+}
+
+type SearchParamsReader = {
+  get(name: string): string | null;
+};
+
+function clean(value: string | null): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.length > ACQUISITION_VALUE_MAX_LENGTH) return undefined;
+  return /^[a-zA-Z0-9._:/-]+$/.test(trimmed) ? trimmed : undefined;
+}
+
+/** Read only the small, non-sensitive attribution values the signup API accepts. */
+export function acquisitionFromSearchParams(
+  params: SearchParamsReader
+): SignupAcquisition | undefined {
+  const source = clean(params.get("source")) ?? clean(params.get("utm_source"));
+  const medium = clean(params.get("utm_medium"));
+  const campaign = clean(params.get("utm_campaign"));
+  if (!source && !medium && !campaign) return undefined;
+  return { source, medium, campaign };
+}

--- a/apps/web/lib/admin/activation-funnel.ts
+++ b/apps/web/lib/admin/activation-funnel.ts
@@ -23,14 +23,22 @@ export interface ActivationFunnelWeek {
   /** ISO date (YYYY-MM-DD) of the Monday the week starts on. */
   weekStart: string;
   signups: number;
+  setupStarted: number;
+  setupCompleted: number;
   activated: number;
   subscribed: number;
 }
 
 export interface ActivationFunnelTotals {
   signups: number;
+  setupStarted: number;
+  setupCompleted: number;
   activated: number;
   subscribed: number;
+  /** setupStarted / signups; 0 when there are no signups. */
+  setupStartRate: number;
+  /** setupCompleted / signups; 0 when there are no signups. */
+  setupCompletionRate: number;
   /** activated / signups; 0 when there are no signups. */
   activationRate: number;
   /** subscribed / signups; 0 when there are no signups. */
@@ -51,6 +59,8 @@ export function funnelRate(part: number, whole: number): number {
 interface FunnelRow {
   weekStart: string;
   signups: number | string;
+  setupStarted: number | string;
+  setupCompleted: number | string;
   activated: number | string;
   subscribed: number | string;
 }
@@ -76,6 +86,7 @@ export async function computeActivationFunnel(
           p.id,
           p.created_at,
           p.billing_status,
+          p.settings,
           date_trunc('week', p.created_at) as week_start,
           coalesce(p.settings -> 'demoData' -> 'clientIds', '[]'::jsonb)
             as demo_client_ids,
@@ -88,6 +99,14 @@ export async function computeActivationFunnel(
       select
         to_char(s.week_start, 'YYYY-MM-DD') as "weekStart",
         count(*)::int as "signups",
+        count(*) filter (
+          where nullif(s.settings -> 'onboardingState' ->> 'journeyStepId', '')
+            is not null
+            or nullif(s.settings ->> 'onboardingCompletedAt', '') is not null
+        )::int as "setupStarted",
+        count(*) filter (
+          where nullif(s.settings ->> 'onboardingCompletedAt', '') is not null
+        )::int as "setupCompleted",
         count(*) filter (
           where exists (
             select 1
@@ -117,12 +136,19 @@ export async function computeActivationFunnel(
     (row) => ({
       weekStart: String(row.weekStart),
       signups: Number(row.signups) || 0,
+      setupStarted: Number(row.setupStarted) || 0,
+      setupCompleted: Number(row.setupCompleted) || 0,
       activated: Number(row.activated) || 0,
       subscribed: Number(row.subscribed) || 0,
     })
   );
 
   const signups = weeks.reduce((sum, week) => sum + week.signups, 0);
+  const setupStarted = weeks.reduce((sum, week) => sum + week.setupStarted, 0);
+  const setupCompleted = weeks.reduce(
+    (sum, week) => sum + week.setupCompleted,
+    0
+  );
   const activated = weeks.reduce((sum, week) => sum + week.activated, 0);
   const subscribed = weeks.reduce((sum, week) => sum + week.subscribed, 0);
 
@@ -131,8 +157,12 @@ export async function computeActivationFunnel(
     weeks,
     totals: {
       signups,
+      setupStarted,
+      setupCompleted,
       activated,
       subscribed,
+      setupStartRate: funnelRate(setupStarted, signups),
+      setupCompletionRate: funnelRate(setupCompleted, signups),
       activationRate: funnelRate(activated, signups),
       conversionRate: funnelRate(subscribed, signups),
     },

--- a/apps/web/server/__tests__/admin-activation-funnel.test.ts
+++ b/apps/web/server/__tests__/admin-activation-funnel.test.ts
@@ -72,21 +72,25 @@ describe("admin activation funnel", () => {
   it("sums weekly rows and computes activation and conversion rates", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
     mocks.executeResults.push([
-      { weekStart: "2026-06-15", signups: 4, activated: 2, subscribed: 1 },
-      { weekStart: "2026-06-22", signups: 6, activated: 3, subscribed: 2 },
+      { weekStart: "2026-06-15", signups: 4, setupStarted: 3, setupCompleted: 1, activated: 2, subscribed: 1 },
+      { weekStart: "2026-06-22", signups: 6, setupStarted: 4, setupCompleted: 2, activated: 3, subscribed: 2 },
     ]);
 
     const result = await caller().activationFunnel({ days: 30 });
 
     expect(result.days).toBe(30);
     expect(result.weeks).toEqual([
-      { weekStart: "2026-06-15", signups: 4, activated: 2, subscribed: 1 },
-      { weekStart: "2026-06-22", signups: 6, activated: 3, subscribed: 2 },
+      { weekStart: "2026-06-15", signups: 4, setupStarted: 3, setupCompleted: 1, activated: 2, subscribed: 1 },
+      { weekStart: "2026-06-22", signups: 6, setupStarted: 4, setupCompleted: 2, activated: 3, subscribed: 2 },
     ]);
     expect(result.totals).toEqual({
       signups: 10,
+      setupStarted: 7,
+      setupCompleted: 3,
       activated: 5,
       subscribed: 3,
+      setupStartRate: 0.7,
+      setupCompletionRate: 0.3,
       activationRate: 0.5,
       conversionRate: 0.3,
     });
@@ -113,8 +117,12 @@ describe("admin activation funnel", () => {
 
     expect(result.totals).toEqual({
       signups: 0,
+      setupStarted: 0,
+      setupCompleted: 0,
       activated: 0,
       subscribed: 0,
+      setupStartRate: 0,
+      setupCompletionRate: 0,
       activationRate: 0,
       conversionRate: 0,
     });
@@ -123,7 +131,7 @@ describe("admin activation funnel", () => {
   it("coerces string counts from the driver into numbers", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
     mocks.executeResults.push([
-      { weekStart: "2026-06-29", signups: "2", activated: "1", subscribed: "0" },
+      { weekStart: "2026-06-29", signups: "2", setupStarted: "1", setupCompleted: "0", activated: "1", subscribed: "0" },
     ]);
 
     const result = await caller().activationFunnel({ days: 30 });

--- a/apps/web/server/__tests__/admin-overview.test.ts
+++ b/apps/web/server/__tests__/admin-overview.test.ts
@@ -81,6 +81,13 @@ describe("admin overview", () => {
           timezone: "America/Los_Angeles",
           country: "US",
           createdAt: new Date("2026-06-01T02:00:00.000Z"),
+          settings: {
+            acquisition: { source: "homepage_hero", campaign: "summer_launch" },
+            onboardingState: {
+              journeyStepId: "data",
+              journeyDismissed: true,
+            },
+          },
         },
       ],
       [{ practiceId: PRACTICE_ID, c: 3 }],
@@ -98,6 +105,8 @@ describe("admin overview", () => {
       locationCount: 2,
       clientCount: 25,
       patientCount: 40,
+      acquisitionSource: "homepage_hero · summer_launch",
+      setupStage: "Paused at Data import",
     });
     expect(mocks.withSystem).toHaveBeenCalledWith(
       mocks.db,

--- a/apps/web/server/__tests__/auth-router.test.ts
+++ b/apps/web/server/__tests__/auth-router.test.ts
@@ -258,6 +258,15 @@ describe("auth router input validation", () => {
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
+      caller.register({
+        email: "owner@example.com",
+        password: "password123",
+        practiceName: "Neighborhood Veterinary",
+        acquisition: { source: "<script>" },
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    await expect(
       caller.requestPasswordReset({
         email: `${"b".repeat(250)}@example.com`,
       })
@@ -296,6 +305,11 @@ describe("auth router input validation", () => {
             },
           ],
         },
+        acquisition: {
+          source: "  homepage_hero  ",
+          medium: "website",
+          campaign: "summer_launch",
+        },
       })
     ).resolves.toMatchObject({
       id: "user-1",
@@ -328,6 +342,12 @@ describe("auth router input validation", () => {
     );
     expect(updateSet).toHaveBeenCalledWith({
       settings: {
+        acquisition: {
+          source: "homepage_hero",
+          medium: "website",
+          campaign: "summer_launch",
+          capturedAt: expect.any(String),
+        },
         onboardingDraft: {
           logoName: "Neighborhood",
           brandColor: "#aabbcc",

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -25,6 +25,48 @@ const platformAdminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
   return next();
 });
 
+type AdminPracticeSettings = {
+  acquisition?: { source?: string; campaign?: string };
+  onboardingCompletedAt?: string | null;
+  onboardingState?: {
+    journeyStepId?: string | null;
+    journeyDismissed?: boolean;
+  };
+};
+
+const setupStepLabels: Record<string, string> = {
+  basics: "Clinic basics",
+  branding: "Branding",
+  team: "Team",
+  data: "Data import",
+  agent: "AI helper",
+  phone: "Texting",
+  billing: "Billing",
+  allSet: "Finish",
+};
+
+function conversionContext(value: unknown) {
+  const settings = (value ?? {}) as AdminPracticeSettings;
+  const acquisition = settings.acquisition;
+  const acquisitionSource =
+    [acquisition?.source, acquisition?.campaign].filter(Boolean).join(" · ") ||
+    "Unknown";
+
+  if (settings.onboardingCompletedAt) {
+    return { acquisitionSource, setupStage: "Complete" };
+  }
+  const state = settings.onboardingState;
+  const step = state?.journeyStepId;
+  if (step) {
+    const label = setupStepLabels[step] ?? step;
+    return {
+      acquisitionSource,
+      setupStage: state?.journeyDismissed ? `Paused at ${label}` : label,
+    };
+  }
+  return { acquisitionSource, setupStage: "Not started" };
+}
+
 export const adminRouter = createRouter({
   /** Am I a platform admin? (drives whether the /admin nav shows.) */
   isPlatformAdmin: protectedProcedure.query(({ ctx }) => {
@@ -45,6 +87,7 @@ export const adminRouter = createRouter({
         timezone: practices.timezone,
         country: practices.country,
         createdAt: practices.createdAt,
+        settings: practices.settings,
       })
       .from(practices)
       .where(isNull(practices.deletedAt))
@@ -73,6 +116,7 @@ export const adminRouter = createRouter({
       ]);
 
     const practiceRows = rows.map((p) => {
+      const { settings, ...practice } = p;
       const userCount = userCounts.get(p.id) ?? 0;
       const locationCount = Math.max(1, locationCounts.get(p.id) ?? 0);
       const estimatedMrr =
@@ -81,7 +125,8 @@ export const adminRouter = createRouter({
             userCount * CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD
           : 0;
       return {
-        ...p,
+        ...practice,
+        ...conversionContext(settings),
         userCount,
         locationCount,
         estimatedMrr,

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -33,6 +33,7 @@ import {
   AUTH_ONBOARDING_TEAM_MEMBER_NAME_MAX_LENGTH,
   AUTH_PRACTICE_NAME_MAX_LENGTH,
 } from "@/lib/auth-input-policy";
+import { ACQUISITION_VALUE_MAX_LENGTH } from "@/lib/acquisition";
 
 /** Display name from explicit input, else derived from the email local-part. */
 function deriveName(name: string | undefined, email: string): string {
@@ -108,6 +109,21 @@ const onboardingDraftSchema = z.object({
   teamMembers: z.array(onboardingTeamMemberSchema).max(8).optional(),
 });
 
+const acquisitionValueSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(ACQUISITION_VALUE_MAX_LENGTH)
+  .regex(/^[a-zA-Z0-9._:/-]+$/);
+
+const signupAcquisitionSchema = z
+  .object({
+    source: acquisitionValueSchema.optional(),
+    medium: acquisitionValueSchema.optional(),
+    campaign: acquisitionValueSchema.optional(),
+  })
+  .strict();
+
 const authTokenSchema = z
   .string()
   .regex(/^[a-f0-9]{64}$/i, "Invalid or expired link.");
@@ -152,6 +168,7 @@ export const authRouter = createRouter({
           AUTH_LOCATION_NAME_MAX_LENGTH
         ).optional(),
         onboardingDraft: onboardingDraftSchema.optional(),
+        acquisition: signupAcquisitionSchema.optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -330,6 +347,12 @@ export const authRouter = createRouter({
       // On the hosted service, seed demo data + start onboarding so the trial
       // lands on a lively dashboard. Non-fatal. Self-host skips this.
       const practiceSettings: Record<string, unknown> = {};
+      if (input.acquisition) {
+        practiceSettings.acquisition = {
+          ...input.acquisition,
+          capturedAt: new Date().toISOString(),
+        };
+      }
       if (onboardingDraft) {
         practiceSettings.onboardingDraft = onboardingDraft;
       }
@@ -349,9 +372,9 @@ export const authRouter = createRouter({
           .where(eq(practices.id, practice.id));
       }
 
-      // On the hosted service, require email verification before login. Issue a
-      // token + send the email. Non-fatal: signup still succeeds. Self-host
-      // skips this (frictionless).
+      // On the hosted service, request email verification without blocking the
+      // trial. Issue a token + send the email; the in-app banner follows up.
+      // Non-fatal: signup still succeeds. Self-host skips this.
       let verificationRequired = false;
       let verificationUrl: string | undefined;
       let verificationEmailSent: boolean | undefined;


### PR DESCRIPTION
## What changed

- carry the marketing acquisition source through registration and practice creation
- expose source and activation-stage context in the admin funnel and digest
- clarify the verification-email handoff and preserve the intended no-card trial flow
- add focused acquisition and funnel coverage

## Why

The public site can create interest, but conversion work is only useful if we can see where a clinic came from and whether it completes setup. This closes that measurement gap without adding a schema migration.

## Impact

New signups retain source attribution in existing setup state, and admins can distinguish acquisition source and activation progress when reviewing the funnel.

## Validation

- production build passed
- 244 test files passed
- 2,174 tests passed