### PR TITLE
Fail safely on incompatible clinic imports

### DIFF
--- a/apps/web/lib/csv/__tests__/import.test.ts
+++ b/apps/web/lib/csv/__tests__/import.test.ts
@@ -68,6 +68,31 @@ describe("csvToClientRecords", () => {
     expect(records).toEqual([]);
     expect(errors).toEqual(["CSV has an unterminated quoted field."]);
   });
+
+  it("rejects an empty or header-only file before import", () => {
+    expect(csvToClientRecords("")).toEqual({
+      records: [],
+      errors: ["CSV is empty or is missing a header row."],
+    });
+    expect(csvToClientRecords("First Name,Last Name\n")).toEqual({
+      records: [],
+      errors: ["CSV has a header row but no data rows."],
+    });
+  });
+
+  it("reports missing columns once at file level without echoing row data", () => {
+    const csv =
+      "Full Name,Email\n" +
+      "Sensitive Client Name,sensitive@example.com\n".repeat(100);
+    const { records, errors } = csvToClientRecords(csv);
+
+    expect(records).toEqual([]);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toMatch(/missing a recognized client first-name column/i);
+    expect(errors[1]).toMatch(/missing a recognized client last-name column/i);
+    expect(errors.join(" ")).not.toContain("Sensitive Client Name");
+    expect(errors.join(" ")).not.toContain("sensitive@example.com");
+  });
 });
 
 describe("csvToPatientRecords", () => {
@@ -135,6 +160,33 @@ describe("csvToPatientRecords", () => {
     const csv = "clientEmail,name,species,dob\njane@x.com,Rex,canine,last spring";
     const { records } = csvToPatientRecords(csv);
     expect(records[0]!.dob).toBe("last spring");
+  });
+
+  it("stops an ID-linked raw PIMS table before row mapping and explains assisted migration", () => {
+    const csv =
+      "Client ID,Patient Name,Species\n" +
+      "client-4839,Rex,Dog\n".repeat(100);
+    const { records, errors } = csvToPatientRecords(csv);
+
+    expect(records).toEqual([]);
+    expect(errors).toEqual([
+      expect.stringMatching(
+        /owner\/client ID column.*currently links records by owner email.*assisted migration/i
+      ),
+    ]);
+    expect(errors[0]).not.toContain("client-4839");
+    expect(errors[0]).not.toContain("Rex");
+  });
+
+  it("reports absent required headers before producing per-row errors", () => {
+    const { records, errors } = csvToPatientRecords(
+      "Owner Email,Patient Name\nowner@example.com,Rex"
+    );
+
+    expect(records).toEqual([]);
+    expect(errors).toEqual([
+      expect.stringMatching(/missing a recognized species column/i),
+    ]);
   });
 });
 
@@ -208,6 +260,17 @@ describe("csvToVaccinationRecords", () => {
     );
     expect(records).toEqual([]);
     expect(errors).toEqual(["CSV has an unterminated quoted field."]);
+  });
+
+  it("detects an ID-linked export before parsing vaccination rows", () => {
+    const { records, errors } = csvToVaccinationRecords(
+      "Account Number,Patient Name,Vaccine,Date Given\n42,Rex,Rabies,2025-01-01"
+    );
+
+    expect(records).toEqual([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/owner\/client ID column/i);
+    expect(errors[0]).not.toContain("Rabies");
   });
 });
 
@@ -314,5 +377,18 @@ describe("csvToSoapNoteRecords", () => {
     );
     expect(records).toEqual([]);
     expect(errors).toEqual(["CSV has an unterminated quoted field."]);
+  });
+
+  it("requires a recognized note-content column at file preflight", () => {
+    const { records, errors } = csvToSoapNoteRecords(
+      "Owner Email,Patient Name,Visit Date,Provider\nowner@example.com,Rex,2025-01-01,Dr. Example"
+    );
+
+    expect(records).toEqual([]);
+    expect(errors).toEqual([
+      expect.stringMatching(/missing a recognized medical-note content column/i),
+    ]);
+    expect(errors[0]).not.toContain("owner@example.com");
+    expect(errors[0]).not.toContain("Rex");
   });
 });

