### PR TITLE
Measure the demo-to-trial conversion funnel

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
@@ -11,6 +11,12 @@ import {
 import { AUTH_PASSWORD_MAX_LENGTH } from "@/lib/auth-password-policy";
 import { PawMark } from "@/components/brand/paw-mark";
 import { isValidEmail } from "@/lib/utils";
+import {
+  buildCloudSignupUrl,
+  cloudSignupAppOrigin,
+  FUNNEL_EVENTS,
+} from "@/lib/funnel-analytics";
+import { trackFunnelEvent } from "@/lib/track-funnel-event";
 
 const DEMO_ROLES = [
   {
@@ -80,11 +86,26 @@ function LoginPageInner() {
   const canSubmit =
     isAuthEmailLengthValid(email) && isValidEmail(email) && passwordMeetsPolicy;
 
-  async function signInWith(emailValue: string, passwordValue: string) {
+  useEffect(() => {
+    if (!DEMO_MODE) return;
+    trackFunnelEvent(FUNNEL_EVENTS.demoLand);
+  }, []);
+
+  async function signInWith(
+    emailValue: string,
+    passwordValue: string,
+    roleLabel?: string
+  ) {
     setError("");
     setLoading(true);
     setEmail(emailValue);
     setPassword(passwordValue);
+
+    if (DEMO_MODE && roleLabel) {
+      trackFunnelEvent(FUNNEL_EVENTS.demoRoleSelected, {
+        role: roleLabel.toLowerCase().replace(/\s+/g, "_"),
+      });
+    }
 
     const result = await signIn("credentials", {
       email: emailValue,
@@ -136,7 +157,9 @@ function LoginPageInner() {
                 <button
                   key={role.email}
                   type="button"
-                  onClick={() => signInWith(role.email, role.password)}
+                  onClick={() =>
+                    signInWith(role.email, role.password, role.label)
+                  }
                   disabled={loading}
                   className="group flex flex-col rounded-md border border-border bg-background p-2.5 text-left transition-colors hover:border-primary hover:bg-primary/5 disabled:opacity-50"
                 >
@@ -228,9 +251,29 @@ function LoginPageInner() {
         </p>
         <p className="mt-2 text-center text-sm text-muted-foreground">
           Don&apos;t have an account?{" "}
-          <Link href="/register" className="text-primary hover:underline">
-            Register your practice
-          </Link>
+          {DEMO_MODE ? (
+            <a
+              href={buildCloudSignupUrl({
+                appOrigin: cloudSignupAppOrigin(),
+                source: "demo",
+                medium: "product",
+                campaign: "demo_login",
+              })}
+              onClick={() =>
+                trackFunnelEvent(FUNNEL_EVENTS.demoCtaStartClinic, {
+                  tool: "login",
+                  path: "/login",
+                })
+              }
+              className="text-primary hover:underline"
+            >
+              Start my clinic
+            </a>
+          ) : (
+            <Link href="/register" className="text-primary hover:underline">
+              Register your practice
+            </Link>
+          )}
         </p>
       </div>
     </div>

--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
@@ -35,6 +35,8 @@ import {
 } from "@/lib/auth-input-policy";
 import { isSafeCheckoutRedirectUrl } from "@/lib/checkout-redirect";
 import { acquisitionFromSearchParams } from "@/lib/acquisition";
+import { FUNNEL_EVENTS } from "@/lib/funnel-analytics";
+import { trackFunnelEvent } from "@/lib/track-funnel-event";
 
 export default function RegisterPage() {
   return (
@@ -60,6 +62,16 @@ function RegisterPageInner() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    trackFunnelEvent(FUNNEL_EVENTS.signupLand, {
+      intent: cloudIntent ? "cloud" : "default",
+      source: acquisition?.source ?? "none",
+      campaign: acquisition?.campaign ?? "none",
+    });
+    // Fire once on land; acquisition is derived from the URL for this mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- signup attribution snapshot
+  }, []);
 
   const registerMutation = trpc.auth.register.useMutation({
     onSuccess: async (data) => {

--- a/apps/web/app/(dashboard)/layout.tsx
+++ b/apps/web/app/(dashboard)/layout.tsx
@@ -11,6 +11,8 @@ import { OnboardingJourneyProvider } from "@/components/onboarding/journey-overl
 import { WelcomeProvider } from "@/components/welcome/welcome-provider";
 import { BrandTheme } from "@/components/brand/brand-theme";
 import { VerifyEmailBanner } from "@/components/layout/verify-email-banner";
+import { DemoConversionBar } from "@/components/demo/demo-conversion-bar";
+import { DemoFunnelTracker } from "@/components/demo/demo-funnel-tracker";
 
 export default function DashboardLayout({
   children,
@@ -78,6 +80,8 @@ export default function DashboardLayout({
               onMenuOpen={() => setMobileNavOpen(true)}
               onSearchOpen={() => setSearchOpen(true)}
             />
+            <DemoConversionBar />
+            <DemoFunnelTracker />
             <VerifyEmailBanner />
             <main id="main-content" className="flex-1 overflow-y-auto bg-surface p-4 sm:p-6">
               <ErrorBoundary>{children}</ErrorBoundary>

--- a/apps/web/components/demo/demo-conversion-bar.tsx
+++ b/apps/web/components/demo/demo-conversion-bar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+  buildCloudSignupUrl,
+  cloudSignupAppOrigin,
+  FUNNEL_EVENTS,
+  funnelToolFromPath,
+  isDemoMode,
+} from "@/lib/funnel-analytics";
+import { trackFunnelEvent } from "@/lib/track-funnel-event";
+import { usePathname } from "next/navigation";
+
+/**
+ * Persistent demo → Cloud signup bridge. Job language on purpose: we sell a
+ * workflow they just tried, not a full PIMS rip-replace.
+ */
+export function DemoConversionBar() {
+  const pathname = usePathname();
+  if (!isDemoMode()) return null;
+
+  const tool = funnelToolFromPath(pathname);
+  const href = buildCloudSignupUrl({
+    appOrigin: cloudSignupAppOrigin(),
+    tool,
+    source: "demo",
+    medium: "product",
+    campaign: `demo_${tool}`,
+  });
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 border-b border-primary/20 bg-primary/5 px-3 py-2 sm:px-6">
+      <p className="text-sm text-foreground">
+        <span className="font-medium">Like this workflow?</span>{" "}
+        <span className="text-muted-foreground">
+          Start a free Cloud trial with your own clinic data.
+        </span>
+      </p>
+      <a
+        href={href}
+        onClick={() =>
+          trackFunnelEvent(FUNNEL_EVENTS.demoCtaStartClinic, {
+            tool,
+            path: pathname,
+          })
+        }
+        className="inline-flex h-8 shrink-0 items-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+      >
+        Start my clinic
+      </a>
+    </div>
+  );
+}

--- a/apps/web/components/demo/demo-funnel-tracker.tsx
+++ b/apps/web/components/demo/demo-funnel-tracker.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import {
+  FUNNEL_EVENTS,
+  funnelToolFromPath,
+  isDemoMode,
+} from "@/lib/funnel-analytics";
+import { trackFunnelEvent } from "@/lib/track-funnel-event";
+
+/**
+ * On the demo deployment, emit demo_tool_opened once per distinct tool path
+ * per page session so we can see which jobs people try before signup.
+ */
+export function DemoFunnelTracker() {
+  const pathname = usePathname();
+  const seen = useRef(new Set<string>());
+
+  useEffect(() => {
+    if (!isDemoMode()) return;
+    const tool = funnelToolFromPath(pathname);
+    if (seen.current.has(tool)) return;
+    seen.current.add(tool);
+    trackFunnelEvent(FUNNEL_EVENTS.demoToolOpened, { tool, path: pathname });
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/web/lib/__tests__/demo-conversion-ui.test.ts
+++ b/apps/web/lib/__tests__/demo-conversion-ui.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("demo conversion bridge UI", () => {
+  const login = readFileSync("app/(auth)/login/page.tsx", "utf8");
+  const register = readFileSync("app/(auth)/register/page.tsx", "utf8");
+  const layout = readFileSync("app/(dashboard)/layout.tsx", "utf8");
+  const bar = readFileSync("components/demo/demo-conversion-bar.tsx", "utf8");
+  const tracker = readFileSync(
+    "components/demo/demo-funnel-tracker.tsx",
+    "utf8"
+  );
+
+  it("instruments demo login land, role, and start-clinic CTA", () => {
+    expect(login).toContain("FUNNEL_EVENTS.demoLand");
+    expect(login).toContain("FUNNEL_EVENTS.demoRoleSelected");
+    expect(login).toContain("FUNNEL_EVENTS.demoCtaStartClinic");
+    expect(login).toContain("buildCloudSignupUrl");
+    expect(login).toContain("Start my clinic");
+  });
+
+  it("tracks signup land with acquisition context", () => {
+    expect(register).toContain("FUNNEL_EVENTS.signupLand");
+    expect(register).toContain("acquisition?.source");
+  });
+
+  it("mounts the demo bar and path tracker in the dashboard shell", () => {
+    expect(layout).toContain("DemoConversionBar");
+    expect(layout).toContain("DemoFunnelTracker");
+    expect(bar).toContain("Start my clinic");
+    expect(bar).toContain("buildCloudSignupUrl");
+    expect(tracker).toContain("FUNNEL_EVENTS.demoToolOpened");
+  });
+});

--- a/apps/web/lib/__tests__/funnel-analytics.test.ts
+++ b/apps/web/lib/__tests__/funnel-analytics.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCloudSignupUrl,
+  FUNNEL_EVENTS,
+  funnelToolFromPath,
+} from "@/lib/funnel-analytics";
+
+describe("funnelToolFromPath", () => {
+  it("maps primary demo surfaces to stable tool ids", () => {
+    expect(funnelToolFromPath("/agent")).toBe("ask_ai");
+    expect(funnelToolFromPath("/agent?q=1")).toBe("ask_ai");
+    expect(funnelToolFromPath("/schedule")).toBe("day_board");
+    expect(funnelToolFromPath("/whiteboard")).toBe("whiteboard");
+    expect(funnelToolFromPath("/patients/abc")).toBe("patients");
+    expect(funnelToolFromPath("/billing/new")).toBe("billing");
+    expect(funnelToolFromPath("/")).toBe("dashboard");
+  });
+
+  it("falls back to other for unknown paths", () => {
+    expect(funnelToolFromPath("/api-docs")).toBe("other");
+  });
+});
+
+describe("buildCloudSignupUrl", () => {
+  it("builds a relative register URL with acquisition params", () => {
+    const url = buildCloudSignupUrl({ tool: "ask_ai" });
+    expect(url.startsWith("/register?")).toBe(true);
+    const params = new URLSearchParams(url.slice("/register?".length));
+    expect(params.get("intent")).toBe("cloud");
+    expect(params.get("source")).toBe("demo");
+    expect(params.get("utm_source")).toBe("demo");
+    expect(params.get("utm_medium")).toBe("product");
+    expect(params.get("utm_campaign")).toBe("demo_ask_ai");
+  });
+
+  it("prefixes an absolute app origin when provided", () => {
+    const url = buildCloudSignupUrl({
+      appOrigin: "https://app.openvpm.com/",
+      campaign: "demo_login",
+    });
+    expect(url).toBe(
+      "https://app.openvpm.com/register?intent=cloud&source=demo&utm_source=demo&utm_medium=product&utm_campaign=demo_login"
+    );
+  });
+
+  it("falls back to relative path when origin is invalid", () => {
+    const url = buildCloudSignupUrl({
+      appOrigin: "not a url",
+      source: "demo",
+    });
+    expect(url.startsWith("/register?")).toBe(true);
+  });
+});
+
+describe("FUNNEL_EVENTS", () => {
+  it("keeps stable event name contracts", () => {
+    expect(FUNNEL_EVENTS.demoLand).toBe("demo_land");
+    expect(FUNNEL_EVENTS.demoRoleSelected).toBe("demo_role_selected");
+    expect(FUNNEL_EVENTS.demoToolOpened).toBe("demo_tool_opened");
+    expect(FUNNEL_EVENTS.demoCtaStartClinic).toBe("demo_cta_start_clinic");
+    expect(FUNNEL_EVENTS.signupLand).toBe("signup_land");
+  });
+});

--- a/apps/web/lib/funnel-analytics.ts
+++ b/apps/web/lib/funnel-analytics.ts
@@ -1,0 +1,121 @@
+/**
+ * Funnel analytics helpers for demo → signup attribution.
+ *
+ * Event names are stable contracts for Vercel Web Analytics custom events and
+ * the Monday conversion digest. Keep values short, snake_case, and free of PHI.
+ */
+
+import { ACQUISITION_VALUE_MAX_LENGTH } from "@/lib/acquisition";
+
+export const FUNNEL_EVENTS = {
+  demoLand: "demo_land",
+  demoRoleSelected: "demo_role_selected",
+  demoToolOpened: "demo_tool_opened",
+  demoCtaStartClinic: "demo_cta_start_clinic",
+  signupLand: "signup_land",
+} as const;
+
+export type FunnelEventName =
+  (typeof FUNNEL_EVENTS)[keyof typeof FUNNEL_EVENTS];
+
+/** Stable tool ids used in picker / demo path mapping / UTMs. */
+export type FunnelToolId =
+  | "ask_ai"
+  | "day_board"
+  | "whiteboard"
+  | "client_portal"
+  | "patients"
+  | "clients"
+  | "records"
+  | "billing"
+  | "inbox"
+  | "inventory"
+  | "reports"
+  | "settings"
+  | "dashboard"
+  | "other";
+
+const PATH_TOOL_MAP: Array<{ prefix: string; tool: FunnelToolId }> = [
+  { prefix: "/agent", tool: "ask_ai" },
+  { prefix: "/schedule", tool: "day_board" },
+  { prefix: "/whiteboard", tool: "whiteboard" },
+  { prefix: "/portal", tool: "client_portal" },
+  { prefix: "/patients", tool: "patients" },
+  { prefix: "/clients", tool: "clients" },
+  { prefix: "/records", tool: "records" },
+  { prefix: "/billing", tool: "billing" },
+  { prefix: "/inbox", tool: "inbox" },
+  { prefix: "/inventory", tool: "inventory" },
+  { prefix: "/reports", tool: "reports" },
+  { prefix: "/settings", tool: "settings" },
+  { prefix: "/", tool: "dashboard" },
+];
+
+export function funnelToolFromPath(pathname: string): FunnelToolId {
+  const path = pathname.split("?")[0] || "/";
+  for (const { prefix, tool } of PATH_TOOL_MAP) {
+    if (prefix === "/") {
+      if (path === "/" || path === "") return tool;
+      continue;
+    }
+    if (path === prefix || path.startsWith(`${prefix}/`)) return tool;
+  }
+  return "other";
+}
+
+function cleanParam(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.length > ACQUISITION_VALUE_MAX_LENGTH) return undefined;
+  return /^[a-zA-Z0-9._:/-]+$/.test(trimmed) ? trimmed : undefined;
+}
+
+export type CloudSignupUrlOptions = {
+  /** Absolute app origin (e.g. https://app.openvpm.com). Empty → relative /register. */
+  appOrigin?: string | null;
+  tool?: FunnelToolId | string | null;
+  source?: string;
+  medium?: string;
+  campaign?: string;
+};
+
+/**
+ * Build the Cloud register URL with acquisition params the signup API accepts.
+ * Demo CTAs should always go through this so UTMs land on practice.settings.acquisition.
+ */
+export function buildCloudSignupUrl(opts: CloudSignupUrlOptions = {}): string {
+  const params = new URLSearchParams();
+  params.set("intent", "cloud");
+  const source = cleanParam(opts.source) ?? "demo";
+  const medium = cleanParam(opts.medium) ?? "product";
+  const campaign =
+    cleanParam(opts.campaign) ??
+    cleanParam(opts.tool ? `demo_${opts.tool}` : "demo_cta") ??
+    "demo_cta";
+  params.set("source", source);
+  params.set("utm_source", source);
+  params.set("utm_medium", medium);
+  params.set("utm_campaign", campaign);
+
+  const path = `/register?${params.toString()}`;
+  const origin = opts.appOrigin?.trim().replace(/\/$/, "");
+  if (!origin) return path;
+  try {
+    return new URL(path, origin).toString();
+  } catch {
+    return path;
+  }
+}
+
+export function cloudSignupAppOrigin(): string | undefined {
+  const raw = process.env.NEXT_PUBLIC_APP_URL?.trim();
+  if (!raw) return undefined;
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isDemoMode(): boolean {
+  return process.env.NEXT_PUBLIC_DEMO_MODE?.trim() === "true";
+}

--- a/apps/web/lib/track-funnel-event.ts
+++ b/apps/web/lib/track-funnel-event.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { track } from "@vercel/analytics";
+import type { FunnelEventName } from "@/lib/funnel-analytics";
+
+type FunnelProps = Record<string, string | number | boolean | null | undefined>;
+
+/**
+ * Fire a named funnel event to Vercel Web Analytics. Never include PHI —
+ * only tool ids, roles, and coarse path labels.
+ */
+export function trackFunnelEvent(
+  name: FunnelEventName,
+  props?: FunnelProps
+): void {
+  try {
+    const cleaned: Record<string, string | number | boolean> = {};
+    if (props) {
+      for (const [key, value] of Object.entries(props)) {
+        if (value === null || value === undefined) continue;
+        cleaned[key] = value;
+      }
+    }
+    track(name, cleaned);
+  } catch {
+    // Analytics must never break demo/signup UX.
+  }
+}


### PR DESCRIPTION
## What this changes
- tracks demo landing, role selection, tool opens, and trial CTA clicks without PII
- preserves demo attribution through Cloud registration
- adds an in-product demo-to-trial conversion bar
- routes demo CTAs to the hosted app through `NEXT_PUBLIC_APP_URL`

## Verification
- `pnpm --filter @openpims/web type-check`
- `pnpm --filter @openpims/web test -- lib/__tests__/funnel-analytics.test.ts lib/__tests__/demo-conversion-ui.test.ts`

## Deployment note
`NEXT_PUBLIC_APP_URL=https://app.openvpm.com` is configured on the demo Vercel project. The email gate will land as a follow-up stacked change.