### PR TITLE
Turn new signups into active clinics

### DIFF
--- a/apps/web/app/(auth)/register/page.tsx
+++ b/apps/web/app/(auth)/register/page.tsx
@@ -34,9 +34,13 @@ import {
   isRequiredAuthTextValid,
 } from "@/lib/auth-input-policy";
 import { isSafeCheckoutRedirectUrl } from "@/lib/checkout-redirect";
-import { acquisitionFromSearchParams } from "@/lib/acquisition";
+import {
+  acquisitionFromSearchParams,
+  acquisitionWithFunnelVisitorId,
+} from "@/lib/acquisition";
 import { FUNNEL_EVENTS } from "@/lib/funnel-analytics";
 import { trackFunnelEvent } from "@/lib/track-funnel-event";
+import { getFunnelVisitorId } from "@/lib/funnel-visitor";
 
 export default function RegisterPage() {
   return (
@@ -146,11 +150,15 @@ function RegisterPageInner() {
     }
     setError("");
     setLoading(true);
+    const registrationAcquisition = acquisitionWithFunnelVisitorId(
+      acquisition,
+      getFunnelVisitorId()
+    );
     registerMutation.mutate({
       email: email.trim().toLowerCase(),
       password,
       practiceName: practiceName.trim(),
-      acquisition,
+      acquisition: registrationAcquisition,
     });
   }
 

--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -662,7 +662,23 @@ export default function AdminPage() {
           <tbody className="divide-y divide-border">
             {data.practices.map((p) => (
               <tr key={p.id} className="hover:bg-muted/20">
-                <td className="px-4 py-2.5 font-medium">{p.name}</td>
+                <td className="px-4 py-2.5">
+                  <p className="font-medium">{p.name}</p>
+                  {p.adminEmail ? (
+                    <a
+                      href={`mailto:${p.adminEmail}`}
+                      className="mt-0.5 block text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                    >
+                      {p.adminName ? `${p.adminName} · ` : ""}
+                      {p.adminEmail}
+                      {!p.adminEmailVerifiedAt ? " · unverified" : ""}
+                    </a>
+                  ) : (
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      No active admin contact
+                    </p>
+                  )}
+                </td>
                 <td className="px-4 py-2.5 capitalize">{p.tier}</td>
                 <td className="px-4 py-2.5">
                   <span
@@ -680,7 +696,12 @@ export default function AdminPage() {
                   {p.onboardingIntent}
                 </td>
                 <td className="px-4 py-2.5 text-muted-foreground">
-                  {p.setupStage}
+                  <p>{p.setupStage}</p>
+                  {p.setupHelpRequestedAt ? (
+                    <p className="mt-0.5 text-xs font-medium text-emerald-700">
+                      Help requested {formatDate(p.setupHelpRequestedAt, p.timezone)}
+                    </p>
+                  ) : null}
                 </td>
                 <td className="px-4 py-2.5">
                   <button

--- a/apps/web/components/dashboard/activation-checklist.tsx
+++ b/apps/web/components/dashboard/activation-checklist.tsx
@@ -7,6 +7,8 @@ import {
   AlertTriangle,
   ArrowRight,
   Check,
+  Headphones,
+  Loader2,
   PartyPopper,
   Sparkles,
   X,
@@ -16,6 +18,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { useTour } from "@/components/tour/tour-provider";
+import { toast } from "sonner";
 import {
   DEFAULT_ONBOARDING_INTENT,
   getOnboardingIntentOption,
@@ -60,6 +63,14 @@ export function ActivationChecklist() {
     opts
   );
   const dismiss = trpc.settings.dismissSetup.useMutation();
+  const utils = trpc.useUtils();
+  const requestSetupHelp = trpc.settings.requestOnboardingHelp.useMutation({
+    onSuccess: async () => {
+      await utils.settings.getOnboardingState.invalidate();
+      toast.success("Setup request received");
+    },
+    onError: (error) => toast.error(error.message),
+  });
 
   if (!isAdmin) return null;
 
@@ -182,10 +193,17 @@ export function ActivationChecklist() {
   const goLiveMilestones: Milestone[] = [
     {
       key: "data",
-      label: "Bring in your real data",
-      hint: "Import a few real clients and pets while you evaluate.",
-      done: onboardingData.hasRealData || !onboardingData.hasDemoData,
-      href: "/settings?tab=data",
+      label: "Add one real client and pet",
+      hint: "Start small: create one client, then add their pet.",
+      done: onboardingData.hasRealData,
+      href: "/clients/new",
+    },
+    {
+      key: "firstAppointment",
+      label: "Book that pet's first appointment",
+      hint: "Put one real appointment on the schedule. Your current PIMS can stay in place.",
+      done: onboardingData.hasRealAppointment,
+      href: "/schedule",
     },
     {
       key: "team",
@@ -207,13 +225,6 @@ export function ActivationChecklist() {
       hint: "Choose a number and submit carrier registration. Approval can take 1–2 weeks.",
       done: textingData.hasAnyNumber,
       href: "/settings?tab=messaging&setup=texting",
-    },
-    {
-      key: "firstAppointment",
-      label: "Run your first real appointment",
-      hint: "Check out one real visit while your current PIMS stays in place as a safety net.",
-      done: onboardingData.hasCompletedRealAppointment,
-      href: "/schedule",
     },
     ...(clientPaymentData.stripeConfigured
       ? [
@@ -278,6 +289,7 @@ export function ActivationChecklist() {
   const doneCount = milestones.filter((m) => m.done).length;
   const pct = total === 0 ? 100 : (doneCount / total) * 100;
   const allDone = doneCount === total;
+  const setupHelpRequestedAt = checklistState.setupHelpRequestedAt ?? null;
 
   // The corner X just hides the checklist for this session — it comes back next
   // visit ("show later"). "Don't show this again" dismisses it for good.
@@ -291,7 +303,7 @@ export function ActivationChecklist() {
 
   if (allDone) {
     return (
-      <div className="fixed bottom-4 right-4 z-[70] hidden w-[340px] sm:block">
+      <div className="relative z-20 w-full sm:fixed sm:bottom-4 sm:right-4 sm:z-[70] sm:w-[340px]">
         <div className="flex items-center gap-3 rounded-2xl border border-zinc-800 bg-zinc-900 p-4 text-zinc-50 shadow-2xl shadow-black/30">
           <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-emerald-500 text-zinc-950">
             <PartyPopper className="h-4 w-4" />
@@ -319,7 +331,7 @@ export function ActivationChecklist() {
   // Docked launcher: a compact dark card pinned bottom-right, out of the way
   // of the day's real work but always one glance from the next setup win.
   return (
-    <div className="fixed bottom-4 right-4 z-[70] hidden w-[340px] sm:block">
+    <div className="relative z-20 w-full sm:fixed sm:bottom-4 sm:right-4 sm:z-[70] sm:w-[340px]">
       <div className="relative rounded-2xl border border-zinc-800 bg-zinc-900 p-4 text-zinc-50 shadow-2xl shadow-black/30">
         <button
           type="button"
@@ -404,7 +416,27 @@ export function ActivationChecklist() {
           })}
         </div>
 
-        <div className="mt-3 flex justify-end border-t border-zinc-800 pt-2.5">
+        <div className="mt-3 flex items-center justify-between gap-3 border-t border-zinc-800 pt-2.5">
+          {setupHelpRequestedAt ? (
+            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-400">
+              <Check className="h-3.5 w-3.5" />
+              Setup help requested
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={() => requestSetupHelp.mutate()}
+              disabled={requestSetupHelp.isPending}
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-400 transition-colors hover:text-emerald-300 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {requestSetupHelp.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Headphones className="h-3.5 w-3.5" />
+              )}
+              Help me set this up
+            </button>
+          )}
           <button
             type="button"
             onClick={dontShowAgain}
@@ -417,7 +449,6 @@ export function ActivationChecklist() {
     </div>
   );
 }
-
 function ActivationChecklistLoading() {
   // The docked card simply appears once its data is ready; a floating
   // skeleton in the corner would only draw the eye to nothing.
@@ -432,7 +463,7 @@ function ActivationChecklistError({
   onRetry: () => void;
 }) {
   return (
-    <div className="fixed bottom-4 right-4 z-[70] hidden w-[340px] sm:block">
+    <div className="relative z-20 w-full sm:fixed sm:bottom-4 sm:right-4 sm:z-[70] sm:w-[340px]">
       <div className="flex items-start gap-3 rounded-2xl border border-zinc-800 bg-zinc-900 p-4 text-zinc-50 shadow-2xl shadow-black/30">
         <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
         <div className="min-w-0 flex-1">

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,81 @@
+import type { Instrumentation } from "next";
+
+const REQUEST_ERROR_DEDUPE_MS = 60_000;
+const MAX_RECENT_REQUEST_ERRORS = 100;
+const recentRequestErrors = new Map<string, number>();
+
+function errorFingerprint(
+  error: Error & { digest?: string },
+  routePath: string,
+  routeType: string
+): string {
+  return [error.digest ?? error.message, routePath, routeType].join(":");
+}
+
+function shouldReportRequestError(key: string, now = Date.now()): boolean {
+  const previous = recentRequestErrors.get(key);
+  if (previous !== undefined && now - previous < REQUEST_ERROR_DEDUPE_MS) {
+    return false;
+  }
+
+  recentRequestErrors.set(key, now);
+  if (recentRequestErrors.size > MAX_RECENT_REQUEST_ERRORS) {
+    for (const [candidate, reportedAt] of recentRequestErrors) {
+      if (now - reportedAt >= REQUEST_ERROR_DEDUPE_MS) {
+        recentRequestErrors.delete(candidate);
+      }
+    }
+    while (recentRequestErrors.size > MAX_RECENT_REQUEST_ERRORS) {
+      const oldest = recentRequestErrors.keys().next().value;
+      if (oldest === undefined) break;
+      recentRequestErrors.delete(oldest);
+    }
+  }
+  return true;
+}
+
+export const onRequestError: Instrumentation.onRequestError = async (
+  error,
+  request,
+  context
+) => {
+  const normalizedError =
+    error instanceof Error ? error : new Error("Unhandled request error");
+  const digest =
+    typeof error === "object" &&
+    error !== null &&
+    "digest" in error &&
+    typeof error.digest === "string"
+      ? error.digest
+      : undefined;
+  const reportableError = Object.assign(normalizedError, { digest });
+  const key = errorFingerprint(
+    reportableError,
+    context.routePath,
+    context.routeType
+  );
+  if (!shouldReportRequestError(key)) return;
+
+  // The ops alert implementation is intentionally Node-only. Edge failures
+  // remain visible in Vercel logs without pulling Node dependencies into an
+  // Edge bundle.
+  if (process.env.NEXT_RUNTIME === "edge") {
+    console.error(
+      `[next-request-error] ${context.routeType} ${context.routePath} digest=${digest ?? "unavailable"}`
+    );
+    return;
+  }
+
+  const { captureException } = await import("@/lib/error-tracking");
+  await captureException({
+    source: `next-${context.routeType}`,
+    message: normalizedError.message || "Unhandled request error",
+    stack: normalizedError.stack ?? null,
+    digest: digest ?? null,
+    path: request.path,
+  });
+};
+
+export function resetRequestErrorDedupeForTests(): void {
+  if (process.env.NODE_ENV === "test") recentRequestErrors.clear();
+}

--- a/apps/web/lib/__tests__/acquisition.test.ts
+++ b/apps/web/lib/__tests__/acquisition.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   ACQUISITION_VALUE_MAX_LENGTH,
   acquisitionFromSearchParams,
+  acquisitionWithFunnelVisitorId,
 } from "@/lib/acquisition";
 
 describe("signup acquisition", () => {
@@ -49,5 +50,49 @@ describe("signup acquisition", () => {
       utm_campaign: "x".repeat(ACQUISITION_VALUE_MAX_LENGTH + 1),
     });
     expect(acquisitionFromSearchParams(params)).toBeUndefined();
+  });
+
+  it("uses a first-party visitor id when the registration URL has none", () => {
+    expect(
+      acquisitionWithFunnelVisitorId(
+        undefined,
+        "123E4567-E89B-42D3-A456-426614174000"
+      )
+    ).toEqual({
+      funnelId: "123e4567-e89b-42d3-a456-426614174000",
+    });
+
+    expect(
+      acquisitionWithFunnelVisitorId(
+        { source: "direct", campaign: "register" },
+        "123E4567-E89B-42D3-A456-426614174000"
+      )
+    ).toEqual({
+      source: "direct",
+      campaign: "register",
+      funnelId: "123e4567-e89b-42d3-a456-426614174000",
+    });
+  });
+
+  it("preserves explicit cross-domain attribution over a local fallback", () => {
+    expect(
+      acquisitionWithFunnelVisitorId(
+        {
+          source: "marketing",
+          funnelId: "123e4567-e89b-42d3-a456-426614174000",
+        },
+        "223e4567-e89b-42d3-a456-426614174000"
+      )
+    ).toEqual({
+      source: "marketing",
+      funnelId: "123e4567-e89b-42d3-a456-426614174000",
+    });
+  });
+
+  it("does not persist malformed fallback identities", () => {
+    expect(
+      acquisitionWithFunnelVisitorId({ source: "direct" }, "not-a-uuid")
+    ).toEqual({ source: "direct" });
+    expect(acquisitionWithFunnelVisitorId(undefined, null)).toBeUndefined();
   });
 });

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -62,12 +62,15 @@ describe("admin UI", () => {
     expect(source).toContain("{p.acquisitionSource}");
     expect(source).toContain("{p.onboardingIntent}");
     expect(source).toContain("{p.setupStage}");
+    expect(source).toContain("{p.setupHelpRequestedAt ? (");
     expect(source).toContain(">Source</th>");
     expect(source).toContain(">Intent</th>");
     expect(source).toContain(">Setup</th>");
     expect(source).toContain(">Metrics</th>");
     expect(source).toContain("setAnalyticsExcluded.mutate({");
     expect(source).toContain('{p.analyticsExcluded ? "Excluded" : "Exclude"}');
+    expect(source).toContain('href={`mailto:${p.adminEmail}`}');
+    expect(source).toContain('!p.adminEmailVerifiedAt ? " · unverified" : ""');
   });
 
   it("renders practice dates in each practice timezone", () => {

--- a/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
@@ -52,7 +52,7 @@ describe("dashboard onboarding UI states", () => {
     );
     expect(activationSource).toContain("done: !!practiceData.logoUrl || !!brandColor");
     expect(activationSource).toContain(
-      "done: onboardingData.hasRealData || !onboardingData.hasDemoData"
+      "done: onboardingData.hasRealData"
     );
     expect(activationSource).toContain('label: "Publish online booking"');
     expect(activationSource).toContain(
@@ -60,11 +60,13 @@ describe("dashboard onboarding UI states", () => {
     );
     expect(activationSource).toContain('label: "Start texting registration"');
     expect(activationSource).toContain("done: textingData.hasAnyNumber");
+    expect(activationSource).toContain('label: "Add one real client and pet"');
+    expect(activationSource).toContain('href: "/clients/new"');
     expect(activationSource).toContain(
-      'label: "Run your first real appointment"'
+      'label: "Book that pet\'s first appointment"'
     );
     expect(activationSource).toContain(
-      "done: onboardingData.hasCompletedRealAppointment"
+      "done: onboardingData.hasRealAppointment"
     );
     expect(activationSource).toContain('label: "Set up client card payments"');
     expect(activationSource).toContain("done: clientPaymentData.enabled");
@@ -122,6 +124,25 @@ describe("dashboard onboarding UI states", () => {
     expect(activationSource).toContain("label: pathway.firstWin");
     expect(activationSource).toContain("hint: pathway.firstWinHint");
     expect(activationSource).toContain("{pathway.shortLabel} · {doneCount}");
+  });
+
+  it("turns the activation checklist into a mobile first-win path with a persisted help request", () => {
+    expect(activationSource).toContain(
+      "trpc.settings.requestOnboardingHelp.useMutation"
+    );
+    expect(activationSource).toContain("Help me set this up");
+    expect(activationSource).toContain("Setup help requested");
+    expect(activationSource).toContain("setupHelpRequestedAt");
+    expect(activationSource).toContain(
+      "relative z-20 w-full sm:fixed sm:bottom-4"
+    );
+    expect(activationSource).not.toContain(
+      "fixed bottom-4 right-4 z-[70] hidden"
+    );
+    expect(settingsRouter).toContain(
+      "requestOnboardingHelp: adminProcedure.mutation"
+    );
+    expect(settingsRouter).toContain('"Hands-on onboarding requested"');
   });
 
   it("auto-opens the wizard for unfinished, non-dismissed onboarding and resumes durably", () => {

--- a/apps/web/lib/__tests__/demo-conversion-ui.test.ts
+++ b/apps/web/lib/__tests__/demo-conversion-ui.test.ts
@@ -27,6 +27,9 @@ describe("demo conversion bridge UI", () => {
   it("tracks signup land with acquisition context", () => {
     expect(register).toContain("FUNNEL_EVENTS.signupLand");
     expect(register).toContain("acquisition?.source");
+    expect(register).toContain("acquisitionWithFunnelVisitorId");
+    expect(register).toContain("getFunnelVisitorId()");
+    expect(register).toContain("acquisition: registrationAcquisition");
   });
 
   it("mounts the demo bar and path tracker in the dashboard shell", () => {

--- a/apps/web/lib/__tests__/funnel-events-server.test.ts
+++ b/apps/web/lib/__tests__/funnel-events-server.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const selectResults: unknown[][] = [];
+  const select = vi.fn(() => {
+    const result = selectResults.shift() ?? [];
+    const builder = {
+      from: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      limit: vi.fn(async () => result),
+    };
+    return builder;
+  });
+
+  const insertResults: unknown[][] = [];
+  const returning = vi.fn(async () => insertResults.shift() ?? [{ id: "event" }]);
+  const onConflictDoNothing = vi.fn(() => ({ returning }));
+  const values = vi.fn(() => ({ onConflictDoNothing }));
+  const insert = vi.fn(() => ({ values }));
+
+  return {
+    db: { select, insert },
+    selectResults,
+    insertResults,
+    select,
+    insert,
+    values,
+    onConflictDoNothing,
+    returning,
+  };
+});
+
+const {
+  ensureRegistrationFirstTouch,
+  recordPracticeFunnelStage,
+} = await import("../funnel-events-server");
+
+const VISITOR_ID = "123e4567-e89b-42d3-a456-426614174000";
+const PRACTICE_ID = "323e4567-e89b-42d3-a456-426614174000";
+const CREATED_AT = new Date("2026-08-07T15:00:00.000Z");
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mocks.selectResults.length = 0;
+  mocks.insertResults.length = 0;
+});
+
+describe("registration funnel attribution", () => {
+  it("does not duplicate an existing first-party touch", async () => {
+    mocks.selectResults.push([{ id: "touch" }]);
+
+    await expect(
+      ensureRegistrationFirstTouch(mocks.db as never, {
+        anonymousId: VISITOR_ID,
+        source: "marketing",
+        createdAt: CREATED_AT,
+      })
+    ).resolves.toBe(false);
+
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("creates a privacy-bounded signup touch when browser telemetry is absent", async () => {
+    mocks.selectResults.push([]);
+
+    await expect(
+      ensureRegistrationFirstTouch(mocks.db as never, {
+        anonymousId: VISITOR_ID,
+        source: "direct",
+        createdAt: CREATED_AT,
+      })
+    ).resolves.toBe(true);
+
+    expect(mocks.values).toHaveBeenCalledWith({
+      eventName: "signup_land",
+      anonymousId: VISITOR_ID,
+      practiceId: null,
+      source: "direct",
+      path: "/register",
+      origin: null,
+      metadata: { serverFallback: true },
+      createdAt: CREATED_AT,
+    });
+  });
+
+  it("normalizes the UUID and links registration to the fallback touch", async () => {
+    mocks.selectResults.push(
+      [
+        {
+          settings: {
+            acquisition: {
+              funnelId: VISITOR_ID.toUpperCase(),
+              source: "homepage",
+            },
+          },
+          createdAt: CREATED_AT,
+        },
+      ],
+      []
+    );
+
+    await expect(
+      recordPracticeFunnelStage(
+        mocks.db as never,
+        PRACTICE_ID,
+        "registration"
+      )
+    ).resolves.toBe(true);
+
+    expect(mocks.values).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        eventName: "signup_land",
+        anonymousId: VISITOR_ID,
+        metadata: { serverFallback: true },
+      })
+    );
+    expect(mocks.values).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        eventName: "registration",
+        anonymousId: VISITOR_ID,
+        practiceId: PRACTICE_ID,
+      })
+    );
+  });
+
+  it("does not invent an anonymous identity for historical registrations", async () => {
+    mocks.selectResults.push([
+      { settings: {}, createdAt: CREATED_AT },
+    ]);
+
+    await expect(
+      recordPracticeFunnelStage(
+        mocks.db as never,
+        PRACTICE_ID,
+        "registration"
+      )
+    ).resolves.toBe(true);
+
+    expect(mocks.select).toHaveBeenCalledOnce();
+    expect(mocks.values).toHaveBeenCalledOnce();
+    expect(mocks.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventName: "registration",
+        anonymousId: null,
+        practiceId: PRACTICE_ID,
+      })
+    );
+  });
+});

--- a/apps/web/lib/__tests__/funnel-visitor.test.ts
+++ b/apps/web/lib/__tests__/funnel-visitor.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const VISITOR_ID = "123e4567-e89b-42d3-a456-426614174000";
+const SECOND_VISITOR_ID = "223e4567-e89b-42d3-a456-426614174000";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe("funnel visitor identity", () => {
+  it("reuses one volatile UUID when privacy settings block local storage", async () => {
+    const randomUUID = vi
+      .fn()
+      .mockReturnValueOnce(VISITOR_ID)
+      .mockReturnValueOnce(SECOND_VISITOR_ID);
+    vi.stubGlobal("crypto", { randomUUID });
+    vi.stubGlobal("window", {
+      location: { search: "" },
+      localStorage: {
+        getItem: vi.fn(() => {
+          throw new Error("blocked");
+        }),
+        setItem: vi.fn(() => {
+          throw new Error("blocked");
+        }),
+      },
+    });
+
+    const { getFunnelVisitorId } = await import("../funnel-visitor");
+
+    expect(getFunnelVisitorId()).toBe(VISITOR_ID);
+    expect(getFunnelVisitorId()).toBe(VISITOR_ID);
+    expect(randomUUID).toHaveBeenCalledOnce();
+  });
+
+  it("lets a valid URL identity override a stale local value", async () => {
+    const setItem = vi.fn();
+    vi.stubGlobal("window", {
+      location: { search: `?funnel_id=${VISITOR_ID}` },
+      localStorage: {
+        getItem: vi.fn(() => SECOND_VISITOR_ID),
+        setItem,
+      },
+    });
+
+    const { getFunnelVisitorId } = await import("../funnel-visitor");
+
+    expect(getFunnelVisitorId()).toBe(VISITOR_ID);
+    expect(setItem).toHaveBeenCalledWith("openvpm_funnel_id", VISITOR_ID);
+  });
+});

--- a/apps/web/lib/__tests__/instrumentation.test.ts
+++ b/apps/web/lib/__tests__/instrumentation.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  captureException: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/error-tracking", () => ({
+  captureException: mocks.captureException,
+}));
+
+const { onRequestError, resetRequestErrorDedupeForTests } = await import(
+  "../../instrumentation"
+);
+
+const request = {
+  path: "/patients/00000000-0000-4000-8000-000000000001?tab=chart",
+  method: "GET",
+  headers: {},
+};
+
+const context = {
+  routerKind: "App Router" as const,
+  routePath: "/patients/[id]",
+  routeType: "render" as const,
+  renderSource: "server-rendering" as const,
+  revalidateReason: undefined,
+  renderType: "dynamic" as const,
+};
+
+afterEach(() => {
+  resetRequestErrorDedupeForTests();
+  vi.clearAllMocks();
+});
+
+describe("Next request error instrumentation", () => {
+  it("forwards request failures through the privacy-safe ops reporter", async () => {
+    const error = Object.assign(new Error("database unavailable"), {
+      digest: "request-digest",
+    });
+
+    await onRequestError(error, request, context);
+
+    expect(mocks.captureException).toHaveBeenCalledWith({
+      source: "next-render",
+      message: "database unavailable",
+      stack: expect.any(String),
+      digest: "request-digest",
+      path: request.path,
+    });
+  });
+
+  it("deduplicates an alert storm for the same error and route", async () => {
+    const error = Object.assign(new Error("database unavailable"), {
+      digest: "same-digest",
+    });
+
+    await onRequestError(error, request, context);
+    await onRequestError(error, request, context);
+
+    expect(mocks.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps distinct routes independently observable", async () => {
+    const error = Object.assign(new Error("database unavailable"), {
+      digest: "shared-digest",
+    });
+
+    await onRequestError(error, request, context);
+    await onRequestError(error, request, {
+      ...context,
+      routePath: "/invoices/[id]",
+    });
+
+    expect(mocks.captureException).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/acquisition.ts
+++ b/apps/web/lib/acquisition.ts
@@ -1,5 +1,8 @@
 export const ACQUISITION_VALUE_MAX_LENGTH = 80;
 
+const FUNNEL_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export interface SignupAcquisition {
   source?: string;
   medium?: string;
@@ -26,10 +29,7 @@ export function acquisitionFromSearchParams(
   const campaign = clean(params.get("utm_campaign"));
   const funnelId = clean(params.get("funnel_id"));
   const validFunnelId =
-    funnelId &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-      funnelId
-    )
+    funnelId && FUNNEL_ID_RE.test(funnelId)
       ? funnelId.toLowerCase()
       : undefined;
   if (!source && !medium && !campaign && !validFunnelId) return undefined;
@@ -38,5 +38,27 @@ export function acquisitionFromSearchParams(
     medium,
     campaign,
     ...(validFunnelId ? { funnelId: validFunnelId } : {}),
+  };
+}
+
+/**
+ * Attach the first-party visitor UUID when signup did not arrive with one in
+ * the URL. Explicit cross-domain attribution always wins. Invalid values are
+ * ignored, and no identity or contact data is introduced.
+ */
+export function acquisitionWithFunnelVisitorId(
+  acquisition: SignupAcquisition | undefined,
+  visitorId: string | null | undefined
+): SignupAcquisition | undefined {
+  if (acquisition?.funnelId) return acquisition;
+
+  const normalizedVisitorId = visitorId?.trim().toLowerCase();
+  if (!normalizedVisitorId || !FUNNEL_ID_RE.test(normalizedVisitorId)) {
+    return acquisition;
+  }
+
+  return {
+    ...acquisition,
+    funnelId: normalizedVisitorId,
   };
 }

--- a/apps/web/lib/funnel-events-server.ts
+++ b/apps/web/lib/funnel-events-server.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Database } from "@openpims/db/client";
 import { funnelEvents, practices } from "@openpims/db";
 import { withSystem } from "@/lib/tenant-db";
@@ -21,6 +21,12 @@ type FunnelPracticeSettings = {
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const FIRST_TOUCH_EVENT_NAMES = [
+  "visit",
+  "demo_land",
+  "demo_gate_viewed",
+  "signup_land",
+];
 
 export async function insertFunnelEvent(
   db: Database,
@@ -54,6 +60,44 @@ export async function insertFunnelEvent(
   return rows.length > 0;
 }
 
+/**
+ * Browser telemetry is best-effort and can be blocked. Registration itself
+ * proves the visitor reached /register, so add a minimal server-owned touch
+ * only when that anonymous UUID has no earlier first-party touch. The UUID,
+ * coarse route, and acquisition source are the complete payload—never contact
+ * or clinic data.
+ */
+export async function ensureRegistrationFirstTouch(
+  db: Database,
+  input: {
+    anonymousId: string;
+    source?: string | null;
+    createdAt: Date;
+  }
+): Promise<boolean> {
+  const [existing] = await db
+    .select({ id: funnelEvents.id })
+    .from(funnelEvents)
+    .where(
+      and(
+        eq(funnelEvents.anonymousId, input.anonymousId),
+        inArray(funnelEvents.eventName, FIRST_TOUCH_EVENT_NAMES),
+        isNull(funnelEvents.deletedAt)
+      )
+    )
+    .limit(1);
+  if (existing) return false;
+
+  return insertFunnelEvent(db, {
+    eventName: "signup_land",
+    anonymousId: input.anonymousId,
+    source: input.source ?? null,
+    path: "/register",
+    metadata: { serverFallback: true },
+    createdAt: input.createdAt,
+  });
+}
+
 export async function recordPracticeFunnelStage(
   db: Database,
   practiceId: string,
@@ -73,10 +117,20 @@ export async function recordPracticeFunnelStage(
   const settings = (practice.settings ?? {}) as FunnelPracticeSettings;
   const acquisition = settings.acquisition;
   const funnelId = acquisition?.funnelId?.trim();
+  const anonymousId =
+    funnelId && UUID_RE.test(funnelId) ? funnelId.toLowerCase() : null;
+
+  if (eventName === "registration" && anonymousId) {
+    await ensureRegistrationFirstTouch(db, {
+      anonymousId,
+      source: acquisition?.source ?? null,
+      createdAt: practice.createdAt,
+    });
+  }
 
   return insertFunnelEvent(db, {
     eventName,
-    anonymousId: funnelId && UUID_RE.test(funnelId) ? funnelId : null,
+    anonymousId,
     practiceId,
     source: acquisition?.source ?? null,
     metadata,

--- a/apps/web/lib/funnel-visitor.ts
+++ b/apps/web/lib/funnel-visitor.ts
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 const FUNNEL_VISITOR_STORAGE_KEY = "openvpm_funnel_id";
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+let volatileFunnelVisitorId: string | null = null;
 
 export function validFunnelVisitorId(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
@@ -18,6 +19,7 @@ export function getFunnelVisitorId(): string | null {
     new URLSearchParams(window.location.search).get("funnel_id")
   );
   if (fromUrl) {
+    volatileFunnelVisitorId = fromUrl;
     try {
       window.localStorage.setItem(FUNNEL_VISITOR_STORAGE_KEY, fromUrl);
     } catch {
@@ -30,13 +32,21 @@ export function getFunnelVisitorId(): string | null {
     const stored = validFunnelVisitorId(
       window.localStorage.getItem(FUNNEL_VISITOR_STORAGE_KEY)
     );
-    if (stored) return stored;
+    if (stored) {
+      volatileFunnelVisitorId = stored;
+      return stored;
+    }
   } catch {
-    // Fall through to an in-memory id for this page.
+    // Fall through to the in-memory id for this page.
   }
 
-  const generated = globalThis.crypto?.randomUUID?.() ?? null;
+  if (volatileFunnelVisitorId) return volatileFunnelVisitorId;
+
+  const generated = validFunnelVisitorId(
+    globalThis.crypto?.randomUUID?.() ?? null
+  );
   if (!generated) return null;
+  volatileFunnelVisitorId = generated;
   try {
     window.localStorage.setItem(FUNNEL_VISITOR_STORAGE_KEY, generated);
   } catch {

--- a/apps/web/server/__tests__/admin-overview.test.ts
+++ b/apps/web/server/__tests__/admin-overview.test.ts
@@ -88,6 +88,7 @@ describe("admin overview", () => {
               onboardingIntent: "alongside",
               journeyStepId: "data",
               journeyDismissed: true,
+              setupHelpRequestedAt: "2026-06-15T12:00:00.000Z",
             },
           },
         },
@@ -95,7 +96,16 @@ describe("admin overview", () => {
       [{ practiceId: PRACTICE_ID, c: 3 }],
       [{ practiceId: PRACTICE_ID, c: 25 }],
       [{ practiceId: PRACTICE_ID, c: 40 }],
-      [{ practiceId: PRACTICE_ID, c: 2 }]
+      [{ practiceId: PRACTICE_ID, c: 2 }],
+      [
+        {
+          practiceId: PRACTICE_ID,
+          name: "Clinic Owner",
+          email: "owner@westside.example",
+          emailVerifiedAt: new Date("2026-06-01T03:00:00.000Z"),
+          createdAt: new Date("2026-06-01T02:00:00.000Z"),
+        },
+      ]
     );
 
     const result = await caller().overview();
@@ -107,14 +117,65 @@ describe("admin overview", () => {
       locationCount: 2,
       clientCount: 25,
       patientCount: 40,
+      adminName: "Clinic Owner",
+      adminEmail: "owner@westside.example",
+      adminEmailVerifiedAt: new Date("2026-06-01T03:00:00.000Z"),
       acquisitionSource: "homepage_hero · summer_launch",
       onboardingIntent: "Alongside current PIMS",
       analyticsExcluded: true,
       setupStage: "Paused at Data import",
+      setupHelpRequestedAt: "2026-06-15T12:00:00.000Z",
     });
     expect(mocks.withSystem).toHaveBeenCalledWith(
       mocks.db,
       expect.any(Function)
     );
+  });
+
+  it("uses the first admin as the practice activation contact", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.selectResults.push(
+      [
+        {
+          id: PRACTICE_ID,
+          name: "Westside Vet",
+          tier: "free",
+          billingStatus: "trialing",
+          trialEndsAt: null,
+          timezone: "UTC",
+          country: "US",
+          createdAt: new Date("2026-06-01T02:00:00.000Z"),
+          settings: {},
+        },
+      ],
+      [{ practiceId: PRACTICE_ID, c: 2 }],
+      [],
+      [],
+      [],
+      [
+        {
+          practiceId: PRACTICE_ID,
+          name: "First Admin",
+          email: "first@example.com",
+          emailVerifiedAt: null,
+          createdAt: new Date("2026-06-01T02:00:00.000Z"),
+        },
+        {
+          practiceId: PRACTICE_ID,
+          name: "Second Admin",
+          email: "second@example.com",
+          emailVerifiedAt: new Date("2026-06-02T02:00:00.000Z"),
+          createdAt: new Date("2026-06-02T02:00:00.000Z"),
+        },
+      ]
+    );
+
+    const result = await caller().overview();
+
+    expect(result.practices[0]).toMatchObject({
+      adminName: "First Admin",
+      adminEmail: "first@example.com",
+      adminEmailVerifiedAt: null,
+    });
   });
 });

--- a/apps/web/server/__tests__/settings-onboarding-help.test.ts
+++ b/apps/web/server/__tests__/settings-onboarding-help.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  alertOps: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/alerts", () => ({
+  alertOps: mocks.alertOps,
+}));
+
+vi.mock("@/lib/billing/subscription-sync", () => ({
+  syncPracticeSubscriptionQuantities: vi.fn(async () => ({
+    status: "ok",
+    message: "synced",
+    updatedAt: new Date("2026-08-07T00:00:00.000Z").toISOString(),
+    locationCount: 1,
+    billableSeatCount: 1,
+  })),
+}));
+
+const { settingsRouter } = await import("../routers/settings");
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+
+function callerWithRole(db: Record<string, unknown>, role = "admin") {
+  return settingsRouter.createCaller({
+    db,
+    session: {
+      user: {
+        id: USER_ID,
+        email: "owner@example.com",
+        name: "Owner",
+        role,
+        practiceId: PRACTICE_ID,
+      },
+    },
+  } as never);
+}
+
+function createDb(opts: { practiceRows: unknown[]; updatedRows?: unknown[] }) {
+  const select = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        limit: vi.fn(async () => opts.practiceRows),
+      })),
+    })),
+  }));
+  const updateReturning = vi.fn(async () => opts.updatedRows ?? []);
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+  const db: Record<string, unknown> = {
+    select,
+    update,
+    execute: vi.fn(async () => undefined),
+  };
+  db.transaction = async (fn: (tx: unknown) => unknown) => fn(db);
+
+  return { db, select, updateSet };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("settings.requestOnboardingHelp", () => {
+  it("persists an admin's request and notifies operations", async () => {
+    const { db, updateSet } = createDb({
+      practiceRows: [{ name: "Aspen Creek Animal Hospital", settings: {} }],
+      updatedRows: [{ id: PRACTICE_ID }],
+    });
+
+    const result = await callerWithRole(db).requestOnboardingHelp();
+
+    expect(result.requestedAt).toEqual(expect.any(String));
+    expect(updateSet).toHaveBeenCalledTimes(1);
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Hands-on onboarding requested",
+      expect.stringContaining(`practice=${PRACTICE_ID}`),
+    );
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Hands-on onboarding requested",
+      expect.stringContaining("requestedBy=owner@example.com"),
+    );
+  });
+
+  it("returns an existing request without writing or alerting twice", async () => {
+    const requestedAt = "2026-08-07T12:00:00.000Z";
+    const { db, updateSet } = createDb({
+      practiceRows: [
+        {
+          name: "Aspen Creek Animal Hospital",
+          settings: { onboardingState: { setupHelpRequestedAt: requestedAt } },
+        },
+      ],
+    });
+
+    await expect(callerWithRole(db).requestOnboardingHelp()).resolves.toEqual({
+      requestedAt,
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+
+  it("keeps the request admin-only", async () => {
+    const { db, select, updateSet } = createDb({ practiceRows: [] });
+
+    await expect(
+      callerWithRole(db, "front_desk").requestOnboardingHelp(),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(select).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+
+  it("does not create a request for a missing or deleted practice", async () => {
+    const { db, updateSet } = createDb({ practiceRows: [] });
+
+    await expect(
+      callerWithRole(db).requestOnboardingHelp(),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -269,6 +269,7 @@ type AdminPracticeSettings = {
     onboardingIntent?: OnboardingIntent;
     journeyStepId?: string | null;
     journeyDismissed?: boolean;
+    setupHelpRequestedAt?: string | null;
   };
 };
 
@@ -293,12 +294,14 @@ function conversionContext(value: unknown) {
   const state = settings.onboardingState;
   const onboardingIntent = onboardingIntentLabel(state?.onboardingIntent);
   const analyticsExcluded = settings.analyticsExcluded === true;
+  const setupHelpRequestedAt = state?.setupHelpRequestedAt ?? null;
 
   if (settings.onboardingCompletedAt) {
     return {
       acquisitionSource,
       onboardingIntent,
       analyticsExcluded,
+      setupHelpRequestedAt,
       setupStage: "Complete",
     };
   }
@@ -309,6 +312,7 @@ function conversionContext(value: unknown) {
       acquisitionSource,
       onboardingIntent,
       analyticsExcluded,
+      setupHelpRequestedAt,
       setupStage: state?.journeyDismissed ? `Paused at ${label}` : label,
     };
   }
@@ -316,6 +320,7 @@ function conversionContext(value: unknown) {
     acquisitionSource,
     onboardingIntent,
     analyticsExcluded,
+    setupHelpRequestedAt,
     setupStage: "Not started",
   };
 }
@@ -360,16 +365,38 @@ export const adminRouter = createRouter({
       return new Map(res.map((r) => [r.practiceId, Number(r.c)]));
     };
 
-    const [userCounts, clientCounts, patientCounts, locationCounts] =
+    const [userCounts, clientCounts, patientCounts, locationCounts, adminRows] =
       await Promise.all([
         countBy(users),
         countBy(clients),
         countBy(patients),
         countBy(locations),
+        tx
+          .select({
+            practiceId: users.practiceId,
+            name: users.name,
+            email: users.email,
+            emailVerifiedAt: users.emailVerifiedAt,
+            createdAt: users.createdAt,
+          })
+          .from(users)
+          .where(and(eq(users.role, "admin"), isNull(users.deletedAt)))
+          .orderBy(users.practiceId, users.createdAt),
       ]);
+
+    const primaryAdminByPractice = new Map<
+      string,
+      (typeof adminRows)[number]
+    >();
+    for (const admin of adminRows) {
+      if (!primaryAdminByPractice.has(admin.practiceId)) {
+        primaryAdminByPractice.set(admin.practiceId, admin);
+      }
+    }
 
     const practiceRows = rows.map((p) => {
       const { settings, ...practice } = p;
+      const primaryAdmin = primaryAdminByPractice.get(p.id);
       const userCount = userCounts.get(p.id) ?? 0;
       const locationCount = Math.max(1, locationCounts.get(p.id) ?? 0);
       const estimatedMrr =
@@ -385,6 +412,9 @@ export const adminRouter = createRouter({
         estimatedMrr,
         clientCount: clientCounts.get(p.id) ?? 0,
         patientCount: patientCounts.get(p.id) ?? 0,
+        adminName: primaryAdmin?.name ?? null,
+        adminEmail: primaryAdmin?.email ?? null,
+        adminEmailVerifiedAt: primaryAdmin?.emailVerifiedAt ?? null,
       };
     });
 

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -276,6 +276,10 @@ interface PracticeSettings {
     journeyStepId?: string | null;
     /** "I'll finish later" — suppresses auto-open without completing onboarding. */
     journeyDismissed?: boolean;
+    /** A clinic-admin request for an OpenVPM-assisted first setup session. */
+    setupHelpRequestedAt?: string;
+    setupHelpRequestedByUserId?: string;
+    setupHelpRequestedByEmail?: string;
   };
   accountDeletionRequest?: {
     status: "requested";
@@ -1082,6 +1086,57 @@ export const settingsRouter = createRouter({
       }
       return { ok: true };
     }),
+
+  /**
+   * Let a stalled clinic ask for hands-on setup without leaving the product.
+   * The durable marker makes retries idempotent and keeps the request visible
+   * even if the optional ops-alert webhook is temporarily unavailable.
+   */
+  requestOnboardingHelp: adminProcedure.mutation(async ({ ctx }) => {
+    const [practice] = await ctx.db
+      .select({ name: practices.name, settings: practices.settings })
+      .from(practices)
+      .where(activePracticeWhere(ctx.practiceId))
+      .limit(1);
+    if (!practice) {
+      throw practiceNotFound();
+    }
+
+    const settings = (practice.settings ?? {}) as PracticeSettings;
+    const existingRequestedAt =
+      settings.onboardingState?.setupHelpRequestedAt;
+    if (existingRequestedAt) {
+      return { requestedAt: existingRequestedAt };
+    }
+
+    const requestedAt = new Date().toISOString();
+    const [updated] = await ctx.db
+      .update(practices)
+      .set({
+        settings: onboardingStateMergePatch({
+          setupHelpRequestedAt: requestedAt,
+          setupHelpRequestedByUserId: ctx.user.id,
+          setupHelpRequestedByEmail: ctx.user.email,
+        }),
+      })
+      .where(activePracticeWhere(ctx.practiceId))
+      .returning({ id: practices.id });
+    if (!updated) {
+      throw practiceNotFound();
+    }
+
+    await alertOps(
+      "Hands-on onboarding requested",
+      [
+        `practice=${ctx.practiceId}`,
+        `practiceName=${practice.name}`,
+        `requestedBy=${ctx.user.email}`,
+        `requestedAt=${requestedAt}`,
+      ].join(" ")
+    );
+
+    return { requestedAt };
+  }),
 
   /** Dismiss the dashboard "finish setup" card. */
   dismissSetup: adminProcedure.mutation(async ({ ctx }) => {


### PR DESCRIPTION
## Outcome

Turns the measured signup-to-activation gap into an explicit first-win workflow while making assisted activation and failures actionable for the operator.

## Clinic conversion

- Reorders the activation checklist around one real client/pet and one real appointment, matching the production activation definition.
- Makes the checklist available on mobile.
- Adds one-click, admin-only `Help me set this up` with a durable idempotent request and a single ops alert.
- Shows help requests and the primary clinic-admin contact/verification state in the platform admin view.

## Funnel integrity

- Persists the first-party visitor UUID on direct registration even without URL attribution.
- Keeps an explicit cross-domain `funnel_id` authoritative.
- Reuses an in-memory UUID when privacy settings block local storage.
- Adds a minimal server-owned `signup_land` only when registration has an anonymous UUID but browser telemetry did not establish a prior touch.
- Does not attempt a speculative historical backfill. The 29 unattributed production registrations were confirmed as migration-generated `metadata.backfilled=true` rows.

## Operations

- Adds Next.js request-error instrumentation so server component, route, and action failures reach the existing privacy-bounded ops reporter.
- Deduplicates identical request-error alerts for 60 seconds.
- Avoids exposing raw Edge errors; Edge logs include only static route context and a digest.

## Safety

- No schema migration.
- No patient/client data or contact data is added to funnel events.
- Setup-help retries do not duplicate writes or alerts.
- Cross-tenant contact visibility remains platform-admin gated.

## Validation

- `pnpm test` — 264 files / 2,356 tests passed
- `pnpm type-check`
- `pnpm build`
- `git diff --cached --check`