--- a/apps/web/lib/csv/import.ts
+++ b/apps/web/lib/csv/import.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { parseCsv, normalizeRow } from "./parse";
+import { parseCsv, normalizeKey, normalizeRow } from "./parse";
 import {
   normalizeDateValue,
   normalizeSexValue,
@@ -145,6 +145,80 @@ const SOAP_PATIENT_NAME_MAX = 128;
 // rejecting the whole file and blocking the dry run.
 const importEmailCheck = z.string().trim().email().max(255);
 
+interface RequiredCsvColumn {
+  label: string;
+  aliases: string[];
+  examples: string;
+  detectExternalClientId?: boolean;
+}
+
+// Raw PIMS exports (including Shepherd's CSV tables) commonly relate tables
+// with an internal client/account ID. OpenVPM's self-serve import deliberately
+// does not guess those relationships: the current persisted link is owner
+// email. Detecting an ID-only export up front gives a clinic a safe assisted-
+// migration path instead of producing one error per patient/history row.
+const EXTERNAL_CLIENT_ID_ALIASES = [
+  "clientid",
+  "ownerid",
+  "accountid",
+  "clientnumber",
+  "ownernumber",
+  "accountnumber",
+];
+
+function hasHeader(headers: string[], aliases: string[]): boolean {
+  const normalized = new Set(headers.map(normalizeKey));
+  return aliases.some((alias) => normalized.has(alias));
+}
+
+function preflightCsvHeaders(
+  headers: string[],
+  rows: Record<string, string>[],
+  required: RequiredCsvColumn[],
+  options?: {
+    contentColumns?: RequiredCsvColumn;
+  }
+): string[] {
+  if (headers.length === 0) {
+    return ["CSV is empty or is missing a header row."];
+  }
+
+  if (rows.length === 0) {
+    return ["CSV has a header row but no data rows."];
+  }
+
+  const errors: string[] = [];
+  for (const column of required) {
+    if (hasHeader(headers, column.aliases)) continue;
+
+    if (
+      column.detectExternalClientId &&
+      hasHeader(headers, EXTERNAL_CLIENT_ID_ALIASES)
+    ) {
+      errors.push(
+        "This CSV has an owner/client ID column but no recognized owner email column. " +
+          "OpenVPM's self-serve import currently links records by owner email; export an owner email with each row or use assisted migration for ID-based table mapping."
+      );
+      continue;
+    }
+
+    errors.push(
+      `CSV is missing a recognized ${column.label} column. Add one of: ${column.examples}.`
+    );
+  }
+
+  if (
+    options?.contentColumns &&
+    !hasHeader(headers, options.contentColumns.aliases)
+  ) {
+    errors.push(
+      `CSV is missing a recognized ${options.contentColumns.label} column. Add one of: ${options.contentColumns.examples}.`
+    );
+  }
+
+  return errors;
+}
+
 function opt(v: string | undefined): string | undefined {
   const t = v?.trim();
   return t ? t : undefined;
@@ -163,12 +237,28 @@ function fromAliases(
 }
 
 export function csvToClientRecords(csv: string): ParseResult<ClientImportRecord> {
-  const { rows, errors: parseErrors } = parseCsv(csv);
+  const { headers, rows, errors: parseErrors } = parseCsv(csv);
   const records: ClientImportRecord[] = [];
   const errors: string[] = [...parseErrors];
 
   if (parseErrors.length > 0) {
     return { records, errors };
+  }
+
+  const preflightErrors = preflightCsvHeaders(headers, rows, [
+    {
+      label: "client first-name",
+      aliases: CLIENT_ALIASES.firstName,
+      examples: "First Name, Client First Name, or Given Name",
+    },
+    {
+      label: "client last-name",
+      aliases: CLIENT_ALIASES.lastName,
+      examples: "Last Name, Client Last Name, or Surname",
+    },
+  ]);
+  if (preflightErrors.length > 0) {
+    return { records, errors: preflightErrors };
   }
 
   rows.forEach((raw, i) => {
@@ -195,12 +285,38 @@ export function csvToClientRecords(csv: string): ParseResult<ClientImportRecord>
 }
 
 export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecord> {
-  const { rows, errors: parseErrors } = parseCsv(csv);
+  const { headers, rows, errors: parseErrors } = parseCsv(csv);
   const records: PatientImportRecord[] = [];
   const errors: string[] = [...parseErrors];
 
   if (parseErrors.length > 0) {
     return { records, errors };
+  }
+
+  const preflightErrors = preflightCsvHeaders(
+    headers,
+    rows,
+    [
+      {
+        label: "owner email",
+        aliases: PATIENT_ALIASES.clientEmail,
+        examples: "Owner Email, Client Email, or Email Address",
+        detectExternalClientId: true,
+      },
+      {
+        label: "patient name",
+        aliases: PATIENT_ALIASES.name,
+        examples: "Patient Name, Pet Name, or Animal Name",
+      },
+      {
+        label: "species",
+        aliases: PATIENT_ALIASES.species,
+        examples: "Species or Animal Type",
+      },
+    ]
+  );
+  if (preflightErrors.length > 0) {
+    return { records, errors: preflightErrors };
   }
 
   rows.forEach((raw, i) => {
@@ -248,12 +364,43 @@ export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecor
 export function csvToVaccinationRecords(
   csv: string
 ): ParseResult<VaccinationImportRecord> {
-  const { rows, errors: parseErrors } = parseCsv(csv);
+  const { headers, rows, errors: parseErrors } = parseCsv(csv);
   const records: VaccinationImportRecord[] = [];
   const errors: string[] = [...parseErrors];
 
   if (parseErrors.length > 0) {
     return { records, errors };
+  }
+
+  const preflightErrors = preflightCsvHeaders(
+    headers,
+    rows,
+    [
+      {
+        label: "owner email",
+        aliases: VACCINATION_ALIASES.clientEmail,
+        examples: "Owner Email, Client Email, or Email Address",
+        detectExternalClientId: true,
+      },
+      {
+        label: "patient name",
+        aliases: VACCINATION_ALIASES.patientName,
+        examples: "Patient Name, Pet Name, or Animal Name",
+      },
+      {
+        label: "vaccine name",
+        aliases: VACCINATION_ALIASES.vaccineName,
+        examples: "Vaccine Name, Vaccine, or Vaccination",
+      },
+      {
+        label: "administered date",
+        aliases: VACCINATION_ALIASES.administeredAt,
+        examples: "Date Given, Vaccination Date, or Date Administered",
+      },
+    ]
+  );
+  if (preflightErrors.length > 0) {
+    return { records, errors: preflightErrors };
   }
 
   rows.forEach((raw, i) => {
@@ -316,12 +463,52 @@ export function csvToVaccinationRecords(
 export function csvToSoapNoteRecords(
   csv: string
 ): ParseResult<SoapNoteImportRecord> {
-  const { rows, errors: parseErrors } = parseCsv(csv);
+  const { headers, rows, errors: parseErrors } = parseCsv(csv);
   const records: SoapNoteImportRecord[] = [];
   const errors: string[] = [...parseErrors];
 
   if (parseErrors.length > 0) {
     return { records, errors };
+  }
+
+  const noteAliases = [
+    ...SOAP_NOTE_ALIASES.subjective,
+    ...SOAP_NOTE_ALIASES.objective,
+    ...SOAP_NOTE_ALIASES.assessment,
+    ...SOAP_NOTE_ALIASES.plan,
+    ...SOAP_NOTE_ALIASES.note,
+  ];
+  const preflightErrors = preflightCsvHeaders(
+    headers,
+    rows,
+    [
+      {
+        label: "owner email",
+        aliases: SOAP_NOTE_ALIASES.clientEmail,
+        examples: "Owner Email, Client Email, or Email Address",
+        detectExternalClientId: true,
+      },
+      {
+        label: "patient name",
+        aliases: SOAP_NOTE_ALIASES.patientName,
+        examples: "Patient Name, Pet Name, or Animal Name",
+      },
+      {
+        label: "visit date",
+        aliases: SOAP_NOTE_ALIASES.date,
+        examples: "Visit Date, Date of Service, or Encounter Date",
+      },
+    ],
+    {
+      contentColumns: {
+        label: "medical-note content",
+        aliases: noteAliases,
+        examples: "Notes, Subjective, Objective, Assessment, or Plan",
+      },
+    }
+  );
+  if (preflightErrors.length > 0) {
+    return { records, errors: preflightErrors };
   }
 
   rows.forEach((raw, i) => {


### PR DESCRIPTION
## Outcome

Makes clinic CSV migration fail early and explainably when a file cannot be mapped safely, instead of generating thousands of repetitive row errors or guessing relationships.

## What changed

- Rejects empty and header-only files before mapping.
- Validates required headers once per file for clients, patients, vaccinations, and medical history.
- Detects ID-linked exports (`Client ID`, `Owner ID`, `Account ID`, and number variants) when downstream records lack owner email.
- Routes those files to assisted migration because the current self-serve importer links patients/history by owner email and must not guess an ID relationship.
- Requires a recognized SOAP or generic note-content column for medical-history imports.
- Keeps preflight diagnostics free of imported row values and PHI.

## Shepherd boundary

Shepherd documents a client-list CSV export and contractually provides raw CSV data tables, but does not publish a stable export schema. This PR improves safety for those exports; it does **not** claim turnkey Shepherd compatibility. Deterministic support still requires a sanitized real export bundle and an ID-based cross-file reconciliation design.

- Export walkthrough: https://vimeo.com/870758367
- Data-export language: https://www.shepherd.vet/pdf/Shepherd_Service_Agreement_EULA_-_Main_%28updated_20240522%29.pdf

## Validation

- CSV import suite — 32 tests passed
- `pnpm type-check`
- Included in the full pre-split regression run — 264 files / 2,356 tests passed
- `git diff --cached --check`