### PR TITLE
Let clinics correct draft visit charges

### DIFF
--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -24,6 +24,7 @@ import { trpc } from "@/lib/trpc";
 import { formatCurrency } from "@/lib/locale/format";
 import {
   BILLING_INVOICE_MAX_ITEMS,
+  isBillingInvoiceLineTotalValid,
   isBillingInvoiceSubtotalValid,
 } from "@/lib/billing/policy";
 import { ServicePicker } from "@/components/billing/service-picker";
@@ -47,7 +48,7 @@ type ChargeItem = {
   quantity: number;
   unitPrice: string;
   itemType: "service" | "product";
-  itemId: string;
+  itemId?: string;
 };
 
 const APPOINTMENT_STATUS_LABELS: Record<string, string> = {
@@ -372,7 +373,14 @@ export default function EncounterWorkspacePage() {
           clientId={appointment.clientId}
           patientId={appointment.patientId}
           canManage={canManageBilling(role)}
-          hasActiveInvoice={activeInvoices.length > 0}
+          activeInvoice={
+            activeInvoices[0]
+              ? {
+                  id: activeInvoices[0].id,
+                  status: activeInvoices[0].status,
+                }
+              : null
+          }
           invoiceStateReady={
             Boolean(invoicesQuery.data) && !invoicesQuery.error
           }
@@ -497,7 +505,7 @@ function ChargeCapture({
   clientId,
   patientId,
   canManage,
-  hasActiveInvoice,
+  activeInvoice,
   invoiceStateReady,
   invoiceStateLoading,
 }: {
@@ -505,7 +513,7 @@ function ChargeCapture({
   clientId: string | null;
   patientId: string | null;
   canManage: boolean;
-  hasActiveInvoice: boolean;
+  activeInvoice: { id: string; status: string } | null;
   invoiceStateReady: boolean;
   invoiceStateLoading: boolean;
 }) {
@@ -513,20 +521,71 @@ function ChargeCapture({
   const [selectedCatalogId, setSelectedCatalogId] = useState("");
   const [quantity, setQuantity] = useState(1);
   const [items, setItems] = useState<ChargeItem[]>([]);
+  const [loadedInvoiceId, setLoadedInvoiceId] = useState<string | null>(null);
   const configQuery = trpc.billing.getTaxConfig.useQuery(undefined, {
     staleTime: 5 * 60 * 1000,
   });
   const configReady = Boolean(configQuery.data) && !configQuery.error;
+  const activeInvoiceIsDraft = activeInvoice?.status === "draft";
+  const invoiceDetailQuery = trpc.billing.getInvoice.useQuery(
+    {
+      id:
+        activeInvoice?.id ?? "00000000-0000-0000-0000-000000000000",
+    },
+    { enabled: Boolean(canManage && activeInvoiceIsDraft) }
+  );
+  const invoiceDetailReady =
+    !activeInvoice ||
+    (activeInvoiceIsDraft && Boolean(invoiceDetailQuery.data));
   const servicesQuery = trpc.billing.listServices.useQuery(undefined, {
-    enabled: canManage && configReady && invoiceStateReady && !hasActiveInvoice,
+    enabled:
+      canManage &&
+      configReady &&
+      invoiceStateReady &&
+      (!activeInvoice || (activeInvoiceIsDraft && invoiceDetailReady)),
   });
   const productsQuery = trpc.billing.listProducts.useQuery(
     { limit: 100 },
     {
       enabled:
-        canManage && configReady && invoiceStateReady && !hasActiveInvoice,
+        canManage &&
+        configReady &&
+        invoiceStateReady &&
+        (!activeInvoice || (activeInvoiceIsDraft && invoiceDetailReady)),
     }
   );
+
+  useEffect(() => {
+    if (!activeInvoice) {
+      if (loadedInvoiceId) {
+        setItems([]);
+        setLoadedInvoiceId(null);
+      }
+      return;
+    }
+    if (
+      activeInvoiceIsDraft &&
+      invoiceDetailQuery.data?.id === activeInvoice.id &&
+      loadedInvoiceId !== activeInvoice.id
+    ) {
+      setItems(
+        invoiceDetailQuery.data.items.map((item) => ({
+          key: item.id,
+          description: item.description,
+          quantity: item.quantity,
+          unitPrice: item.unitPrice,
+          itemType: item.itemType,
+          itemId: item.itemId ?? undefined,
+        }))
+      );
+      setLoadedInvoiceId(activeInvoice.id);
+    }
+  }, [
+    activeInvoice,
+    activeInvoiceIsDraft,
+    invoiceDetailQuery.data,
+    loadedInvoiceId,
+  ]);
 
   const catalog = useMemo(() => {
     const services = (servicesQuery.data ?? []).map((service) => ({
@@ -576,10 +635,14 @@ function ChargeCapture({
   const canSubmit =
     Boolean(clientId && patientId) &&
     items.length > 0 &&
+    items.every((item) =>
+      isBillingInvoiceLineTotalValid(item.unitPrice, item.quantity)
+    ) &&
     isBillingInvoiceSubtotalValid(items) &&
     configReady &&
     invoiceStateReady &&
-    !hasActiveInvoice;
+    invoiceDetailReady &&
+    (!activeInvoice || activeInvoiceIsDraft);
 
   const createInvoice = trpc.billing.createInvoice.useMutation({
     onSuccess: () => {
@@ -595,6 +658,21 @@ function ChargeCapture({
     },
     onError: (error) => toast.error(error.message),
   });
+  const updateInvoiceItems = trpc.billing.updateInvoiceItems.useMutation({
+    onSuccess: () => {
+      toast.success("Visit invoice charges updated");
+      utils.billing.listInvoices.invalidate({
+        appointmentId,
+        limit: 25,
+        offset: 0,
+      });
+      if (activeInvoice) {
+        utils.billing.getInvoice.invalidate({ id: activeInvoice.id });
+      }
+    },
+    onError: (error) => toast.error(error.message),
+  });
+  const isSaving = createInvoice.isPending || updateInvoiceItems.isPending;
 
   function addSelectedItem() {
     if (!selected || !canAdd) return;
@@ -615,19 +693,24 @@ function ChargeCapture({
 
   function saveCharges() {
     if (!clientId || !patientId || !canSubmit) return;
+    const lineItems = items.map(
+      ({ description, quantity, unitPrice, itemType, itemId }) => ({
+        description,
+        quantity,
+        unitPrice,
+        itemType,
+        itemId,
+      })
+    );
+    if (activeInvoice) {
+      updateInvoiceItems.mutate({ id: activeInvoice.id, items: lineItems });
+      return;
+    }
     createInvoice.mutate({
       appointmentId,
       clientId,
       patientId,
-      items: items.map(
-        ({ description, quantity, unitPrice, itemType, itemId }) => ({
-          description,
-          quantity,
-          unitPrice,
-          itemType,
-          itemId,
-        })
-      ),
+      items: lineItems,
       isEstimate: false,
     });
   }
@@ -637,8 +720,9 @@ function ChargeCapture({
       <CardHeader>
         <CardTitle>Charge capture</CardTitle>
         <CardDescription>
-          Add the services and products performed or dispensed during this
-          visit.
+          {activeInvoiceIsDraft
+            ? "Correct or add services and products before this invoice is sent."
+            : "Add the services and products performed or dispensed during this visit."}
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -657,10 +741,22 @@ function ChargeCapture({
             Charge capture is locked because invoice state could not be
             confirmed. Refresh before creating charges.
           </div>
-        ) : hasActiveInvoice ? (
+        ) : activeInvoice && !activeInvoiceIsDraft ? (
           <div className="rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
-            This visit already has an active invoice. Open it from Invoice state
-            to send, collect payment, or review the balance.
+            This visit invoice is already {activeInvoice.status}. Open it from
+            Invoice state to collect payment or review the balance. Only unpaid
+            draft charges can be edited.
+          </div>
+        ) : activeInvoiceIsDraft && invoiceDetailQuery.isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading existing visit charges...
+          </div>
+        ) : activeInvoiceIsDraft &&
+          (invoiceDetailQuery.error || !invoiceDetailQuery.data) ? (
+          <div className="rounded-md border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+            Existing charges could not be loaded. Refresh before editing this
+            draft invoice.
           </div>
         ) : configQuery.isLoading ? (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -687,7 +783,7 @@ function ChargeCapture({
             <Loader2 className="h-4 w-4 animate-spin" />
             Loading services and products...
           </div>
-        ) : catalog.length === 0 ? (
+        ) : catalog.length === 0 && items.length === 0 ? (
           <EmptyState
             icon={Package}
             title="Charge catalog is empty"
@@ -701,7 +797,7 @@ function ChargeCapture({
                 services={catalog}
                 value={selectedCatalogId}
                 onSelect={setSelectedCatalogId}
-                disabled={createInvoice.isPending}
+                disabled={isSaving}
                 formatPrice={fmt}
               />
               <Input
@@ -718,7 +814,7 @@ function ChargeCapture({
               <Button
                 type="button"
                 variant="outline"
-                disabled={!canAdd || createInvoice.isPending}
+                disabled={!canAdd || isSaving}
                 onClick={addSelectedItem}
               >
                 <Plus className="mr-2 h-4 w-4" />
@@ -741,35 +837,92 @@ function ChargeCapture({
                 {items.map((item) => (
                   <div
                     key={item.key}
-                    className="flex items-center gap-3 rounded-md border border-border p-3"
+                    className="flex flex-col gap-3 rounded-md border border-border p-3 sm:flex-row sm:items-center"
                   >
                     <div className="min-w-0 flex-1">
                       <p className="truncate text-sm font-medium">
                         {item.description}
                       </p>
                       <p className="text-xs capitalize text-muted-foreground">
-                        {item.itemType} · {item.quantity} ×{" "}
-                        {fmt(item.unitPrice)}
+                        {item.itemType}
                       </p>
                     </div>
-                    <span className="text-sm font-medium tabular-nums">
-                      {fmt(item.quantity * Number(item.unitPrice))}
-                    </span>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={`Remove ${item.description}`}
-                      onClick={() =>
-                        setItems((current) =>
-                          current.filter(
-                            (candidate) => candidate.key !== item.key
+                    <div className="flex flex-wrap items-center gap-2">
+                      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                        Qty
+                        <Input
+                          type="number"
+                          min={1}
+                          max={10000}
+                          value={item.quantity}
+                          aria-label={`${item.description} quantity`}
+                          className="w-20 text-foreground"
+                          disabled={isSaving}
+                          onChange={(event) =>
+                            setItems((current) =>
+                              current.map((candidate) =>
+                                candidate.key === item.key
+                                  ? {
+                                      ...candidate,
+                                      quantity: Math.max(
+                                        1,
+                                        Number(event.target.value) || 1
+                                      ),
+                                    }
+                                  : candidate
+                              )
+                            )
+                          }
+                        />
+                      </label>
+                      <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                        Unit price
+                        <Input
+                          type="number"
+                          min={0}
+                          step="0.01"
+                          value={item.unitPrice}
+                          aria-label={`${item.description} unit price`}
+                          className="w-28 text-foreground"
+                          disabled={isSaving}
+                          onChange={(event) =>
+                            setItems((current) =>
+                              current.map((candidate) =>
+                                candidate.key === item.key
+                                  ? {
+                                      ...candidate,
+                                      unitPrice: event.target.value,
+                                    }
+                                  : candidate
+                              )
+                            )
+                          }
+                        />
+                      </label>
+                      <span className="flex w-24 flex-col gap-1 text-right text-xs text-muted-foreground">
+                        Line total
+                        <span className="text-sm font-medium text-foreground tabular-nums">
+                          {fmt(item.quantity * Number(item.unitPrice || 0))}
+                        </span>
+                      </span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="self-end"
+                        aria-label={`Remove ${item.description}`}
+                        disabled={isSaving}
+                        onClick={() =>
+                          setItems((current) =>
+                            current.filter(
+                              (candidate) => candidate.key !== item.key
+                            )
                           )
-                        )
-                      }
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                        }
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </div>
                 ))}
               </div>
@@ -795,19 +948,22 @@ function ChargeCapture({
             ) : null}
 
             <Button
-              disabled={!canSubmit || createInvoice.isPending}
+              disabled={!canSubmit || isSaving}
               onClick={saveCharges}
             >
-              {createInvoice.isPending ? (
+              {isSaving ? (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               ) : (
                 <Receipt className="mr-2 h-4 w-4" />
               )}
-              Create visit invoice
+              {activeInvoiceIsDraft
+                ? "Update visit invoice"
+                : "Create visit invoice"}
             </Button>
             <p className="text-xs text-muted-foreground">
-              This creates a draft linked to the appointment. Product stock is
-              deducted atomically when the invoice is created.
+              {activeInvoiceIsDraft
+                ? "Product stock is restored and re-deducted atomically when draft charges change."
+                : "This creates a draft linked to the appointment. Product stock is deducted atomically when the invoice is created."}
             </p>
           </div>
         )}

--- a/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
+++ b/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
@@ -52,6 +52,19 @@ describe("clinic encounter workspace", () => {
     expect(workspaceSource).toContain("formatPrice={fmt}");
   });
 
+  it("edits an existing unpaid draft without creating a duplicate invoice", () => {
+    expect(workspaceSource).toContain(
+      "trpc.billing.updateInvoiceItems.useMutation"
+    );
+    expect(workspaceSource).toContain("Loading existing visit charges...");
+    expect(workspaceSource).toContain("Only unpaid");
+    expect(workspaceSource).toContain("Update visit invoice");
+    expect(workspaceSource).toContain(
+      "Product stock is restored and re-deducted atomically"
+    );
+    expect(workspaceSource).toContain("isBillingInvoiceLineTotalValid");
+  });
+
   it("locks charge creation until invoice state is known and surfaces failures", () => {
     expect(workspaceSource).toContain("invoiceStateReady");
     expect(workspaceSource).toContain("Confirming visit invoice state...");

--- a/apps/web/server/__tests__/billing-invoice-integrity.test.ts
+++ b/apps/web/server/__tests__/billing-invoice-integrity.test.ts
@@ -422,6 +422,187 @@ describe("billing invoice integrity", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
+  it("replaces unpaid draft lines and reconciles inventory atomically", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [{ id: PRODUCT_ID }],
+        [{ taxRatePercent: "10.00" }],
+        [
+          {
+            id: INVOICE_ID,
+            paidAmount: "0.00",
+            status: "draft",
+            isEstimate: false,
+          },
+        ],
+        [{ itemType: "product", itemId: PRODUCT_ID, quantity: 1 }],
+      ],
+      updateReturns: [
+        [{ id: PRODUCT_ID, stockQuantity: 9 }],
+        [{ id: PRODUCT_ID, stockQuantity: 6 }],
+        [
+          {
+            id: INVOICE_ID,
+            subtotal: "45.00",
+            tax: "4.50",
+            total: "49.50",
+            status: "draft",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).updateInvoiceItems({
+        id: INVOICE_ID,
+        items: [{ ...productLine, quantity: 3 }],
+      })
+    ).resolves.toMatchObject({
+      id: INVOICE_ID,
+      subtotal: "45.00",
+      tax: "4.50",
+      total: "49.50",
+    });
+
+    expect(db.execute).toHaveBeenCalled();
+    expect(updateSet).toHaveBeenNthCalledWith(1, {
+      stockQuantity: expect.anything(),
+    });
+    expect(updateSet).toHaveBeenNthCalledWith(2, {
+      stockQuantity: expect.anything(),
+    });
+    expect(updateSet).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        subtotal: "45.00",
+        tax: "4.50",
+        total: "49.50",
+      })
+    );
+    expect(updateSet).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        deletedAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      })
+    );
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({
+        invoiceId: INVOICE_ID,
+        itemType: "product",
+        itemId: PRODUCT_ID,
+        quantity: 3,
+        unitPrice: "15.00",
+        total: "45.00",
+      }),
+    ]);
+  });
+
+  it("does not edit a sent invoice or touch its inventory", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [{ id: PRODUCT_ID }],
+        [{ taxRatePercent: "0.00" }],
+        [
+          {
+            id: INVOICE_ID,
+            paidAmount: "0.00",
+            status: "sent",
+            isEstimate: false,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).updateInvoiceItems({
+        id: INVOICE_ID,
+        items: [productLine],
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Only an unpaid draft invoice can have its line items changed.",
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("keeps estimate editing out of the visit-invoice mutation", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [{ taxRatePercent: "0.00" }],
+        [
+          {
+            id: INVOICE_ID,
+            paidAmount: "0.00",
+            status: "draft",
+            isEstimate: true,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).updateInvoiceItems({
+        id: INVOICE_ID,
+        items: [
+          {
+            description: "Exam",
+            quantity: 1,
+            unitPrice: "45.00",
+            itemType: "service",
+          },
+        ],
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Convert or replace the estimate before editing visit invoice charges.",
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("fails a stale draft edit before replacing line items", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [{ taxRatePercent: "0.00" }],
+        [
+          {
+            id: INVOICE_ID,
+            paidAmount: "0.00",
+            status: "draft",
+            isEstimate: false,
+          },
+        ],
+        [],
+      ],
+      updateReturns: [[]],
+    });
+
+    await expect(
+      callerWithDb(db).updateInvoiceItems({
+        id: INVOICE_ID,
+        items: [
+          {
+            description: "Exam",
+            quantity: 1,
+            unitPrice: "45.00",
+            itemType: "service",
+          },
+        ],
+      })
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Invoice state changed while saving charges. Refresh and try again.",
+    });
+
+    expect(updateSet).toHaveBeenCalledTimes(1);
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("deducts product stock when converting an estimate to an invoice", async () => {
     const { db, updateSet } = createDb({
       selectResults: [

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -166,6 +166,31 @@ const createInvoiceInput = z
     }
   });
 
+const updateInvoiceItemsInput = z
+  .object({
+    id: z.string().uuid(),
+    items: z
+      .array(invoiceLineInput)
+      .min(1, "An invoice must include at least one line item.")
+      .max(
+        BILLING_INVOICE_MAX_ITEMS,
+        `Invoices can include at most ${BILLING_INVOICE_MAX_ITEMS} items.`
+      ),
+  })
+  .superRefine((input, ctx) => {
+    const subtotalCents = input.items.reduce(
+      (sum, item) => sum + moneyToCents(item.unitPrice) * item.quantity,
+      0
+    );
+    if (subtotalCents > BILLING_MAX_MONEY_CENTS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["items"],
+        message: "Invoice subtotal must fit a currency amount.",
+      });
+    }
+  });
+
 type InvoiceLineInput = {
   description: string;
   quantity: number;
@@ -1292,6 +1317,130 @@ export const billingRouter = createRouter({
         }
 
         return invoice!;
+      });
+    }),
+
+  updateInvoiceItems: protectedProcedure
+    .use(requireRole("admin", "front_desk"))
+    .input(updateInvoiceItemsInput)
+    .mutation(async ({ ctx, input }) => {
+      await assertLineItemReferences(ctx, input.items);
+
+      const subtotalCents = input.items.reduce(
+        (sum, item) => sum + moneyToCents(item.unitPrice) * item.quantity,
+        0
+      );
+      const [practice] = await ctx.db
+        .select({ taxRatePercent: practices.taxRatePercent })
+        .from(practices)
+        .where(activePracticeWhere(ctx.practiceId))
+        .limit(1);
+      if (!practice) {
+        throw practiceNotFound();
+      }
+
+      const taxRatePercent = Number(practice.taxRatePercent ?? "8.00");
+      const taxCents = Math.round((subtotalCents * taxRatePercent) / 100);
+      const totalCents = subtotalCents + taxCents;
+
+      return ctx.db.transaction(async (tx) => {
+        const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${input.id}, 0))`
+        );
+
+        const [existing] = await tx
+          .select({
+            id: invoices.id,
+            status: invoices.status,
+            isEstimate: invoices.isEstimate,
+            paidAmount: invoices.paidAmount,
+          })
+          .from(invoices)
+          .where(
+            and(
+              eq(invoices.id, input.id),
+              eq(invoices.practiceId, ctx.practiceId),
+              isNull(invoices.deletedAt)
+            )
+          )
+          .limit(1);
+
+        if (!existing) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Invoice not found" });
+        }
+        if (existing.isEstimate) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Convert or replace the estimate before editing visit invoice charges.",
+          });
+        }
+        if (existing.status !== "draft" || moneyToCents(existing.paidAmount) > 0) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Only an unpaid draft invoice can have its line items changed.",
+          });
+        }
+
+        const previousItems = await invoiceProductItemsForStock(txCtx, input.id);
+        await restoreProductStock(txCtx, previousItems);
+        await deductProductStock(txCtx, input.items);
+
+        const [invoice] = await tx
+          .update(invoices)
+          .set({
+            subtotal: centsToMoney(subtotalCents),
+            tax: centsToMoney(taxCents),
+            total: centsToMoney(totalCents),
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(invoices.id, input.id),
+              eq(invoices.practiceId, ctx.practiceId),
+              isNull(invoices.deletedAt),
+              eq(invoices.status, "draft"),
+              eq(invoices.isEstimate, existing.isEstimate),
+              eq(invoices.paidAmount, existing.paidAmount ?? "0.00")
+            )
+          )
+          .returning();
+
+        if (!invoice) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "Invoice state changed while saving charges. Refresh and try again.",
+          });
+        }
+
+        const changedAt = new Date();
+        await tx
+          .update(invoiceItems)
+          .set({ deletedAt: changedAt, updatedAt: changedAt })
+          .where(
+            and(
+              eq(invoiceItems.invoiceId, input.id),
+              invoiceItemPracticeScope(txCtx),
+              isNull(invoiceItems.deletedAt)
+            )
+          );
+
+        await tx.insert(invoiceItems).values(
+          input.items.map((item) => ({
+            invoiceId: input.id,
+            description: item.description,
+            quantity: item.quantity,
+            unitPrice: item.unitPrice,
+            total: centsToMoney(moneyToCents(item.unitPrice) * item.quantity),
+            itemType: item.itemType,
+            itemId: item.itemId ?? null,
+          }))
+        );
+
+        return invoice;
       });
     }),
 


### PR DESCRIPTION
## Outcome

Closes the clinic-day gap where a visit invoice became read-only immediately after charge capture. Admin and front-desk staff can now reopen an unpaid draft from the encounter, correct quantities or prices, remove lines, and add newly discovered services/products before sending it.

## Safety and accounting

- Restricts line-item changes to real, unpaid draft invoices.
- Rejects estimates, sent/paid/overdue/void invoices, cross-tenant invoices, stale state, invalid amounts, invalid catalog references, and empty updates.
- Serializes edits per invoice with a transaction advisory lock.
- Restores previously deducted product stock and deducts the replacement basket in the same transaction.
- Uses optimistic invoice-state conditions so a concurrent send/void loses safely and rolls back inventory changes.
- Soft-deletes replaced lines for auditability instead of overwriting history.
- Recalculates practice tax and totals from validated currency cents.

## Clinic UX

- Loads current visit charges directly into Charge capture.
- Gives visible quantity, unit-price, line-total, and remove controls.
- Supports responsive wrapping for narrow/mobile clinic screens.
- Clearly locks non-draft invoices and explains why.
- Refreshes both visit invoice state and invoice detail after save.

## Validation

- `pnpm type-check`
- `pnpm test` — 260 files / 2,331 tests passed
- Focused billing/encounter suite — 30 tests passed
- `pnpm build`
- `git diff --cached --check`