### PR TITLE
Stop the database falling behind the deployed code

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -1,0 +1,94 @@
+name: Apply migrations
+
+# Schema changes ship with the code that needs them.
+#
+# Applying migrations by hand is how a deploy ended up running against a
+# database that never got its column: the pull request merged, the code went
+# live, and the migration sat unapplied until a customer reported the error.
+#
+# Every environment that serves traffic gets its migrations applied here, on
+# merge, in one place. Adding an environment means adding a secret — not
+# remembering a manual step.
+
+on:
+  push:
+    branches: [main]
+  # Allow a re-run from the Actions tab if an environment was down at merge time.
+  workflow_dispatch:
+
+# Never let two merges migrate the same database concurrently.
+concurrency:
+  group: apply-migrations
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: ${{ matrix.environment }}
+    runs-on: ubuntu-latest
+    strategy:
+      # One environment failing must not stop the others from being migrated.
+      fail-fast: false
+      matrix:
+        include:
+          - environment: production
+            secret_name: PRODUCTION_DATABASE_URL
+          - environment: demo
+            secret_name: DEMO_DATABASE_URL
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      # An environment is opted in by adding its secret. Until then this is a
+      # no-op rather than a red build, so adding the workflow does not require
+      # every environment to be wired up on day one.
+      - name: Check environment is configured
+        id: configured
+        env:
+          DATABASE_URL: ${{ secrets[matrix.secret_name] }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::notice::${{ matrix.secret_name }} is not set — skipping ${{ matrix.environment }}."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Report drift before touching anything, so the log says what this run is
+      # about to change.
+      - name: Schema state before
+        if: steps.configured.outputs.ready == 'true'
+        continue-on-error: true
+        env:
+          DATABASE_URL: ${{ secrets[matrix.secret_name] }}
+        run: pnpm db:drift
+
+      - name: Apply migrations
+        if: steps.configured.outputs.ready == 'true'
+        env:
+          DATABASE_URL: ${{ secrets[matrix.secret_name] }}
+        run: pnpm db:migrate
+
+      # New tables arrive without policies. Re-applying is idempotent and keeps
+      # tenant isolation from silently regressing the moment a table is added.
+      - name: Re-apply row-level security
+        if: steps.configured.outputs.ready == 'true'
+        env:
+          DATABASE_URL: ${{ secrets[matrix.secret_name] }}
+          OPENPIMS_APP_DB_PASSWORD: ${{ secrets.OPENPIMS_APP_DB_PASSWORD }}
+        run: pnpm db:rls
+
+      # Fail the job if anything the code expects is still missing, so a partial
+      # or skipped migration cannot pass silently.
+      - name: Verify schema matches the code
+        if: steps.configured.outputs.ready == 'true'
+        env:
+          DATABASE_URL: ${{ secrets[matrix.secret_name] }}
+        run: pnpm db:drift

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -24,6 +24,10 @@ const mocks = vi.hoisted(() => ({
     ok: true,
     detail: "Object storage bucket reachable",
   })),
+  findSchemaDrift: vi.fn(async () => ({
+    missingTables: [] as string[],
+    missingColumns: [] as { table: string; column: string }[],
+  })),
 }));
 
 vi.mock("@openpims/db/client", () => ({
@@ -31,6 +35,13 @@ vi.mock("@openpims/db/client", () => ({
     execute: mocks.dbExecute,
   },
 }));
+
+vi.mock("@openpims/db/schema-drift", async () => {
+  const actual = await vi.importActual<
+    typeof import("@openpims/db/schema-drift")
+  >("@openpims/db/schema-drift");
+  return { ...actual, findSchemaDrift: mocks.findSchemaDrift };
+});
 
 vi.mock("@/lib/billing/plans", () => ({
   STRIPE_PRICE_CLOUD_LOCATION_ENV: "STRIPE_PRICE_CLOUD_LOCATION",
@@ -114,6 +125,77 @@ afterEach(() => {
   mocks.checkObjectStorageHealth.mockResolvedValue({
     ok: true,
     detail: "Object storage bucket reachable",
+  });
+  mocks.findSchemaDrift.mockResolvedValue({
+    missingTables: [],
+    missingColumns: [],
+  });
+});
+
+describe("health route schema drift", () => {
+  it("reports healthy when the database matches the deployed code", async () => {
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.checks.schema).toEqual({
+      ok: true,
+      detail: "Database schema matches the deployed code",
+    });
+  });
+
+  it("fails the readiness gate when a migration was never applied", async () => {
+    mocks.findSchemaDrift.mockResolvedValue({
+      missingTables: [],
+      missingColumns: [{ table: "soap_notes", column: "imported" }],
+    });
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.ok).toBe(false);
+    expect(json.checks.schema.ok).toBe(false);
+    expect(json.checks.schema.detail).toContain("soap_notes.imported");
+  });
+
+  it("names a missing table so the operator knows what to apply", async () => {
+    mocks.findSchemaDrift.mockResolvedValue({
+      missingTables: ["invoice_adjustments"],
+      missingColumns: [],
+    });
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(json.checks.schema.detail).toContain("invoice_adjustments");
+  });
+
+  it("skips the drift check when the database is unreachable", async () => {
+    mocks.dbExecute.mockRejectedValueOnce(new Error("connection refused"));
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(json.checks.database.ok).toBe(false);
+    expect(json.checks.schema).toBeUndefined();
+    expect(mocks.findSchemaDrift).not.toHaveBeenCalled();
+  });
+
+  it("does not leak connection details when the drift check itself fails", async () => {
+    mocks.findSchemaDrift.mockRejectedValueOnce(
+      new Error("password=secret host=prod-db")
+    );
+
+    const response = await GET();
+    const json = await response.json();
+
+    expect(json.checks.schema).toEqual({
+      ok: false,
+      detail: "Schema drift check failed",
+    });
+    expect(JSON.stringify(json)).not.toContain("password=secret");
   });
 });
 

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server";
 import { sql } from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import {
+  describeDrift,
+  driftIsClean,
+  findSchemaDrift,
+} from "@openpims/db/schema-drift";
+import {
   STRIPE_PRICE_CLOUD_LOCATION_ENV,
   billingEnforced,
 } from "@/lib/billing/plans";
@@ -177,15 +182,34 @@ export async function GET() {
     { ok: boolean; detail?: string; advisory?: boolean }
   > = {};
 
+  let databaseReachable = false;
   try {
     await db.execute(sql`select 1`);
     checks.database = { ok: true };
+    databaseReachable = true;
   } catch (err) {
     void err;
     checks.database = {
       ok: false,
       detail: "Database check failed",
     };
+  }
+
+  // A deploy whose migrations were never applied still boots, connects, and
+  // serves most pages — it just 500s on whichever feature touches the missing
+  // column. Surface that here so a drifted environment reports unhealthy
+  // instead of waiting for a customer to notice.
+  if (databaseReachable) {
+    try {
+      const drift = await findSchemaDrift(db);
+      checks.schema = {
+        ok: driftIsClean(drift),
+        detail: describeDrift(drift),
+      };
+    } catch (err) {
+      void err;
+      checks.schema = { ok: false, detail: "Schema drift check failed" };
+    }
   }
 
   if (billingEnforced()) {

--- a/apps/web/lib/__tests__/schema-drift.test.ts
+++ b/apps/web/lib/__tests__/schema-drift.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  declaredSchema,
+  describeDrift,
+  driftIsClean,
+  findSchemaDrift,
+} from "@openpims/db/schema-drift";
+
+/**
+ * Regression cover for the failure that reached a customer: the deployed code
+ * queried prescriptions.product_id against a database that never got the
+ * migration, and nothing reported it until someone emailed.
+ */
+
+type ColumnRow = { table_name: string; column_name: string };
+
+/** Stand-in for the Drizzle client that returns a fixed information_schema. */
+function fakeDb(rows: ColumnRow[]) {
+  return { execute: async () => rows };
+}
+
+/** The live database, minus whatever we want to pretend was never migrated. */
+function liveSchemaWithout(omit: (row: ColumnRow) => boolean): ColumnRow[] {
+  const rows: ColumnRow[] = [];
+  for (const [table, columns] of declaredSchema()) {
+    for (const column of columns) {
+      const row = { table_name: table, column_name: column };
+      if (!omit(row)) rows.push(row);
+    }
+  }
+  return rows;
+}
+
+describe("declaredSchema", () => {
+  it("picks up the real application tables", () => {
+    const declared = declaredSchema();
+    expect(declared.has("prescriptions")).toBe(true);
+    expect(declared.has("soap_notes")).toBe(true);
+    expect(declared.get("prescriptions")?.has("product_id")).toBe(true);
+    expect(declared.get("soap_notes")?.has("imported")).toBe(true);
+  });
+
+  it("uses database column names, not camelCase property names", () => {
+    expect(declaredSchema().get("prescriptions")?.has("productId")).toBe(false);
+  });
+});
+
+describe("findSchemaDrift", () => {
+  it("reports no drift when the database matches the code", async () => {
+    const drift = await findSchemaDrift(fakeDb(liveSchemaWithout(() => false)));
+    expect(drift).toEqual({ missingTables: [], missingColumns: [] });
+    expect(driftIsClean(drift)).toBe(true);
+  });
+
+  it("catches a missing column (the prescriptions.product_id outage)", async () => {
+    const db = fakeDb(
+      liveSchemaWithout(
+        (row) =>
+          row.table_name === "prescriptions" && row.column_name === "product_id"
+      )
+    );
+
+    const drift = await findSchemaDrift(db);
+
+    expect(drift.missingColumns).toContainEqual({
+      table: "prescriptions",
+      column: "product_id",
+    });
+    expect(drift.missingTables).toEqual([]);
+    expect(driftIsClean(drift)).toBe(false);
+  });
+
+  it("catches a missing column (the soap_notes.imported outage)", async () => {
+    const db = fakeDb(
+      liveSchemaWithout(
+        (row) =>
+          row.table_name === "soap_notes" && row.column_name === "imported"
+      )
+    );
+
+    const drift = await findSchemaDrift(db);
+
+    expect(drift.missingColumns).toContainEqual({
+      table: "soap_notes",
+      column: "imported",
+    });
+    expect(driftIsClean(drift)).toBe(false);
+  });
+
+  it("catches an entirely missing table without also listing its columns", async () => {
+    const db = fakeDb(
+      liveSchemaWithout((row) => row.table_name === "wellness_plans")
+    );
+
+    const drift = await findSchemaDrift(db);
+
+    expect(drift.missingTables).toContain("wellness_plans");
+    expect(
+      drift.missingColumns.some((c) => c.table === "wellness_plans")
+    ).toBe(false);
+  });
+
+  it("ignores extra tables and columns the database has but the code does not", async () => {
+    const rows = liveSchemaWithout(() => false);
+    rows.push({ table_name: "legacy_scratch", column_name: "id" });
+    rows.push({ table_name: "prescriptions", column_name: "retired_field" });
+
+    const drift = await findSchemaDrift(fakeDb(rows));
+
+    expect(driftIsClean(drift)).toBe(true);
+  });
+
+  it("reads node-postgres style { rows } results as well as arrays", async () => {
+    const rows = liveSchemaWithout(() => false);
+    const drift = await findSchemaDrift({ execute: async () => ({ rows }) });
+    expect(driftIsClean(drift)).toBe(true);
+  });
+
+  it("treats an empty database as fully drifted rather than healthy", async () => {
+    const drift = await findSchemaDrift(fakeDb([]));
+    expect(drift.missingTables.length).toBeGreaterThan(10);
+    expect(driftIsClean(drift)).toBe(false);
+  });
+});
+
+describe("describeDrift", () => {
+  it("names the missing objects so the operator knows what to apply", async () => {
+    const drift = await findSchemaDrift(
+      fakeDb(
+        liveSchemaWithout(
+          (row) =>
+            row.table_name === "soap_notes" && row.column_name === "imported"
+        )
+      )
+    );
+
+    const summary = describeDrift(drift);
+    expect(summary).toContain("soap_notes.imported");
+    expect(summary).toContain("behind the deployed code");
+  });
+
+  it("says so plainly when the schema is clean", () => {
+    expect(describeDrift({ missingTables: [], missingColumns: [] })).toBe(
+      "Database schema matches the deployed code"
+    );
+  });
+
+  it("truncates long lists instead of dumping every object", () => {
+    const summary = describeDrift({
+      missingTables: ["a", "b", "c", "d", "e", "f", "g"],
+      missingColumns: [],
+    });
+    expect(summary).toContain("7 tables missing");
+    expect(summary).toContain("…");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "db:reset": "pnpm --filter @openpims/db db:reset",
     "db:rls": "pnpm --filter @openpims/db db:rls",
     "db:rls:test": "pnpm --filter @openpims/db db:rls:test",
+    "db:drift": "pnpm --filter @openpims/db db:drift",
+    "db:baseline": "pnpm --filter @openpims/db db:baseline",
     "db:studio": "pnpm --filter @openpims/db db:studio",
     "clean": "turbo clean",
     "test:e2e": "playwright test",

--- a/packages/db/baseline.ts
+++ b/packages/db/baseline.ts
@@ -25,10 +25,22 @@ config({ path: "../../.env" });
 
 import { createHash } from "crypto";
 import { readFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import postgres from "postgres";
+import {
+  describeDrift,
+  driftIsClean,
+  type SchemaDrift,
+} from "./schema-drift";
 
 type JournalEntry = { idx: number; tag: string; when: number };
+type SnapshotTable = {
+  name: string;
+  schema: string;
+  columns: Record<string, { name: string }>;
+};
+type MigrationSnapshot = { tables: Record<string, SnapshotTable> };
 
 const args = process.argv.slice(2);
 const apply = args.includes("--apply");
@@ -48,7 +60,8 @@ if (!url) {
   process.exit(1);
 }
 
-const journalPath = join(__dirname, "drizzle", "meta", "_journal.json");
+const here = dirname(fileURLToPath(import.meta.url));
+const journalPath = join(here, "drizzle", "meta", "_journal.json");
 const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
   entries: JournalEntry[];
 };
@@ -65,11 +78,65 @@ if (cutoff === -1) {
 const toMark = journal.entries.slice(0, cutoff + 1);
 const remaining = journal.entries.slice(cutoff + 1);
 
+function snapshotPath(entry: JournalEntry): string {
+  const prefix = entry.tag.split("_", 1)[0];
+  return join(here, "drizzle", "meta", `${prefix}_snapshot.json`);
+}
+
+/** Verify the live database contains every table/column at the chosen cutoff. */
+async function findBaselineDrift(entry: JournalEntry): Promise<SchemaDrift> {
+  const snapshot = JSON.parse(
+    readFileSync(snapshotPath(entry), "utf8")
+  ) as MigrationSnapshot;
+  const expected = new Map<string, Set<string>>();
+
+  for (const table of Object.values(snapshot.tables)) {
+    if (table.schema && table.schema !== "public") continue;
+    expected.set(
+      table.name,
+      new Set(Object.values(table.columns).map((column) => column.name))
+    );
+  }
+
+  const rows = await client<
+    { table_name: string; column_name: string }[]
+  >`select table_name, column_name
+    from information_schema.columns
+    where table_schema = 'public'`;
+  const live = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const columns = live.get(row.table_name);
+    if (columns) columns.add(row.column_name);
+    else live.set(row.table_name, new Set([row.column_name]));
+  }
+
+  const missingTables: string[] = [];
+  const missingColumns: SchemaDrift["missingColumns"] = [];
+  for (const [table, columns] of expected) {
+    const liveColumns = live.get(table);
+    if (!liveColumns) {
+      missingTables.push(table);
+      continue;
+    }
+    for (const column of columns) {
+      if (!liveColumns.has(column)) missingColumns.push({ table, column });
+    }
+  }
+
+  missingTables.sort();
+  missingColumns.sort((a, b) =>
+    a.table === b.table
+      ? a.column.localeCompare(b.column)
+      : a.table.localeCompare(b.table)
+  );
+  return { missingTables, missingColumns };
+}
+
 // drizzle-kit identifies an applied migration by the SHA-256 of the migration
 // file's contents, so the ledger has to be written with the same hash it will
 // compute on the next `migrate` run.
 function migrationHash(tag: string): string {
-  const sql = readFileSync(join(__dirname, "drizzle", `${tag}.sql`), "utf8");
+  const sql = readFileSync(join(here, "drizzle", `${tag}.sql`), "utf8");
   return createHash("sha256").update(sql).digest("hex");
 }
 
@@ -111,6 +178,19 @@ async function main() {
     return 1;
   }
 
+  const target = toMark[toMark.length - 1]!;
+  const drift = await findBaselineDrift(target);
+  if (!driftIsClean(drift)) {
+    console.error(
+      `Cannot baseline through ${target.tag}: the live database does not match that migration snapshot.`
+    );
+    console.error(describeDrift(drift));
+    console.error(
+      "Apply or push the missing schema changes, then run the baseline again."
+    );
+    return 1;
+  }
+
   console.log(`\nWill mark ${toMark.length} migration(s) as already applied:`);
   for (const entry of toMark) console.log(`  ✓ ${entry.tag}`);
 
@@ -120,7 +200,7 @@ async function main() {
     );
     for (const entry of remaining) console.log(`  → ${entry.tag}`);
   } else {
-    console.log("\nNo migrations left over — the database is fully current.");
+    console.log("\nNo migrations left over — the selected snapshot is current.");
   }
 
   if (!apply) {
@@ -129,19 +209,20 @@ async function main() {
   }
 
   await client.begin(async (tx) => {
-    await tx`create schema if not exists drizzle`;
-    await tx`
+    await tx.unsafe("create schema if not exists drizzle");
+    await tx.unsafe(`
       create table if not exists drizzle."__drizzle_migrations" (
         id serial primary key,
         hash text not null,
         created_at bigint
       )
-    `;
+    `);
     for (const entry of toMark) {
-      await tx`
-        insert into drizzle."__drizzle_migrations" (hash, created_at)
-        values (${migrationHash(entry.tag)}, ${entry.when})
-      `;
+      await tx.unsafe(
+        `insert into drizzle."__drizzle_migrations" (hash, created_at)
+         values ($1, $2)`,
+        [migrationHash(entry.tag), entry.when]
+      );
     }
   });
 

--- a/packages/db/baseline.ts
+++ b/packages/db/baseline.ts
@@ -1,0 +1,162 @@
+/**
+ * One-time migration baseline.
+ *
+ * Environments built with `drizzle-kit push` have no migration ledger, so
+ * `drizzle-kit migrate` would try to replay every migration from 0000 against a
+ * database that already has the schema. Without a ledger there is also no way
+ * to ask a database what it has applied, which is how a deploy shipped ahead of
+ * production and stayed broken until a customer noticed.
+ *
+ * This writes the ledger drizzle-kit expects and marks migrations as already
+ * applied, so `pnpm db:migrate` becomes the normal way to move any environment
+ * forward from here on.
+ *
+ * Usage:
+ *   pnpm db:baseline --through 0030            # dry run, prints the plan
+ *   pnpm db:baseline --through 0030 --apply    # write the ledger
+ *
+ * Pick --through by checking what the database actually has first:
+ *   pnpm db:drift
+ *
+ * Anything after --through is left for `pnpm db:migrate` to apply normally.
+ */
+import { config } from "dotenv";
+config({ path: "../../.env" });
+
+import { createHash } from "crypto";
+import { readFileSync } from "fs";
+import { join } from "path";
+import postgres from "postgres";
+
+type JournalEntry = { idx: number; tag: string; when: number };
+
+const args = process.argv.slice(2);
+const apply = args.includes("--apply");
+const throughArg = args[args.indexOf("--through") + 1];
+
+if (!args.includes("--through") || !throughArg || throughArg.startsWith("--")) {
+  console.error(
+    "Usage: pnpm db:baseline --through <migration-prefix> [--apply]\n" +
+      "Example: pnpm db:baseline --through 0030 --apply"
+  );
+  process.exit(1);
+}
+
+const url = process.env.DATABASE_URL?.trim();
+if (!url) {
+  console.error("DATABASE_URL not set");
+  process.exit(1);
+}
+
+const journalPath = join(__dirname, "drizzle", "meta", "_journal.json");
+const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+  entries: JournalEntry[];
+};
+
+const cutoff = journal.entries.findIndex((e) => e.tag.startsWith(throughArg));
+if (cutoff === -1) {
+  console.error(
+    `No migration in the journal starts with "${throughArg}".\n` +
+      `Known tags: ${journal.entries.map((e) => e.tag).join(", ")}`
+  );
+  process.exit(1);
+}
+
+const toMark = journal.entries.slice(0, cutoff + 1);
+const remaining = journal.entries.slice(cutoff + 1);
+
+// drizzle-kit identifies an applied migration by the SHA-256 of the migration
+// file's contents, so the ledger has to be written with the same hash it will
+// compute on the next `migrate` run.
+function migrationHash(tag: string): string {
+  const sql = readFileSync(join(__dirname, "drizzle", `${tag}.sql`), "utf8");
+  return createHash("sha256").update(sql).digest("hex");
+}
+
+const pooled =
+  url.includes("pooler.supabase.com") ||
+  url.includes(":6543") ||
+  url.includes("pgbouncer=true");
+const client = postgres(url, { max: 1, prepare: !pooled });
+
+function safeTarget(raw: string): string {
+  try {
+    const parsed = new URL(raw);
+    return `${parsed.host}${parsed.pathname}`;
+  } catch {
+    return "(unparseable DATABASE_URL)";
+  }
+}
+
+async function main() {
+  console.log(`Target: ${safeTarget(url!)}`);
+
+  const existing = await client`
+    select count(*)::int as n
+    from information_schema.tables
+    where table_schema = 'drizzle' and table_name = '__drizzle_migrations'
+  `;
+  const ledgerExists = existing[0]?.n > 0;
+
+  if (ledgerExists) {
+    const applied = await client`
+      select count(*)::int as n from drizzle."__drizzle_migrations"
+    `;
+    console.log(
+      `A migration ledger already exists with ${applied[0]?.n ?? 0} row(s).`
+    );
+    console.log(
+      "Baselining is a one-time operation — use `pnpm db:migrate` instead."
+    );
+    return 1;
+  }
+
+  console.log(`\nWill mark ${toMark.length} migration(s) as already applied:`);
+  for (const entry of toMark) console.log(`  ✓ ${entry.tag}`);
+
+  if (remaining.length > 0) {
+    console.log(
+      `\nWill leave ${remaining.length} migration(s) for \`pnpm db:migrate\`:`
+    );
+    for (const entry of remaining) console.log(`  → ${entry.tag}`);
+  } else {
+    console.log("\nNo migrations left over — the database is fully current.");
+  }
+
+  if (!apply) {
+    console.log("\nDry run. Re-run with --apply to write the ledger.");
+    return 0;
+  }
+
+  await client.begin(async (tx) => {
+    await tx`create schema if not exists drizzle`;
+    await tx`
+      create table if not exists drizzle."__drizzle_migrations" (
+        id serial primary key,
+        hash text not null,
+        created_at bigint
+      )
+    `;
+    for (const entry of toMark) {
+      await tx`
+        insert into drizzle."__drizzle_migrations" (hash, created_at)
+        values (${migrationHash(entry.tag)}, ${entry.when})
+      `;
+    }
+  });
+
+  console.log(`\nBaseline written. ${toMark.length} migration(s) recorded.`);
+  console.log("Run `pnpm db:migrate` to apply anything outstanding.");
+  return 0;
+}
+
+main()
+  .then(async (code) => {
+    await client.end();
+    process.exit(code);
+  })
+  .catch(async (err) => {
+    console.error("Baseline failed:", err instanceof Error ? err.message : err);
+    await client.end();
+    process.exit(1);
+  });

--- a/packages/db/check-drift.ts
+++ b/packages/db/check-drift.ts
@@ -1,0 +1,85 @@
+/**
+ * Schema drift check. Connects to DATABASE_URL and reports any table or column
+ * the deployed code expects but the database does not have.
+ *
+ * Run with: pnpm db:drift
+ *
+ * Point DATABASE_URL at any environment to audit it before or after a deploy:
+ *   DATABASE_URL='postgres://…demo…' pnpm db:drift
+ *
+ * Exits non-zero on drift so it can gate a deploy or run from cron.
+ */
+import { config } from "dotenv";
+config({ path: "../../.env" });
+
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { findSchemaDrift, driftIsClean } from "./schema-drift";
+
+const url = process.env.DATABASE_URL?.trim();
+if (!url) {
+  console.error("DATABASE_URL not set");
+  process.exit(1);
+}
+
+// Supabase's transaction pooler rejects the prepared statements postgres-js
+// uses by default; mirror the app client's handling so this works everywhere.
+const pooled =
+  url.includes("pooler.supabase.com") ||
+  url.includes(":6543") ||
+  url.includes("pgbouncer=true");
+
+const client = postgres(url, { max: 1, prepare: !pooled });
+const db = drizzle(client);
+
+// Show which database was inspected without ever printing the password.
+function safeTarget(raw: string): string {
+  try {
+    const parsed = new URL(raw);
+    return `${parsed.host}${parsed.pathname}`;
+  } catch {
+    return "(unparseable DATABASE_URL)";
+  }
+}
+
+async function main() {
+  console.log(`Checking schema drift against ${safeTarget(url!)}`);
+  const drift = await findSchemaDrift(db);
+
+  if (driftIsClean(drift)) {
+    console.log("OK — database schema matches the deployed code.");
+    return 0;
+  }
+
+  console.error("\nDRIFT DETECTED — the database is behind the code.\n");
+
+  if (drift.missingTables.length > 0) {
+    console.error(`Missing tables (${drift.missingTables.length}):`);
+    for (const table of drift.missingTables) console.error(`  - ${table}`);
+    console.error("");
+  }
+
+  if (drift.missingColumns.length > 0) {
+    console.error(`Missing columns (${drift.missingColumns.length}):`);
+    for (const { table, column } of drift.missingColumns) {
+      console.error(`  - ${table}.${column}`);
+    }
+    console.error("");
+  }
+
+  console.error(
+    "Apply the outstanding migrations with `pnpm db:migrate` against this database."
+  );
+  return 1;
+}
+
+main()
+  .then(async (code) => {
+    await client.end();
+    process.exit(code);
+  })
+  .catch(async (err) => {
+    console.error("Drift check failed:", err instanceof Error ? err.message : err);
+    await client.end();
+    process.exit(1);
+  });

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,6 +9,7 @@
     "./schema-drift": "./schema-drift.ts"
   },
   "scripts": {
+    "type-check": "tsc --noEmit",
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./schema/index.ts",
-    "./client": "./client.ts"
+    "./client": "./client.ts",
+    "./schema-drift": "./schema-drift.ts"
   },
   "scripts": {
     "db:push": "drizzle-kit push",
@@ -15,6 +16,8 @@
     "db:reset": "tsx reset.ts",
     "db:rls": "tsx apply-rls.ts",
     "db:rls:test": "tsx test-rls.ts",
+    "db:drift": "tsx check-drift.ts",
+    "db:baseline": "tsx baseline.ts",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/packages/db/schema-drift.ts
+++ b/packages/db/schema-drift.ts
@@ -1,0 +1,150 @@
+import { getTableConfig, type PgTable } from "drizzle-orm/pg-core";
+import { is, sql } from "drizzle-orm";
+import { PgTable as PgTableClass } from "drizzle-orm/pg-core";
+import * as schema from "./schema/index";
+
+/**
+ * Schema drift detection.
+ *
+ * The app's Drizzle schema is the source of truth for what the running code
+ * expects. When a deploy ships a schema change whose migration was never
+ * applied, the code keeps querying a column the database does not have and the
+ * failure only surfaces as a 500 on whichever page happens to touch it — which
+ * is how "column prescriptions.product_id does not exist" reached a customer
+ * instead of an alert.
+ *
+ * This compares what the schema *declares* against what the database *has*, so
+ * any environment running ahead of its database reports unhealthy immediately
+ * rather than silently erroring one feature at a time.
+ *
+ * Deliberately one-directional: extra tables/columns in the database are not
+ * drift. Rolling deploys and expand-then-contract migrations both leave columns
+ * behind on purpose, and flagging them would make the check cry wolf.
+ */
+
+export type DeclaredColumn = {
+  table: string;
+  column: string;
+};
+
+export type SchemaDrift = {
+  missingTables: string[];
+  missingColumns: DeclaredColumn[];
+};
+
+/** Every table the Drizzle schema declares, with its database column names. */
+export function declaredSchema(): Map<string, Set<string>> {
+  const declared = new Map<string, Set<string>>();
+
+  for (const exported of Object.values(schema)) {
+    if (!is(exported, PgTableClass)) continue;
+    const config = getTableConfig(exported as PgTable);
+    // Views and tables outside the default schema are managed elsewhere.
+    if (config.schema && config.schema !== "public") continue;
+    declared.set(
+      config.name,
+      new Set(config.columns.map((column) => column.name))
+    );
+  }
+
+  return declared;
+}
+
+type ColumnRow = { table_name: string; column_name: string };
+
+type Queryable = {
+  execute: (query: ReturnType<typeof sql>) => Promise<unknown>;
+};
+
+function toRows(result: unknown): ColumnRow[] {
+  // postgres-js returns the rows array directly; node-postgres wraps them in
+  // { rows }. Support both so this works against the app client and a plain
+  // script connection.
+  if (Array.isArray(result)) return result as ColumnRow[];
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows: unknown }).rows;
+    if (Array.isArray(rows)) return rows as ColumnRow[];
+  }
+  return [];
+}
+
+/**
+ * Compare the declared schema against the live database.
+ *
+ * One introspection query, no per-table round trips, so this is cheap enough to
+ * run on a health check.
+ */
+export async function findSchemaDrift(db: Queryable): Promise<SchemaDrift> {
+  const result = await db.execute(sql`
+    select table_name, column_name
+    from information_schema.columns
+    where table_schema = 'public'
+  `);
+
+  const live = new Map<string, Set<string>>();
+  for (const row of toRows(result)) {
+    const existing = live.get(row.table_name);
+    if (existing) {
+      existing.add(row.column_name);
+    } else {
+      live.set(row.table_name, new Set([row.column_name]));
+    }
+  }
+
+  const missingTables: string[] = [];
+  const missingColumns: DeclaredColumn[] = [];
+
+  for (const [table, columns] of declaredSchema()) {
+    const liveColumns = live.get(table);
+    if (!liveColumns) {
+      missingTables.push(table);
+      continue;
+    }
+    for (const column of columns) {
+      if (!liveColumns.has(column)) {
+        missingColumns.push({ table, column });
+      }
+    }
+  }
+
+  missingTables.sort();
+  missingColumns.sort((a, b) =>
+    a.table === b.table
+      ? a.column.localeCompare(b.column)
+      : a.table.localeCompare(b.table)
+  );
+
+  return { missingTables, missingColumns };
+}
+
+export function driftIsClean(drift: SchemaDrift): boolean {
+  return drift.missingTables.length === 0 && drift.missingColumns.length === 0;
+}
+
+/** Short operator-facing summary, e.g. "2 tables and 1 column missing". */
+export function describeDrift(drift: SchemaDrift): string {
+  if (driftIsClean(drift)) return "Database schema matches the deployed code";
+
+  const parts: string[] = [];
+  if (drift.missingTables.length > 0) {
+    parts.push(
+      `${drift.missingTables.length} table${
+        drift.missingTables.length === 1 ? "" : "s"
+      } missing (${drift.missingTables.slice(0, 5).join(", ")}${
+        drift.missingTables.length > 5 ? ", …" : ""
+      })`
+    );
+  }
+  if (drift.missingColumns.length > 0) {
+    const shown = drift.missingColumns
+      .slice(0, 5)
+      .map((c) => `${c.table}.${c.column}`)
+      .join(", ");
+    parts.push(
+      `${drift.missingColumns.length} column${
+        drift.missingColumns.length === 1 ? "" : "s"
+      } missing (${shown}${drift.missingColumns.length > 5 ? ", …" : ""})`
+    );
+  }
+  return `Database is behind the deployed code: ${parts.join("; ")}`;
+}


### PR DESCRIPTION
## The problem

A deploy whose migration was never applied could still boot and serve most pages, then fail only when a feature touched a missing table or column. Manual migrations and databases created with drizzle-kit push made that drift easy to miss.

## What this adds

- Applies migrations on merges to main for each configured environment.
- Re-applies row-level security after migrations and verifies schema drift afterward.
- Makes /api/health report schema drift without exposing connection details.
- Adds pnpm db:drift for release checks and a dry-run-by-default pnpm db:baseline command.
- Validates existing tables before baselining so a partial database cannot be mislabeled as current.

## Operational readiness completed

- PRODUCTION_DATABASE_URL and DEMO_DATABASE_URL are stored as encrypted GitHub Actions secrets.
- Production is baselined through migration 0031 with 59 application tables.
- Staging is current through migration 0033 with 61 application tables and RLS reapplied.
- Runtime applications use least-privilege roles; migration owners are separate.

## Verification

- Full suite: 245 test files, 2,191 tests passed.
- Production build and type validation passed on the exact pushed head.
- 38 focused migration and schema-drift tests passed.
- Gitleaks found no leaks across all three PR commits.
- Vercel preview checks pass.

This PR is ready to merge first in the release sequence.