### PR TITLE
Build the clinic encounter-to-charge workflow

### DIFF
--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -1,0 +1,817 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import {
+  AlertCircle,
+  ArrowLeft,
+  CalendarClock,
+  Check,
+  ClipboardList,
+  FileText,
+  Loader2,
+  Package,
+  Plus,
+  Receipt,
+  Stethoscope,
+  Trash2,
+  UserRound,
+} from "lucide-react";
+import { toast } from "sonner";
+import { trpc } from "@/lib/trpc";
+import { formatCurrency } from "@/lib/locale/format";
+import {
+  BILLING_INVOICE_MAX_ITEMS,
+  isBillingInvoiceSubtotalValid,
+} from "@/lib/billing/policy";
+import { ServicePicker } from "@/components/billing/service-picker";
+import { CapturePhotos } from "@/components/records/capture-photos";
+import { ConsentSign } from "@/components/records/consent-sign";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { EmptyState } from "@/components/common/empty-state";
+
+type ChargeItem = {
+  key: string;
+  description: string;
+  quantity: number;
+  unitPrice: string;
+  itemType: "service" | "product";
+  itemId: string;
+};
+
+const APPOINTMENT_STATUS_LABELS: Record<string, string> = {
+  scheduled: "Scheduled",
+  confirmed: "Confirmed",
+  checked_in: "Checked in",
+  in_exam: "In exam",
+  checked_out: "Checked out",
+  no_show: "No show",
+  cancelled: "Cancelled",
+};
+
+function canManageVisit(role?: string | null): boolean {
+  return (
+    role === "admin" ||
+    role === "veterinarian" ||
+    role === "technician" ||
+    role === "front_desk"
+  );
+}
+
+function canCreateSoap(role?: string | null): boolean {
+  return role === "admin" || role === "veterinarian";
+}
+
+function canManageBilling(role?: string | null): boolean {
+  return role === "admin" || role === "front_desk";
+}
+
+function nextVisitAction(status: string): {
+  label: string;
+  status: "checked_in" | "in_exam" | "checked_out";
+} | null {
+  if (status === "scheduled" || status === "confirmed") {
+    return { label: "Check in", status: "checked_in" };
+  }
+  if (status === "checked_in") {
+    return { label: "Start exam", status: "in_exam" };
+  }
+  if (status === "in_exam") {
+    return { label: "Check out", status: "checked_out" };
+  }
+  return null;
+}
+
+function formatAppointmentTime(
+  value: Date | string,
+  timeZone?: string | null
+): string {
+  try {
+    return new Date(value).toLocaleString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone: timeZone ?? undefined,
+    });
+  } catch {
+    return new Date(value).toLocaleString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+}
+
+function EncounterLoading() {
+  return (
+    <div className="flex items-center justify-center gap-2 rounded-lg border border-border bg-card p-12 text-sm text-muted-foreground">
+      <Loader2 className="h-4 w-4 animate-spin" />
+      Loading visit workspace...
+    </div>
+  );
+}
+
+export default function EncounterWorkspacePage() {
+  const params = useParams<{ appointmentId: string }>();
+  const { data: session, status: sessionStatus } = useSession();
+  const appointmentId = params.appointmentId;
+  const utils = trpc.useUtils();
+
+  const appointmentQuery = trpc.appointments.getById.useQuery(
+    { id: appointmentId },
+    { enabled: Boolean(appointmentId) }
+  );
+  const appointment = appointmentQuery.data;
+  const patientQuery = trpc.patients.getById.useQuery(
+    { id: appointment?.patientId ?? "" },
+    { enabled: Boolean(appointment?.patientId) }
+  );
+  const taxConfigQuery = trpc.billing.getTaxConfig.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+  const invoicesQuery = trpc.billing.listInvoices.useQuery(
+    { appointmentId, limit: 25, offset: 0 },
+    { enabled: Boolean(appointmentId) }
+  );
+
+  const updateStatus = trpc.appointments.updateStatus.useMutation({
+    onSuccess: () => {
+      toast.success("Visit status updated");
+      utils.appointments.getById.invalidate({ id: appointmentId });
+      utils.appointments.list.invalidate();
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  if (sessionStatus === "loading" || appointmentQuery.isLoading) {
+    return <EncounterLoading />;
+  }
+
+  if (appointmentQuery.error || !appointment) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="Unable to load this visit"
+        description={
+          appointmentQuery.error?.message ??
+          "The appointment may have been removed or belongs to another clinic."
+        }
+        action={{
+          label: "Back to schedule",
+          onClick: () => window.location.assign("/schedule"),
+          icon: ArrowLeft,
+        }}
+      />
+    );
+  }
+
+  const role = session?.user?.role;
+  const patient = patientQuery.data;
+  const clientName = [appointment.clientFirstName, appointment.clientLastName]
+    .filter(Boolean)
+    .join(" ");
+  const nextAction = nextVisitAction(appointment.status);
+  const activeInvoices =
+    invoicesQuery.data?.items.filter(
+      (invoice) => !invoice.isEstimate && invoice.status !== "void"
+    ) ?? [];
+  const visitInvoices = invoicesQuery.data?.items ?? [];
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-6">
+      <div>
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/schedule">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to schedule
+          </Link>
+        </Button>
+      </div>
+
+      <header className="flex flex-col gap-4 rounded-lg border border-border bg-card p-5 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Stethoscope className="h-5 w-5" />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="font-heading text-2xl font-semibold">
+                {appointment.patientName ?? "Unassigned visit"}
+              </h1>
+              <Badge variant="outline">
+                {APPOINTMENT_STATUS_LABELS[appointment.status] ??
+                  appointment.status}
+              </Badge>
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {appointment.typeName ?? "Appointment"} ·{" "}
+              {clientName || "No client"}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
+              <span className="inline-flex items-center gap-1.5">
+                <CalendarClock className="h-4 w-4" />
+                {formatAppointmentTime(
+                  appointment.startTime,
+                  taxConfigQuery.data?.timezone
+                )}
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <UserRound className="h-4 w-4" />
+                {appointment.doctorName
+                  ? `Dr. ${appointment.doctorName}`
+                  : "Unassigned provider"}
+              </span>
+              {appointment.roomName ? (
+                <span>{appointment.roomName}</span>
+              ) : null}
+            </div>
+          </div>
+        </div>
+        {nextAction && canManageVisit(role) ? (
+          <Button
+            disabled={updateStatus.isPending}
+            onClick={() =>
+              updateStatus.mutate({
+                id: appointmentId,
+                status: nextAction.status,
+              })
+            }
+          >
+            {updateStatus.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Check className="mr-2 h-4 w-4" />
+            )}
+            {nextAction.label}
+          </Button>
+        ) : null}
+      </header>
+
+      {appointment.notes ? (
+        <div className="rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm">
+          <span className="font-medium">Visit note:</span> {appointment.notes}
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(340px,0.8fr)]">
+        <div className="flex flex-col gap-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Clinical work</CardTitle>
+              <CardDescription>
+                Document and capture visit work without losing the appointment.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {!appointment.patientId ? (
+                <EmptyState
+                  icon={UserRound}
+                  title="Attach a patient first"
+                  description="Clinical documentation and billing need a patient and client on the appointment."
+                  className="p-8"
+                />
+              ) : patientQuery.error ||
+                (!patientQuery.isLoading && !patient) ? (
+                <div className="rounded-md border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+                  Unable to load the patient chart. Refresh before documenting.
+                </div>
+              ) : patientQuery.isLoading ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Loading patient context...
+                </div>
+              ) : (
+                <div className="flex flex-col gap-4">
+                  <div className="rounded-md border border-border bg-muted/20 p-4">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{patient?.name}</p>
+                        <p className="text-sm capitalize text-muted-foreground">
+                          {[patient?.species, patient?.breed]
+                            .filter(Boolean)
+                            .join(" · ") || "Patient details unavailable"}
+                        </p>
+                      </div>
+                      {patient?.allergies.length ? (
+                        <Badge variant="destructive">
+                          {patient.allergies.length} allerg
+                          {patient.allergies.length === 1 ? "y" : "ies"}
+                        </Badge>
+                      ) : (
+                        <Badge variant="secondary">No recorded allergies</Badge>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    {canCreateSoap(role) ? (
+                      <Button size="sm" asChild>
+                        <Link
+                          href={`/records/new-soap/${appointment.patientId}?appointmentId=${appointmentId}`}
+                        >
+                          <FileText className="mr-2 h-4 w-4" />
+                          Write SOAP note
+                        </Link>
+                      </Button>
+                    ) : null}
+                    <Button size="sm" variant="outline" asChild>
+                      <Link href={`/patients/${appointment.patientId}`}>
+                        <ClipboardList className="mr-2 h-4 w-4" />
+                        Open patient chart
+                      </Link>
+                    </Button>
+                    {canManageVisit(role) ? (
+                      <>
+                        <CapturePhotos
+                          patientId={appointment.patientId}
+                          appointmentId={appointmentId}
+                        />
+                        <ConsentSign
+                          patientId={appointment.patientId}
+                          appointmentId={appointmentId}
+                        />
+                      </>
+                    ) : null}
+                  </div>
+
+                  <p className="text-xs text-muted-foreground">
+                    SOAP notes created here are linked to this appointment.
+                    Photos and signatures captured during an open visit attach
+                    to the active visit automatically.
+                  </p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <EncounterInvoices
+            appointmentId={appointmentId}
+            invoicesQuery={invoicesQuery}
+            visitInvoices={visitInvoices}
+            canManage={canManageBilling(role)}
+          />
+        </div>
+
+        <ChargeCapture
+          appointmentId={appointmentId}
+          clientId={appointment.clientId}
+          patientId={appointment.patientId}
+          canManage={canManageBilling(role)}
+          hasActiveInvoice={activeInvoices.length > 0}
+          invoiceStateReady={
+            Boolean(invoicesQuery.data) && !invoicesQuery.error
+          }
+          invoiceStateLoading={invoicesQuery.isLoading}
+        />
+      </div>
+    </div>
+  );
+}
+
+function EncounterInvoices({
+  appointmentId,
+  invoicesQuery,
+  visitInvoices,
+  canManage,
+}: {
+  appointmentId: string;
+  invoicesQuery: ReturnType<typeof trpc.billing.listInvoices.useQuery>;
+  visitInvoices: Array<{
+    id: string;
+    status: string;
+    total: string;
+    paidAmount: string;
+    adjustedAmount: string;
+    isEstimate: boolean;
+  }>;
+  canManage: boolean;
+}) {
+  const fmt = useCurrencyFormatterWithConfig();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Invoice state</CardTitle>
+        <CardDescription>
+          Charges and payment status linked directly to this visit.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {invoicesQuery.isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading visit invoices...
+          </div>
+        ) : invoicesQuery.error || !invoicesQuery.data ? (
+          <div className="rounded-md border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+            Unable to load invoice state. Do not create duplicate charges until
+            this is resolved.
+          </div>
+        ) : visitInvoices.length === 0 ? (
+          <EmptyState
+            icon={Receipt}
+            title="No active invoice for this visit"
+            description={
+              canManage
+                ? "Add all known services and products in Charge capture to create a visit-linked draft."
+                : "An admin or front desk teammate can create this visit's charges."
+            }
+            className="p-8"
+          />
+        ) : (
+          <div className="flex flex-col gap-3">
+            {visitInvoices.map((invoice) => {
+              const paid = Number(invoice.paidAmount ?? 0);
+              const adjusted = Number(invoice.adjustedAmount ?? 0);
+              const balance = Math.max(
+                0,
+                Number(invoice.total ?? 0) - paid - adjusted
+              );
+              return (
+                <div
+                  key={invoice.id}
+                  className="flex flex-col gap-3 rounded-md border border-border p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <p className="font-medium">
+                        {invoice.isEstimate ? "Estimate" : "Invoice"}
+                      </p>
+                      <Badge
+                        variant={
+                          invoice.status === "paid" ? "success" : "outline"
+                        }
+                      >
+                        {invoice.status}
+                      </Badge>
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Total {fmt(invoice.total)} · Balance {fmt(balance)}
+                    </p>
+                  </div>
+                  <Button size="sm" variant="outline" asChild>
+                    <Link href={`/billing?expand=${invoice.id}`}>
+                      Open invoice
+                    </Link>
+                  </Button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        <span className="sr-only">Appointment {appointmentId}</span>
+      </CardContent>
+    </Card>
+  );
+}
+
+function useCurrencyFormatterWithConfig() {
+  const config = trpc.billing.getTaxConfig.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+  return (value: number | string | null | undefined) =>
+    formatCurrency(
+      value,
+      config.data?.currency ?? "usd",
+      config.data?.country ?? "US"
+    );
+}
+
+function ChargeCapture({
+  appointmentId,
+  clientId,
+  patientId,
+  canManage,
+  hasActiveInvoice,
+  invoiceStateReady,
+  invoiceStateLoading,
+}: {
+  appointmentId: string;
+  clientId: string | null;
+  patientId: string | null;
+  canManage: boolean;
+  hasActiveInvoice: boolean;
+  invoiceStateReady: boolean;
+  invoiceStateLoading: boolean;
+}) {
+  const utils = trpc.useUtils();
+  const [selectedCatalogId, setSelectedCatalogId] = useState("");
+  const [quantity, setQuantity] = useState(1);
+  const [items, setItems] = useState<ChargeItem[]>([]);
+  const configQuery = trpc.billing.getTaxConfig.useQuery(undefined, {
+    staleTime: 5 * 60 * 1000,
+  });
+  const configReady = Boolean(configQuery.data) && !configQuery.error;
+  const servicesQuery = trpc.billing.listServices.useQuery(undefined, {
+    enabled: canManage && configReady && invoiceStateReady && !hasActiveInvoice,
+  });
+  const productsQuery = trpc.billing.listProducts.useQuery(
+    { limit: 100 },
+    {
+      enabled:
+        canManage && configReady && invoiceStateReady && !hasActiveInvoice,
+    }
+  );
+
+  const catalog = useMemo(() => {
+    const services = (servicesQuery.data ?? []).map((service) => ({
+      id: `service:${service.id}`,
+      itemId: service.id,
+      itemType: "service" as const,
+      name: service.name,
+      category: ["Service", service.category].filter(Boolean).join(" · "),
+      defaultPrice: service.defaultPrice,
+      stockQuantity: null as number | null,
+    }));
+    const products = (productsQuery.data ?? []).map((product) => ({
+      id: `product:${product.id}`,
+      itemId: product.id,
+      itemType: "product" as const,
+      name: product.name,
+      category: `Product · ${product.stockQuantity} in stock`,
+      defaultPrice: product.unitPrice,
+      stockQuantity: product.stockQuantity,
+    }));
+    return [...services, ...products];
+  }, [productsQuery.data, servicesQuery.data]);
+
+  const selected = catalog.find((entry) => entry.id === selectedCatalogId);
+  const subtotal = items.reduce(
+    (sum, item) => sum + item.quantity * Number(item.unitPrice),
+    0
+  );
+  const taxRate = Number(configQuery.data?.taxRatePercent ?? 0) / 100;
+  const tax = Math.round(subtotal * taxRate * 100) / 100;
+  const total = subtotal + tax;
+  const fmt = (value: number | string | null | undefined) =>
+    formatCurrency(
+      value,
+      configQuery.data?.currency ?? "usd",
+      configQuery.data?.country ?? "US"
+    );
+  const selectedHasStock =
+    selected?.itemType !== "product" ||
+    (selected.stockQuantity !== null && quantity <= selected.stockQuantity);
+  const canAdd =
+    Boolean(selected) &&
+    Number.isInteger(quantity) &&
+    quantity > 0 &&
+    selectedHasStock &&
+    items.length < BILLING_INVOICE_MAX_ITEMS;
+  const canSubmit =
+    Boolean(clientId && patientId) &&
+    items.length > 0 &&
+    isBillingInvoiceSubtotalValid(items) &&
+    configReady &&
+    invoiceStateReady &&
+    !hasActiveInvoice;
+
+  const createInvoice = trpc.billing.createInvoice.useMutation({
+    onSuccess: () => {
+      toast.success("Visit charges saved as a draft invoice");
+      setItems([]);
+      setSelectedCatalogId("");
+      setQuantity(1);
+      utils.billing.listInvoices.invalidate({
+        appointmentId,
+        limit: 25,
+        offset: 0,
+      });
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  function addSelectedItem() {
+    if (!selected || !canAdd) return;
+    setItems((current) => [
+      ...current,
+      {
+        key: crypto.randomUUID(),
+        description: selected.name,
+        quantity,
+        unitPrice: selected.defaultPrice,
+        itemType: selected.itemType,
+        itemId: selected.itemId,
+      },
+    ]);
+    setSelectedCatalogId("");
+    setQuantity(1);
+  }
+
+  function saveCharges() {
+    if (!clientId || !patientId || !canSubmit) return;
+    createInvoice.mutate({
+      appointmentId,
+      clientId,
+      patientId,
+      items: items.map(
+        ({ description, quantity, unitPrice, itemType, itemId }) => ({
+          description,
+          quantity,
+          unitPrice,
+          itemType,
+          itemId,
+        })
+      ),
+      isEstimate: false,
+    });
+  }
+
+  return (
+    <Card className="h-fit lg:sticky lg:top-4">
+      <CardHeader>
+        <CardTitle>Charge capture</CardTitle>
+        <CardDescription>
+          Add the services and products performed or dispensed during this
+          visit.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {!canManage ? (
+          <div className="rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+            Charge capture is read-only for your role. An admin or front desk
+            teammate can create the invoice.
+          </div>
+        ) : invoiceStateLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Confirming visit invoice state...
+          </div>
+        ) : !invoiceStateReady ? (
+          <div className="rounded-md border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+            Charge capture is locked because invoice state could not be
+            confirmed. Refresh before creating charges.
+          </div>
+        ) : hasActiveInvoice ? (
+          <div className="rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+            This visit already has an active invoice. Open it from Invoice state
+            to send, collect payment, or review the balance.
+          </div>
+        ) : configQuery.isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading practice tax and currency settings...
+          </div>
+        ) : !configReady ? (
+          <div className="rounded-md border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+            Charge capture is locked because tax and currency settings could not
+            be confirmed. Refresh before creating charges.
+          </div>
+        ) : !clientId || !patientId ? (
+          <div className="rounded-md border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+            Add both a client and patient to the appointment before capturing
+            charges.
+          </div>
+        ) : servicesQuery.error || productsQuery.error ? (
+          <div className="rounded-md border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+            Unable to load the charge catalog. Refresh before creating an
+            invoice.
+          </div>
+        ) : servicesQuery.isLoading || productsQuery.isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading services and products...
+          </div>
+        ) : catalog.length === 0 ? (
+          <EmptyState
+            icon={Package}
+            title="Charge catalog is empty"
+            description="Add services or inventory products before building a visit invoice."
+            className="p-8"
+          />
+        ) : (
+          <div className="flex flex-col gap-4">
+            <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_90px_auto] lg:grid-cols-1 xl:grid-cols-[minmax(0,1fr)_80px_auto]">
+              <ServicePicker
+                services={catalog}
+                value={selectedCatalogId}
+                onSelect={setSelectedCatalogId}
+                disabled={createInvoice.isPending}
+                formatPrice={fmt}
+              />
+              <Input
+                type="number"
+                min={1}
+                max={selected?.stockQuantity ?? undefined}
+                value={quantity}
+                aria-label="Charge quantity"
+                aria-invalid={!selectedHasStock}
+                onChange={(event) =>
+                  setQuantity(Math.max(1, Number(event.target.value) || 1))
+                }
+              />
+              <Button
+                type="button"
+                variant="outline"
+                disabled={!canAdd || createInvoice.isPending}
+                onClick={addSelectedItem}
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Add
+              </Button>
+            </div>
+
+            {!selectedHasStock ? (
+              <p className="text-xs font-medium text-destructive">
+                Quantity exceeds available inventory.
+              </p>
+            ) : null}
+
+            {items.length === 0 ? (
+              <p className="rounded-md border border-dashed border-border p-4 text-center text-sm text-muted-foreground">
+                No charges added yet.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {items.map((item) => (
+                  <div
+                    key={item.key}
+                    className="flex items-center gap-3 rounded-md border border-border p-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium">
+                        {item.description}
+                      </p>
+                      <p className="text-xs capitalize text-muted-foreground">
+                        {item.itemType} · {item.quantity} ×{" "}
+                        {fmt(item.unitPrice)}
+                      </p>
+                    </div>
+                    <span className="text-sm font-medium tabular-nums">
+                      {fmt(item.quantity * Number(item.unitPrice))}
+                    </span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Remove ${item.description}`}
+                      onClick={() =>
+                        setItems((current) =>
+                          current.filter(
+                            (candidate) => candidate.key !== item.key
+                          )
+                        )
+                      }
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {items.length > 0 ? (
+              <div className="flex flex-col gap-1 rounded-md bg-muted/30 p-4 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Subtotal</span>
+                  <span>{fmt(subtotal)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">
+                    Tax ({configQuery.data?.taxRatePercent ?? "0.00"}%)
+                  </span>
+                  <span>{fmt(tax)}</span>
+                </div>
+                <div className="mt-1 flex justify-between border-t border-border pt-2 font-semibold">
+                  <span>Draft total</span>
+                  <span>{fmt(total)}</span>
+                </div>
+              </div>
+            ) : null}
+
+            <Button
+              disabled={!canSubmit || createInvoice.isPending}
+              onClick={saveCharges}
+            >
+              {createInvoice.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Receipt className="mr-2 h-4 w-4" />
+              )}
+              Create visit invoice
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              This creates a draft linked to the appointment. Product stock is
+              deducted atomically when the invoice is created.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/(dashboard)/records/new-soap/[patientId]/page.tsx
+++ b/apps/web/app/(dashboard)/records/new-soap/[patientId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import dynamic from "next/dynamic";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import {
   AlertCircle,
@@ -63,10 +63,15 @@ function draftTextToHtml(text: string): string {
 export default function NewSoapNotePage() {
   const params = useParams<{ patientId: string }>();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: session, status } = useSession();
   const userRole = session?.user?.role;
   const canCreateSoapNote = canCreateSoapNoteRole(userRole);
   const accessDenied = status !== "loading" && !canCreateSoapNote;
+  const appointmentId = searchParams.get("appointmentId") ?? undefined;
+  const returnPath = appointmentId
+    ? `/encounters/${encodeURIComponent(appointmentId)}`
+    : "/records";
 
   const [subjective, setSubjective] = useState("");
   const [objective, setObjective] = useState("");
@@ -92,7 +97,7 @@ export default function NewSoapNotePage() {
   const createNote = trpc.records.createSoapNote.useMutation({
     onSuccess: () => {
       toast.success("SOAP note created");
-      router.push("/records");
+      router.push(returnPath);
     },
     onError: (err) => {
       toast.error(err.message);
@@ -137,6 +142,7 @@ export default function NewSoapNotePage() {
     }
     createNote.mutate({
       patientId: params.patientId,
+      appointmentId,
       subjective: normalizeSoapSection(subjective),
       objective: normalizeSoapSection(objective),
       assessment: normalizeSoapSection(assessment),
@@ -173,9 +179,9 @@ export default function NewSoapNotePage() {
         <Button
           variant="outline"
           className="mt-4"
-          onClick={() => router.push("/records")}
+          onClick={() => router.push(returnPath)}
         >
-          Back to Records
+          {appointmentId ? "Back to visit" : "Back to Records"}
         </Button>
       </div>
     );
@@ -222,11 +228,11 @@ export default function NewSoapNotePage() {
       <Button
         variant="ghost"
         size="sm"
-        onClick={() => router.push("/records")}
+        onClick={() => router.push(returnPath)}
         className="mb-4"
       >
         <ArrowLeft className="mr-2 h-4 w-4" />
-        Back to Records
+        {appointmentId ? "Back to visit" : "Back to Records"}
       </Button>
 
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -241,6 +247,11 @@ export default function NewSoapNotePage() {
               {patient.breed ? ` (${patient.breed})` : ""}
             </p>
           )}
+          {appointmentId ? (
+            <p className="text-xs text-muted-foreground">
+              This note will be linked to the current appointment.
+            </p>
+          ) : null}
         </div>
         <div className="flex flex-col items-end gap-1">
           <div className="flex flex-wrap items-center gap-2">
@@ -385,7 +396,7 @@ export default function NewSoapNotePage() {
               Add at least one section to save this note.
             </p>
           )}
-          <Button variant="outline" onClick={() => router.push("/records")}>
+          <Button variant="outline" onClick={() => router.push(returnPath)}>
             Cancel
           </Button>
           {createNote.isError && (

--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -15,6 +15,7 @@ import {
   Plus,
   Mail,
   Repeat2,
+  Stethoscope,
 } from "lucide-react";
 import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
@@ -1102,13 +1103,20 @@ function AppointmentDetailPopover({
         )}
 
         {/* Actions */}
-        {(appointment.patientId ||
+        {(appointment.id ||
+          appointment.patientId ||
           visibleStatusActions.length > 0 ||
           (canManageSchedule && canMoveAppointment) ||
           (canManageSchedule && appointment.recurringSeriesId) ||
           (canSendReminders &&
             (current === "scheduled" || current === "confirmed"))) && (
           <div className="flex flex-wrap gap-2 border-t border-border px-4 py-3">
+            <Button size="sm" asChild>
+              <Link href={`/encounters/${appointment.id}`}>
+                <Stethoscope className="mr-1.5 h-3 w-3" />
+                Open visit
+              </Link>
+            </Button>
             {appointment.patientId && (
               <Button size="sm" variant="outline" asChild>
                 <Link href={`/patients/${appointment.patientId}`}>View chart</Link>

--- a/apps/web/app/api/cron/reminders/route.test.ts
+++ b/apps/web/app/api/cron/reminders/route.test.ts
@@ -116,7 +116,7 @@ function appointment(overrides: Record<string, unknown> = {}) {
     clientId: CLIENT_ID,
     clientFirstName: "Ada",
     clientLastName: "Lovelace",
-    clientEmail: "ada@example.com",
+    clientEmail: "ada@lovelacevet.com",
     emailSuppressionReason: null,
     clientPhone: "(555) 555-0100",
     preferredContactMethod: "sms",
@@ -161,10 +161,69 @@ describe("appointment reminder cron", () => {
       failed: 0,
       skipped: 0,
       deduped: 0,
+      suppressed: 0,
     });
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
     expect(mocks.insertValues).not.toHaveBeenCalled();
+  });
+
+  it("suppresses seeded demo appointments before any provider or delivery claim", async () => {
+    mocks.selectResults.push([
+      appointment({
+        isSeededDemoAppointment: true,
+      }),
+    ]);
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/reminders")
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      sent: 0,
+      failed: 0,
+      skipped: 0,
+      deduped: 0,
+      suppressed: 1,
+    });
+    expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
+    expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+    expect(consoleLog).toHaveBeenCalledWith(
+      "Cron reminders completed: 0 sent, 0 failed, 0 deferred (quiet hours), 0 deduped, 1 suppressed (1 demo, 0 reserved address) out of 1 total"
+    );
+    expect(consoleLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("Miso")
+    );
+    expect(consoleLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("lovelacevet.com")
+    );
+  });
+
+  it("suppresses reserved fixture email domains even when SMS is preferred", async () => {
+    mocks.selectResults.push([
+      appointment({
+        clientEmail: " ada@reminders.openvpm.test ",
+      }),
+    ]);
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/reminders")
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      sent: 0,
+      failed: 0,
+      skipped: 0,
+      deduped: 0,
+      suppressed: 1,
+    });
+    expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
+    expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+    expect(consoleLog).toHaveBeenCalledWith(
+      "Cron reminders completed: 0 sent, 0 failed, 0 deferred (quiet hours), 0 deduped, 1 suppressed (0 demo, 1 reserved address) out of 1 total"
+    );
   });
 
   it("uses an active practice sender for scheduled SMS reminders", async () => {
@@ -191,6 +250,7 @@ describe("appointment reminder cron", () => {
       failed: 0,
       skipped: 0,
       deduped: 0,
+      suppressed: 0,
     });
     expect(mocks.sendAppointmentReminderSms).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -225,9 +285,10 @@ describe("appointment reminder cron", () => {
       success: true,
       id: "email-cron-1",
     });
-    mocks.selectResults.push([
-      appointment({ clientEmail: " Ada@Example.COM " }),
-    ], []);
+    mocks.selectResults.push(
+      [appointment({ clientEmail: " Ada@LovelaceVet.COM " })],
+      []
+    );
 
     const response = await GET(
       new Request("https://openvpm.test/api/cron/reminders")
@@ -238,10 +299,11 @@ describe("appointment reminder cron", () => {
       failed: 0,
       skipped: 0,
       deduped: 0,
+      suppressed: 0,
     });
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
     expect(mocks.sendAppointmentReminder).toHaveBeenCalledWith(
-      expect.objectContaining({ to: "ada@example.com" })
+      expect.objectContaining({ to: "ada@lovelacevet.com" })
     );
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -267,7 +329,7 @@ describe("appointment reminder cron", () => {
     });
     mocks.selectResults.push([
       appointment({
-        clientEmail: " Ada@Example.COM ",
+        clientEmail: " Ada@LovelaceVet.COM ",
         clientPhone: "12345",
       }),
     ]);
@@ -281,10 +343,11 @@ describe("appointment reminder cron", () => {
       failed: 0,
       skipped: 0,
       deduped: 0,
+      suppressed: 0,
     });
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
     expect(mocks.sendAppointmentReminder).toHaveBeenCalledWith(
-      expect.objectContaining({ to: "ada@example.com" })
+      expect.objectContaining({ to: "ada@lovelacevet.com" })
     );
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -321,6 +384,7 @@ describe("appointment reminder cron", () => {
       failed: 0,
       skipped: 1,
       deduped: 0,
+      suppressed: 0,
     });
     expect(mocks.insertValues).not.toHaveBeenCalled();
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
@@ -346,6 +410,7 @@ describe("appointment reminder cron", () => {
       failed: 1,
       skipped: 0,
       deduped: 0,
+      suppressed: 0,
     });
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
     expect(mocks.insertValues).toHaveBeenCalledWith(
@@ -379,6 +444,7 @@ describe("appointment reminder cron", () => {
       failed: 1,
       skipped: 0,
       deduped: 0,
+      suppressed: 0,
     });
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
@@ -411,6 +477,7 @@ describe("appointment reminder cron", () => {
       failed: 0,
       skipped: 0,
       deduped: 1,
+      suppressed: 0,
     });
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
@@ -439,6 +506,7 @@ describe("appointment reminder cron", () => {
       failed: 0,
       skipped: 0,
       deduped: 1,
+      suppressed: 0,
     });
     expect(mocks.deleteRows).not.toHaveBeenCalled();
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
@@ -467,6 +535,7 @@ describe("appointment reminder cron", () => {
       failed: 0,
       skipped: 0,
       deduped: 0,
+      suppressed: 0,
     });
     expect(mocks.deleteRows).toHaveBeenCalledOnce();
     expect(mocks.insertReturning).toHaveBeenCalledTimes(2);
@@ -501,6 +570,7 @@ describe("appointment reminder cron", () => {
       failed: 0,
       skipped: 0,
       deduped: 0,
+      suppressed: 0,
     });
     expect(mocks.deleteRows).toHaveBeenCalledOnce();
     expect(mocks.insertReturning).toHaveBeenCalledTimes(2);
@@ -526,6 +596,7 @@ describe("appointment reminder cron", () => {
       failed: 1,
       skipped: 0,
       deduped: 0,
+      suppressed: 0,
     });
     expect(mocks.sendAppointmentReminder).toHaveBeenCalledOnce();
     expect(mocks.sendAppointmentReminder).toHaveBeenCalledWith(
@@ -577,6 +648,13 @@ describe("appointment reminder cron query scoping", () => {
     expect(source).not.toContain(
       "sql`${emailSuppressions.email} = lower(${clients.email})`"
     );
+  });
+
+  it("projects both demo-data markers needed for pre-provider suppression", () => {
+    expect(source).toContain("isSeededDemoClient: sql<boolean>");
+    expect(source).toContain("isSeededDemoAppointment: sql<boolean>");
+    expect(source).toContain("'demoData' -> 'clientIds'");
+    expect(source).toContain("'demoData' -> 'appointmentIds'");
   });
 
   it("formats reminder appointment times in the practice timezone", () => {

--- a/apps/web/app/api/cron/reminders/route.ts
+++ b/apps/web/app/api/cron/reminders/route.ts
@@ -33,6 +33,7 @@ import {
   emailSuppressionSendBlockMessage,
   normalizeEmailSuppressionAddress,
 } from "@/lib/email-suppression";
+import { automatedAppointmentReminderSuppressionReason } from "@/lib/automated-reminder-policy";
 
 type ReminderChannel = "sms" | "email";
 const REMINDER_PENDING_RECLAIM_MS = 30 * 60 * 1000;
@@ -226,6 +227,14 @@ export async function GET(request: Request) {
           practicePhone: practices.phone,
           practiceTimezone: practices.timezone,
           locationId: rooms.locationId,
+          isSeededDemoClient: sql<boolean>`
+            coalesce(${practices.settings} -> 'demoData' -> 'clientIds', '[]'::jsonb)
+              @> to_jsonb(${appointments.clientId}::text)
+          `,
+          isSeededDemoAppointment: sql<boolean>`
+            coalesce(${practices.settings} -> 'demoData' -> 'appointmentIds', '[]'::jsonb)
+              @> to_jsonb(${appointments.id}::text)
+          `,
         })
         .from(appointments)
         .leftJoin(
@@ -295,6 +304,9 @@ export async function GET(request: Request) {
     let failed = 0;
     let skipped = 0; // SMS-preferred but deferred by quiet hours (no email fallback)
     let deduped = 0;
+    let suppressed = 0; // Seeded demo rows or reserved fixture addresses.
+    let suppressedDemo = 0;
+    let suppressedReservedAddress = 0;
     const senderLocationCache = new Map<string, string | null>();
 
     const activeSenderLocation = async (
@@ -354,6 +366,18 @@ export async function GET(request: Request) {
     };
 
     for (const appt of upcomingAppointments) {
+      const suppressionReason =
+        automatedAppointmentReminderSuppressionReason(appt);
+      if (suppressionReason) {
+        suppressed++;
+        if (suppressionReason === "seeded_demo_data") {
+          suppressedDemo++;
+        } else {
+          suppressedReservedAddress++;
+        }
+        continue;
+      }
+
       if (!appt.clientId) {
         failed++;
         continue;
@@ -529,31 +553,36 @@ export async function GET(request: Request) {
       }
     }
 
+    const eligible = upcomingAppointments.length - suppressed;
     console.log(
-      `Cron reminders completed: ${sent} sent, ${failed} failed, ${skipped} deferred (quiet hours), ${deduped} deduped out of ${upcomingAppointments.length} total`,
+      `Cron reminders completed: ${sent} sent, ${failed} failed, ${skipped} deferred (quiet hours), ${deduped} deduped, ${suppressed} suppressed (${suppressedDemo} demo, ${suppressedReservedAddress} reserved address) out of ${upcomingAppointments.length} total`
     );
 
     if (failed > 0) {
       void alertOps(
         "Appointment reminders had failures",
-        `${failed} of ${upcomingAppointments.length} reminders failed to send (${sent} sent, ${skipped} deferred, ${deduped} deduped).`,
+        `${failed} of ${eligible} eligible reminders failed to send (${sent} sent, ${skipped} deferred, ${deduped} deduped, ${suppressed} suppressed).`
       );
     }
 
     await reportCronHeartbeat({
       job: "reminders",
       status: failed > 0 ? "degraded" : "ok",
-      detail: `${sent} sent, ${failed} failed, ${skipped} deferred, ${deduped} deduped`,
+      detail: `${sent} sent, ${failed} failed, ${skipped} deferred, ${deduped} deduped, ${suppressed} suppressed`,
       metrics: {
         total: upcomingAppointments.length,
+        eligible,
         sent,
         failed,
         skipped,
         deduped,
+        suppressed,
+        suppressedDemo,
+        suppressedReservedAddress,
       },
     });
 
-    return NextResponse.json({ sent, failed, skipped, deduped });
+    return NextResponse.json({ sent, failed, skipped, deduped, suppressed });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     void alertOps(

--- a/apps/web/components/billing/service-picker.tsx
+++ b/apps/web/components/billing/service-picker.tsx
@@ -23,11 +23,13 @@ export function ServicePicker({
   value,
   onSelect,
   disabled,
+  formatPrice,
 }: {
   services: ServicePickerService[];
   value: string;
   onSelect: (serviceId: string) => void;
   disabled?: boolean;
+  formatPrice?: (price: string) => string;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -183,7 +185,9 @@ export function ServicePicker({
                     </span>
                   ) : null}
                   <span className="shrink-0 tabular-nums text-muted-foreground">
-                    ${service.defaultPrice}
+                    {formatPrice
+                      ? formatPrice(service.defaultPrice)
+                      : `$${service.defaultPrice}`}
                   </span>
                 </button>
               ))

--- a/apps/web/components/dashboard/activation-checklist.tsx
+++ b/apps/web/components/dashboard/activation-checklist.tsx
@@ -42,9 +42,8 @@ export function ActivationChecklist() {
   const isAdmin =
     status === "authenticated" && session?.user?.role === "admin";
 
-  // No long staleTime: each dashboard mount re-checks, so a milestone you just
-  // completed (uploaded a logo, invited a teammate, asked the AI) shows as done
-  // when you come back here.
+  // No long staleTime: each dashboard mount re-checks, so operational progress
+  // such as publishing booking or completing a visit shows as done immediately.
   const opts = {
     enabled: isAdmin,
     retry: false,
@@ -55,11 +54,23 @@ export function ActivationChecklist() {
   const practice = trpc.settings.getPractice.useQuery(undefined, opts);
   const sub = trpc.subscription.get.useQuery(undefined, opts);
   const texting = trpc.messaging.activationSummary.useQuery(undefined, opts);
+  const booking = trpc.booking.getMyPage.useQuery(undefined, opts);
+  const clientPayments = trpc.billing.paymentAccountStatus.useQuery(
+    undefined,
+    opts
+  );
   const dismiss = trpc.settings.dismissSetup.useMutation();
 
   if (!isAdmin) return null;
 
-  const loadError = state.error ?? onboarding.error ?? practice.error ?? sub.error;
+  const loadError =
+    state.error ??
+    onboarding.error ??
+    practice.error ??
+    sub.error ??
+    texting.error ??
+    booking.error ??
+    clientPayments.error;
   if (loadError) {
     return (
       <ActivationChecklistError
@@ -70,6 +81,9 @@ export function ActivationChecklist() {
             onboarding.refetch(),
             practice.refetch(),
             sub.refetch(),
+            texting.refetch(),
+            booking.refetch(),
+            clientPayments.refetch(),
           ]);
         }}
       />
@@ -80,11 +94,22 @@ export function ActivationChecklist() {
     state.isLoading ||
     onboarding.isLoading ||
     practice.isLoading ||
-    sub.isLoading;
+    sub.isLoading ||
+    texting.isLoading ||
+    booking.isLoading ||
+    clientPayments.isLoading;
 
   // Wait for the core signals before rendering so we never flash a wrong state.
   if (isChecklistLoading) return <ActivationChecklistLoading />;
-  if (!state.data || !onboarding.data || !practice.data || !sub.data) {
+  if (
+    !state.data ||
+    !onboarding.data ||
+    !practice.data ||
+    !sub.data ||
+    !texting.data ||
+    !booking.data ||
+    !clientPayments.data
+  ) {
     return (
       <ActivationChecklistError
         message="Setup checklist data was unavailable. Try loading it again."
@@ -94,6 +119,9 @@ export function ActivationChecklist() {
             onboarding.refetch(),
             practice.refetch(),
             sub.refetch(),
+            texting.refetch(),
+            booking.refetch(),
+            clientPayments.refetch(),
           ]);
         }}
       />
@@ -105,6 +133,9 @@ export function ActivationChecklist() {
   const onboardingData = onboarding.data;
   const practiceData = practice.data;
   const subscriptionData = sub.data;
+  const textingData = texting.data;
+  const bookingData = booking.data;
+  const clientPaymentData = clientPayments.data;
 
   const enforced = subscriptionData.billingEnforced;
   const tourDone =
@@ -117,7 +148,7 @@ export function ActivationChecklist() {
     checklistState.onboardingIntent ?? DEFAULT_ONBOARDING_INTENT
   );
 
-  const standardMilestones: Milestone[] = [
+  const explorationMilestones: Milestone[] = [
     {
       key: "tour",
       label: "Take the 60-second tour",
@@ -146,6 +177,9 @@ export function ActivationChecklist() {
       done: (subscriptionData.usage?.aiRuns ?? 0) > 0,
       href: "/agent",
     },
+  ];
+
+  const goLiveMilestones: Milestone[] = [
     {
       key: "data",
       label: "Bring in your real data",
@@ -154,12 +188,44 @@ export function ActivationChecklist() {
       href: "/settings?tab=data",
     },
     {
+      key: "team",
+      label: "Invite a teammate",
+      hint: "Test the handoff between a doctor and the front desk.",
+      done: (subscriptionData.billableSeatCount ?? 1) > 1,
+      href: "/settings?tab=staff",
+    },
+    {
+      key: "booking",
+      label: "Publish online booking",
+      hint: "Put one appointment type live and test the client booking path.",
+      done: bookingData.page?.published === true,
+      href: "/settings?tab=booking",
+    },
+    {
       key: "texting",
-      label: "Turn on texting",
-      hint: "Add a number for reminders and two-way texts with clients.",
-      done: texting.data?.hasActiveNumber ?? false,
+      label: "Start texting registration",
+      hint: "Choose a number and submit carrier registration. Approval can take 1–2 weeks.",
+      done: textingData.hasAnyNumber,
       href: "/settings?tab=messaging&setup=texting",
     },
+    {
+      key: "firstAppointment",
+      label: "Run your first real appointment",
+      hint: "Check out one real visit while your current PIMS stays in place as a safety net.",
+      done: onboardingData.hasCompletedRealAppointment,
+      href: "/schedule",
+    },
+    ...(clientPaymentData.stripeConfigured
+      ? [
+          {
+            key: "clientPayments",
+            label: "Set up client card payments",
+            hint: "Connect the clinic's Stripe account so pet-owner payments go directly to the clinic.",
+            done: clientPaymentData.enabled,
+            href: "/settings?tab=billing",
+          } as Milestone,
+        ]
+      : []),
     ...(enforced
       ? [
           {
@@ -172,6 +238,29 @@ export function ActivationChecklist() {
         ]
       : []),
   ];
+
+  // Evaluation remains deliberately light. Clinics running alongside or
+  // replacing another PIMS see only the operational go-live path; setup chores
+  // such as branding and trying AI stay in the guided tour instead of diluting
+  // the activation checklist.
+  const standardMilestones =
+    pathway.value === "explore"
+      ? [
+          ...explorationMilestones,
+          goLiveMilestones.find((milestone) => milestone.key === "data")!,
+        ]
+      : pathway.value === "self_host"
+        ? [
+            explorationMilestones.find(
+              (milestone) => milestone.key === "brand"
+            )!,
+            goLiveMilestones.find((milestone) => milestone.key === "data")!,
+            goLiveMilestones.find((milestone) => milestone.key === "team")!,
+            goLiveMilestones.find(
+              (milestone) => milestone.key === "firstAppointment"
+            )!,
+          ]
+        : goLiveMilestones;
   const firstWinBase =
     standardMilestones.find((milestone) => milestone.key === pathway.firstWinTarget) ??
     standardMilestones[0]!;

--- a/apps/web/components/records/capture-photos.tsx
+++ b/apps/web/components/records/capture-photos.tsx
@@ -15,7 +15,13 @@ const CAPTURE_POLL_INTERVAL_MS = 5_000;
  * Photos attach to this patient and appear here as thumbnails while the
  * modal is open. Mount only for roles that can manage the patient.
  */
-export function CapturePhotos({ patientId }: { patientId: string }) {
+export function CapturePhotos({
+  patientId,
+  appointmentId,
+}: {
+  patientId: string;
+  appointmentId?: string;
+}) {
   const [open, setOpen] = useState(false);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const baselineCountRef = useRef<number | null>(null);
@@ -66,7 +72,7 @@ export function CapturePhotos({ patientId }: { patientId: string }) {
 
   function handleOpen() {
     setOpen(true);
-    createSession.mutate({ patientId });
+    createSession.mutate({ patientId, appointmentId });
   }
 
   function handleClose() {
@@ -130,7 +136,9 @@ export function CapturePhotos({ patientId }: { patientId: string }) {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => createSession.mutate({ patientId })}
+                      onClick={() =>
+                        createSession.mutate({ patientId, appointmentId })
+                      }
                     >
                       <RefreshCw className="mr-2 h-4 w-4" />
                       Try again

--- a/apps/web/components/records/consent-sign.tsx
+++ b/apps/web/components/records/consent-sign.tsx
@@ -20,7 +20,13 @@ const CONSENT_POLL_INTERVAL_MS = 5_000;
  * a handed-over tablet via the no-login /sign/[token] page. The signed
  * status shows here live. Mount only for roles that can manage the patient.
  */
-export function ConsentSign({ patientId }: { patientId: string }) {
+export function ConsentSign({
+  patientId,
+  appointmentId,
+}: {
+  patientId: string;
+  appointmentId?: string;
+}) {
   const [open, setOpen] = useState(false);
   const [formId, setFormId] = useState<string | null>(null);
   const [title, setTitle] = useState("");
@@ -211,6 +217,7 @@ export function ConsentSign({ patientId }: { patientId: string }) {
                       onClick={() =>
                         createRequest.mutate({
                           patientId,
+                          appointmentId,
                           formId: formId!,
                           title: title.trim(),
                           bodyText: bodyText.trim(),
@@ -234,6 +241,7 @@ export function ConsentSign({ patientId }: { patientId: string }) {
                         onClick={() =>
                           createRequest.mutate({
                             patientId,
+                            appointmentId,
                             formId: formId!,
                             title: title.trim(),
                             bodyText: bodyText.trim(),

--- a/apps/web/lib/__tests__/automated-reminder-policy.test.ts
+++ b/apps/web/lib/__tests__/automated-reminder-policy.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  automatedAppointmentReminderSuppressionReason,
+  hasReservedEmailDomain,
+} from "../automated-reminder-policy";
+
+describe("automated reminder delivery policy", () => {
+  it("suppresses records marked as either a seeded demo client or appointment", () => {
+    expect(
+      automatedAppointmentReminderSuppressionReason({
+        isSeededDemoClient: true,
+        clientEmail: "client@realclinic.com",
+      })
+    ).toBe("seeded_demo_data");
+
+    expect(
+      automatedAppointmentReminderSuppressionReason({
+        isSeededDemoAppointment: true,
+        clientEmail: "client@realclinic.com",
+      })
+    ).toBe("seeded_demo_data");
+  });
+
+  it.each([
+    "client@example.com",
+    "client@subdomain.example.net",
+    "client@clinic.example",
+    "client@clinic.invalid",
+    "client@clinic.localhost",
+    "client@reminders.openvpm.test",
+  ])("recognizes reserved fixture address %s", (email) => {
+    expect(hasReservedEmailDomain(email)).toBe(true);
+    expect(
+      automatedAppointmentReminderSuppressionReason({ clientEmail: email })
+    ).toBe("reserved_email_domain");
+  });
+
+  it.each([
+    "client@realclinic.com",
+    "test@gmail.com",
+    "client@example.health",
+    "client@contest.com",
+  ])("does not suppress deliverable-looking address %s", (email) => {
+    expect(hasReservedEmailDomain(email)).toBe(false);
+    expect(
+      automatedAppointmentReminderSuppressionReason({ clientEmail: email })
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
@@ -19,18 +19,14 @@ describe("dashboard onboarding UI states", () => {
   it("surfaces activation checklist query failures before hiding for missing data", () => {
     expect(activationSource).toContain("function ActivationChecklistError");
     expect(activationSource).toContain("function ActivationChecklistLoading");
-    expect(activationSource).toContain(
-      "const loadError = state.error ?? onboarding.error ?? practice.error ?? sub.error"
-    );
+    expect(activationSource).toContain("const loadError =");
     expect(activationSource).toContain("Setup checklist could not load");
     expect(activationSource).toContain("const isChecklistLoading");
     expect(activationSource).toContain("practice.isLoading");
     expect(activationSource).toContain(
       "if (isChecklistLoading) return <ActivationChecklistLoading />"
     );
-    expect(activationSource).toContain(
-      "if (!state.data || !onboarding.data || !practice.data || !sub.data)"
-    );
+    expect(activationSource).toContain("!clientPayments.data");
     expect(activationSource).toContain(
       "Setup checklist data was unavailable. Try loading it again."
     );
@@ -42,15 +38,11 @@ describe("dashboard onboarding UI states", () => {
       activationSource.indexOf("if (isChecklistLoading)")
     );
     expect(activationSource.indexOf("if (isChecklistLoading)")).toBeLessThan(
-      activationSource.indexOf(
-        "if (!state.data || !onboarding.data || !practice.data || !sub.data)"
-      )
+      activationSource.indexOf("!clientPayments.data")
     );
-    expect(
-      activationSource.indexOf(
-        "if (!state.data || !onboarding.data || !practice.data || !sub.data)"
-      )
-    ).toBeLessThan(activationSource.indexOf("const practiceData = practice.data"));
+    expect(activationSource.indexOf("!clientPayments.data")).toBeLessThan(
+      activationSource.indexOf("const practiceData = practice.data")
+    );
     expect(activationSource).toContain("const checklistState = state.data");
     expect(activationSource).toContain("const onboardingData = onboarding.data");
     expect(activationSource).toContain("const practiceData = practice.data");
@@ -62,6 +54,21 @@ describe("dashboard onboarding UI states", () => {
     expect(activationSource).toContain(
       "done: onboardingData.hasRealData || !onboardingData.hasDemoData"
     );
+    expect(activationSource).toContain('label: "Publish online booking"');
+    expect(activationSource).toContain(
+      "done: bookingData.page?.published === true"
+    );
+    expect(activationSource).toContain('label: "Start texting registration"');
+    expect(activationSource).toContain("done: textingData.hasAnyNumber");
+    expect(activationSource).toContain(
+      'label: "Run your first real appointment"'
+    );
+    expect(activationSource).toContain(
+      "done: onboardingData.hasCompletedRealAppointment"
+    );
+    expect(activationSource).toContain('label: "Set up client card payments"');
+    expect(activationSource).toContain("done: clientPaymentData.enabled");
+    expect(activationSource).toContain('pathway.value === "explore"');
     expect(activationSource).not.toContain("practice.data?.");
     expect(activationSource).not.toContain("sub.data.");
     expect(activationSource).not.toContain("onboarding.data.hasDemoData");

--- a/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
+++ b/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const workspaceSource = readFileSync(
+  "app/(dashboard)/encounters/[appointmentId]/page.tsx",
+  "utf8"
+);
+const scheduleSource = readFileSync(
+  "app/(dashboard)/schedule/page.tsx",
+  "utf8"
+);
+const soapSource = readFileSync(
+  "app/(dashboard)/records/new-soap/[patientId]/page.tsx",
+  "utf8"
+);
+
+describe("clinic encounter workspace", () => {
+  it("opens from an appointment and keeps visit and patient context together", () => {
+    expect(scheduleSource).toContain("Open visit");
+    expect(scheduleSource).toContain("href={`/encounters/${appointment.id}`}");
+    expect(workspaceSource).toContain("trpc.appointments.getById.useQuery");
+    expect(workspaceSource).toContain("trpc.patients.getById.useQuery");
+    expect(workspaceSource).toContain("Clinical work");
+    expect(workspaceSource).toContain("Invoice state");
+    expect(workspaceSource).toContain("Charge capture");
+  });
+
+  it("links SOAP documentation to the appointment and returns to the visit", () => {
+    expect(workspaceSource).toContain("?appointmentId=${appointmentId}");
+    expect(soapSource).toContain(
+      'const appointmentId = searchParams.get("appointmentId") ?? undefined'
+    );
+    expect(soapSource).toContain("appointmentId,");
+    expect(soapSource).toContain(
+      "`/encounters/${encodeURIComponent(appointmentId)}`"
+    );
+    expect(soapSource).toContain(
+      "This note will be linked to the current appointment."
+    );
+  });
+
+  it("creates appointment-linked service and product charges with role guards", () => {
+    expect(workspaceSource).toContain(
+      'role === "admin" || role === "front_desk"'
+    );
+    expect(workspaceSource).toContain('itemType: "service" as const');
+    expect(workspaceSource).toContain('itemType: "product" as const');
+    expect(workspaceSource).toContain("trpc.billing.createInvoice.useMutation");
+    expect(workspaceSource).toContain("appointmentId,");
+    expect(workspaceSource).toContain("Product stock is");
+    expect(workspaceSource).toContain("deducted atomically");
+    expect(workspaceSource).toContain("formatPrice={fmt}");
+  });
+
+  it("locks charge creation until invoice state is known and surfaces failures", () => {
+    expect(workspaceSource).toContain("invoiceStateReady");
+    expect(workspaceSource).toContain("Confirming visit invoice state...");
+    expect(workspaceSource).toContain(
+      "Charge capture is locked because invoice state could not be"
+    );
+    expect(workspaceSource).toContain(
+      "Unable to load invoice state. Do not create duplicate charges"
+    );
+    expect(workspaceSource).toContain("No active invoice for this visit");
+    expect(workspaceSource).toContain("!invoice.isEstimate");
+    expect(workspaceSource).toContain("Charge catalog is empty");
+    expect(workspaceSource).toContain(
+      "Charge capture is locked because tax and currency settings could"
+    );
+  });
+});

--- a/apps/web/lib/__tests__/onboarding-ui-states.test.ts
+++ b/apps/web/lib/__tests__/onboarding-ui-states.test.ts
@@ -65,6 +65,12 @@ describe("onboarding UI states", () => {
     expect(settingsRouter).toContain("setOnboardingIntent: adminProcedure");
     expect(settingsRouter).toContain("setJourneyProgress: adminProcedure");
     expect(settingsRouter).toContain("hasRealData: existingPatients.some(");
+    expect(settingsRouter).toContain(
+      "hasRealAppointment: firstRealAppointment.length > 0"
+    );
+    expect(settingsRouter).toContain(
+      "hasCompletedRealAppointment: completedRealAppointment.length > 0"
+    );
   });
 
   it("starts with a persisted adoption pathway and recommends running alongside", () => {

--- a/apps/web/lib/automated-reminder-policy.ts
+++ b/apps/web/lib/automated-reminder-policy.ts
@@ -1,0 +1,64 @@
+export type AutomatedReminderSuppressionReason =
+  | "seeded_demo_data"
+  | "reserved_email_domain";
+
+const RESERVED_EMAIL_DOMAINS = new Set([
+  "example.com",
+  "example.net",
+  "example.org",
+  "localhost",
+]);
+
+const RESERVED_EMAIL_SUFFIXES = [".example", ".invalid", ".localhost", ".test"];
+
+/**
+ * RFC-reserved domains are useful in examples and fixtures but must never be
+ * handed to a real delivery provider. Exact example.com/net/org names and
+ * their subdomains are reserved, as are the four special-use test TLDs.
+ */
+export function hasReservedEmailDomain(
+  value: string | null | undefined
+): boolean {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return false;
+
+  const at = normalized.lastIndexOf("@");
+  if (at <= 0 || at !== normalized.indexOf("@")) return false;
+
+  const domain = normalized.slice(at + 1).replace(/\.$/, "");
+  if (!domain) return false;
+
+  if (RESERVED_EMAIL_DOMAINS.has(domain)) return true;
+  if (
+    [...RESERVED_EMAIL_DOMAINS].some((reserved) =>
+      domain.endsWith(`.${reserved}`)
+    )
+  ) {
+    return true;
+  }
+
+  return RESERVED_EMAIL_SUFFIXES.some(
+    (suffix) => domain === suffix.slice(1) || domain.endsWith(suffix)
+  );
+}
+
+/**
+ * Fail closed before an automated reminder creates a delivery claim. Sample
+ * records stay visible in the product, but neither they nor reserved fixture
+ * addresses can reach an email/SMS provider.
+ */
+export function automatedAppointmentReminderSuppressionReason(input: {
+  isSeededDemoClient?: boolean | null;
+  isSeededDemoAppointment?: boolean | null;
+  clientEmail?: string | null;
+}): AutomatedReminderSuppressionReason | null {
+  if (input.isSeededDemoClient || input.isSeededDemoAppointment) {
+    return "seeded_demo_data";
+  }
+
+  if (hasReservedEmailDomain(input.clientEmail)) {
+    return "reserved_email_domain";
+  }
+
+  return null;
+}

--- a/apps/web/server/__tests__/billing-invoice-integrity.test.ts
+++ b/apps/web/server/__tests__/billing-invoice-integrity.test.ts
@@ -16,6 +16,7 @@ const CLIENT_ID = "00000000-0000-0000-0000-000000000002";
 const PATIENT_ID = "00000000-0000-0000-0000-000000000003";
 const PRODUCT_ID = "00000000-0000-0000-0000-000000000004";
 const INVOICE_ID = "00000000-0000-0000-0000-000000000005";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000006";
 
 function callerWithDb(db: Record<string, unknown>, role = "front_desk") {
   const session = {
@@ -231,6 +232,88 @@ describe("billing invoice integrity", () => {
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects an appointment that does not belong to the selected client and patient", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [[{ id: CLIENT_ID }], [{ id: PATIENT_ID }], []],
+    });
+
+    await expect(
+      callerWithDb(db).createInvoice({
+        clientId: CLIENT_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        items: [productLine],
+        isEstimate: false,
+      })
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Appointment not found for this client and patient.",
+    });
+
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("stores a verified appointment link and prevents a duplicate active visit invoice", async () => {
+    const first = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID }],
+        [{ id: PATIENT_ID }],
+        [{ id: APPOINTMENT_ID }],
+        [{ id: PRODUCT_ID }],
+        [{ taxRatePercent: "0.00" }],
+        [],
+      ],
+      invoiceInsert: { id: INVOICE_ID, isEstimate: false },
+      updateReturns: [[{ id: PRODUCT_ID, stockQuantity: 8 }]],
+    });
+
+    await callerWithDb(first.db).createInvoice({
+      clientId: CLIENT_ID,
+      patientId: PATIENT_ID,
+      appointmentId: APPOINTMENT_ID,
+      items: [productLine],
+      isEstimate: false,
+    });
+
+    expect(first.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        clientId: CLIENT_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+      })
+    );
+
+    const duplicate = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID }],
+        [{ id: PATIENT_ID }],
+        [{ id: APPOINTMENT_ID }],
+        [{ id: PRODUCT_ID }],
+        [{ taxRatePercent: "0.00" }],
+        [{ id: INVOICE_ID }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(duplicate.db).createInvoice({
+        clientId: CLIENT_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        items: [productLine],
+        isEstimate: false,
+      })
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message:
+        "This visit already has an active invoice. Open it instead of creating a duplicate.",
+    });
+
+    expect(duplicate.db.execute).toHaveBeenCalled();
+    expect(duplicate.updateSet).not.toHaveBeenCalled();
+    expect(duplicate.insertValues).not.toHaveBeenCalled();
   });
 
   it("rejects product line references outside the practice", async () => {

--- a/apps/web/server/__tests__/billing-list-inputs.test.ts
+++ b/apps/web/server/__tests__/billing-list-inputs.test.ts
@@ -98,6 +98,14 @@ describe("billing list input validation", () => {
 
     await expect(
       caller.listInvoices({
+        appointmentId: "not-an-appointment-id",
+        limit: 25,
+        offset: 0,
+      } as never)
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    await expect(
+      caller.listInvoices({
         limit: 1.5,
         offset: 0,
       } as never)

--- a/apps/web/server/__tests__/records-target-safety.test.ts
+++ b/apps/web/server/__tests__/records-target-safety.test.ts
@@ -845,6 +845,38 @@ describe("capture sessions", () => {
     );
   });
 
+  it("stamps the encounter-selected visit even before check-in", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [patientRow, [{ id: APPOINTMENT_ID }]],
+      insertedRows: [{ id: RECORD_ID }],
+    });
+
+    const result = await callerWithDb(db).createCaptureSession({
+      patientId: PATIENT_ID,
+      appointmentId: APPOINTMENT_ID,
+    });
+
+    expect(result.appointmentId).toBe(APPOINTMENT_ID);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ appointmentId: APPOINTMENT_ID })
+    );
+  });
+
+  it("rejects an encounter-selected visit outside the patient", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [patientRow, []],
+    });
+
+    await expect(
+      callerWithDb(db).createCaptureSession({
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("leaves the visit blank when the patient has no open visit", async () => {
     const { db, insertValues } = createDb({
       selectResults: [patientRow, []],
@@ -1002,6 +1034,40 @@ describe("consent requests", () => {
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({ appointmentId: APPOINTMENT_ID })
     );
+  });
+
+  it("stamps the encounter-selected visit on a consent before check-in", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [patientRow, formRow, [{ id: APPOINTMENT_ID }]],
+      insertedRows: [{ id: RECORD_ID }],
+    });
+
+    const result = await callerWithDb(db).createConsentRequest({
+      patientId: PATIENT_ID,
+      appointmentId: APPOINTMENT_ID,
+      formId: FORM_ID,
+    });
+
+    expect(result.appointmentId).toBe(APPOINTMENT_ID);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ appointmentId: APPOINTMENT_ID })
+    );
+  });
+
+  it("rejects an encounter-selected consent visit outside the patient", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [patientRow, formRow, []],
+    });
+
+    await expect(
+      callerWithDb(db).createConsentRequest({
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        formId: FORM_ID,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("snapshots custom consent copy onto the request", async () => {

--- a/apps/web/server/__tests__/settings-welcome-context.test.ts
+++ b/apps/web/server/__tests__/settings-welcome-context.test.ts
@@ -141,6 +141,8 @@ describe("settings.onboardingStatus", () => {
     const { db } = createDb([
       [{ settings: demoSettings }],
       [{ id: DEMO_PATIENT_ID }],
+      [],
+      [],
     ]);
 
     await expect(
@@ -152,10 +154,55 @@ describe("settings.onboardingStatus", () => {
     const { db } = createDb([
       [{ settings: demoSettings }],
       [{ id: DEMO_PATIENT_ID }, { id: "real-patient-1" }],
+      [],
+      [],
     ]);
 
     await expect(
       callerWithRole(db, "admin").onboardingStatus()
     ).resolves.toMatchObject({ hasDemoData: true, hasRealData: true });
+  });
+
+  it("does not count seeded appointments as a first live appointment", async () => {
+    const demoAppointmentId = "00000000-0000-0000-0000-000000000099";
+    const { db } = createDb([
+      [
+        {
+          settings: {
+            ...demoSettings,
+            demoData: {
+              ...demoSettings.demoData,
+              appointmentIds: [demoAppointmentId],
+            },
+          },
+        },
+      ],
+      [{ id: DEMO_PATIENT_ID }],
+      [],
+      [],
+    ]);
+
+    await expect(
+      callerWithRole(db, "admin").onboardingStatus()
+    ).resolves.toMatchObject({
+      hasRealAppointment: false,
+      hasCompletedRealAppointment: false,
+    });
+  });
+
+  it("recognizes a completed non-demo appointment", async () => {
+    const { db } = createDb([
+      [{ settings: demoSettings }],
+      [{ id: DEMO_PATIENT_ID }],
+      [{ id: "real-appointment-1" }],
+      [{ id: "real-appointment-1" }],
+    ]);
+
+    await expect(
+      callerWithRole(db, "admin").onboardingStatus()
+    ).resolves.toMatchObject({
+      hasRealAppointment: true,
+      hasCompletedRealAppointment: true,
+    });
   });
 });

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, isNull, desc, sql, inArray, ilike, type SQL } from "drizzle-orm";
+import { eq, and, isNull, desc, sql, inArray, ilike, ne, type SQL } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
 import {
@@ -58,6 +58,7 @@ import {
   practicePaymentAccounts,
   users,
   practices,
+  appointments,
 } from "@openpims/db";
 import {
   clinicalDateInput,
@@ -141,6 +142,7 @@ const createInvoiceInput = z
   .object({
     clientId: z.string().uuid(),
     patientId: z.string().uuid().optional(),
+    appointmentId: z.string().uuid().optional(),
     items: z
       .array(invoiceLineInput)
       .max(
@@ -530,6 +532,38 @@ async function assertPatientBelongsToClient(
   }
 }
 
+async function assertAppointmentBelongsToClientPatient(
+  ctx: BillingContext,
+  appointmentId: string,
+  clientId: string,
+  patientId?: string
+) {
+  const conditions = [
+    eq(appointments.id, appointmentId),
+    eq(appointments.practiceId, ctx.practiceId),
+    eq(appointments.clientId, clientId),
+    isNull(appointments.deletedAt),
+  ];
+  if (patientId) {
+    conditions.push(eq(appointments.patientId, patientId));
+  }
+
+  const [appointment] = await ctx.db
+    .select({ id: appointments.id })
+    .from(appointments)
+    .where(and(...conditions))
+    .limit(1);
+
+  if (!appointment) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Appointment not found for this client and patient.",
+    });
+  }
+
+  return appointment;
+}
+
 async function assertLineItemReferences(
   ctx: BillingContext,
   items: readonly InvoiceLineInput[]
@@ -850,6 +884,7 @@ export const billingRouter = createRouter({
         status: invoiceStatusSchema.optional(),
         isEstimate: z.boolean().optional(),
         patientId: z.string().uuid().optional(),
+        appointmentId: z.string().uuid().optional(),
         limit: z.number().int().min(1).max(100).default(25),
         offset: listOffsetInput,
       })
@@ -866,6 +901,10 @@ export const billingRouter = createRouter({
 
       if (input.patientId) {
         conditions.push(eq(invoices.patientId, input.patientId));
+      }
+
+      if (input.appointmentId) {
+        conditions.push(eq(invoices.appointmentId, input.appointmentId));
       }
 
       if (input.isEstimate !== undefined) {
@@ -893,6 +932,7 @@ export const billingRouter = createRouter({
             clientFirstName: clients.firstName,
             clientLastName: clients.lastName,
             patientName: patients.name,
+            appointmentId: invoices.appointmentId,
           })
           .from(invoices)
           .leftJoin(
@@ -1160,6 +1200,14 @@ export const billingRouter = createRouter({
       if (input.patientId) {
         await assertPatientBelongsToClient(ctx, input.patientId, input.clientId);
       }
+      if (input.appointmentId) {
+        await assertAppointmentBelongsToClientPatient(
+          ctx,
+          input.appointmentId,
+          input.clientId,
+          input.patientId
+        );
+      }
       await assertLineItemReferences(ctx, input.items);
 
       const subtotal = input.items.reduce((sum, item) => {
@@ -1181,6 +1229,33 @@ export const billingRouter = createRouter({
 
       return ctx.db.transaction(async (tx) => {
         const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+        if (input.appointmentId) {
+          // Serialize charge capture for one visit so two front-desk tabs
+          // cannot both pass the duplicate check and create competing bills.
+          await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${input.appointmentId}, 0))`
+          );
+          const [existingVisitInvoice] = await tx
+            .select({ id: invoices.id })
+            .from(invoices)
+            .where(
+              and(
+                eq(invoices.practiceId, ctx.practiceId),
+                eq(invoices.appointmentId, input.appointmentId),
+                eq(invoices.isEstimate, input.isEstimate ?? false),
+                ne(invoices.status, "void"),
+                isNull(invoices.deletedAt)
+              )
+            )
+            .limit(1);
+          if (existingVisitInvoice) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "This visit already has an active invoice. Open it instead of creating a duplicate.",
+            });
+          }
+        }
         if (!(input.isEstimate ?? false)) {
           await deductProductStock(txCtx, input.items);
         }
@@ -1191,6 +1266,7 @@ export const billingRouter = createRouter({
             practiceId: ctx.practiceId,
             clientId: input.clientId,
             patientId: input.patientId ?? null,
+            appointmentId: input.appointmentId ?? null,
             status: "draft",
             subtotal: subtotal.toFixed(2),
             tax: tax.toFixed(2),

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -1093,10 +1093,23 @@ export const recordsRouter = createRouter({
   // patient management (patients.addAllergy): all staff except viewers.
   createCaptureSession: protectedProcedure
     .use(requireRole("admin", "veterinarian", "technician", "front_desk"))
-    .input(z.object({ patientId: z.string().uuid() }))
+    .input(
+      z.object({
+        patientId: z.string().uuid(),
+        appointmentId: z.string().uuid().optional(),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       await assertPatientBelongsToPractice(ctx, input.patientId);
-      const appointmentId = await findActiveVisitId(ctx, input.patientId);
+      const appointmentId = input.appointmentId
+        ? (
+            await assertAppointmentBelongsToPatient(
+              ctx,
+              input.appointmentId,
+              input.patientId
+            )
+          ).id
+        : await findActiveVisitId(ctx, input.patientId);
       const token = generateCaptureToken();
       const expiresAt = new Date(Date.now() + CAPTURE_TOKEN_TTL_MS);
       await ctx.db
@@ -1270,6 +1283,7 @@ export const recordsRouter = createRouter({
     .input(
       z.object({
         patientId: z.string().uuid(),
+        appointmentId: z.string().uuid().optional(),
         formId: z.string().uuid(),
         title: z.string().trim().min(1).max(CONSENT_TITLE_MAX_LENGTH).optional(),
         bodyText: z.string().trim().min(1).max(CONSENT_BODY_MAX_LENGTH).optional(),
@@ -1299,7 +1313,15 @@ export const recordsRouter = createRouter({
           message: "Consent form not found",
         });
       }
-      const appointmentId = await findActiveVisitId(ctx, input.patientId);
+      const appointmentId = input.appointmentId
+        ? (
+            await assertAppointmentBelongsToPatient(
+              ctx,
+              input.appointmentId,
+              input.patientId
+            )
+          ).id
+        : await findActiveVisitId(ctx, input.patientId);
       const token = generateCaptureToken();
       const expiresAt = new Date(Date.now() + CONSENT_TOKEN_TTL_MS);
       const [created] = await ctx.db

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { randomUUID } from "crypto";
-import { eq, and, isNull, inArray, ne, sql } from "drizzle-orm";
+import { eq, and, isNull, inArray, ne, notInArray, sql } from "drizzle-orm";
 import { hash } from "bcryptjs";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
@@ -799,16 +799,47 @@ export const settingsRouter = createRouter({
     // A practice that already runs on real data (e.g. seeded demo, or a
     // self-host upgrading into the wizard feature) must not be greeted like
     // a brand-new signup, even though it never recorded a completion date.
-    const existingPatients = await ctx.db
-      .select({ id: patients.id })
-      .from(patients)
-      .where(
-        and(
-          eq(patients.practiceId, ctx.practiceId),
-          isNull(patients.deletedAt)
-        )
-      )
-      .limit(ESTABLISHED_PRACTICE_PATIENT_THRESHOLD);
+    const demoAppointmentIds = settings.demoData?.appointmentIds ?? [];
+    const realAppointmentFilter =
+      demoAppointmentIds.length > 0
+        ? notInArray(appointments.id, demoAppointmentIds)
+        : undefined;
+    const [existingPatients, firstRealAppointment, completedRealAppointment] =
+      await Promise.all([
+        ctx.db
+          .select({ id: patients.id })
+          .from(patients)
+          .where(
+            and(
+              eq(patients.practiceId, ctx.practiceId),
+              isNull(patients.deletedAt)
+            )
+          )
+          .limit(ESTABLISHED_PRACTICE_PATIENT_THRESHOLD),
+        ctx.db
+          .select({ id: appointments.id })
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.practiceId, ctx.practiceId),
+              isNull(appointments.deletedAt),
+              realAppointmentFilter
+            )
+          )
+          .limit(1),
+        ctx.db
+          .select({ id: appointments.id })
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.practiceId, ctx.practiceId),
+              eq(appointments.status, "checked_out"),
+              isNull(appointments.deletedAt),
+              realAppointmentFilter
+            )
+          )
+          .limit(1),
+      ]);
     const demoPatientIds = new Set(settings.demoData?.patientIds ?? []);
     return {
       completedAt: settings.onboardingCompletedAt ?? null,
@@ -819,6 +850,12 @@ export const settingsRouter = createRouter({
       hasRealData: existingPatients.some(
         (patient) => !demoPatientIds.has(patient.id)
       ),
+      // Scheduling a real appointment is the first operational commitment in
+      // the clinic-ready path. Demo appointments must never complete it.
+      hasRealAppointment: firstRealAppointment.length > 0,
+      // Checked out is the first durable signal that the practice has run the
+      // workflow, rather than merely exploring the calendar.
+      hasCompletedRealAppointment: completedRealAppointment.length > 0,
       onboardingDraft: settings.onboardingDraft ?? null,
       establishedPractice:
         existingPatients.length >= ESTABLISHED_PRACTICE_PATIENT_THRESHOLD,


### PR DESCRIPTION
## What changed

- adds a visit workspace opened directly from each scheduled appointment
- keeps appointment, patient, client, provider, room, allergy, documentation, and invoice context together
- supports check-in, start-exam, and check-out actions
- links SOAP notes, photo capture, and consent signatures to the selected appointment
- adds service/product charge capture with tenant validation, atomic inventory deduction, and concurrent duplicate-invoice protection
- lets staff open the visit-linked invoice to send, collect, or review it
- replaces vanity setup chores with an operational clinic go-live checklist, completed only after a real non-demo visit is checked out
- suppresses seeded/demo and RFC-reserved fixture records before automated reminder provider calls, with non-PII suppression metrics

## Why

A clinic cannot evaluate OpenVPM from disconnected feature pages. This creates the smallest durable daily workflow: schedule → visit → documentation → charges → invoice, while keeping evaluation data and automated communications safe.

## Safety

- all appointment/client/patient/invoice links are tenant-scoped
- product deduction and invoice creation are one transaction
- per-appointment advisory locking prevents duplicate active invoices
- estimates do not block a real visit invoice
- charge capture fails closed when invoice, tax, currency, catalog, or permission state is unavailable
- demo/reserved reminders are suppressed before communication claims or provider calls

## Validation

- all package type-checks pass
- full web suite: 260 files / 2,327 tests pass
- production build passes, including `/encounters/[appointmentId]`
- `git diff --check` passes

## Known boundary

Once a visit-linked invoice exists, staff can open/send/collect/review it, but line items cannot yet be appended from the encounter workspace. First capture should include all known charges.