### PR TITLE
Make clinic data imports source-safe

### DIFF
--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1374,8 +1374,9 @@ function BillingTab() {
               <span className="font-medium text-foreground">
                 {daysLeft} days
               </span>{" "}
-              left. After that, {currentPlan?.name ?? "Cloud"} is {priceSentence}
-              . Unlimited staff, and everything you see today stays on.
+              left. After that, {currentPlan?.name ?? "Cloud"} is{" "}
+              {priceSentence}. Unlimited staff, and everything you see today
+              stays on.
             </>
           ) : (
             <>
@@ -2761,8 +2762,10 @@ function downloadJSON(data: unknown, filename: string) {
 }
 
 type ImportPreview = {
+  requestKey: string;
   total: number;
   willInsert: number;
+  willReconcile?: number;
   duplicates?: number;
   unmatchedClient?: number;
   unmatchedPatient?: number;
@@ -2770,15 +2773,28 @@ type ImportPreview = {
 };
 type ImportMode = "clients" | "patients" | "vaccinations" | "soapNotes";
 const IMPORT_CSV_SIZE_MESSAGE = "CSV imports must be 5 MB or less.";
+function importPreviewRequestKey(
+  mode: ImportMode,
+  source: string,
+  csv: string,
+): string {
+  let hash = 2_166_136_261;
+  const input = `${mode}\u0000${source}\u0000${csv}`;
+  for (let index = 0; index < input.length; index++) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return `${mode}:${source}:${csv.length}:${(hash >>> 0).toString(16)}`;
+}
 const IMPORT_COLUMN_HINTS: Record<ImportMode, string> = {
   clients:
-    "Expected columns: firstName, lastName, email, phone, address, city, state, zip",
+    "Expected columns: firstName, lastName, plus email or client ID. Optional: phone, address, city, state, zip",
   patients:
-    "Expected columns: clientEmail, name, species, breed, sex, dob, color, microchipNumber",
+    "Expected columns: clientEmail or client ID, name, species. Patient ID is recommended. Optional: breed, sex, dob, color, microchipNumber",
   vaccinations:
-    "Expected columns: clientEmail, patientName, vaccineName, dateGiven, nextDueDate, lotNumber, manufacturer",
+    "Expected columns: patient ID, or an owner reference plus patientName; vaccineName and dateGiven. Optional: nextDueDate, lotNumber, manufacturer",
   soapNotes:
-    "Expected columns: clientEmail, patientName, date (use YYYY-MM-DD), and either subjective, objective, assessment, plan or a single notes column",
+    "Expected columns: patient ID, or an owner reference plus patientName; date, and either subjective, objective, assessment, plan or a single notes column",
 };
 
 // ── Data Tab ─────────────────────────────────────────────────
@@ -2788,6 +2804,7 @@ function DataTab() {
   const [migrationSource, setMigrationSource] = useState<
     (typeof MIGRATION_SOURCES)[number]["id"] | null
   >(null);
+  const importSource = migrationSource ?? "other";
   const [csvText, setCsvText] = useState("");
   const [csvFileName, setCsvFileName] = useState("");
   const [importPreview, setImportPreview] = useState<ImportPreview | null>(
@@ -2795,6 +2812,7 @@ function DataTab() {
   );
   const [importResult, setImportResult] = useState<{
     imported: number;
+    reconciled?: number;
     errors?: string[];
   } | null>(null);
   const [backupFileName, setBackupFileName] = useState("");
@@ -2819,6 +2837,8 @@ function DataTab() {
   const [confirmExportDownloaded, setConfirmExportDownloaded] = useState(false);
   const [confirmManualReview, setConfirmManualReview] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const importRequestKeyRef = useRef<string | null>(null);
+  const importFileReadVersionRef = useRef(0);
   const backupFileInputRef = useRef<HTMLInputElement>(null);
 
   const utils = trpc.useUtils();
@@ -2886,11 +2906,19 @@ function DataTab() {
     : null;
 
   const importClientsCsv = trpc.data.importClientsCsv.useMutation({
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       if ("dryRun" in data && data.dryRun) {
+        const requestKey = importPreviewRequestKey(
+          "clients",
+          variables.source ?? "other",
+          variables.csv,
+        );
+        if (importRequestKeyRef.current !== requestKey) return;
         setImportPreview({
+          requestKey,
           total: data.total,
           willInsert: data.willInsert,
+          willReconcile: data.willReconcile,
           duplicates: data.duplicates,
           errors: data.errors,
         });
@@ -2899,7 +2927,11 @@ function DataTab() {
         return;
       }
 
-      setImportResult({ imported: data.imported ?? 0, errors: data.errors });
+      setImportResult({
+        imported: data.imported ?? 0,
+        reconciled: data.reconciled,
+        errors: data.errors,
+      });
       setImportPreview(null);
       setCsvText("");
       setCsvFileName("");
@@ -2910,11 +2942,19 @@ function DataTab() {
     },
   });
   const importPatientsCsv = trpc.data.importPatientsCsv.useMutation({
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       if ("dryRun" in data && data.dryRun) {
+        const requestKey = importPreviewRequestKey(
+          "patients",
+          variables.source ?? "other",
+          variables.csv,
+        );
+        if (importRequestKeyRef.current !== requestKey) return;
         setImportPreview({
+          requestKey,
           total: data.total,
           willInsert: data.willInsert,
+          willReconcile: data.willReconcile,
           duplicates: data.duplicates,
           unmatchedClient: data.unmatchedClient,
           errors: data.errors,
@@ -2924,7 +2964,11 @@ function DataTab() {
         return;
       }
 
-      setImportResult({ imported: data.imported ?? 0, errors: data.errors });
+      setImportResult({
+        imported: data.imported ?? 0,
+        reconciled: data.reconciled,
+        errors: data.errors,
+      });
       setImportPreview(null);
       setCsvText("");
       setCsvFileName("");
@@ -2935,9 +2979,16 @@ function DataTab() {
     },
   });
   const importVaccinationsCsv = trpc.data.importVaccinationsCsv.useMutation({
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       if ("dryRun" in data && data.dryRun) {
+        const requestKey = importPreviewRequestKey(
+          "vaccinations",
+          variables.source ?? "other",
+          variables.csv,
+        );
+        if (importRequestKeyRef.current !== requestKey) return;
         setImportPreview({
+          requestKey,
           total: data.total,
           willInsert: data.willInsert,
           duplicates: data.duplicates,
@@ -2960,9 +3011,16 @@ function DataTab() {
     },
   });
   const importSoapNotesCsv = trpc.data.importSoapNotesCsv.useMutation({
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       if ("dryRun" in data && data.dryRun) {
+        const requestKey = importPreviewRequestKey(
+          "soapNotes",
+          variables.source ?? "other",
+          variables.csv,
+        );
+        if (importRequestKeyRef.current !== requestKey) return;
         setImportPreview({
+          requestKey,
           total: data.total,
           willInsert: data.willInsert,
           duplicates: data.duplicates,
@@ -3182,7 +3240,9 @@ function DataTab() {
   const handleFileSelect = useCallback(
     (file: File) => {
       if (!importMode) return;
+      const readVersion = ++importFileReadVersionRef.current;
       function clearImportFile() {
+        importRequestKeyRef.current = null;
         setCsvFileName("");
         setCsvText("");
         setImportPreview(null);
@@ -3201,6 +3261,7 @@ function DataTab() {
       setImportResult(null);
       const reader = new FileReader();
       reader.onload = (e) => {
+        if (importFileReadVersionRef.current !== readVersion) return;
         const text = String(e.target?.result ?? "");
         if (!text.trim()) {
           setCsvFileName("");
@@ -3214,17 +3275,39 @@ function DataTab() {
         }
 
         setCsvText(text);
+        importRequestKeyRef.current = importPreviewRequestKey(
+          importMode,
+          importSource,
+          text,
+        );
         if (importMode === "clients") {
-          importClientsCsv.mutate({ csv: text, dryRun: true });
+          importClientsCsv.mutate({
+            csv: text,
+            dryRun: true,
+            source: importSource,
+          });
         } else if (importMode === "patients") {
-          importPatientsCsv.mutate({ csv: text, dryRun: true });
+          importPatientsCsv.mutate({
+            csv: text,
+            dryRun: true,
+            source: importSource,
+          });
         } else if (importMode === "vaccinations") {
-          importVaccinationsCsv.mutate({ csv: text, dryRun: true });
+          importVaccinationsCsv.mutate({
+            csv: text,
+            dryRun: true,
+            source: importSource,
+          });
         } else {
-          importSoapNotesCsv.mutate({ csv: text, dryRun: true });
+          importSoapNotesCsv.mutate({
+            csv: text,
+            dryRun: true,
+            source: importSource,
+          });
         }
       };
       reader.onerror = () => {
+        if (importFileReadVersionRef.current !== readVersion) return;
         setCsvFileName("");
         toast.error("Could not read CSV file");
       };
@@ -3232,6 +3315,7 @@ function DataTab() {
     },
     [
       importClientsCsv,
+      importSource,
       importMode,
       importPatientsCsv,
       importVaccinationsCsv,
@@ -3257,19 +3341,47 @@ function DataTab() {
       toast.error(IMPORT_CSV_SIZE_MESSAGE);
       return;
     }
+    const currentRequestKey = importPreviewRequestKey(
+      importMode,
+      importSource,
+      csvText,
+    );
+    if (importPreview.requestKey !== currentRequestKey) {
+      importRequestKeyRef.current = null;
+      setImportPreview(null);
+      toast.error("The file or source changed. Check the CSV again.");
+      return;
+    }
     if (importMode === "clients") {
-      importClientsCsv.mutate({ csv: csvText, dryRun: false });
+      importClientsCsv.mutate({
+        csv: csvText,
+        dryRun: false,
+        source: importSource,
+      });
     } else if (importMode === "patients") {
-      importPatientsCsv.mutate({ csv: csvText, dryRun: false });
+      importPatientsCsv.mutate({
+        csv: csvText,
+        dryRun: false,
+        source: importSource,
+      });
     } else if (importMode === "vaccinations") {
-      importVaccinationsCsv.mutate({ csv: csvText, dryRun: false });
+      importVaccinationsCsv.mutate({
+        csv: csvText,
+        dryRun: false,
+        source: importSource,
+      });
     } else {
-      importSoapNotesCsv.mutate({ csv: csvText, dryRun: false });
+      importSoapNotesCsv.mutate({
+        csv: csvText,
+        dryRun: false,
+        source: importSource,
+      });
     }
   }, [
     csvText,
     importMode,
     importPreview,
+    importSource,
     importClientsCsv,
     importPatientsCsv,
     importVaccinationsCsv,
@@ -3711,7 +3823,8 @@ function DataTab() {
           vaccine history, then medical history (visit notes). Every file is
           dry-run first so you see duplicates and missing matches before
           anything is saved. Common column names from AVImark, Cornerstone,
-          ezyVet, and Shepherd exports are understood automatically.
+          ezyVet, and Shepherd exports are understood automatically. Owner and
+          patient IDs stay linked across files, even when an owner has no email.
         </p>
 
         {/* Where the data is coming from (export instructions per source) */}
@@ -3723,11 +3836,17 @@ function DataTab() {
             <button
               key={source.id}
               type="button"
-              onClick={() =>
+              onClick={() => {
+                importFileReadVersionRef.current += 1;
+                importRequestKeyRef.current = null;
                 setMigrationSource(
                   migrationSource === source.id ? null : source.id,
-                )
-              }
+                );
+                setCsvText("");
+                setCsvFileName("");
+                setImportPreview(null);
+                setImportResult(null);
+              }}
               className={cn(
                 "rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
                 migrationSource === source.id
@@ -3767,6 +3886,8 @@ function DataTab() {
               variant={importMode === mode ? "default" : "outline"}
               size="sm"
               onClick={() => {
+                importFileReadVersionRef.current += 1;
+                importRequestKeyRef.current = null;
                 setImportMode(mode);
                 setCsvText("");
                 setCsvFileName("");
@@ -3810,6 +3931,10 @@ function DataTab() {
               <p className="mt-1 text-xs text-muted-foreground">
                 CSV files must be 5 MB or less. The file is dry-run first; no
                 rows import until you confirm.
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Existing owners connect by one exact email. Existing pets need a
+                matching microchip or date of birth before an ID is connected.
               </p>
               <input
                 ref={fileInputRef}
@@ -3862,6 +3987,13 @@ function DataTab() {
                         value={importPreview.duplicates ?? 0}
                       />
                     )}
+                    {typeof importPreview.willReconcile === "number" &&
+                      importPreview.willReconcile > 0 && (
+                        <ImportStat
+                          label="IDs to connect"
+                          value={importPreview.willReconcile}
+                        />
+                      )}
                     {importMode === "patients" && (
                       <ImportStat
                         label="Missing owners"
@@ -3897,7 +4029,12 @@ function DataTab() {
                 <div className="flex flex-wrap gap-2">
                   <Button
                     size="sm"
-                    disabled={isImportPending || importPreview.willInsert === 0}
+                    disabled={
+                      isImportPending ||
+                      importPreview.willInsert +
+                        (importPreview.willReconcile ?? 0) ===
+                        0
+                    }
                     onClick={handleImportConfirm}
                   >
                     {isImportPending ? (
@@ -3905,12 +4042,17 @@ function DataTab() {
                     ) : (
                       <Check className="mr-2 h-4 w-4" />
                     )}
-                    Confirm Import ({importPreview.willInsert} rows)
+                    Confirm Import (
+                    {importPreview.willInsert +
+                      (importPreview.willReconcile ?? 0)}{" "}
+                    changes)
                   </Button>
                   <Button
                     size="sm"
                     variant="ghost"
                     onClick={() => {
+                      importFileReadVersionRef.current += 1;
+                      importRequestKeyRef.current = null;
                       setCsvText("");
                       setCsvFileName("");
                       setImportPreview(null);
@@ -3928,6 +4070,9 @@ function DataTab() {
                 <div className="flex items-center gap-2 text-sm font-medium text-green-600 dark:text-green-400">
                   <Check className="h-4 w-4" />
                   {importResult.imported} records imported successfully
+                  {(importResult.reconciled ?? 0) > 0
+                    ? `; ${importResult.reconciled} existing record IDs connected`
+                    : ""}
                 </div>
                 {importResult.errors && importResult.errors.length > 0 && (
                   <div className="space-y-1">

--- a/apps/web/components/onboarding/steps/bring-data.tsx
+++ b/apps/web/components/onboarding/steps/bring-data.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import {
   ArrowRight,
@@ -18,6 +18,7 @@ import {
   isImportCsvSizeValid,
 } from "@/lib/import/policy";
 import { getOnboardingIntentOption } from "@/lib/onboarding/intent";
+import { MIGRATION_SOURCES } from "@/lib/import/sources";
 import { toast } from "sonner";
 import type { StepHandle, StepProps } from "../journey-types";
 
@@ -25,15 +26,16 @@ type Choice = "import" | "api" | "keep";
 type CsvPreview = {
   total: number;
   willInsert: number;
+  willReconcile?: number;
   duplicates?: number;
   unmatchedClient?: number;
   errors: string[];
 };
 
 const CLIENT_COLUMNS =
-  "firstName, lastName, email, phone, address, city, state, zip";
+  "firstName, lastName, email or client ID, phone, address, city, state, zip";
 const PET_COLUMNS =
-  "clientEmail, name, species, breed, sex, dob, color, microchipNumber";
+  "clientEmail or client ID, patient ID, name, species, breed, sex, dob, color, microchipNumber";
 const IMPORT_CSV_SIZE_MESSAGE = "CSV imports must be 5 MB or less.";
 
 const textareaClass =
@@ -56,51 +58,61 @@ function readFileText(file: File): Promise<string> {
  * Step 4: choose how real data gets in. Import from a file now, connect by API
  * later, or keep the sample data for now (the default and the skip behavior).
  */
-export function BringDataStep({
-  register,
-  state,
-  setState,
-}: StepProps) {
+export function BringDataStep({ register, state, setState }: StepProps) {
   const importClientsCsv = trpc.data.importClientsCsv.useMutation();
   const importPatientsCsv = trpc.data.importPatientsCsv.useMutation();
 
   // Default to keeping the sample data; the skip behavior matches this too.
   const [choice, setChoice] = useState<Choice>("keep");
+  const [migrationSource, setMigrationSource] =
+    useState<(typeof MIGRATION_SOURCES)[number]["id"]>("other");
   const [clientsCsv, setClientsCsv] = useState("");
   const [petsCsv, setPetsCsv] = useState("");
   const [clientsFileName, setClientsFileName] = useState("");
   const [petsFileName, setPetsFileName] = useState("");
   const [clientsPreview, setClientsPreview] = useState<CsvPreview | null>(null);
   const [petsPreview, setPetsPreview] = useState<CsvPreview | null>(null);
+  const importReviewVersionRef = useRef(0);
+  const fileReadVersionRef = useRef({ clients: 0, pets: 0 });
   const [result, setResult] = useState<{
     clients: number;
     pets: number;
+    reconciled: number;
     errors: string[];
   } | null>(null);
 
   function clearImportReview() {
+    importReviewVersionRef.current += 1;
     setClientsPreview(null);
     setPetsPreview(null);
     setResult(null);
   }
 
   function updateClientsCsv(value: string) {
+    fileReadVersionRef.current.clients += 1;
     setClientsCsv(value);
     clearImportReview();
   }
 
   function updatePetsCsv(value: string) {
+    fileReadVersionRef.current.pets += 1;
     setPetsCsv(value);
     clearImportReview();
+  }
+
+  function invalidatePendingFileReads() {
+    fileReadVersionRef.current.clients += 1;
+    fileReadVersionRef.current.pets += 1;
   }
 
   async function onPickFile(
     e: React.ChangeEvent<HTMLInputElement>,
     setCsv: (v: string) => void,
-    which: "clients" | "pets"
+    which: "clients" | "pets",
   ) {
     const file = e.target.files?.[0];
     if (!file) return;
+    const readVersion = ++fileReadVersionRef.current[which];
     function clearPickedFile() {
       setCsv("");
       if (which === "clients") setClientsFileName("");
@@ -114,6 +126,7 @@ export function BringDataStep({
     }
     try {
       const text = await readFileText(file);
+      if (fileReadVersionRef.current[which] !== readVersion) return;
       if (!isImportCsvSizeValid(text)) {
         clearPickedFile();
         toast.error(IMPORT_CSV_SIZE_MESSAGE);
@@ -123,6 +136,7 @@ export function BringDataStep({
       if (which === "clients") setClientsFileName(file.name);
       else setPetsFileName(file.name);
     } catch {
+      if (fileReadVersionRef.current[which] !== readVersion) return;
       toast.error("Could not read that file. Try again.");
     }
   }
@@ -144,6 +158,8 @@ export function BringDataStep({
   const previewReady = hasImportCsv && !needsDryRun;
   const previewWillInsert =
     (clientsPreview?.willInsert ?? 0) + (petsPreview?.willInsert ?? 0);
+  const previewWillReconcile =
+    (clientsPreview?.willReconcile ?? 0) + (petsPreview?.willReconcile ?? 0);
 
   // Finish only clears sample data after real rows have imported. Checking a
   // CSV or connecting later leaves the demo clinic intact.
@@ -166,15 +182,19 @@ export function BringDataStep({
         }
 
         if (needsDryRun) {
+          const reviewVersion = importReviewVersionRef.current;
           if (hasClientsCsv) {
             const r = await importClientsCsv.mutateAsync({
               csv: clientsCsv.trim(),
               dryRun: true,
+              source: migrationSource,
             });
+            if (importReviewVersionRef.current !== reviewVersion) return false;
             if ("dryRun" in r && r.dryRun) {
               setClientsPreview({
                 total: r.total,
                 willInsert: r.willInsert,
+                willReconcile: r.willReconcile,
                 duplicates: r.duplicates,
                 errors: r.errors,
               });
@@ -184,11 +204,15 @@ export function BringDataStep({
             const r = await importPatientsCsv.mutateAsync({
               csv: petsCsv.trim(),
               dryRun: true,
+              source: migrationSource,
+              clientCsv: hasClientsCsv ? clientsCsv.trim() : undefined,
             });
+            if (importReviewVersionRef.current !== reviewVersion) return false;
             if ("dryRun" in r && r.dryRun) {
               setPetsPreview({
                 total: r.total,
                 willInsert: r.willInsert,
+                willReconcile: r.willReconcile,
                 unmatchedClient: r.unmatchedClient,
                 errors: r.errors,
               });
@@ -198,10 +222,11 @@ export function BringDataStep({
           return false;
         }
 
-        if (previewWillInsert === 0) {
+        if (previewWillInsert + previewWillReconcile === 0) {
           setResult({
             clients: 0,
             pets: 0,
+            reconciled: 0,
             errors: [
               "No new rows were found to import. You can adjust the CSV or continue with sample data.",
             ],
@@ -212,26 +237,36 @@ export function BringDataStep({
         const errors: string[] = [];
         let clientsImported = 0;
         let petsImported = 0;
+        let reconciled = 0;
 
         if (hasClientsCsv) {
           const r = await importClientsCsv.mutateAsync({
             csv: clientsCsv.trim(),
             dryRun: false,
+            source: migrationSource,
           });
           clientsImported = r.imported ?? 0;
+          reconciled += r.reconciled ?? 0;
           if (r.errors?.length) errors.push(...r.errors);
         }
         if (hasPetsCsv) {
           const r = await importPatientsCsv.mutateAsync({
             csv: petsCsv.trim(),
             dryRun: false,
+            source: migrationSource,
           });
           petsImported = r.imported ?? 0;
+          reconciled += r.reconciled ?? 0;
           if (r.errors?.length) errors.push(...r.errors);
         }
-        setResult({ clients: clientsImported, pets: petsImported, errors });
+        setResult({
+          clients: clientsImported,
+          pets: petsImported,
+          reconciled,
+          errors,
+        });
         toast.success(
-          `Added ${clientsImported} clients and ${petsImported} pets`
+          `Added ${clientsImported} clients and ${petsImported} pets${reconciled > 0 ? `; connected ${reconciled} IDs` : ""}`,
         );
         // Stay on the step so they can see the result before moving on.
         return false;
@@ -248,6 +283,8 @@ export function BringDataStep({
     importCsvSizeError,
     needsDryRun,
     previewWillInsert,
+    previewWillReconcile,
+    migrationSource,
     result,
     importClientsCsv,
     importPatientsCsv,
@@ -277,6 +314,7 @@ export function BringDataStep({
           title="Import from a file"
           subtitle="Paste your clients and pets from a spreadsheet."
           onClick={() => {
+            invalidatePendingFileReads();
             setChoice("import");
             clearImportReview();
           }}
@@ -287,6 +325,31 @@ export function BringDataStep({
               Pick a CSV file for each one, or paste the rows below. Continue
               checks the files first; nothing imports until you review the plan.
             </p>
+            <p className="text-xs text-slate-500">
+              Existing owners connect by one exact email. Existing pets need a
+              matching microchip or date of birth before an ID is connected.
+            </p>
+            <label className="block space-y-1.5 text-sm font-medium text-slate-700">
+              <span>Which system are you moving from?</span>
+              <select
+                value={migrationSource}
+                onChange={(event) => {
+                  invalidatePendingFileReads();
+                  setMigrationSource(
+                    event.target
+                      .value as (typeof MIGRATION_SOURCES)[number]["id"],
+                  );
+                  clearImportReview();
+                }}
+                className="h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm font-normal"
+              >
+                {MIGRATION_SOURCES.map((source) => (
+                  <option key={source.id} value={source.id}>
+                    {source.name}
+                  </option>
+                ))}
+              </select>
+            </label>
             <div className="space-y-1.5">
               <span className="text-sm font-medium text-slate-700">
                 Clients
@@ -335,7 +398,9 @@ export function BringDataStep({
                 aria-label="Choose a pets CSV file"
               />
               {petsFileName ? (
-                <p className="text-xs text-emerald-700">Loaded {petsFileName}</p>
+                <p className="text-xs text-emerald-700">
+                  Loaded {petsFileName}
+                </p>
               ) : null}
               <textarea
                 rows={4}
@@ -362,8 +427,8 @@ export function BringDataStep({
                     Dry-run preview
                   </p>
                   <p className="mt-1 text-xs text-slate-500">
-                    No data has been imported yet. Review the counts, then
-                    press Continue again to import.
+                    No data has been imported yet. Review the counts, then press
+                    Continue again to import.
                   </p>
                 </div>
                 {clientsPreview ? (
@@ -394,6 +459,9 @@ export function BringDataStep({
               <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-900">
                 <p className="font-medium">
                   Added {result.clients} clients and {result.pets} pets.
+                  {result.reconciled > 0
+                    ? ` Connected ${result.reconciled} existing record IDs.`
+                    : ""}
                 </p>
                 {result.errors.length > 0 ? (
                   <>
@@ -427,6 +495,7 @@ export function BringDataStep({
           title="Connect later by API"
           subtitle="Move data in from another system whenever you want."
           onClick={() => {
+            invalidatePendingFileReads();
             setChoice("api");
             clearImportReview();
           }}
@@ -453,6 +522,7 @@ export function BringDataStep({
           title="Keep the sample data for now"
           subtitle="Explore with the example pets we set up for you."
           onClick={() => {
+            invalidatePendingFileReads();
             setChoice("keep");
             clearImportReview();
           }}
@@ -478,12 +548,20 @@ function CsvPreviewCard({
       <div className="flex items-center justify-between gap-3">
         <p className="text-sm font-medium text-slate-800">{title}</p>
         <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700">
-          {preview.willInsert > 0 ? "Ready" : "Review"}
+          {preview.willInsert + (preview.willReconcile ?? 0) > 0
+            ? "Ready"
+            : "Review"}
         </span>
       </div>
       <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
         <ImportStat label="Rows" value={preview.total} />
         <ImportStat label="Will import" value={preview.willInsert} />
+        {(preview.willReconcile ?? 0) > 0 ? (
+          <ImportStat
+            label="IDs to connect"
+            value={preview.willReconcile ?? 0}
+          />
+        ) : null}
         <ImportStat label={duplicateLabel} value={duplicateValue} />
         <ImportStat label="Issues" value={preview.errors.length} />
       </div>
@@ -533,13 +611,15 @@ function ChoiceCard({
         "flex items-start gap-3 rounded-lg border bg-white p-4 text-left transition-colors",
         active
           ? "border-emerald-300 ring-1 ring-emerald-300"
-          : "border-slate-200 hover:border-slate-300"
+          : "border-slate-200 hover:border-slate-300",
       )}
     >
       <span
         className={cn(
           "flex h-9 w-9 shrink-0 items-center justify-center rounded-md",
-          active ? "bg-emerald-100 text-emerald-700" : "bg-slate-100 text-slate-500"
+          active
+            ? "bg-emerald-100 text-emerald-700"
+            : "bg-slate-100 text-slate-500",
         )}
       >
         {icon}
@@ -550,9 +630,7 @@ function ChoiceCard({
         </span>
         <span className="mt-0.5 block text-xs text-slate-500">{subtitle}</span>
       </span>
-      {active ? (
-        <Check className="h-5 w-5 shrink-0 text-emerald-600" />
-      ) : null}
+      {active ? <Check className="h-5 w-5 shrink-0 text-emerald-600" /> : null}
     </button>
   );
 }

--- a/apps/web/lib/__tests__/audit.test.ts
+++ b/apps/web/lib/__tests__/audit.test.ts
@@ -5,21 +5,37 @@ const UUID = "11111111-1111-1111-1111-111111111111";
 
 describe("parseAuditPath", () => {
   it("splits entity and action on the first dot", () => {
-    expect(parseAuditPath("clients.create")).toEqual({ entityType: "clients", action: "create" });
+    expect(parseAuditPath("clients.create")).toEqual({
+      entityType: "clients",
+      action: "create",
+    });
     expect(parseAuditPath("treatmentPlans.updateItemStatus")).toEqual({
       entityType: "treatmentPlans",
       action: "updateItemStatus",
     });
   });
   it("handles a path with no dot", () => {
-    expect(parseAuditPath("health")).toEqual({ entityType: "health", action: "" });
+    expect(parseAuditPath("health")).toEqual({
+      entityType: "health",
+      action: "",
+    });
   });
 });
 
 describe("redactSecrets", () => {
   it("redacts secret-ish keys, keeps the rest", () => {
-    const out = redactSecrets({ name: "Rex", password: "hunter2", apiKey: "x", note: "ok" });
-    expect(out).toEqual({ name: "Rex", password: "[redacted]", apiKey: "[redacted]", note: "ok" });
+    const out = redactSecrets({
+      name: "Rex",
+      password: "hunter2",
+      apiKey: "x",
+      note: "ok",
+    });
+    expect(out).toEqual({
+      name: "Rex",
+      password: "[redacted]",
+      apiKey: "[redacted]",
+      note: "ok",
+    });
   });
   it("redacts keyHash/secret/token variants", () => {
     const out = redactSecrets({ keyHash: "a", secret: "b", authToken: "c" })!;
@@ -58,6 +74,12 @@ describe("redactSecrets", () => {
       dryRun: true,
     })!;
     expect(out.csv).toBe("[redacted-bulk-payload]");
+    const onboarding = redactSecrets({
+      csv: "patient rows",
+      clientCsv: "client rows with PII",
+    })!;
+    expect(onboarding.csv).toBe("[redacted-bulk-payload]");
+    expect(onboarding.clientCsv).toBe("[redacted-bulk-payload]");
     expect(out.dryRun).toBe(true);
 
     const restore = redactSecrets({

--- a/apps/web/lib/__tests__/onboarding-import-ui.test.ts
+++ b/apps/web/lib/__tests__/onboarding-import-ui.test.ts
@@ -9,22 +9,39 @@ import {
 describe("onboarding import UI", () => {
   const source = readFileSync(
     "components/onboarding/steps/bring-data.tsx",
-    "utf8"
+    "utf8",
   );
 
   it("dry-runs CSV imports before committing first-run data", () => {
     expect(source).toContain(
-      "const importClientsCsv = trpc.data.importClientsCsv.useMutation"
+      "const importClientsCsv = trpc.data.importClientsCsv.useMutation",
     );
     expect(source).toContain(
-      "const importPatientsCsv = trpc.data.importPatientsCsv.useMutation"
+      "const importPatientsCsv = trpc.data.importPatientsCsv.useMutation",
     );
     expect(source).toContain("dryRun: true");
     expect(source).toContain("dryRun: false");
     expect(source).toContain("setClientsPreview");
     expect(source).toContain("setPetsPreview");
     expect(source).toContain("if (result) return true");
-    expect(source).toContain("press Continue again to import");
+    expect(source).toContain("Continue again to import.");
+    expect(source).toContain("source: migrationSource");
+    expect(source).toContain("Which system are you moving from?");
+    expect(source).toContain("MIGRATION_SOURCES.map");
+    expect(source).toContain(
+      "clientCsv: hasClientsCsv ? clientsCsv.trim() : undefined",
+    );
+    expect(source).toContain("willReconcile");
+    expect(source).toContain(
+      "const fileReadVersionRef = useRef({ clients: 0, pets: 0 })",
+    );
+    expect(source).toContain(
+      "const readVersion = ++fileReadVersionRef.current[which]",
+    );
+    expect(source).toContain(
+      "if (fileReadVersionRef.current[which] !== readVersion) return;",
+    );
+    expect(source).toContain("invalidatePendingFileReads()");
     expect(source).not.toContain("function parseCSV");
     expect(source).not.toContain("row.first_name");
   });
@@ -32,21 +49,19 @@ describe("onboarding import UI", () => {
   it("uses the shared CSV size policy before import dry-runs", () => {
     expect(IMPORT_CSV_MAX_BYTES).toBe(5_000_000);
     expect(csvByteLength("é")).toBe(2);
-    expect(isImportCsvSizeValid("a".repeat(IMPORT_CSV_MAX_BYTES))).toBe(
-      true
-    );
+    expect(isImportCsvSizeValid("a".repeat(IMPORT_CSV_MAX_BYTES))).toBe(true);
     expect(isImportCsvSizeValid("a".repeat(IMPORT_CSV_MAX_BYTES + 1))).toBe(
-      false
+      false,
     );
 
     expect(source).toContain('from "@/lib/import/policy"');
     expect(source).toContain("file.size > IMPORT_CSV_MAX_BYTES");
     expect(source).toContain("isImportCsvSizeValid(text)");
     expect(source).toContain(
-      "const clientsCsvTooLarge = !isImportCsvSizeValid(clientsCsv);"
+      "const clientsCsvTooLarge = !isImportCsvSizeValid(clientsCsv);",
     );
     expect(source).toContain(
-      "const petsCsvTooLarge = !isImportCsvSizeValid(petsCsv);"
+      "const petsCsvTooLarge = !isImportCsvSizeValid(petsCsv);",
     );
     expect(source).toContain("if (hasImportCsvSizeError) {");
     expect(source.match(/maxLength={IMPORT_CSV_MAX_BYTES}/g)).toHaveLength(2);

--- a/apps/web/lib/__tests__/settings-ui-states.test.ts
+++ b/apps/web/lib/__tests__/settings-ui-states.test.ts
@@ -8,10 +8,7 @@ import {
   PRACTICE_BACKUP_JSON_MAX_BYTES,
   isPracticeBackupJsonSizeValid,
 } from "../backup/policy";
-import {
-  IMPORT_CSV_MAX_BYTES,
-  isImportCsvSizeValid,
-} from "../import/policy";
+import { IMPORT_CSV_MAX_BYTES, isImportCsvSizeValid } from "../import/policy";
 import {
   ACCOUNT_DELETION_REASON_MAX_LENGTH,
   APPOINTMENT_TYPE_DURATION_MAX_MINUTES,
@@ -40,22 +37,26 @@ describe("settings UI states", () => {
     expect(source).toContain('if (status === "loading")');
     expect(source).toContain("Checking settings access...");
     expect(source).toContain('if (session?.user?.role !== "admin")');
-    expect(source).toContain("Only administrators can access practice settings.");
+    expect(source).toContain(
+      "Only administrators can access practice settings.",
+    );
     expect(source.indexOf('if (status === "loading")')).toBeLessThan(
-      source.indexOf('if (session?.user?.role !== "admin")')
+      source.indexOf('if (session?.user?.role !== "admin")'),
     );
     expect(source.indexOf('if (session?.user?.role !== "admin")')).toBeLessThan(
-      source.indexOf('{activeTab === "practice" && <PracticeInfoTab />}')
+      source.indexOf('{activeTab === "practice" && <PracticeInfoTab />}'),
     );
   });
 
   it("surfaces query failures in core settings tabs", () => {
     const billingTab = source.slice(
       source.indexOf("function BillingTab"),
-      source.indexOf("function PlanGrid")
+      source.indexOf("function PlanGrid"),
     );
 
-    expect(source).toContain('import { EmptyState } from "@/components/common/empty-state"');
+    expect(source).toContain(
+      'import { EmptyState } from "@/components/common/empty-state"',
+    );
     expect(source).toContain("function SettingsLoadError");
     expect(source).toContain("error: practiceError");
     expect(source).toContain("error: locationsError");
@@ -69,27 +70,27 @@ describe("settings UI states", () => {
     expect(source).toContain('title="Could not load billing details"');
     expect(source).toContain("onRetry={() => void refetchBilling()}");
     expect(source).toContain(
-      'import { isSafeCheckoutRedirectUrl } from "@/lib/checkout-redirect"'
+      'import { isSafeCheckoutRedirectUrl } from "@/lib/checkout-redirect"',
     );
     expect(source).toContain("function redirectToHostedBillingUrl");
     expect(source).toContain("if (!isSafeCheckoutRedirectUrl(url))");
     expect(source).toContain("redirectToHostedBillingUrl(r.url)");
     expect(source).not.toContain("if (r.url) window.location.href = r.url");
     expect(billingTab.indexOf("if (billingError)")).toBeLessThan(
-      billingTab.indexOf("if (isLoading)")
+      billingTab.indexOf("if (isLoading)"),
     );
     expect(billingTab.indexOf("if (isLoading)")).toBeLessThan(
-      billingTab.indexOf("if (!data)")
+      billingTab.indexOf("if (!data)"),
     );
     expect(billingTab).toContain(
-      "The billing details request finished without returning data. Try loading it again."
+      "The billing details request finished without returning data. Try loading it again.",
     );
     expect(billingTab).not.toContain("if (isLoading || !data)");
   });
 
   it("uses the public support address for enterprise contact links", () => {
     expect(source).toContain(
-      "mailto:support@openvpm.com?subject=OpenVPM%20Enterprise"
+      "mailto:support@openvpm.com?subject=OpenVPM%20Enterprise",
     );
     expect(source).not.toContain("mailto:evan@openvpm.com");
   });
@@ -108,22 +109,26 @@ describe("settings UI states", () => {
   it("builds the practice form only after a practice profile is present", () => {
     const practiceTab = source.slice(
       source.indexOf("function PracticeInfoTab"),
-      source.indexOf("// ── Locations")
+      source.indexOf("// ── Locations"),
     );
 
     expect(practiceTab).toContain('title="Practice settings unavailable"');
     expect(practiceTab.indexOf("if (!practice)")).toBeLessThan(
-      practiceTab.indexOf("const currentBrandColor")
+      practiceTab.indexOf("const currentBrandColor"),
     );
     expect(practiceTab.indexOf("if (!practice)")).toBeLessThan(
-      practiceTab.indexOf("const current: PracticeInfoForm")
+      practiceTab.indexOf("const current: PracticeInfoForm"),
     );
-    expect(practiceTab).toContain("name: practice.name ?? \"\"");
-    expect(practiceTab).toContain("timezone: practice.timezone ?? \"America/New_York\"");
-    expect(practiceTab).toContain("taxRatePercent: practice.taxRatePercent ?? \"8.00\"");
+    expect(practiceTab).toContain('name: practice.name ?? ""');
+    expect(practiceTab).toContain(
+      'timezone: practice.timezone ?? "America/New_York"',
+    );
+    expect(practiceTab).toContain(
+      'taxRatePercent: practice.taxRatePercent ?? "8.00"',
+    );
     expect(practiceTab).toContain("{practice.logoUrl ? (");
     expect(practiceTab).toContain(
-      '{practice.logoUrl ? "Replace logo" : "Upload logo"}'
+      '{practice.logoUrl ? "Replace logo" : "Upload logo"}',
     );
     expect(practiceTab).not.toContain("practice?.");
   });
@@ -132,81 +137,79 @@ describe("settings UI states", () => {
     expect(source).toContain("Scheduled invoice billing");
     expect(source).toContain("No auto-charge");
     expect(source).toContain("Invoice schedule");
+    expect(source).toContain("Wellness plans generate due invoices by cadence");
     expect(source).toContain(
-      "Wellness plans generate due invoices by cadence"
-    );
-    expect(source).toContain(
-      "Create a plan to package preventive care into scheduled invoice memberships."
+      "Create a plan to package preventive care into scheduled invoice memberships.",
     );
   });
 
   it("surfaces missing settings list payloads before empty states", () => {
     const locationsTab = source.slice(
       source.indexOf("function LocationsTab"),
-      source.indexOf("// ── Billing")
+      source.indexOf("// ── Billing"),
     );
     const staffTab = source.slice(
       source.indexOf("function StaffTab"),
-      source.indexOf("// ── Appointment Types")
+      source.indexOf("// ── Appointment Types"),
     );
     const appointmentTypesTab = source.slice(
       source.indexOf("function AppointmentTypesTab"),
-      source.indexOf("// ── CSV Helpers")
+      source.indexOf("// ── CSV Helpers"),
     );
     const roomsTab = source.slice(
       source.indexOf("function RoomsTab"),
-      source.indexOf("// ── Wellness Plans")
+      source.indexOf("// ── Wellness Plans"),
     );
     const wellnessTab = source.slice(
       source.indexOf("function WellnessPlansTab"),
-      source.indexOf("// ── Templates")
+      source.indexOf("// ── Templates"),
     );
     const templatesTab = source.slice(
       source.indexOf("function TemplatesTab"),
-      source.length
+      source.length,
     );
 
     expect(locationsTab).toContain("const locationsMissing =");
     expect(locationsTab).toContain('title="Could not load locations"');
     expect(locationsTab).toContain("onRetry={() => void refetchLocations()}");
     expect(locationsTab.indexOf("if (locationsMissing)")).toBeLessThan(
-      locationsTab.indexOf('title="No active locations configured"')
+      locationsTab.indexOf('title="No active locations configured"'),
     );
 
     expect(staffTab).toContain("const staffMissing =");
     expect(staffTab).toContain('title="Could not load staff"');
     expect(staffTab).toContain("onRetry={() => void refetchStaff()}");
     expect(staffTab.indexOf("if (staffMissing)")).toBeLessThan(
-      staffTab.indexOf('title="No staff members found"')
+      staffTab.indexOf('title="No staff members found"'),
     );
 
     expect(appointmentTypesTab).toContain("const appointmentTypesMissing =");
     expect(appointmentTypesTab).toContain(
-      'title="Could not load appointment types"'
+      'title="Could not load appointment types"',
     );
     expect(appointmentTypesTab).toContain(
-      "onRetry={() => void refetchAppointmentTypes()}"
+      "onRetry={() => void refetchAppointmentTypes()}",
     );
     expect(
-      appointmentTypesTab.indexOf("if (appointmentTypesMissing)")
+      appointmentTypesTab.indexOf("if (appointmentTypesMissing)"),
     ).toBeLessThan(
-      appointmentTypesTab.indexOf('title="No appointment types configured"')
+      appointmentTypesTab.indexOf('title="No appointment types configured"'),
     );
 
     expect(roomsTab).toContain("const roomsMissing =");
     expect(roomsTab).toContain('title="Could not load rooms"');
     expect(roomsTab).toContain("onRetry={() => void refetchRooms()}");
     expect(roomsTab.indexOf("if (roomsMissing)")).toBeLessThan(
-      roomsTab.indexOf('title="No rooms configured"')
+      roomsTab.indexOf('title="No rooms configured"'),
     );
 
     expect(wellnessTab).toContain("const wellnessPlansMissing =");
     expect(wellnessTab).toContain('title="Could not load wellness plans"');
     expect(wellnessTab).toContain(
-      "onRetry={() => void refetchWellnessPlans()}"
+      "onRetry={() => void refetchWellnessPlans()}",
     );
     expect(wellnessTab.indexOf("if (wellnessPlansMissing)")).toBeLessThan(
-      wellnessTab.indexOf('title="No wellness plans configured"')
+      wellnessTab.indexOf('title="No wellness plans configured"'),
     );
 
     expect(templatesTab).toContain("const templatesMissing =");
@@ -215,13 +218,13 @@ describe("settings UI states", () => {
     expect(templatesTab).toContain('title="Could not load template items"');
     expect(templatesTab).toContain("onRetry={() => void refetchTemplates()}");
     expect(templatesTab).toContain(
-      "onRetry={() => void refetchSelectedTemplate()}"
+      "onRetry={() => void refetchSelectedTemplate()}",
     );
     expect(templatesTab.indexOf("if (templatesMissing)")).toBeLessThan(
-      templatesTab.indexOf('title="No templates configured"')
+      templatesTab.indexOf('title="No templates configured"'),
     );
     expect(templatesTab.indexOf("selectedTemplateMissing ? (")).toBeLessThan(
-      templatesTab.indexOf('title="No items in this template"')
+      templatesTab.indexOf('title="No items in this template"'),
     );
   });
 
@@ -230,7 +233,9 @@ describe("settings UI states", () => {
     expect(isPracticeBackupJsonSizeValid("abc", 3)).toBe(true);
     expect(isPracticeBackupJsonSizeValid("abcd", 3)).toBe(false);
 
-    expect(source).toContain("const restoreBackup = trpc.data.restoreBackup.useMutation");
+    expect(source).toContain(
+      "const restoreBackup = trpc.data.restoreBackup.useMutation",
+    );
     expect(source).toContain("Restore Full Backup");
     expect(source).toContain("Choose Backup JSON");
     expect(source).toContain('from "@/lib/backup/policy"');
@@ -253,27 +258,27 @@ describe("settings UI states", () => {
     expect(source).toContain("function requireSettingsExportData<T>(");
     expect(source).toContain("if (result.error) {");
     expect(source).toContain(
-      "throw new Error(result.error.message || fallbackMessage)"
+      "throw new Error(result.error.message || fallbackMessage)",
     );
     expect(source).toContain("if (result.data === undefined) {");
     expect(source).toContain("throw new Error(fallbackMessage)");
     expect(source).toContain(
-      'requireSettingsExportData(\n            result,\n            "Could not export clients"'
+      'requireSettingsExportData(\n            result,\n            "Could not export clients"',
     );
     expect(source).toContain(
-      'requireSettingsExportData(\n            result,\n            "Could not export patients"'
+      'requireSettingsExportData(\n            result,\n            "Could not export patients"',
     );
     expect(source).toContain(
-      'requireSettingsExportData(\n            result,\n            "Could not export appointments"'
+      'requireSettingsExportData(\n            result,\n            "Could not export appointments"',
     );
     expect(source).toContain(
-      'requireSettingsExportData(\n            result,\n            "Could not export invoices"'
+      'requireSettingsExportData(\n            result,\n            "Could not export invoices"',
     );
     expect(source).toContain(
-      'requireSettingsExportData(\n        result,\n        "Could not export full backup"'
+      'requireSettingsExportData(\n        result,\n        "Could not export full backup"',
     );
     expect(source).toContain(
-      'err instanceof Error ? err.message : "Could not export data"'
+      'err instanceof Error ? err.message : "Could not export data"',
     );
     expect(source).not.toContain("data = (result.data ?? [])");
     expect(source).not.toContain("const raw = result.data ?? []");
@@ -282,44 +287,52 @@ describe("settings UI states", () => {
 
   it("names full backup exports from the practice timezone date", () => {
     expect(source).toContain(
-      'import { formatDateInputForTimeZone } from "@/lib/date-input"'
+      'import { formatDateInputForTimeZone } from "@/lib/date-input"',
     );
     expect(source).toContain("function formatSettingsDateInput(");
     expect(source).toContain(
-      'return formatDateInputForTimeZone(value, timeZone?.trim() || "UTC")'
+      'return formatDateInputForTimeZone(value, timeZone?.trim() || "UTC")',
     );
     expect(source).toContain("const practiceSettingsMissing =");
     expect(source).toContain("const verifiedPracticeSettings =");
     expect(source).toContain(
-      "const settingsTimeZone = verifiedPracticeSettings\n    ? verifiedPracticeSettings.timezone\n    : null"
+      "const settingsTimeZone = verifiedPracticeSettings\n    ? verifiedPracticeSettings.timezone\n    : null",
     );
     expect(source).toContain(
-      'throw new Error("Could not load practice settings for backup export")'
+      'throw new Error("Could not load practice settings for backup export")',
     );
     expect(source).toContain(
-      "const date = formatSettingsDateInput(new Date(), settingsTimeZone)"
+      "const date = formatSettingsDateInput(new Date(), settingsTimeZone)",
     );
     expect(source).toContain("openvpm-full-backup-${date}.json");
     expect(source).toContain(
-      "[exportFullBackup, settingsTimeZone, verifiedPracticeSettings]"
+      "[exportFullBackup, settingsTimeZone, verifiedPracticeSettings]",
     );
-    expect(source).toContain("Unable to load practice settings for backup export.");
-    expect(source).not.toContain("const settingsTimeZone = practiceSettings?.timezone");
+    expect(source).toContain(
+      "Unable to load practice settings for backup export.",
+    );
+    expect(source).not.toContain(
+      "const settingsTimeZone = practiceSettings?.timezone",
+    );
     expect(source).not.toContain("new Date().toISOString().slice(0, 10)");
   });
 
   it("fails closed when sample-data status is unavailable", () => {
-    expect(source).toContain("const onboarding = trpc.settings.onboardingStatus.useQuery()");
+    expect(source).toContain(
+      "const onboarding = trpc.settings.onboardingStatus.useQuery()",
+    );
     expect(source).toContain("const onboardingMissing =");
     expect(source).toContain("const verifiedOnboardingStatus =");
     expect(source).toContain(
-      "const hasDemo = verifiedOnboardingStatus\n    ? verifiedOnboardingStatus.hasDemoData\n    : false"
+      "const hasDemo = verifiedOnboardingStatus\n    ? verifiedOnboardingStatus.hasDemoData\n    : false",
     );
     expect(source).toContain("if (!verifiedOnboardingStatus) return;");
     expect(source).toContain("Boolean(onboarding.error)");
     expect(source).toContain("onboardingMissing");
     expect(source).toContain("!verifiedOnboardingStatus");
-    expect(source).toContain("Unable to load sample data status. Please retry.");
+    expect(source).toContain(
+      "Unable to load sample data status. Please retry.",
+    );
     expect(source).not.toContain("onboarding.data?.hasDemoData ?? false");
   });
 
@@ -327,22 +340,37 @@ describe("settings UI states", () => {
     expect(IMPORT_CSV_MAX_BYTES).toBe(5_000_000);
     expect(isImportCsvSizeValid("a".repeat(IMPORT_CSV_MAX_BYTES))).toBe(true);
     expect(isImportCsvSizeValid("a".repeat(IMPORT_CSV_MAX_BYTES + 1))).toBe(
-      false
+      false,
     );
 
-    expect(source).toContain("const importClientsCsv = trpc.data.importClientsCsv.useMutation");
-    expect(source).toContain("const importPatientsCsv = trpc.data.importPatientsCsv.useMutation");
+    expect(source).toContain(
+      "const importClientsCsv = trpc.data.importClientsCsv.useMutation",
+    );
+    expect(source).toContain(
+      "const importPatientsCsv = trpc.data.importPatientsCsv.useMutation",
+    );
     expect(source).toContain('from "@/lib/import/policy"');
     expect(source).toContain("file.size > IMPORT_CSV_MAX_BYTES");
     expect(source).toContain("isImportCsvSizeValid(text)");
     expect(source).toContain("isImportCsvSizeValid(csvText)");
     expect(source).toContain("CSV imports must be 5 MB or less.");
     expect(source).toContain("CSV files must be 5 MB or less.");
-    expect(source).toContain("importClientsCsv.mutate({ csv: text, dryRun: true })");
-    expect(source).toContain("importPatientsCsv.mutate({ csv: text, dryRun: true })");
+    expect(source).toContain('const importSource = migrationSource ?? "other"');
+    expect(source).toContain("importClientsCsv.mutate({");
+    expect(source).toContain("importPatientsCsv.mutate({");
+    expect(source).toContain("source: importSource");
     expect(source).toContain("duplicates: data.duplicates");
     expect(source).toContain('label="Row issues"');
-    expect(source).toContain("Confirm Import ({importPreview.willInsert} rows)");
+    expect(source).toContain("IDs to connect");
+    expect(source).toContain("Confirm Import (");
+    expect(source).toContain("changes)");
+    expect(source).toContain("const importFileReadVersionRef = useRef(0)");
+    expect(source).toContain(
+      "const readVersion = ++importFileReadVersionRef.current",
+    );
+    expect(source).toContain(
+      "if (importFileReadVersionRef.current !== readVersion) return;",
+    );
     expect(source).not.toContain("function parseCSV");
     expect(source).not.toContain("row.first_name");
   });
@@ -352,23 +380,21 @@ describe("settings UI states", () => {
     expect(ACCOUNT_DELETION_REASON_MAX_LENGTH).toBe(1000);
     expect(source).toContain("ACCOUNT_DELETION_REASON_MAX_LENGTH");
     expect(source).toContain("maxLength={SETTINGS_EMAIL_MAX_LENGTH}");
+    expect(source).toContain("maxLength={ACCOUNT_DELETION_REASON_MAX_LENGTH}");
     expect(source).toContain(
-      "maxLength={ACCOUNT_DELETION_REASON_MAX_LENGTH}"
+      "const isDeletionContactEmailValid = (email: string) =>",
     );
     expect(source).toContain(
-      "const isDeletionContactEmailValid = (email: string) =>"
+      "email.trim().length <= SETTINGS_EMAIL_MAX_LENGTH",
     );
     expect(source).toContain(
-      "email.trim().length <= SETTINGS_EMAIL_MAX_LENGTH"
+      "const isDeletionReasonValid = (reason: string) =>",
     );
     expect(source).toContain(
-      "const isDeletionReasonValid = (reason: string) =>"
+      "reason.trim().length <= ACCOUNT_DELETION_REASON_MAX_LENGTH",
     );
     expect(source).toContain(
-      "reason.trim().length <= ACCOUNT_DELETION_REASON_MAX_LENGTH"
-    );
-    expect(source).toContain(
-      "isDeletionContactEmailValid(deletionContactEmail)"
+      "isDeletionContactEmailValid(deletionContactEmail)",
     );
     expect(source).toContain("isDeletionReasonValid(deletionReason)");
     expect(source).not.toContain("maxLength={1000}");
@@ -377,39 +403,41 @@ describe("settings UI states", () => {
   it("renders account deletion timestamps in the practice timezone", () => {
     expect(source).toContain("function formatSettingsDateTime(");
     expect(source).toContain(
-      'const resolvedTimeZone = timeZone?.trim() || "UTC"'
+      'const resolvedTimeZone = timeZone?.trim() || "UTC"',
     );
     expect(source).toContain(
-      "data: practiceSettings,\n    isLoading: practiceSettingsLoading,\n    error: practiceSettingsError"
+      "data: practiceSettings,\n    isLoading: practiceSettingsLoading,\n    error: practiceSettingsError",
     );
     expect(source).toContain("} = trpc.settings.getPractice.useQuery();");
     expect(source).toContain("const verifiedPracticeSettings =");
     expect(source).toContain(
-      "const settingsTimeZone = verifiedPracticeSettings\n    ? verifiedPracticeSettings.timezone\n    : null"
+      "const settingsTimeZone = verifiedPracticeSettings\n    ? verifiedPracticeSettings.timezone\n    : null",
     );
     expect(source).toContain(
-      "formatSettingsDateTime(deletionRequest.requestedAt, settingsTimeZone)"
+      "formatSettingsDateTime(deletionRequest.requestedAt, settingsTimeZone)",
     );
     expect(source).toContain("const deletionSettingsMissing =");
     expect(source).toContain(
-      'new Error("Could not load practice settings. Please retry.")'
+      'new Error("Could not load practice settings. Please retry.")',
     );
     expect(source).toContain("practiceSettingsLoading");
     expect(source).toContain("practiceSettingsError");
     expect(source).toContain("Could not load deletion status");
-    expect(source).not.toContain("const settingsTimeZone = practiceSettings?.timezone");
+    expect(source).not.toContain(
+      "const settingsTimeZone = practiceSettings?.timezone",
+    );
     expect(source).not.toContain("new Intl.DateTimeFormat(undefined");
     expect(source).not.toContain(
-      "format(new Date(deletionRequest.requestedAt))"
+      "format(new Date(deletionRequest.requestedAt))",
     );
   });
 
   it("counts billing trial days from the practice timezone", () => {
     expect(source).toContain(
-      'import { trialCalendarDaysLeft } from "@/lib/billing/trial-days"'
+      'import { trialCalendarDaysLeft } from "@/lib/billing/trial-days"',
     );
     expect(source).toContain(
-      "const daysLeft = trialCalendarDaysLeft(data.trialEndsAt, data.timezone) ?? 0"
+      "const daysLeft = trialCalendarDaysLeft(data.trialEndsAt, data.timezone) ?? 0",
     );
     expect(source).not.toContain("trialEnds.getTime() - Date.now()");
   });
@@ -418,10 +446,10 @@ describe("settings UI states", () => {
     expect(AUTH_PASSWORD_MIN_LENGTH).toBe(8);
     expect(AUTH_PASSWORD_MAX_LENGTH).toBe(128);
     expect(source).toContain(
-      'AUTH_PASSWORD_MAX_LENGTH,\n  AUTH_PASSWORD_MIN_LENGTH,'
+      "AUTH_PASSWORD_MAX_LENGTH,\n  AUTH_PASSWORD_MIN_LENGTH,",
     );
     expect(source).toContain(
-      "placeholder={`Password (min ${AUTH_PASSWORD_MIN_LENGTH} chars)`}"
+      "placeholder={`Password (min ${AUTH_PASSWORD_MIN_LENGTH} chars)`}",
     );
     expect(source).toContain("maxLength={AUTH_PASSWORD_MAX_LENGTH}");
     expect(source).toContain("password.length >= AUTH_PASSWORD_MIN_LENGTH");
@@ -436,10 +464,10 @@ describe("settings UI states", () => {
     expect(source).toContain("APPOINTMENT_TYPE_DURATION_MIN_MINUTES");
     expect(source).toContain("APPOINTMENT_TYPE_DURATION_MAX_MINUTES");
     expect(source).toContain(
-      "duration >= APPOINTMENT_TYPE_DURATION_MIN_MINUTES"
+      "duration >= APPOINTMENT_TYPE_DURATION_MIN_MINUTES",
     );
     expect(source).toContain(
-      "duration <= APPOINTMENT_TYPE_DURATION_MAX_MINUTES"
+      "duration <= APPOINTMENT_TYPE_DURATION_MAX_MINUTES",
     );
     expect(source).toContain("min={APPOINTMENT_TYPE_DURATION_MIN_MINUTES}");
     expect(source).toContain("max={APPOINTMENT_TYPE_DURATION_MAX_MINUTES}");
@@ -453,14 +481,14 @@ describe("settings UI states", () => {
     expect(source).toContain("APPOINTMENT_TYPE_NAME_MAX_LENGTH");
     expect(source).toContain("ROOM_NAME_MAX_LENGTH");
     expect(
-      source.match(/maxLength={APPOINTMENT_TYPE_NAME_MAX_LENGTH}/g)
+      source.match(/maxLength={APPOINTMENT_TYPE_NAME_MAX_LENGTH}/g),
     ).toHaveLength(2);
     expect(source).toContain("maxLength={ROOM_NAME_MAX_LENGTH}");
     expect(source).toContain(
-      "const isAppointmentTypeNameValid = (name: string) =>"
+      "const isAppointmentTypeNameValid = (name: string) =>",
     );
     expect(source).toContain(
-      "name.trim().length <= APPOINTMENT_TYPE_NAME_MAX_LENGTH"
+      "name.trim().length <= APPOINTMENT_TYPE_NAME_MAX_LENGTH",
     );
     expect(source).toContain("const isRoomNameValid = (name: string) =>");
     expect(source).toContain("name.trim().length <= ROOM_NAME_MAX_LENGTH");
@@ -468,7 +496,7 @@ describe("settings UI states", () => {
     expect(source).toContain("!isAppointmentTypeNameValid(editForm.name)");
     expect(source).toContain("!isRoomNameValid(addForm.name)");
     expect(source).not.toContain(
-      "disabled={!addForm.name || createMutation.isPending}"
+      "disabled={!addForm.name || createMutation.isPending}",
     );
   });
 
@@ -480,27 +508,27 @@ describe("settings UI states", () => {
     expect(source).toContain("SETTINGS_PHONE_MAX_LENGTH");
     expect(source).toContain("SETTINGS_ADDRESS_MAX_LENGTH");
     expect(source.match(/maxLength={LOCATION_NAME_MAX_LENGTH}/g)).toHaveLength(
-      2
+      2,
     );
     expect(source).toContain("maxLength={SETTINGS_PHONE_MAX_LENGTH}");
     expect(source).toContain("maxLength={SETTINGS_ADDRESS_MAX_LENGTH}");
     expect(source).toContain("const isLocationFormValid = (form: {");
     expect(source).toContain(
-      "form.name.trim().length <= LOCATION_NAME_MAX_LENGTH"
+      "form.name.trim().length <= LOCATION_NAME_MAX_LENGTH",
     );
     expect(source).toContain(
-      "form.phone.trim().length <= SETTINGS_PHONE_MAX_LENGTH"
+      "form.phone.trim().length <= SETTINGS_PHONE_MAX_LENGTH",
     );
     expect(source).toContain(
-      "form.address.trim().length <= SETTINGS_ADDRESS_MAX_LENGTH"
+      "form.address.trim().length <= SETTINGS_ADDRESS_MAX_LENGTH",
     );
     expect(source).toContain("!isLocationFormValid(addForm)");
     expect(source).toContain("!isLocationFormValid(editForm)");
     expect(source).not.toContain(
-      "disabled={!addForm.name.trim() || createMutation.isPending}"
+      "disabled={!addForm.name.trim() || createMutation.isPending}",
     );
     expect(source).not.toContain(
-      "disabled={!editForm.name.trim() || updateMutation.isPending}"
+      "disabled={!editForm.name.trim() || updateMutation.isPending}",
     );
   });
 
@@ -521,26 +549,26 @@ describe("settings UI states", () => {
     expect(source).toContain("maxLength={SETTINGS_WEBSITE_MAX_LENGTH}");
     expect(source).toContain("maxLength={SETTINGS_VAT_NUMBER_MAX_LENGTH}");
     expect(source).toContain(
-      "const isPracticeInfoFormValid = (practiceForm: PracticeInfoForm) =>"
+      "const isPracticeInfoFormValid = (practiceForm: PracticeInfoForm) =>",
     );
     expect(source).toContain(
-      "practiceForm.name.trim().length <= PRACTICE_NAME_MAX_LENGTH"
+      "practiceForm.name.trim().length <= PRACTICE_NAME_MAX_LENGTH",
     );
     expect(source).toContain(
-      "practiceForm.address.trim().length <= SETTINGS_ADDRESS_MAX_LENGTH"
+      "practiceForm.address.trim().length <= SETTINGS_ADDRESS_MAX_LENGTH",
     );
     expect(source).toContain(
-      "practiceForm.phone.trim().length <= SETTINGS_PHONE_MAX_LENGTH"
+      "practiceForm.phone.trim().length <= SETTINGS_PHONE_MAX_LENGTH",
     );
     expect(source).toContain(
-      "practiceForm.website.trim().length <= SETTINGS_WEBSITE_MAX_LENGTH"
+      "practiceForm.website.trim().length <= SETTINGS_WEBSITE_MAX_LENGTH",
     );
     expect(source).toContain(
-      "isSupportedPracticeTimezone(practiceForm.timezone)"
+      "isSupportedPracticeTimezone(practiceForm.timezone)",
     );
     expect(source).toContain("SETTINGS_TAX_RATE_PATTERN.test");
     expect(source).toContain(
-      "practiceForm.vatNumber.trim().length <= SETTINGS_VAT_NUMBER_MAX_LENGTH"
+      "practiceForm.vatNumber.trim().length <= SETTINGS_VAT_NUMBER_MAX_LENGTH",
     );
     expect(source).toContain("email: current.email.trim() || undefined");
     expect(source).toContain("!isPracticeInfoFormValid(current)");
@@ -556,17 +584,17 @@ describe("settings UI states", () => {
     expect(source.match(/maxLength={STAFF_NAME_MAX_LENGTH}/g)).toHaveLength(3);
     expect(source).toContain("maxLength={SETTINGS_EMAIL_MAX_LENGTH}");
     expect(
-      source.match(/maxLength={STAFF_LICENSE_NUMBER_MAX_LENGTH}/g)
+      source.match(/maxLength={STAFF_LICENSE_NUMBER_MAX_LENGTH}/g),
     ).toHaveLength(2);
     expect(source).toContain("maxLength={SETTINGS_PHONE_MAX_LENGTH}");
     expect(source).toContain(
-      "const isStaffCreateFormValid = (form: typeof addForm) =>"
+      "const isStaffCreateFormValid = (form: typeof addForm) =>",
     );
     expect(source).toContain(
-      "const isStaffInviteFormValid = (form: typeof inviteForm) =>"
+      "const isStaffInviteFormValid = (form: typeof inviteForm) =>",
     );
     expect(source).toContain(
-      "const isStaffEditFormValid = (form: typeof editForm) =>"
+      "const isStaffEditFormValid = (form: typeof editForm) =>",
     );
     expect(source).toContain("isSettingsEmailInputValid(form.email)");
     expect(source).toContain("isStaffContactFieldsValid(form)");
@@ -575,7 +603,7 @@ describe("settings UI states", () => {
     expect(source).toContain("!isStaffEditFormValid(editForm)");
     expect(source).not.toContain("disabled={!isValidEmail(inviteForm.email)");
     expect(source).not.toContain(
-      "addForm.password.length < AUTH_PASSWORD_MIN_LENGTH"
+      "addForm.password.length < AUTH_PASSWORD_MIN_LENGTH",
     );
   });
 });

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -7,15 +7,19 @@ import { auditLog } from "@openpims/db";
  * best-effort insert and must never throw into the request path.
  */
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const SECRET_KEY_RE = /pass(word)?|secret|token|keyhash|^key$|apikey/i;
 // Bulk import/restore payloads (raw CSV, full backup JSON) can be megabytes of
 // medical records + client PII. The audit trail records who ran the import and
 // when, not a second copy of the data, so these are replaced with a marker.
-const BULK_PAYLOAD_KEY_RE = /^(csv|backup)$/i;
+const BULK_PAYLOAD_KEY_RE = /(?:csv$|^backup$)/i;
 
 /** "clients.create" -> { entityType: "clients", action: "create" }. */
-export function parseAuditPath(path: string): { entityType: string; action: string } {
+export function parseAuditPath(path: string): {
+  entityType: string;
+  action: string;
+} {
   const dot = path.indexOf(".");
   const entityType = (dot === -1 ? path : path.slice(0, dot)).slice(0, 64);
   const action = (dot === -1 ? "" : path.slice(dot + 1)).slice(0, 64);
@@ -50,11 +54,16 @@ export function redactSecrets(input: unknown): Record<string, unknown> | null {
 }
 
 /** Best-effort entity id: prefer the created/updated row's id, else input.id. */
-export function extractEntityId(rawInput: unknown, resultData: unknown): string | null {
+export function extractEntityId(
+  rawInput: unknown,
+  resultData: unknown,
+): string | null {
   const fromResult = (resultData as { id?: unknown } | null)?.id;
-  if (typeof fromResult === "string" && UUID_RE.test(fromResult)) return fromResult;
+  if (typeof fromResult === "string" && UUID_RE.test(fromResult))
+    return fromResult;
   const fromInput = (rawInput as { id?: unknown } | null)?.id;
-  if (typeof fromInput === "string" && UUID_RE.test(fromInput)) return fromInput;
+  if (typeof fromInput === "string" && UUID_RE.test(fromInput))
+    return fromInput;
   return null;
 }
 
@@ -67,7 +76,7 @@ export async function recordAuditLog(
     path: string;
     rawInput: unknown;
     resultData: unknown;
-  }
+  },
 ): Promise<void> {
   try {
     const { entityType, action } = parseAuditPath(opts.path);

--- a/apps/web/lib/csv/__tests__/import.test.ts
+++ b/apps/web/lib/csv/__tests__/import.test.ts
@@ -51,7 +51,8 @@ describe("parseCsv", () => {
 
 describe("csvToClientRecords", () => {
   it("maps flexible headers and requires first/last name", () => {
-    const csv = "First Name,Last Name,Email\nJane,Doe,jane@x.com\n,Smith,bob@x.com";
+    const csv =
+      "First Name,Last Name,Email\nJane,Doe,jane@x.com\n,Smith,bob@x.com";
     const { records, errors } = csvToClientRecords(csv);
     expect(records).toEqual([
       { firstName: "Jane", lastName: "Doe", email: "jane@x.com" },
@@ -62,7 +63,7 @@ describe("csvToClientRecords", () => {
 
   it("does not map records from malformed quoted CSV", () => {
     const { records, errors } = csvToClientRecords(
-      'First Name,Last Name\n"Jane,Doe'
+      'First Name,Last Name\n"Jane,Doe',
     );
 
     expect(records).toEqual([]);
@@ -124,7 +125,7 @@ describe("csvToPatientRecords", () => {
 
   it("does not map patient records from malformed quoted CSV", () => {
     const { records, errors } = csvToPatientRecords(
-      'clientEmail,name,species\n"owner@example.com,Rex,canine'
+      'clientEmail,name,species\n"owner@example.com,Rex,canine',
     );
 
     expect(records).toEqual([]);
@@ -157,30 +158,29 @@ describe("csvToPatientRecords", () => {
   });
 
   it("passes unreadable DOBs through so the router reports them precisely", () => {
-    const csv = "clientEmail,name,species,dob\njane@x.com,Rex,canine,last spring";
+    const csv =
+      "clientEmail,name,species,dob\njane@x.com,Rex,canine,last spring";
     const { records } = csvToPatientRecords(csv);
     expect(records[0]!.dob).toBe("last spring");
   });
 
-  it("stops an ID-linked raw PIMS table before row mapping and explains assisted migration", () => {
+  it("maps an ID-linked raw PIMS patient table without requiring owner email", () => {
     const csv =
-      "Client ID,Patient Name,Species\n" +
-      "client-4839,Rex,Dog\n".repeat(100);
+      "Client ID,Patient Name,Species\n" + "client-4839,Rex,Dog\n".repeat(100);
     const { records, errors } = csvToPatientRecords(csv);
 
-    expect(records).toEqual([]);
-    expect(errors).toEqual([
-      expect.stringMatching(
-        /owner\/client ID column.*currently links records by owner email.*assisted migration/i
-      ),
-    ]);
-    expect(errors[0]).not.toContain("client-4839");
-    expect(errors[0]).not.toContain("Rex");
+    expect(records).toHaveLength(100);
+    expect(records[0]).toMatchObject({
+      externalClientId: "client-4839",
+      name: "Rex",
+      species: "canine",
+    });
+    expect(errors).toEqual([]);
   });
 
   it("reports absent required headers before producing per-row errors", () => {
     const { records, errors } = csvToPatientRecords(
-      "Owner Email,Patient Name\nowner@example.com,Rex"
+      "Owner Email,Patient Name\nowner@example.com,Rex",
     );
 
     expect(records).toEqual([]);
@@ -208,9 +208,33 @@ describe("csvToClientRecords migration aliases", () => {
       zip: "83701",
     });
   });
+
+  it("preserves opaque external client IDs including leading zeroes and case", () => {
+    const { records, errors } = csvToClientRecords(
+      "Owner ID,First Name,Last Name\n00AbC-19,Jane,Doe",
+    );
+
+    expect(errors).toEqual([]);
+    expect(records[0]).toMatchObject({
+      externalClientId: "00AbC-19",
+      firstName: "Jane",
+      lastName: "Doe",
+    });
+  });
 });
 
 describe("csvToVaccinationRecords", () => {
+  it("accepts a direct patient ID without owner email or patient name", () => {
+    const { records, errors } = csvToVaccinationRecords(
+      "Patient ID,Vaccine,Date Given\nPET-002,Rabies,2025-01-01",
+    );
+
+    expect(errors).toEqual([]);
+    expect(records[0]).toMatchObject({
+      externalPatientId: "PET-002",
+      vaccineName: "Rabies",
+    });
+  });
   it("maps vaccine history rows with alias headers and US dates", () => {
     const csv =
       "Owner Email,Pet Name,Vaccine,Date Given,Due Date,Lot,Manufacturer\n" +
@@ -238,7 +262,9 @@ describe("csvToVaccinationRecords", () => {
     const { records, errors } = csvToVaccinationRecords(csv);
     expect(records).toEqual([]);
     expect(errors).toHaveLength(4);
-    expect(errors[0]).toMatch(/Row 1: clientEmail is required/);
+    expect(errors[0]).toMatch(
+      /Row 1: a patient ID or owner reference is required/,
+    );
     expect(errors[1]).toMatch(/Row 2: patientName is required/);
     expect(errors[2]).toMatch(/Row 3: vaccineName is required/);
     expect(errors[3]).toMatch(/Row 4: dateGiven must be a date/);
@@ -256,25 +282,41 @@ describe("csvToVaccinationRecords", () => {
 
   it("does not map vaccination records from malformed quoted CSV", () => {
     const { records, errors } = csvToVaccinationRecords(
-      'clientEmail,patientName,vaccineName,dateGiven\n"jane@x.com,Rex'
+      'clientEmail,patientName,vaccineName,dateGiven\n"jane@x.com,Rex',
     );
     expect(records).toEqual([]);
     expect(errors).toEqual(["CSV has an unterminated quoted field."]);
   });
 
-  it("detects an ID-linked export before parsing vaccination rows", () => {
+  it("maps vaccination rows by external owner ID plus patient name", () => {
     const { records, errors } = csvToVaccinationRecords(
-      "Account Number,Patient Name,Vaccine,Date Given\n42,Rex,Rabies,2025-01-01"
+      "Account Number,Patient Name,Vaccine,Date Given\n42,Rex,Rabies,2025-01-01",
     );
 
-    expect(records).toEqual([]);
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toMatch(/owner\/client ID column/i);
-    expect(errors[0]).not.toContain("Rabies");
+    expect(records).toEqual([
+      expect.objectContaining({
+        externalClientId: "42",
+        patientName: "Rex",
+        vaccineName: "Rabies",
+      }),
+    ]);
+    expect(errors).toEqual([]);
   });
 });
 
 describe("csvToSoapNoteRecords", () => {
+  it("accepts a direct patient ID without owner email or patient name", () => {
+    const { records, errors } = csvToSoapNoteRecords(
+      "Patient ID,Visit Date,Notes\nPET-002,2025-01-01,Annual exam",
+    );
+
+    expect(errors).toEqual([]);
+    expect(records[0]).toMatchObject({
+      externalPatientId: "PET-002",
+      date: "2025-01-01",
+      subjective: "Annual exam",
+    });
+  });
   it("maps split SOAP columns with alias headers and US dates", () => {
     const csv =
       "Owner Email,Pet Name,Visit Date,Subjective,Objective,Assessment,Plan\n" +
@@ -329,9 +371,7 @@ describe("csvToSoapNoteRecords", () => {
     expect(records).toHaveLength(1);
     expect(records[0]!.patientName).toBe("Rex");
     expect(
-      errors.some((e) =>
-        /Row 2: clientEmail "none" is not a valid email/.test(e)
-      )
+      errors.some((e) => /Row 2: clientEmail is not a valid email/.test(e)),
     ).toBe(true);
   });
 
@@ -365,7 +405,9 @@ describe("csvToSoapNoteRecords", () => {
     const { records, errors } = csvToSoapNoteRecords(csv);
     expect(records).toEqual([]);
     expect(errors).toHaveLength(4);
-    expect(errors[0]).toMatch(/Row 1: clientEmail is required/);
+    expect(errors[0]).toMatch(
+      /Row 1: a patient ID or owner reference is required/,
+    );
     expect(errors[1]).toMatch(/Row 2: patientName is required/);
     expect(errors[2]).toMatch(/Row 3: date must be a date/);
     expect(errors[3]).toMatch(/Row 4: needs at least one note/);
@@ -373,7 +415,7 @@ describe("csvToSoapNoteRecords", () => {
 
   it("does not map notes from malformed quoted CSV", () => {
     const { records, errors } = csvToSoapNoteRecords(
-      'clientEmail,patientName,date,notes\n"jane@x.com,Rex'
+      'clientEmail,patientName,date,notes\n"jane@x.com,Rex',
     );
     expect(records).toEqual([]);
     expect(errors).toEqual(["CSV has an unterminated quoted field."]);
@@ -381,12 +423,14 @@ describe("csvToSoapNoteRecords", () => {
 
   it("requires a recognized note-content column at file preflight", () => {
     const { records, errors } = csvToSoapNoteRecords(
-      "Owner Email,Patient Name,Visit Date,Provider\nowner@example.com,Rex,2025-01-01,Dr. Example"
+      "Owner Email,Patient Name,Visit Date,Provider\nowner@example.com,Rex,2025-01-01,Dr. Example",
     );
 
     expect(records).toEqual([]);
     expect(errors).toEqual([
-      expect.stringMatching(/missing a recognized medical-note content column/i),
+      expect.stringMatching(
+        /missing a recognized medical-note content column/i,
+      ),
     ]);
     expect(errors[0]).not.toContain("owner@example.com");
     expect(errors[0]).not.toContain("Rex");

--- a/apps/web/lib/csv/import.ts
+++ b/apps/web/lib/csv/import.ts
@@ -18,6 +18,7 @@ import { SOAP_SECTION_MAX_LENGTH } from "@/lib/records/soap-content";
  */
 
 export interface ClientImportRecord {
+  externalClientId?: string;
   firstName: string;
   lastName: string;
   email?: string;
@@ -29,9 +30,18 @@ export interface ClientImportRecord {
 }
 
 export interface PatientImportRecord {
-  clientEmail: string;
+  clientEmail?: string;
+  externalClientId?: string;
+  externalPatientId?: string;
   name: string;
-  species: "canine" | "feline" | "avian" | "rabbit" | "reptile" | "equine" | "other";
+  species:
+    | "canine"
+    | "feline"
+    | "avian"
+    | "rabbit"
+    | "reptile"
+    | "equine"
+    | "other";
   breed?: string;
   sex?: "male" | "female" | "male_neutered" | "female_spayed";
   dob?: string;
@@ -40,8 +50,10 @@ export interface PatientImportRecord {
 }
 
 export interface VaccinationImportRecord {
-  clientEmail: string;
-  patientName: string;
+  clientEmail?: string;
+  externalClientId?: string;
+  externalPatientId?: string;
+  patientName?: string;
   vaccineName: string;
   administeredAt: string;
   nextDueDate?: string;
@@ -50,8 +62,10 @@ export interface VaccinationImportRecord {
 }
 
 export interface SoapNoteImportRecord {
-  clientEmail: string;
-  patientName: string;
+  clientEmail?: string;
+  externalClientId?: string;
+  externalPatientId?: string;
+  patientName?: string;
   /** Visit date (YYYY-MM-DD). Preserved onto the record so the medical
    * history timeline reads in true chronological order after a migration. */
   date: string;
@@ -66,7 +80,15 @@ export interface ParseResult<T> {
   errors: string[];
 }
 
-const SPECIES = ["canine", "feline", "avian", "rabbit", "reptile", "equine", "other"];
+const SPECIES = [
+  "canine",
+  "feline",
+  "avian",
+  "rabbit",
+  "reptile",
+  "equine",
+  "other",
+];
 
 /**
  * Normalized-header aliases per field (see parse.ts normalizeKey: lowercase,
@@ -74,10 +96,42 @@ const SPECIES = ["canine", "feline", "avian", "rabbit", "reptile", "equine", "ot
  * headers first — a round-trip of our own export must always import.
  */
 const CLIENT_ALIASES: Record<keyof ClientImportRecord, string[]> = {
-  firstName: ["firstname", "first", "clientfirstname", "ownerfirstname", "fname", "givenname"],
-  lastName: ["lastname", "last", "surname", "clientlastname", "ownerlastname", "lname", "familyname"],
+  externalClientId: [
+    "clientid",
+    "ownerid",
+    "accountid",
+    "clientnumber",
+    "ownernumber",
+    "accountnumber",
+  ],
+  firstName: [
+    "firstname",
+    "first",
+    "clientfirstname",
+    "ownerfirstname",
+    "fname",
+    "givenname",
+  ],
+  lastName: [
+    "lastname",
+    "last",
+    "surname",
+    "clientlastname",
+    "ownerlastname",
+    "lname",
+    "familyname",
+  ],
   email: ["email", "emailaddress", "clientemail", "owneremail", "email1"],
-  phone: ["phone", "phonenumber", "homephone", "cellphone", "mobilephone", "mobile", "phone1", "contactnumber"],
+  phone: [
+    "phone",
+    "phonenumber",
+    "homephone",
+    "cellphone",
+    "mobilephone",
+    "mobile",
+    "phone1",
+    "contactnumber",
+  ],
   address: ["address", "address1", "streetaddress", "addressline1", "street"],
   city: ["city", "town"],
   state: ["state", "province", "region"],
@@ -85,6 +139,22 @@ const CLIENT_ALIASES: Record<keyof ClientImportRecord, string[]> = {
 };
 
 const PATIENT_ALIASES: Record<keyof PatientImportRecord, string[]> = {
+  externalClientId: [
+    "clientid",
+    "ownerid",
+    "accountid",
+    "clientnumber",
+    "ownernumber",
+    "accountnumber",
+  ],
+  externalPatientId: [
+    "patientid",
+    "petid",
+    "animalid",
+    "patientnumber",
+    "petnumber",
+    "animalnumber",
+  ],
   clientEmail: ["clientemail", "owneremail", "email", "emailaddress"],
   name: ["name", "patientname", "petname", "patient", "pet", "animalname"],
   species: ["species", "speciesdescription", "kind", "animaltype"],
@@ -92,15 +162,67 @@ const PATIENT_ALIASES: Record<keyof PatientImportRecord, string[]> = {
   sex: ["sex", "gender"],
   dob: ["dob", "dateofbirth", "birthday", "birthdate", "born"],
   color: ["color", "colour", "markings"],
-  microchipNumber: ["microchipnumber", "microchip", "chipnumber", "microchipid", "chipid"],
+  microchipNumber: [
+    "microchipnumber",
+    "microchip",
+    "chipnumber",
+    "microchipid",
+    "chipid",
+  ],
 };
 
 const VACCINATION_ALIASES: Record<keyof VaccinationImportRecord, string[]> = {
+  externalClientId: [
+    "clientid",
+    "ownerid",
+    "accountid",
+    "clientnumber",
+    "ownernumber",
+    "accountnumber",
+  ],
+  externalPatientId: [
+    "patientid",
+    "petid",
+    "animalid",
+    "patientnumber",
+    "petnumber",
+    "animalnumber",
+  ],
   clientEmail: ["clientemail", "owneremail", "email", "emailaddress"],
-  patientName: ["patientname", "name", "petname", "patient", "pet", "animalname"],
-  vaccineName: ["vaccinename", "vaccine", "vaccination", "description", "treatment"],
-  administeredAt: ["administeredat", "dategiven", "givendate", "givenon", "date", "vaccinationdate", "administered", "dateadministered"],
-  nextDueDate: ["nextduedate", "duedate", "nextdue", "due", "dueon", "expires", "expirationdate"],
+  patientName: [
+    "patientname",
+    "name",
+    "petname",
+    "patient",
+    "pet",
+    "animalname",
+  ],
+  vaccineName: [
+    "vaccinename",
+    "vaccine",
+    "vaccination",
+    "description",
+    "treatment",
+  ],
+  administeredAt: [
+    "administeredat",
+    "dategiven",
+    "givendate",
+    "givenon",
+    "date",
+    "vaccinationdate",
+    "administered",
+    "dateadministered",
+  ],
+  nextDueDate: [
+    "nextduedate",
+    "duedate",
+    "nextdue",
+    "due",
+    "dueon",
+    "expires",
+    "expirationdate",
+  ],
   lotNumber: ["lotnumber", "lot", "serialnumber", "serial"],
   manufacturer: ["manufacturer", "maker", "brand", "producer"],
 };
@@ -111,35 +233,94 @@ const VACCINATION_ALIASES: Record<keyof VaccinationImportRecord, string[]> = {
  * (not split into S/O/A/P) land it in the Subjective section. Explicit
  * subjective/objective/assessment/plan columns always win when present.
  */
-const SOAP_NOTE_ALIASES: Record<
-  keyof SoapNoteImportRecord | "note",
-  string[]
-> = {
-  clientEmail: ["clientemail", "owneremail", "email", "emailaddress"],
-  patientName: ["patientname", "name", "petname", "patient", "pet", "animalname"],
-  date: [
-    "date",
-    "visitdate",
-    "dateofservice",
-    "servicedate",
-    "serviceddate",
-    "examdate",
-    "recorddate",
-    "recordeddate",
-    "dateofvisit",
-    "encounterdate",
-    "dateseen",
-  ],
-  subjective: ["subjective", "history", "presentingcomplaint", "chiefcomplaint", "reasonforvisit", "complaint"],
-  objective: ["objective", "examfindings", "physicalexam", "findings", "examination"],
-  assessment: ["assessment", "diagnosis", "impression", "dx"],
-  plan: ["plan", "treatmentplan", "treatment", "recommendations", "planofcare"],
-  note: ["note", "notes", "medicalnotes", "visitnotes", "soapnote", "soap", "chartnote", "clinicalnotes", "progressnote", "recordtext", "summary", "description"],
-};
+const SOAP_NOTE_ALIASES: Record<keyof SoapNoteImportRecord | "note", string[]> =
+  {
+    externalClientId: [
+      "clientid",
+      "ownerid",
+      "accountid",
+      "clientnumber",
+      "ownernumber",
+      "accountnumber",
+    ],
+    externalPatientId: [
+      "patientid",
+      "petid",
+      "animalid",
+      "patientnumber",
+      "petnumber",
+      "animalnumber",
+    ],
+    clientEmail: ["clientemail", "owneremail", "email", "emailaddress"],
+    patientName: [
+      "patientname",
+      "name",
+      "petname",
+      "patient",
+      "pet",
+      "animalname",
+    ],
+    date: [
+      "date",
+      "visitdate",
+      "dateofservice",
+      "servicedate",
+      "serviceddate",
+      "examdate",
+      "recorddate",
+      "recordeddate",
+      "dateofvisit",
+      "encounterdate",
+      "dateseen",
+    ],
+    subjective: [
+      "subjective",
+      "history",
+      "presentingcomplaint",
+      "chiefcomplaint",
+      "reasonforvisit",
+      "complaint",
+    ],
+    objective: [
+      "objective",
+      "examfindings",
+      "physicalexam",
+      "findings",
+      "examination",
+    ],
+    assessment: ["assessment", "diagnosis", "impression", "dx"],
+    plan: [
+      "plan",
+      "treatmentplan",
+      "treatment",
+      "recommendations",
+      "planofcare",
+    ],
+    note: [
+      "note",
+      "notes",
+      "medicalnotes",
+      "visitnotes",
+      "soapnote",
+      "soap",
+      "chartnote",
+      "clinicalnotes",
+      "progressnote",
+      "recordtext",
+      "summary",
+      "description",
+    ],
+  };
 
 /** SOAP sections in the order a standalone notes column fills empty ones. */
-const SOAP_SECTION_KEYS = ["subjective", "objective", "assessment", "plan"] as const;
+const SOAP_SECTION_KEYS = [
+  "subjective",
+  "objective",
+  "assessment",
+  "plan",
+] as const;
 const SOAP_PATIENT_NAME_MAX = 128;
+const EXTERNAL_ID_MAX = 160;
 // Mirrors the router's per-field validation so a single bad cell is reported
 // as a per-row issue (and skipped) instead of the stricter server layer
 // rejecting the whole file and blocking the dry run.
@@ -149,14 +330,8 @@ interface RequiredCsvColumn {
   label: string;
   aliases: string[];
   examples: string;
-  detectExternalClientId?: boolean;
 }
 
-// Raw PIMS exports (including Shepherd's CSV tables) commonly relate tables
-// with an internal client/account ID. OpenVPM's self-serve import deliberately
-// does not guess those relationships: the current persisted link is owner
-// email. Detecting an ID-only export up front gives a clinic a safe assisted-
-// migration path instead of producing one error per patient/history row.
 const EXTERNAL_CLIENT_ID_ALIASES = [
   "clientid",
   "ownerid",
@@ -164,6 +339,14 @@ const EXTERNAL_CLIENT_ID_ALIASES = [
   "clientnumber",
   "ownernumber",
   "accountnumber",
+];
+const EXTERNAL_PATIENT_ID_ALIASES = [
+  "patientid",
+  "petid",
+  "animalid",
+  "patientnumber",
+  "petnumber",
+  "animalnumber",
 ];
 
 function hasHeader(headers: string[], aliases: string[]): boolean {
@@ -177,7 +360,7 @@ function preflightCsvHeaders(
   required: RequiredCsvColumn[],
   options?: {
     contentColumns?: RequiredCsvColumn;
-  }
+  },
 ): string[] {
   if (headers.length === 0) {
     return ["CSV is empty or is missing a header row."];
@@ -191,19 +374,8 @@ function preflightCsvHeaders(
   for (const column of required) {
     if (hasHeader(headers, column.aliases)) continue;
 
-    if (
-      column.detectExternalClientId &&
-      hasHeader(headers, EXTERNAL_CLIENT_ID_ALIASES)
-    ) {
-      errors.push(
-        "This CSV has an owner/client ID column but no recognized owner email column. " +
-          "OpenVPM's self-serve import currently links records by owner email; export an owner email with each row or use assisted migration for ID-based table mapping."
-      );
-      continue;
-    }
-
     errors.push(
-      `CSV is missing a recognized ${column.label} column. Add one of: ${column.examples}.`
+      `CSV is missing a recognized ${column.label} column. Add one of: ${column.examples}.`,
     );
   }
 
@@ -212,10 +384,35 @@ function preflightCsvHeaders(
     !hasHeader(headers, options.contentColumns.aliases)
   ) {
     errors.push(
-      `CSV is missing a recognized ${options.contentColumns.label} column. Add one of: ${options.contentColumns.examples}.`
+      `CSV is missing a recognized ${options.contentColumns.label} column. Add one of: ${options.contentColumns.examples}.`,
     );
   }
 
+  return errors;
+}
+
+function ownerReferencePreflight(headers: string[]): string[] {
+  if (
+    hasHeader(headers, PATIENT_ALIASES.clientEmail) ||
+    hasHeader(headers, EXTERNAL_CLIENT_ID_ALIASES)
+  ) {
+    return [];
+  }
+
+  return [
+    "CSV is missing a recognized owner reference column. Add Owner Email, Client Email, Client ID, Owner ID, or Account ID.",
+  ];
+}
+
+function patientReferencePreflight(headers: string[]): string[] {
+  if (hasHeader(headers, EXTERNAL_PATIENT_ID_ALIASES)) return [];
+
+  const errors = ownerReferencePreflight(headers);
+  if (!hasHeader(headers, PATIENT_ALIASES.name)) {
+    errors.push(
+      "CSV is missing a recognized patient reference column. Add Patient ID, Patient Name, Pet Name, or Animal Name.",
+    );
+  }
   return errors;
 }
 
@@ -227,7 +424,7 @@ function opt(v: string | undefined): string | undefined {
 /** First non-empty value among a field's normalized-header aliases. */
 function fromAliases(
   row: Record<string, string>,
-  aliases: string[]
+  aliases: string[],
 ): string | undefined {
   for (const key of aliases) {
     const value = opt(row[key]);
@@ -236,7 +433,9 @@ function fromAliases(
   return undefined;
 }
 
-export function csvToClientRecords(csv: string): ParseResult<ClientImportRecord> {
+export function csvToClientRecords(
+  csv: string,
+): ParseResult<ClientImportRecord> {
   const { headers, rows, errors: parseErrors } = parseCsv(csv);
   const records: ClientImportRecord[] = [];
   const errors: string[] = [...parseErrors];
@@ -263,16 +462,33 @@ export function csvToClientRecords(csv: string): ParseResult<ClientImportRecord>
 
   rows.forEach((raw, i) => {
     const r = normalizeRow(raw);
+    const externalClientId = fromAliases(r, CLIENT_ALIASES.externalClientId);
     const firstName = fromAliases(r, CLIENT_ALIASES.firstName);
     const lastName = fromAliases(r, CLIENT_ALIASES.lastName);
+    const email = fromAliases(r, CLIENT_ALIASES.email);
     if (!firstName || !lastName) {
       errors.push(`Row ${i + 1}: firstName and lastName are required.`);
       return;
     }
+    if (!email && !externalClientId) {
+      errors.push(
+        `Row ${i + 1}: an email or external client ID is required for safe repeat imports.`,
+      );
+      return;
+    }
+    if (email && !importEmailCheck.safeParse(email).success) {
+      errors.push(`Row ${i + 1}: email is not a valid email address.`);
+      return;
+    }
+    if ((externalClientId?.length ?? 0) > EXTERNAL_ID_MAX) {
+      errors.push(`Row ${i + 1}: external client ID is too long.`);
+      return;
+    }
     records.push({
+      externalClientId,
       firstName,
       lastName,
-      email: fromAliases(r, CLIENT_ALIASES.email),
+      email,
       phone: fromAliases(r, CLIENT_ALIASES.phone),
       address: fromAliases(r, CLIENT_ALIASES.address),
       city: fromAliases(r, CLIENT_ALIASES.city),
@@ -284,7 +500,9 @@ export function csvToClientRecords(csv: string): ParseResult<ClientImportRecord>
   return { records, errors };
 }
 
-export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecord> {
+export function csvToPatientRecords(
+  csv: string,
+): ParseResult<PatientImportRecord> {
   const { headers, rows, errors: parseErrors } = parseCsv(csv);
   const records: PatientImportRecord[] = [];
   const errors: string[] = [...parseErrors];
@@ -293,16 +511,9 @@ export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecor
     return { records, errors };
   }
 
-  const preflightErrors = preflightCsvHeaders(
-    headers,
-    rows,
-    [
-      {
-        label: "owner email",
-        aliases: PATIENT_ALIASES.clientEmail,
-        examples: "Owner Email, Client Email, or Email Address",
-        detectExternalClientId: true,
-      },
+  const preflightErrors = [
+    ...ownerReferencePreflight(headers),
+    ...preflightCsvHeaders(headers, rows, [
       {
         label: "patient name",
         aliases: PATIENT_ALIASES.name,
@@ -313,8 +524,8 @@ export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecor
         aliases: PATIENT_ALIASES.species,
         examples: "Species or Animal Type",
       },
-    ]
-  );
+    ]),
+  ];
   if (preflightErrors.length > 0) {
     return { records, errors: preflightErrors };
   }
@@ -322,12 +533,25 @@ export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecor
   rows.forEach((raw, i) => {
     const r = normalizeRow(raw);
     const clientEmail = fromAliases(r, PATIENT_ALIASES.clientEmail);
+    const externalClientId = fromAliases(r, PATIENT_ALIASES.externalClientId);
+    const externalPatientId = fromAliases(r, PATIENT_ALIASES.externalPatientId);
     const name = fromAliases(r, PATIENT_ALIASES.name);
     const speciesRaw = fromAliases(r, PATIENT_ALIASES.species);
     const species = normalizeSpeciesValue(speciesRaw);
 
-    if (!clientEmail) {
-      errors.push(`Row ${i + 1}: clientEmail is required to link the pet to an owner.`);
+    if (!clientEmail && !externalClientId) {
+      errors.push(`Row ${i + 1}: an owner email or owner ID is required.`);
+      return;
+    }
+    if (clientEmail && !importEmailCheck.safeParse(clientEmail).success) {
+      errors.push(`Row ${i + 1}: owner email is not a valid email address.`);
+      return;
+    }
+    if (
+      (externalClientId?.length ?? 0) > EXTERNAL_ID_MAX ||
+      (externalPatientId?.length ?? 0) > EXTERNAL_ID_MAX
+    ) {
+      errors.push(`Row ${i + 1}: an external ID is too long.`);
       return;
     }
     if (!name) {
@@ -336,7 +560,7 @@ export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecor
     }
     if (!species) {
       errors.push(
-        `Row ${i + 1}: species must be one of ${SPECIES.join(", ")} (got "${speciesRaw?.toLowerCase() ?? ""}").`
+        `Row ${i + 1}: species must be one of ${SPECIES.join(", ")} (got "${speciesRaw?.toLowerCase() ?? ""}").`,
       );
       return;
     }
@@ -344,10 +568,12 @@ export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecor
     // DOB: normalize common formats; an unreadable value passes through so
     // the router's validation reports it with the exact expected format.
     const dobRaw = fromAliases(r, PATIENT_ALIASES.dob);
-    const dob = dobRaw ? normalizeDateValue(dobRaw) ?? dobRaw : undefined;
+    const dob = dobRaw ? (normalizeDateValue(dobRaw) ?? dobRaw) : undefined;
 
     records.push({
       clientEmail,
+      externalClientId,
+      externalPatientId,
       name,
       species,
       breed: fromAliases(r, PATIENT_ALIASES.breed),
@@ -362,7 +588,7 @@ export function csvToPatientRecords(csv: string): ParseResult<PatientImportRecor
 }
 
 export function csvToVaccinationRecords(
-  csv: string
+  csv: string,
 ): ParseResult<VaccinationImportRecord> {
   const { headers, rows, errors: parseErrors } = parseCsv(csv);
   const records: VaccinationImportRecord[] = [];
@@ -372,21 +598,9 @@ export function csvToVaccinationRecords(
     return { records, errors };
   }
 
-  const preflightErrors = preflightCsvHeaders(
-    headers,
-    rows,
-    [
-      {
-        label: "owner email",
-        aliases: VACCINATION_ALIASES.clientEmail,
-        examples: "Owner Email, Client Email, or Email Address",
-        detectExternalClientId: true,
-      },
-      {
-        label: "patient name",
-        aliases: VACCINATION_ALIASES.patientName,
-        examples: "Patient Name, Pet Name, or Animal Name",
-      },
+  const preflightErrors = [
+    ...patientReferencePreflight(headers),
+    ...preflightCsvHeaders(headers, rows, [
       {
         label: "vaccine name",
         aliases: VACCINATION_ALIASES.vaccineName,
@@ -397,8 +611,8 @@ export function csvToVaccinationRecords(
         aliases: VACCINATION_ALIASES.administeredAt,
         examples: "Date Given, Vaccination Date, or Date Administered",
       },
-    ]
-  );
+    ]),
+  ];
   if (preflightErrors.length > 0) {
     return { records, errors: preflightErrors };
   }
@@ -406,18 +620,37 @@ export function csvToVaccinationRecords(
   rows.forEach((raw, i) => {
     const r = normalizeRow(raw);
     const clientEmail = fromAliases(r, VACCINATION_ALIASES.clientEmail);
+    const externalClientId = fromAliases(
+      r,
+      VACCINATION_ALIASES.externalClientId,
+    );
+    const externalPatientId = fromAliases(
+      r,
+      VACCINATION_ALIASES.externalPatientId,
+    );
     const patientName = fromAliases(r, VACCINATION_ALIASES.patientName);
     const vaccineName = fromAliases(r, VACCINATION_ALIASES.vaccineName);
     const administeredRaw = fromAliases(r, VACCINATION_ALIASES.administeredAt);
 
-    if (!clientEmail) {
+    if (!externalPatientId && !clientEmail && !externalClientId) {
       errors.push(
-        `Row ${i + 1}: clientEmail is required to link the vaccine to a pet.`
+        `Row ${i + 1}: a patient ID or owner reference is required to link the vaccine.`,
       );
       return;
     }
-    if (!patientName) {
+    if (!externalPatientId && !patientName) {
       errors.push(`Row ${i + 1}: patientName is required.`);
+      return;
+    }
+    if (clientEmail && !importEmailCheck.safeParse(clientEmail).success) {
+      errors.push(`Row ${i + 1}: owner email is not a valid email address.`);
+      return;
+    }
+    if (
+      (externalClientId?.length ?? 0) > EXTERNAL_ID_MAX ||
+      (externalPatientId?.length ?? 0) > EXTERNAL_ID_MAX
+    ) {
+      errors.push(`Row ${i + 1}: an external ID is too long.`);
       return;
     }
     if (!vaccineName) {
@@ -427,21 +660,25 @@ export function csvToVaccinationRecords(
     const administeredAt = normalizeDateValue(administeredRaw);
     if (!administeredAt) {
       errors.push(
-        `Row ${i + 1}: dateGiven must be a date (like 2025-10-04 or 10/4/2025), got "${administeredRaw ?? ""}".`
+        `Row ${i + 1}: dateGiven must be a date (like 2025-10-04 or 10/4/2025), got "${administeredRaw ?? ""}".`,
       );
       return;
     }
 
     const dueRaw = fromAliases(r, VACCINATION_ALIASES.nextDueDate);
-    const nextDueDate = dueRaw ? normalizeDateValue(dueRaw) ?? undefined : undefined;
+    const nextDueDate = dueRaw
+      ? (normalizeDateValue(dueRaw) ?? undefined)
+      : undefined;
     if (dueRaw && !nextDueDate) {
       errors.push(
-        `Row ${i + 1}: nextDueDate could not be read as a date (got "${dueRaw}"); the row imports without it.`
+        `Row ${i + 1}: nextDueDate could not be read as a date (got "${dueRaw}"); the row imports without it.`,
       );
     }
 
     records.push({
       clientEmail,
+      externalClientId,
+      externalPatientId,
       patientName,
       vaccineName,
       administeredAt,
@@ -456,12 +693,12 @@ export function csvToVaccinationRecords(
 
 /**
  * Medical history import (migration): each row is one dated visit note for a
- * pet, mapped to a SOAP note. Rows link to pets by owner email + pet name, so
- * run it AFTER clients and patients. A row needs a readable date and at least
- * one note section; the visit date is preserved so the history reads in order.
+ * pet, mapped to a SOAP note. Rows prefer a persisted external patient ID and
+ * fall back to an owner reference + pet name, so run this after clients and
+ * patients. A row needs a readable date and at least one note section.
  */
 export function csvToSoapNoteRecords(
-  csv: string
+  csv: string,
 ): ParseResult<SoapNoteImportRecord> {
   const { headers, rows, errors: parseErrors } = parseCsv(csv);
   const records: SoapNoteImportRecord[] = [];
@@ -478,35 +715,27 @@ export function csvToSoapNoteRecords(
     ...SOAP_NOTE_ALIASES.plan,
     ...SOAP_NOTE_ALIASES.note,
   ];
-  const preflightErrors = preflightCsvHeaders(
-    headers,
-    rows,
-    [
+  const preflightErrors = [
+    ...patientReferencePreflight(headers),
+    ...preflightCsvHeaders(
+      headers,
+      rows,
+      [
+        {
+          label: "visit date",
+          aliases: SOAP_NOTE_ALIASES.date,
+          examples: "Visit Date, Date of Service, or Encounter Date",
+        },
+      ],
       {
-        label: "owner email",
-        aliases: SOAP_NOTE_ALIASES.clientEmail,
-        examples: "Owner Email, Client Email, or Email Address",
-        detectExternalClientId: true,
+        contentColumns: {
+          label: "medical-note content",
+          aliases: noteAliases,
+          examples: "Notes, Subjective, Objective, Assessment, or Plan",
+        },
       },
-      {
-        label: "patient name",
-        aliases: SOAP_NOTE_ALIASES.patientName,
-        examples: "Patient Name, Pet Name, or Animal Name",
-      },
-      {
-        label: "visit date",
-        aliases: SOAP_NOTE_ALIASES.date,
-        examples: "Visit Date, Date of Service, or Encounter Date",
-      },
-    ],
-    {
-      contentColumns: {
-        label: "medical-note content",
-        aliases: noteAliases,
-        examples: "Notes, Subjective, Objective, Assessment, or Plan",
-      },
-    }
-  );
+    ),
+  ];
   if (preflightErrors.length > 0) {
     return { records, errors: preflightErrors };
   }
@@ -514,38 +743,48 @@ export function csvToSoapNoteRecords(
   rows.forEach((raw, i) => {
     const r = normalizeRow(raw);
     const clientEmail = fromAliases(r, SOAP_NOTE_ALIASES.clientEmail);
+    const externalClientId = fromAliases(r, SOAP_NOTE_ALIASES.externalClientId);
+    const externalPatientId = fromAliases(
+      r,
+      SOAP_NOTE_ALIASES.externalPatientId,
+    );
     const patientName = fromAliases(r, SOAP_NOTE_ALIASES.patientName);
     const dateRaw = fromAliases(r, SOAP_NOTE_ALIASES.date);
 
-    if (!clientEmail) {
+    if (!externalPatientId && !clientEmail && !externalClientId) {
       errors.push(
-        `Row ${i + 1}: clientEmail is required to link the note to a pet.`
+        `Row ${i + 1}: a patient ID or owner reference is required to link the note.`,
       );
       return;
     }
-    if (!patientName) {
+    if (!externalPatientId && !patientName) {
       errors.push(`Row ${i + 1}: patientName is required.`);
       return;
     }
     // Validate the email + lengths here (not only "is it present") so one
     // malformed cell reports a per-row issue and is skipped, instead of the
     // stricter server layer rejecting the whole file and blocking the dry run.
-    if (!importEmailCheck.safeParse(clientEmail).success) {
-      errors.push(
-        `Row ${i + 1}: clientEmail "${clientEmail}" is not a valid email address.`
-      );
+    if (clientEmail && !importEmailCheck.safeParse(clientEmail).success) {
+      errors.push(`Row ${i + 1}: clientEmail is not a valid email address.`);
       return;
     }
-    if (patientName.length > SOAP_PATIENT_NAME_MAX) {
+    if (
+      (externalClientId?.length ?? 0) > EXTERNAL_ID_MAX ||
+      (externalPatientId?.length ?? 0) > EXTERNAL_ID_MAX
+    ) {
+      errors.push(`Row ${i + 1}: an external ID is too long.`);
+      return;
+    }
+    if (patientName && patientName.length > SOAP_PATIENT_NAME_MAX) {
       errors.push(
-        `Row ${i + 1}: patientName is too long (max ${SOAP_PATIENT_NAME_MAX} characters).`
+        `Row ${i + 1}: patientName is too long (max ${SOAP_PATIENT_NAME_MAX} characters).`,
       );
       return;
     }
     const date = normalizeDateValue(dateRaw);
     if (!date) {
       errors.push(
-        `Row ${i + 1}: date must be a date (like 2025-10-04 or 10/4/2025), got "${dateRaw ?? ""}".`
+        `Row ${i + 1}: date must be a date (like 2025-10-04 or 10/4/2025), got "${dateRaw ?? ""}".`,
       );
       return;
     }
@@ -579,23 +818,25 @@ export function csvToSoapNoteRecords(
       !sections.plan
     ) {
       errors.push(
-        `Row ${i + 1}: needs at least one note (Subjective, Objective, Assessment, Plan, or a Notes column).`
+        `Row ${i + 1}: needs at least one note (Subjective, Objective, Assessment, Plan, or a Notes column).`,
       );
       return;
     }
 
     const tooLong = SOAP_SECTION_KEYS.find(
-      (key) => (sections[key]?.length ?? 0) > SOAP_SECTION_MAX_LENGTH
+      (key) => (sections[key]?.length ?? 0) > SOAP_SECTION_MAX_LENGTH,
     );
     if (tooLong) {
       errors.push(
-        `Row ${i + 1}: ${tooLong} note is too long (max ${SOAP_SECTION_MAX_LENGTH} characters); split it into a shorter note.`
+        `Row ${i + 1}: ${tooLong} note is too long (max ${SOAP_SECTION_MAX_LENGTH} characters); split it into a shorter note.`,
       );
       return;
     }
 
     records.push({
       clientEmail,
+      externalClientId,
+      externalPatientId,
       patientName,
       date,
       subjective: sections.subjective,

--- a/apps/web/server/__tests__/data-import-dedup.test.ts
+++ b/apps/web/server/__tests__/data-import-dedup.test.ts
@@ -28,14 +28,14 @@ function thenableRows(result: unknown[]) {
     limit: vi.fn(async () => result),
     then: (
       resolve: (value: unknown[]) => unknown,
-      reject?: (error: unknown) => unknown
+      reject?: (error: unknown) => unknown,
     ) => Promise.resolve(result).then(resolve, reject),
   };
 }
 
 function createDb(
   selectRows: unknown[][],
-  practiceRows: unknown[] = [{ id: PRACTICE_ID }]
+  practiceRows: unknown[] = [{ id: PRACTICE_ID }],
 ) {
   const remainingSelects = [practiceRows, ...selectRows];
   const select = vi.fn(() => {
@@ -53,15 +53,20 @@ function createDb(
       Promise.resolve(undefined).then(resolve),
   }));
   const insert = vi.fn(() => ({ values: insertValues }));
+  const updateReturning = vi.fn(async () => [{ id: CLIENT_ID }]);
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
 
   const db: Record<string, unknown> = {
     transaction: async (fn: (tx: unknown) => unknown) => fn(db),
     execute: vi.fn(async () => undefined),
     select,
     insert,
+    update,
   };
 
-  return { db, insertValues, select };
+  return { db, insertValues, select, update, updateSet, updateReturning };
 }
 
 afterEach(() => {
@@ -80,7 +85,7 @@ describe("data import duplicate handling", () => {
             lastName: "Client",
           },
         ],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -92,7 +97,7 @@ describe("data import duplicate handling", () => {
             email: "not-an-email",
           },
         ],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -104,7 +109,7 @@ describe("data import duplicate handling", () => {
             address: "a".repeat(501),
           },
         ],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -118,14 +123,14 @@ describe("data import duplicate handling", () => {
       callerWithDb(db).importClientsCsv({
         csv: oversizedCsv,
         dryRun: true,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).importPatientsCsv({
         csv: oversizedCsv,
         dryRun: true,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -138,7 +143,7 @@ describe("data import duplicate handling", () => {
     await expect(
       callerWithDb(db).importClients({
         clients: [{ firstName: "Ada", lastName: "Client" }],
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -147,10 +152,10 @@ describe("data import duplicate handling", () => {
     await expect(
       callerWithDb(db).importPatientsCsv({
         csv: ["clientEmail,name,species", "owner@example.com,Rex,canine"].join(
-          "\n"
+          "\n",
         ),
         dryRun: true,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -165,9 +170,10 @@ describe("data import duplicate handling", () => {
     await expect(
       callerWithDb(db).importClientsCsv({
         csv: 'firstName,lastName,email\n"Jane,Doe,jane@example.com',
-      })
+      }),
     ).resolves.toEqual({
       imported: 0,
+      reconciled: 0,
       errors: ["CSV has an unterminated quoted field."],
     });
 
@@ -183,7 +189,11 @@ describe("data import duplicate handling", () => {
     await expect(
       callerWithDb(db).importClients({
         clients: [
-          { firstName: "Existing", lastName: "Client", email: "Existing@example.com" },
+          {
+            firstName: "Existing",
+            lastName: "Client",
+            email: "Existing@example.com",
+          },
           {
             firstName: " New ",
             lastName: " Client ",
@@ -197,7 +207,7 @@ describe("data import duplicate handling", () => {
           { firstName: "Again", lastName: "Client", email: "new@example.com" },
           { firstName: "No", lastName: "Email" },
         ],
-      })
+      }),
     ).resolves.toMatchObject({
       imported: 2,
       errors: [
@@ -245,12 +255,13 @@ describe("data import duplicate handling", () => {
           "New,Client,new@example.com",
           "Again,Client, New@example.com ",
         ].join("\n"),
-      })
+      }),
     ).resolves.toMatchObject({
       imported: 1,
+      reconciled: 0,
       errors: [
-        'Row 1: Skipped duplicate client email "existing@example.com".',
-        'Row 3: Skipped duplicate client email "new@example.com".',
+        "Row 1: Skipped a duplicate client.",
+        "Row 3: Skipped a duplicate client.",
       ],
     });
 
@@ -283,15 +294,135 @@ describe("data import duplicate handling", () => {
           "Again,Client,new@example.com",
         ].join("\n"),
         dryRun: true,
-      })
+      }),
     ).resolves.toEqual({
       dryRun: true,
       total: 3,
       willInsert: 1,
+      willReconcile: 0,
       duplicates: 2,
+      errors: [
+        "Row 1: Skipped a duplicate client.",
+        "Row 3: Skipped a duplicate client.",
+      ],
+    });
+
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("imports an ID-only client with a source-scoped external identity", async () => {
+    const { db, insertValues } = createDb([[]]);
+
+    await expect(
+      callerWithDb(db).importClientsCsv({
+        csv: "Owner ID,First Name,Last Name\n00AbC-19,Jane,Doe",
+        source: "shepherd",
+      }),
+    ).resolves.toMatchObject({ imported: 1, reconciled: 0, errors: [] });
+
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        externalSource: "shepherd",
+        externalId: "00AbC-19",
+        firstName: "Jane",
+        lastName: "Doe",
+        email: null,
+      }),
+    ]);
+  });
+
+  it("merges a later external ID into the pending client insert", async () => {
+    const { db, insertValues, update } = createDb([[]]);
+
+    const result = await callerWithDb(db).importClientsCsv({
+      csv: [
+        "Client ID,First Name,Last Name,Email",
+        ",Jane,Doe,jane@example.com",
+        "C-42,Jane,Doe,jane@example.com",
+      ].join("\n"),
+      source: "shepherd",
+    });
+
+    expect(result).toMatchObject({ imported: 1, reconciled: 0, errors: [] });
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({
+        email: "jane@example.com",
+        externalSource: "shepherd",
+        externalId: "C-42",
+      }),
+    ]);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("reconciles an external ID onto one exact existing email match", async () => {
+    const existing = [
+      {
+        id: CLIENT_ID,
+        email: "owner@example.com",
+        externalSource: null,
+        externalId: null,
+        deletedAt: null,
+      },
+    ];
+    const dryRunDb = createDb([existing]);
+    await expect(
+      callerWithDb(dryRunDb.db).importClientsCsv({
+        csv: "Client ID,First Name,Last Name,Email\nC-42,Ada,Client,owner@example.com",
+        source: "shepherd",
+        dryRun: true,
+      }),
+    ).resolves.toMatchObject({
+      dryRun: true,
+      willInsert: 0,
+      willReconcile: 1,
+      duplicates: 0,
       errors: [],
     });
 
+    const commitDb = createDb([
+      existing.map((client) => ({
+        ...client,
+        externalSource: null,
+        externalId: null,
+      })),
+    ]);
+    await expect(
+      callerWithDb(commitDb.db).importClientsCsv({
+        csv: "Client ID,First Name,Last Name,Email\nC-42,Ada,Client,owner@example.com",
+        source: "shepherd",
+      }),
+    ).resolves.toMatchObject({ imported: 0, reconciled: 1, errors: [] });
+    expect(commitDb.updateSet).toHaveBeenCalledWith({
+      externalSource: "shepherd",
+      externalId: "C-42",
+    });
+    expect(commitDb.insertValues).not.toHaveBeenCalled();
+  });
+
+  it("stops when a reconciliation target changed after planning", async () => {
+    const { db, updateReturning, insertValues } = createDb([
+      [
+        {
+          id: CLIENT_ID,
+          email: "owner@example.com",
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+        },
+      ],
+    ]);
+    updateReturning.mockResolvedValueOnce([]);
+
+    await expect(
+      callerWithDb(db).importClientsCsv({
+        csv: "Client ID,First Name,Last Name,Email\nC-42,Ada,Client,owner@example.com",
+        source: "shepherd",
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringMatching(/changed after the dry run/i),
+    });
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -307,7 +438,7 @@ describe("data import duplicate handling", () => {
             species: "canine",
           },
         ],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -319,7 +450,7 @@ describe("data import duplicate handling", () => {
             species: "canine",
           },
         ],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -332,7 +463,7 @@ describe("data import duplicate handling", () => {
             dob: "2026-02-30",
           },
         ],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -345,7 +476,7 @@ describe("data import duplicate handling", () => {
             microchipNumber: "m".repeat(65),
           },
         ],
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -395,7 +526,7 @@ describe("data import duplicate handling", () => {
             species: "canine",
           },
         ],
-      })
+      }),
     ).resolves.toMatchObject({
       imported: 1,
       errors: [
@@ -434,16 +565,311 @@ describe("data import duplicate handling", () => {
           "ghost@example.com,Luna,feline",
         ].join("\n"),
         dryRun: true,
-      })
+      }),
     ).resolves.toEqual({
       dryRun: true,
       total: 2,
       willInsert: 1,
+      willReconcile: 0,
       unmatchedClient: 1,
       duplicates: 0,
-      errors: ['Row 2: No client found with email "ghost@example.com"'],
+      errors: [
+        "Row 2: No matching client was found for the supplied owner reference.",
+      ],
     });
 
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("links an ID-only patient to its external owner ID", async () => {
+    const { db, insertValues } = createDb([
+      [
+        {
+          id: CLIENT_ID,
+          email: null,
+          externalSource: "shepherd",
+          externalId: "C-42",
+          deletedAt: null,
+        },
+      ],
+      [],
+    ]);
+
+    await expect(
+      callerWithDb(db).importPatientsCsv({
+        csv: "Client ID,Patient ID,Patient Name,Species\nC-42,P-9,Rex,Dog",
+        source: "shepherd",
+      }),
+    ).resolves.toMatchObject({ imported: 1, reconciled: 0, errors: [] });
+
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        clientId: CLIENT_ID,
+        externalSource: "shepherd",
+        externalId: "P-9",
+        name: "Rex",
+        species: "canine",
+      }),
+    ]);
+  });
+
+  it("previews patients against clients planned by the same onboarding import", async () => {
+    const { db, insertValues } = createDb([[], []]);
+
+    const result = await callerWithDb(db).importPatientsCsv({
+      csv: "Client ID,Patient ID,Patient Name,Species\nC-42,P-9,Rex,Dog",
+      clientCsv: "Client ID,First Name,Last Name\nC-42,Jane,Doe",
+      source: "other",
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      total: 1,
+      willInsert: 1,
+      unmatchedClient: 0,
+      errors: [],
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("merges a later external ID into the pending patient insert", async () => {
+    const { db, insertValues, update } = createDb([
+      [
+        {
+          id: CLIENT_ID,
+          email: "owner@example.com",
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+        },
+      ],
+      [],
+    ]);
+
+    const result = await callerWithDb(db).importPatientsCsv({
+      csv: [
+        "Owner Email,Patient ID,Patient Name,Species",
+        "owner@example.com,,Rex,Dog",
+        "owner@example.com,P-9,Rex,Dog",
+      ].join("\n"),
+      source: "shepherd",
+    });
+
+    expect(result).toMatchObject({ imported: 1, reconciled: 0, errors: [] });
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({
+        name: "Rex",
+        externalSource: "shepherd",
+        externalId: "P-9",
+      }),
+    ]);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("requires a strong patient match before attaching a durable external ID", async () => {
+    const baseClient = [
+      {
+        id: CLIENT_ID,
+        email: "owner@example.com",
+        externalSource: null,
+        externalId: null,
+        deletedAt: null,
+      },
+    ];
+    const existingPatient = {
+      id: "00000000-0000-0000-0000-0000000000p1",
+      clientId: CLIENT_ID,
+      name: "Rex",
+      species: "canine",
+      dob: "2020-01-01",
+      microchipNumber: null,
+      externalSource: null,
+      externalId: null,
+      deletedAt: null,
+    };
+    const weakDb = createDb([baseClient, [existingPatient]]);
+
+    const weakResult = await callerWithDb(weakDb.db).importPatientsCsv({
+      csv: "Owner Email,Patient ID,Patient Name,Species\nowner@example.com,P-9,Rex,Dog",
+      source: "shepherd",
+      dryRun: true,
+    });
+    expect(weakResult).toMatchObject({
+      willInsert: 0,
+      willReconcile: 0,
+    });
+    expect(weakResult.errors[0]).toMatch(/microchip or date of birth/i);
+
+    const strongDb = createDb([baseClient, [existingPatient]]);
+    const strongResult = await callerWithDb(strongDb.db).importPatientsCsv({
+      csv: "Owner Email,Patient ID,Patient Name,Species,DOB\nowner@example.com,P-9,Rex,Dog,2020-01-01",
+      source: "shepherd",
+      dryRun: true,
+    });
+    expect(strongResult).toMatchObject({
+      willInsert: 0,
+      willReconcile: 1,
+      errors: [],
+    });
+  });
+
+  it("does not match the same external owner ID from a different source", async () => {
+    const { db, insertValues } = createDb([
+      [
+        {
+          id: CLIENT_ID,
+          email: null,
+          externalSource: "avimark",
+          externalId: "C-42",
+          deletedAt: null,
+        },
+      ],
+      [],
+    ]);
+
+    const result = await callerWithDb(db).importPatientsCsv({
+      csv: "Client ID,Patient ID,Patient Name,Species\nC-42,P-9,Rex,Dog",
+      source: "shepherd",
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      willInsert: 0,
+      willReconcile: 0,
+      unmatchedClient: 1,
+    });
+    expect(result.errors.join(" ")).not.toContain("C-42");
+    expect(result.errors.join(" ")).not.toContain("Rex");
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("reserves archived external owner IDs instead of creating a duplicate chart", async () => {
+    const { db, insertValues } = createDb([
+      [
+        {
+          id: CLIENT_ID,
+          email: null,
+          externalSource: "shepherd",
+          externalId: "C-42",
+          deletedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      ],
+      [],
+    ]);
+
+    const result = await callerWithDb(db).importPatientsCsv({
+      csv: "Client ID,Patient ID,Patient Name,Species\nC-42,P-9,Rex,Dog",
+      source: "shepherd",
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      willInsert: 0,
+      unmatchedClient: 1,
+    });
+    expect(result.errors[0]).toMatch(/archived client/i);
+    expect(result.errors.join(" ")).not.toContain("C-42");
+    expect(result.errors.join(" ")).not.toContain("Rex");
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("does not attach a patient ID when two existing charts match the row", async () => {
+    const { db, insertValues, update } = createDb([
+      [
+        {
+          id: CLIENT_ID,
+          email: "owner@example.com",
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+        },
+      ],
+      [
+        {
+          id: "00000000-0000-0000-0000-0000000000p1",
+          clientId: CLIENT_ID,
+          name: "Rex",
+          species: "canine",
+          dob: null,
+          microchipNumber: null,
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+        },
+        {
+          id: "00000000-0000-0000-0000-0000000000p2",
+          clientId: CLIENT_ID,
+          name: "Rex",
+          species: "canine",
+          dob: null,
+          microchipNumber: null,
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+        },
+      ],
+    ]);
+
+    const result = await callerWithDb(db).importPatientsCsv({
+      csv: "Owner Email,Patient ID,Patient Name,Species\nowner@example.com,P-9,Rex,Dog",
+      source: "shepherd",
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({ willInsert: 0, willReconcile: 0 });
+    expect(result.errors[0]).toMatch(/more than one existing patient/i);
+    expect(update).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("does not create a third chart when weak patient matches have different birth dates", async () => {
+    const { db, insertValues, update } = createDb([
+      [
+        {
+          id: CLIENT_ID,
+          email: "owner@example.com",
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+        },
+      ],
+      [
+        {
+          id: "00000000-0000-0000-0000-0000000000p1",
+          clientId: CLIENT_ID,
+          name: "Rex",
+          species: "canine",
+          dob: "2020-01-01",
+          microchipNumber: null,
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+        },
+        {
+          id: "00000000-0000-0000-0000-0000000000p2",
+          clientId: CLIENT_ID,
+          name: "Rex",
+          species: "canine",
+          dob: "2021-02-02",
+          microchipNumber: null,
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+        },
+      ],
+    ]);
+
+    const result = await callerWithDb(db).importPatientsCsv({
+      csv: "Owner Email,Patient ID,Patient Name,Species\nowner@example.com,P-9,Rex,Dog",
+      source: "shepherd",
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({ willInsert: 0, willReconcile: 0 });
+    expect(result.errors[0]).toMatch(/more than one existing patient/i);
+    expect(update).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -453,9 +879,10 @@ describe("data import duplicate handling", () => {
     await expect(
       callerWithDb(db).importPatientsCsv({
         csv: 'clientEmail,name,species\n"owner@example.com,Rex,canine',
-      })
+      }),
     ).resolves.toEqual({
       imported: 0,
+      reconciled: 0,
       errors: ["CSV has an unterminated quoted field."],
     });
 
@@ -486,16 +913,17 @@ describe("data import duplicate handling", () => {
           "owner@example.com,Luna,feline,2021-03-04,985112003009999",
         ].join("\n"),
         dryRun: true,
-      })
+      }),
     ).resolves.toEqual({
       dryRun: true,
       total: 3,
       willInsert: 1,
+      willReconcile: 0,
       unmatchedClient: 0,
       duplicates: 2,
       errors: [
-        'Row 1: Skipped duplicate patient "Rex".',
-        'Row 3: Skipped duplicate patient "Luna".',
+        "Row 1: Skipped a duplicate patient.",
+        "Row 3: Skipped a duplicate patient.",
       ],
     });
 
@@ -508,10 +936,10 @@ describe("data import duplicate handling", () => {
     await expect(
       callerWithDb(db).importClientsCsv({
         csv: [
-          "firstName,lastName,address",
-          `Ada,Client,${"a".repeat(501)}`,
+          "firstName,lastName,email,address",
+          `Ada,Client,ada@example.com,${"a".repeat(501)}`,
         ].join("\n"),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -520,7 +948,7 @@ describe("data import duplicate handling", () => {
           "clientEmail,name,species,dob",
           "owner@example.com,Biscuit,canine,2026-02-30",
         ].join("\n"),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(insertValues).not.toHaveBeenCalled();

--- a/apps/web/server/__tests__/data-import-soap.test.ts
+++ b/apps/web/server/__tests__/data-import-soap.test.ts
@@ -28,14 +28,14 @@ function thenableRows(result: unknown[]) {
     limit: vi.fn(async () => result),
     then: (
       resolve: (value: unknown[]) => unknown,
-      reject?: (error: unknown) => unknown
+      reject?: (error: unknown) => unknown,
     ) => Promise.resolve(result).then(resolve, reject),
   };
 }
 
 function createDb(
   selectRows: unknown[][],
-  practiceRows: unknown[] = [{ id: PRACTICE_ID }]
+  practiceRows: unknown[] = [{ id: PRACTICE_ID }],
 ) {
   const remainingSelects = [practiceRows, ...selectRows];
   const select = vi.fn(() => {
@@ -83,7 +83,7 @@ describe("medical history (SOAP notes) import", () => {
       await expect(
         callerWithDb(db, role).importSoapNotesCsv({
           csv: `${HEADER}\n${REX_ROW}`,
-        })
+        }),
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
     }
     expect(select).not.toHaveBeenCalled();
@@ -95,7 +95,7 @@ describe("medical history (SOAP notes) import", () => {
     await expect(
       callerWithDb(db).importSoapNotesCsv({
         csv: "x".repeat(IMPORT_CSV_MAX_BYTES + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     expect(select).not.toHaveBeenCalled();
   });
@@ -142,7 +142,9 @@ describe("medical history (SOAP notes) import", () => {
       duplicates: 2,
       unmatchedPatient: 1,
     });
-    expect(result.errors.some((e) => /No pet named "Ghost"/.test(e))).toBe(true);
+    expect(
+      result.errors.some((e) => /No matching patient was found/.test(e)),
+    ).toBe(true);
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -171,7 +173,7 @@ describe("medical history (SOAP notes) import", () => {
       imported: true,
     });
     expect((rows[0]!.createdAt as Date).toISOString()).toBe(
-      "2024-03-05T12:00:00.000Z"
+      "2024-03-05T12:00:00.000Z",
     );
   });
 
@@ -211,8 +213,8 @@ describe("medical history (SOAP notes) import", () => {
     expect(result).toMatchObject({ dryRun: true, total: 1, willInsert: 1 });
     expect(
       result.errors.some((e) =>
-        /Row 2: clientEmail "none" is not a valid email/.test(e)
-      )
+        /Row 2: clientEmail is not a valid email/.test(e),
+      ),
     ).toBe(true);
     expect(insertValues).not.toHaveBeenCalled();
   });
@@ -239,8 +241,74 @@ describe("medical history (SOAP notes) import", () => {
       unmatchedPatient: 1,
     });
     expect(
-      result.errors.some((e) => /More than one pet named "Rex"/.test(e))
+      result.errors.some((e) => /patient references are ambiguous/.test(e)),
     ).toBe(true);
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("links medical history directly by external patient ID", async () => {
+    const rows = [
+      {
+        id: PATIENT_ID,
+        name: "Rex",
+        externalSource: "shepherd",
+        externalId: "P-9",
+        clientEmail: null,
+        clientExternalSource: "shepherd",
+        clientExternalId: "C-42",
+      },
+    ];
+    const { db, insertValues } = createDb([rows, []]);
+
+    const result = await callerWithDb(db).importSoapNotesCsv({
+      csv: "Patient ID,Visit Date,Notes\nP-9,2025-02-03,Annual exam",
+      source: "shepherd",
+    });
+
+    expect(result).toMatchObject({ imported: 1, errors: [] });
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({
+        patientId: PATIENT_ID,
+        subjective: "Annual exam",
+        imported: true,
+      }),
+    ]);
+  });
+
+  it("rejects a direct patient ID that conflicts with the supplied owner and name", async () => {
+    const rows = [
+      {
+        id: PATIENT_ID,
+        name: "Rex",
+        externalSource: "shepherd",
+        externalId: "P-1",
+        clientEmail: "rex-owner@example.com",
+        clientExternalSource: "shepherd",
+        clientExternalId: "C-1",
+      },
+      {
+        id: "00000000-0000-0000-0000-0000000000p2",
+        name: "Luna",
+        externalSource: "shepherd",
+        externalId: "P-2",
+        clientEmail: "luna-owner@example.com",
+        clientExternalSource: "shepherd",
+        clientExternalId: "C-2",
+      },
+    ];
+    const { db, insertValues } = createDb([rows, []]);
+
+    const result = await callerWithDb(db).importSoapNotesCsv({
+      csv: [
+        "Patient ID,Owner Email,Patient Name,Visit Date,Notes",
+        "P-1,luna-owner@example.com,Luna,2025-01-01,Annual exam",
+      ].join("\n"),
+      source: "shepherd",
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({ willInsert: 0, unmatchedPatient: 1 });
+    expect(result.errors[0]).toMatch(/ambiguous or conflict/i);
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -263,7 +331,7 @@ describe("medical history (SOAP notes) import", () => {
     await expect(
       callerWithDb(db).importSoapNotesCsv({
         csv: `${HEADER}\n${REX_ROW}`,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });

--- a/apps/web/server/__tests__/data-import-vaccinations.test.ts
+++ b/apps/web/server/__tests__/data-import-vaccinations.test.ts
@@ -28,14 +28,14 @@ function thenableRows(result: unknown[]) {
     limit: vi.fn(async () => result),
     then: (
       resolve: (value: unknown[]) => unknown,
-      reject?: (error: unknown) => unknown
+      reject?: (error: unknown) => unknown,
     ) => Promise.resolve(result).then(resolve, reject),
   };
 }
 
 function createDb(
   selectRows: unknown[][],
-  practiceRows: unknown[] = [{ id: PRACTICE_ID }]
+  practiceRows: unknown[] = [{ id: PRACTICE_ID }],
 ) {
   const remainingSelects = [practiceRows, ...selectRows];
   const select = vi.fn(() => {
@@ -83,7 +83,7 @@ describe("vaccination history import", () => {
       await expect(
         callerWithDb(db, role).importVaccinationsCsv({
           csv: `${HEADER}\n${REX_ROW}`,
-        })
+        }),
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
     }
     expect(select).not.toHaveBeenCalled();
@@ -95,7 +95,7 @@ describe("vaccination history import", () => {
     await expect(
       callerWithDb(db).importVaccinationsCsv({
         csv: "x".repeat(IMPORT_CSV_MAX_BYTES + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     expect(select).not.toHaveBeenCalled();
   });
@@ -139,7 +139,9 @@ describe("vaccination history import", () => {
       duplicates: 2,
       unmatchedPatient: 1,
     });
-    expect(result.errors.some((e) => /No pet named "Ghost"/.test(e))).toBe(true);
+    expect(
+      result.errors.some((e) => /No matching patient was found/.test(e)),
+    ).toBe(true);
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -164,14 +166,18 @@ describe("vaccination history import", () => {
       administeredBy: null,
     });
     expect((rows[0]!.administeredAt as Date).toISOString()).toBe(
-      "2024-10-04T12:00:00.000Z"
+      "2024-10-04T12:00:00.000Z",
     );
   });
 
   it("flags same-named pets under one owner instead of guessing", async () => {
     const twins = [
       { id: PATIENT_ID, name: "Rex", clientEmail: "jane@x.com" },
-      { id: "00000000-0000-0000-0000-0000000000p2", name: "Rex", clientEmail: "jane@x.com" },
+      {
+        id: "00000000-0000-0000-0000-0000000000p2",
+        name: "Rex",
+        clientEmail: "jane@x.com",
+      },
     ];
     const { db, insertValues } = createDb([twins, []]);
 
@@ -186,8 +192,82 @@ describe("vaccination history import", () => {
       unmatchedPatient: 1,
     });
     expect(
-      result.errors.some((e) => /More than one pet named "Rex"/.test(e))
+      result.errors.some((e) => /patient references are ambiguous/.test(e)),
     ).toBe(true);
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("uses a direct external patient ID to disambiguate same-named pets", async () => {
+    const twins = [
+      {
+        id: PATIENT_ID,
+        name: "Rex",
+        externalSource: "shepherd",
+        externalId: "P-1",
+        clientEmail: "jane@x.com",
+        clientExternalSource: "shepherd",
+        clientExternalId: "C-1",
+      },
+      {
+        id: "00000000-0000-0000-0000-0000000000p2",
+        name: "Rex",
+        externalSource: "shepherd",
+        externalId: "P-2",
+        clientEmail: "jane@x.com",
+        clientExternalSource: "shepherd",
+        clientExternalId: "C-1",
+      },
+    ];
+    const { db, insertValues } = createDb([twins, []]);
+
+    const result = await callerWithDb(db).importVaccinationsCsv({
+      csv: "Patient ID,Vaccine,Date Given\nP-2,Rabies,2025-01-01",
+      source: "shepherd",
+    });
+
+    expect(result).toMatchObject({ imported: 1, errors: [] });
+    expect(insertValues).toHaveBeenCalledWith([
+      expect.objectContaining({
+        patientId: "00000000-0000-0000-0000-0000000000p2",
+        vaccineName: "Rabies",
+      }),
+    ]);
+  });
+
+  it("rejects a direct patient ID that conflicts with the supplied owner and name", async () => {
+    const rows = [
+      {
+        id: PATIENT_ID,
+        name: "Rex",
+        externalSource: "shepherd",
+        externalId: "P-1",
+        clientEmail: "rex-owner@example.com",
+        clientExternalSource: "shepherd",
+        clientExternalId: "C-1",
+      },
+      {
+        id: "00000000-0000-0000-0000-0000000000p2",
+        name: "Luna",
+        externalSource: "shepherd",
+        externalId: "P-2",
+        clientEmail: "luna-owner@example.com",
+        clientExternalSource: "shepherd",
+        clientExternalId: "C-2",
+      },
+    ];
+    const { db, insertValues } = createDb([rows, []]);
+
+    const result = await callerWithDb(db).importVaccinationsCsv({
+      csv: [
+        "Patient ID,Owner Email,Patient Name,Vaccine,Date Given",
+        "P-1,luna-owner@example.com,Luna,Rabies,2025-01-01",
+      ].join("\n"),
+      source: "shepherd",
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({ willInsert: 0, unmatchedPatient: 1 });
+    expect(result.errors[0]).toMatch(/ambiguous or conflict/i);
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -210,7 +290,7 @@ describe("vaccination history import", () => {
     await expect(
       callerWithDb(db).importVaccinationsCsv({
         csv: `${HEADER}\n${REX_ROW}`,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
   });
 });

--- a/apps/web/server/routers/data.ts
+++ b/apps/web/server/routers/data.ts
@@ -25,7 +25,10 @@ import {
   csvToVaccinationRecords,
   csvToSoapNoteRecords,
 } from "@/lib/csv/import";
-import { SOAP_SECTION_MAX_LENGTH, hasSoapContent } from "@/lib/records/soap-content";
+import {
+  SOAP_SECTION_MAX_LENGTH,
+  hasSoapContent,
+} from "@/lib/records/soap-content";
 import {
   exportPracticeData,
   restorePracticeData,
@@ -36,7 +39,6 @@ import {
   PRACTICE_BACKUP_JSON_SIZE_MESSAGE,
   isPracticeBackupJsonSizeValid,
 } from "@/lib/backup/policy";
-import { planClientImport } from "@/lib/import/plan";
 import {
   IMPORT_CSV_MAX_BYTES,
   IMPORT_MAX_ROWS,
@@ -91,17 +93,28 @@ const importOptionalText = (label: string, maxLength: number) =>
     .transform((value) => value || undefined);
 const importOptionalEmail = z.preprocess(
   (value) => (typeof value === "string" ? value.trim() || undefined : value),
-  z.string().trim().email().max(255).optional()
+  z.string().trim().email().max(255).optional(),
 );
 const importOptionalDate = z.preprocess(
   (value) => (typeof value === "string" ? value.trim() || undefined : value),
-  clinicalDateInput("Date of birth").optional()
+  clinicalDateInput("Date of birth").optional(),
 );
 const importOptionalDueDate = z.preprocess(
   (value) => (typeof value === "string" ? value.trim() || undefined : value),
-  clinicalDateInput("Next due date").optional()
+  clinicalDateInput("Next due date").optional(),
 );
+const importOptionalExternalId = importOptionalText("External ID", 160);
+const importSourceInput = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .regex(
+    /^[a-z0-9][a-z0-9_-]{0,63}$/,
+    "Import source must use letters, numbers, underscores, or hyphens.",
+  )
+  .default("other");
 const clientImportRecordInput = z.object({
+  externalClientId: importOptionalExternalId,
   firstName: importRequiredText("First name", 128),
   lastName: importRequiredText("Last name", 128),
   email: importOptionalEmail,
@@ -111,7 +124,38 @@ const clientImportRecordInput = z.object({
   state: importOptionalText("State", 64),
   zip: importOptionalText("ZIP", 16),
 });
-const patientImportRecordInput = z.object({
+const patientImportRecordInput = z
+  .object({
+    clientEmail: importOptionalEmail,
+    externalClientId: importOptionalExternalId,
+    externalPatientId: importOptionalExternalId,
+    name: importRequiredText("Patient name", 128),
+    species: importSpeciesInput,
+    breed: importOptionalText("Breed", 128),
+    sex: importSexInput,
+    dob: importOptionalDate,
+    color: importOptionalText("Color", 64),
+    microchipNumber: importOptionalText("Microchip number", 64),
+  })
+  .refine((record) => record.clientEmail || record.externalClientId, {
+    message: "An owner email or external owner ID is required.",
+  });
+const clientImportRecordsInput = z
+  .array(clientImportRecordInput)
+  .max(
+    IMPORT_MAX_ROWS,
+    `Client imports can include at most ${IMPORT_MAX_ROWS} rows.`,
+  );
+const patientImportRecordsInput = z
+  .array(patientImportRecordInput)
+  .max(
+    IMPORT_MAX_ROWS,
+    `Patient imports can include at most ${IMPORT_MAX_ROWS} rows.`,
+  );
+const clientJsonImportRecordInput = clientImportRecordInput.omit({
+  externalClientId: true,
+});
+const patientJsonImportRecordInput = z.object({
   clientEmail: z.string().trim().email().max(255),
   name: importRequiredText("Patient name", 128),
   species: importSpeciesInput,
@@ -121,49 +165,68 @@ const patientImportRecordInput = z.object({
   color: importOptionalText("Color", 64),
   microchipNumber: importOptionalText("Microchip number", 64),
 });
-const clientImportRecordsInput = z
-  .array(clientImportRecordInput)
-  .max(
-    IMPORT_MAX_ROWS,
-    `Client imports can include at most ${IMPORT_MAX_ROWS} rows.`
-  );
-const patientImportRecordsInput = z
-  .array(patientImportRecordInput)
-  .max(
-    IMPORT_MAX_ROWS,
-    `Patient imports can include at most ${IMPORT_MAX_ROWS} rows.`
-  );
 const importClientsInput = z.object({
-  clients: clientImportRecordsInput,
+  clients: z
+    .array(clientJsonImportRecordInput)
+    .max(
+      IMPORT_MAX_ROWS,
+      `Client imports can include at most ${IMPORT_MAX_ROWS} rows.`,
+    ),
 });
 const importPatientsInput = z.object({
-  patients: patientImportRecordsInput,
+  patients: z
+    .array(patientJsonImportRecordInput)
+    .max(
+      IMPORT_MAX_ROWS,
+      `Patient imports can include at most ${IMPORT_MAX_ROWS} rows.`,
+    ),
 });
-const vaccinationImportRecordInput = z.object({
-  clientEmail: z.string().trim().email().max(255),
-  patientName: importRequiredText("Patient name", 128),
-  vaccineName: importRequiredText("Vaccine name", 255),
-  administeredAt: clinicalDateInput("Date given"),
-  nextDueDate: importOptionalDueDate,
-  lotNumber: importOptionalText("Lot number", 64),
-  manufacturer: importOptionalText("Manufacturer", 128),
-});
+const vaccinationImportRecordInput = z
+  .object({
+    clientEmail: importOptionalEmail,
+    externalClientId: importOptionalExternalId,
+    externalPatientId: importOptionalExternalId,
+    patientName: importOptionalText("Patient name", 128),
+    vaccineName: importRequiredText("Vaccine name", 255),
+    administeredAt: clinicalDateInput("Date given"),
+    nextDueDate: importOptionalDueDate,
+    lotNumber: importOptionalText("Lot number", 64),
+    manufacturer: importOptionalText("Manufacturer", 128),
+  })
+  .refine(
+    (record) =>
+      record.externalPatientId ||
+      (record.patientName && (record.clientEmail || record.externalClientId)),
+    {
+      message: "A patient ID or owner reference plus patient name is required.",
+    },
+  );
 const vaccinationImportRecordsInput = z
   .array(vaccinationImportRecordInput)
   .max(
     IMPORT_MAX_ROWS,
-    `Vaccination imports can include at most ${IMPORT_MAX_ROWS} rows.`
+    `Vaccination imports can include at most ${IMPORT_MAX_ROWS} rows.`,
   );
 const soapNoteImportRecordInput = z
   .object({
-    clientEmail: z.string().trim().email().max(255),
-    patientName: importRequiredText("Patient name", 128),
+    clientEmail: importOptionalEmail,
+    externalClientId: importOptionalExternalId,
+    externalPatientId: importOptionalExternalId,
+    patientName: importOptionalText("Patient name", 128),
     date: clinicalDateInput("Visit date"),
     subjective: importOptionalText("Subjective", SOAP_SECTION_MAX_LENGTH),
     objective: importOptionalText("Objective", SOAP_SECTION_MAX_LENGTH),
     assessment: importOptionalText("Assessment", SOAP_SECTION_MAX_LENGTH),
     plan: importOptionalText("Plan", SOAP_SECTION_MAX_LENGTH),
   })
+  .refine(
+    (record) =>
+      record.externalPatientId ||
+      (record.patientName && (record.clientEmail || record.externalClientId)),
+    {
+      message: "A patient ID or owner reference plus patient name is required.",
+    },
+  )
   .refine((record) => hasSoapContent(record), {
     message:
       "Each medical history row needs at least one of Subjective, Objective, Assessment, or Plan.",
@@ -172,15 +235,22 @@ const soapNoteImportRecordsInput = z
   .array(soapNoteImportRecordInput)
   .max(
     IMPORT_MAX_ROWS,
-    `Medical history imports can include at most ${IMPORT_MAX_ROWS} rows.`
+    `Medical history imports can include at most ${IMPORT_MAX_ROWS} rows.`,
   );
+const importCsvTextInput = z
+  .string()
+  .min(1)
+  .max(IMPORT_CSV_MAX_BYTES, "CSV imports must be 5 MB or less.")
+  .refine(isImportCsvSizeValid, "CSV imports must be 5 MB or less.");
 const importCsvInput = z.object({
-  csv: z
-    .string()
-    .min(1)
-    .max(IMPORT_CSV_MAX_BYTES, "CSV imports must be 5 MB or less.")
-    .refine(isImportCsvSizeValid, "CSV imports must be 5 MB or less."),
+  csv: importCsvTextInput,
   dryRun: z.boolean().optional().default(false),
+  source: importSourceInput,
+});
+const importPatientsCsvInput = importCsvInput.extend({
+  /** Optional during dry-run so a two-file onboarding preview can resolve pets
+   * against owners that the client file will create without writing either file. */
+  clientCsv: importCsvTextInput.optional(),
 });
 
 function activePracticeWhere(practiceId: string) {
@@ -221,6 +291,161 @@ function normalizeImportText(value?: string | null): string {
   return value?.trim().toLowerCase().replace(/\s+/g, " ") ?? "";
 }
 
+function normalizeExternalId(value?: string | null): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+function externalIdentityKey(source: string, externalId: string): string {
+  return `${source}|${externalId}`;
+}
+
+type ExistingClientImportIdentity = {
+  id: string;
+  email: string | null;
+  externalSource: string | null;
+  externalId: string | null;
+  deletedAt: Date | null;
+  plannedRowIndex?: number;
+};
+
+type ExternalIdentityUpdate = {
+  id: string;
+  externalSource: string;
+  externalId: string;
+};
+
+function planClientCsvImport(
+  records: ClientImportRecord[],
+  source: string,
+  existingClients: ExistingClientImportIdentity[],
+): {
+  rows: ClientImportRow[];
+  identityUpdates: ExternalIdentityUpdate[];
+  errors: string[];
+  duplicates: number;
+} {
+  const byEmail = new Map<string, ExistingClientImportIdentity>();
+  const ambiguousEmails = new Set<string>();
+  const byExternalId = new Map<string, ExistingClientImportIdentity>();
+
+  for (const client of existingClients) {
+    if (client.externalSource && client.externalId) {
+      byExternalId.set(
+        externalIdentityKey(client.externalSource, client.externalId),
+        client,
+      );
+    }
+    if (client.deletedAt) continue;
+    const email = normalizeImportEmail(client.email);
+    if (!email) continue;
+    if (byEmail.has(email)) ambiguousEmails.add(email);
+    else byEmail.set(email, client);
+  }
+
+  const rows: ClientImportRow[] = [];
+  const identityUpdates: ExternalIdentityUpdate[] = [];
+  const errors: string[] = [];
+  let duplicates = 0;
+
+  records.forEach((client, index) => {
+    const email = normalizeImportEmail(client.email);
+    const externalId = normalizeExternalId(client.externalClientId);
+    const externalKey = externalId
+      ? externalIdentityKey(source, externalId)
+      : null;
+    const externalMatch = externalKey
+      ? byExternalId.get(externalKey)
+      : undefined;
+    const emailMatch =
+      email && !ambiguousEmails.has(email) ? byEmail.get(email) : undefined;
+
+    if (externalMatch) {
+      if (externalMatch.deletedAt) {
+        errors.push(
+          `Row ${index + 1}: This external client ID belongs to an archived client. Restore or review that client before importing.`,
+        );
+        return;
+      }
+      if (emailMatch && emailMatch.id !== externalMatch.id) {
+        errors.push(
+          `Row ${index + 1}: The client email and external ID point to different existing clients. Nothing was changed.`,
+        );
+        return;
+      }
+      duplicates++;
+      errors.push(`Row ${index + 1}: Skipped an already linked client.`);
+      return;
+    }
+
+    if (email && ambiguousEmails.has(email)) {
+      errors.push(
+        `Row ${index + 1}: More than one existing client uses this email. Resolve the duplicate clients before importing.`,
+      );
+      return;
+    }
+
+    if (emailMatch) {
+      if (!externalId) {
+        duplicates++;
+        errors.push(`Row ${index + 1}: Skipped a duplicate client.`);
+        return;
+      }
+      if (emailMatch.externalSource || emailMatch.externalId) {
+        errors.push(
+          `Row ${index + 1}: This client already has a different external identity. Nothing was changed.`,
+        );
+        return;
+      }
+
+      if (emailMatch.plannedRowIndex !== undefined) {
+        const plannedRow = rows[emailMatch.plannedRowIndex];
+        if (!plannedRow) {
+          throw new Error("Missing planned client import row.");
+        }
+        plannedRow.externalSource = source;
+        plannedRow.externalId = externalId;
+      } else {
+        identityUpdates.push({
+          id: emailMatch.id,
+          externalSource: source,
+          externalId,
+        });
+      }
+      emailMatch.externalSource = source;
+      emailMatch.externalId = externalId;
+      byExternalId.set(externalKey!, emailMatch);
+      return;
+    }
+
+    const row: ClientImportRow = {
+      firstName: client.firstName.trim(),
+      lastName: client.lastName.trim(),
+      email,
+      phone: client.phone?.trim() || null,
+      address: client.address?.trim() || null,
+      city: client.city?.trim() || null,
+      state: client.state?.trim() || null,
+      zip: client.zip?.trim() || null,
+      ...(externalId ? { externalSource: source, externalId } : {}),
+    };
+    rows.push(row);
+
+    const planned: ExistingClientImportIdentity = {
+      id: `planned:${index}`,
+      email,
+      externalSource: externalId ? source : null,
+      externalId,
+      deletedAt: null,
+      plannedRowIndex: rows.length - 1,
+    };
+    if (email) byEmail.set(email, planned);
+    if (externalKey) byExternalId.set(externalKey, planned);
+  });
+
+  return { rows, identityUpdates, errors, duplicates };
+}
+
 function patientIdentityKey(input: {
   clientId: string;
   name: string;
@@ -235,6 +460,16 @@ function patientIdentityKey(input: {
   ].join("|");
 }
 
+function patientWeakIdentityKey(input: {
+  clientId: string;
+  name: string;
+  species: string;
+}): string {
+  return [input.clientId, normalizeImportText(input.name), input.species].join(
+    "|",
+  );
+}
+
 function patientMicrochipKey(microchipNumber?: string | null): string | null {
   const normalized = normalizeImportText(microchipNumber);
   return normalized ? `chip:${normalized}` : null;
@@ -242,7 +477,7 @@ function patientMicrochipKey(microchipNumber?: string | null): string | null {
 
 function dedupeClientImport(
   records: ClientImportRecord[],
-  existingEmails: Set<string>
+  existingEmails: Set<string>,
 ): {
   rows: ClientImportRow[];
   errors: string[];
@@ -256,7 +491,7 @@ function dedupeClientImport(
     if (email) {
       if (seen.has(email)) {
         errors.push(
-          `Row ${index + 1}: Skipped duplicate client email "${email}".`
+          `Row ${index + 1}: Skipped duplicate client email "${email}".`,
         );
         return;
       }
@@ -287,7 +522,7 @@ function dedupePatientImport(
     species: string;
     dob: string | null;
     microchipNumber: string | null;
-  }>
+  }>,
 ): {
   rows: PatientImportRow[];
   errors: string[];
@@ -313,7 +548,7 @@ function dedupePatientImport(
     if (!clientId) {
       unmatchedClient++;
       errors.push(
-        `Row ${index + 1}: No client found with email "${patient.clientEmail}"`
+        `Row ${index + 1}: No client found with email "${patient.clientEmail}"`,
       );
       return;
     }
@@ -331,7 +566,7 @@ function dedupePatientImport(
     ) {
       duplicates++;
       errors.push(
-        `Row ${index + 1}: Skipped duplicate patient "${patient.name}".`
+        `Row ${index + 1}: Skipped duplicate patient "${patient.name}".`,
       );
       return;
     }
@@ -353,9 +588,420 @@ function dedupePatientImport(
   return { rows, errors, duplicates, unmatchedClient };
 }
 
-/** Key linking a vaccination row to a pet: owner email + normalized name. */
-function vaccinationPatientKey(clientEmail: string, patientName: string): string {
+type ExistingPatientImportIdentity = {
+  id: string;
+  clientId: string;
+  name: string;
+  species: string;
+  dob: string | null;
+  microchipNumber: string | null;
+  externalSource: string | null;
+  externalId: string | null;
+  deletedAt: Date | null;
+  plannedRowIndex?: number;
+};
+
+type ClientReferenceLookup = {
+  byEmail: Map<string, string | "ambiguous">;
+  byExternalId: Map<string, string | "archived">;
+};
+
+function createClientReferenceLookup(
+  clientsToIndex: ExistingClientImportIdentity[],
+): ClientReferenceLookup {
+  const byEmail = new Map<string, string | "ambiguous">();
+  const byExternalId = new Map<string, string | "archived">();
+
+  for (const client of clientsToIndex) {
+    const email = normalizeImportEmail(client.email);
+    if (email && !client.deletedAt) {
+      byEmail.set(email, byEmail.has(email) ? "ambiguous" : client.id);
+    }
+    if (client.externalSource && client.externalId) {
+      byExternalId.set(
+        externalIdentityKey(client.externalSource, client.externalId),
+        client.deletedAt ? "archived" : client.id,
+      );
+    }
+  }
+
+  return { byEmail, byExternalId };
+}
+
+function resolveClientReference(
+  record: Pick<PatientImportRecord, "clientEmail" | "externalClientId">,
+  source: string,
+  lookup: ClientReferenceLookup,
+): { clientId?: string; issue?: "ambiguous" | "archived" | "conflict" } {
+  const email = normalizeImportEmail(record.clientEmail);
+  const externalId = normalizeExternalId(record.externalClientId);
+  const emailResult = email ? lookup.byEmail.get(email) : undefined;
+  const externalResult = externalId
+    ? lookup.byExternalId.get(externalIdentityKey(source, externalId))
+    : undefined;
+
+  if (externalId) {
+    if (externalResult === "archived") return { issue: "archived" };
+    if (!externalResult) return {};
+    if (emailResult === "ambiguous") return { issue: "ambiguous" };
+    if (emailResult && emailResult !== externalResult) {
+      return { issue: "conflict" };
+    }
+    return { clientId: externalResult };
+  }
+
+  if (emailResult === "ambiguous") return { issue: "ambiguous" };
+  return { clientId: emailResult };
+}
+
+function planPatientCsvImport(
+  records: PatientImportRecord[],
+  source: string,
+  clientLookup: ClientReferenceLookup,
+  existingPatients: ExistingPatientImportIdentity[],
+): {
+  rows: PatientImportRow[];
+  identityUpdates: ExternalIdentityUpdate[];
+  errors: string[];
+  duplicates: number;
+  unmatchedClient: number;
+} {
+  const byExternalId = new Map<string, ExistingPatientImportIdentity>();
+  const byIdentity = new Map<
+    string,
+    ExistingPatientImportIdentity | "ambiguous"
+  >();
+  const byMicrochip = new Map<
+    string,
+    ExistingPatientImportIdentity | "ambiguous"
+  >();
+  const byWeakIdentity = new Map<
+    string,
+    ExistingPatientImportIdentity | "ambiguous"
+  >();
+
+  for (const patient of existingPatients) {
+    if (patient.externalSource && patient.externalId) {
+      byExternalId.set(
+        externalIdentityKey(patient.externalSource, patient.externalId),
+        patient,
+      );
+    }
+    if (patient.deletedAt) continue;
+    const identityKey = patientIdentityKey(patient);
+    byIdentity.set(
+      identityKey,
+      byIdentity.has(identityKey) ? "ambiguous" : patient,
+    );
+    const weakIdentityKey = patientWeakIdentityKey(patient);
+    byWeakIdentity.set(
+      weakIdentityKey,
+      byWeakIdentity.has(weakIdentityKey) ? "ambiguous" : patient,
+    );
+    const chipKey = patientMicrochipKey(patient.microchipNumber);
+    if (chipKey) {
+      byMicrochip.set(
+        chipKey,
+        byMicrochip.has(chipKey) ? "ambiguous" : patient,
+      );
+    }
+  }
+
+  const rows: PatientImportRow[] = [];
+  const identityUpdates: ExternalIdentityUpdate[] = [];
+  const errors: string[] = [];
+  let duplicates = 0;
+  let unmatchedClient = 0;
+
+  records.forEach((patient, index) => {
+    const owner = resolveClientReference(patient, source, clientLookup);
+    if (!owner.clientId) {
+      unmatchedClient++;
+      const message =
+        owner.issue === "archived"
+          ? "The external owner ID belongs to an archived client. Restore or review that client before importing."
+          : owner.issue === "ambiguous"
+            ? "The owner reference matches more than one client. Resolve the duplicate clients before importing."
+            : owner.issue === "conflict"
+              ? "The owner email and external ID point to different clients. Nothing was changed."
+              : "No matching client was found for the supplied owner reference.";
+      errors.push(`Row ${index + 1}: ${message}`);
+      return;
+    }
+
+    const externalId = normalizeExternalId(patient.externalPatientId);
+    const externalKey = externalId
+      ? externalIdentityKey(source, externalId)
+      : null;
+    const externalMatch = externalKey
+      ? byExternalId.get(externalKey)
+      : undefined;
+    if (externalMatch) {
+      if (externalMatch.deletedAt) {
+        errors.push(
+          `Row ${index + 1}: This external patient ID belongs to an archived patient. Restore or review that patient before importing.`,
+        );
+        return;
+      }
+      if (externalMatch.clientId !== owner.clientId) {
+        errors.push(
+          `Row ${index + 1}: The patient ID is linked to a different owner. Nothing was changed.`,
+        );
+        return;
+      }
+      duplicates++;
+      errors.push(`Row ${index + 1}: Skipped an already linked patient.`);
+      return;
+    }
+
+    const identityKey = patientIdentityKey({
+      clientId: owner.clientId,
+      name: patient.name,
+      species: patient.species,
+      dob: patient.dob ?? null,
+    });
+    const identityMatch = byIdentity.get(identityKey);
+    const weakIdentityKey = patientWeakIdentityKey({
+      clientId: owner.clientId,
+      name: patient.name,
+      species: patient.species,
+    });
+    const weakIdentityMatch = byWeakIdentity.get(weakIdentityKey);
+    const chipKey = patientMicrochipKey(patient.microchipNumber);
+    const chipMatch = chipKey ? byMicrochip.get(chipKey) : undefined;
+    if (chipMatch === "ambiguous") {
+      errors.push(
+        `Row ${index + 1}: This microchip matches more than one patient. Resolve the duplicate charts before importing.`,
+      );
+      return;
+    }
+    if (identityMatch === "ambiguous") {
+      errors.push(
+        `Row ${index + 1}: More than one existing patient matches this row. Resolve the duplicate charts before importing.`,
+      );
+      return;
+    }
+    if (chipMatch && chipMatch.clientId !== owner.clientId) {
+      errors.push(
+        `Row ${index + 1}: This microchip is already linked to a patient under a different owner. Nothing was changed.`,
+      );
+      return;
+    }
+    if (identityMatch && chipMatch && identityMatch.id !== chipMatch.id) {
+      errors.push(
+        `Row ${index + 1}: The patient identity and microchip point to different charts. Nothing was changed.`,
+      );
+      return;
+    }
+
+    const existingMatch = identityMatch ?? chipMatch;
+    if (existingMatch) {
+      if (!externalId) {
+        duplicates++;
+        errors.push(`Row ${index + 1}: Skipped a duplicate patient.`);
+        return;
+      }
+      if (existingMatch.externalSource || existingMatch.externalId) {
+        errors.push(
+          `Row ${index + 1}: This patient already has a different external identity. Nothing was changed.`,
+        );
+        return;
+      }
+      if (
+        existingMatch.plannedRowIndex === undefined &&
+        !chipMatch &&
+        !patient.dob
+      ) {
+        errors.push(
+          `Row ${index + 1}: An existing patient may match this external ID, but a microchip or date of birth is needed before OpenVPM can connect it safely.`,
+        );
+        return;
+      }
+      if (existingMatch.plannedRowIndex !== undefined) {
+        const plannedRow = rows[existingMatch.plannedRowIndex];
+        if (!plannedRow) {
+          throw new Error("Missing planned patient import row.");
+        }
+        plannedRow.externalSource = source;
+        plannedRow.externalId = externalId;
+      } else {
+        identityUpdates.push({
+          id: existingMatch.id,
+          externalSource: source,
+          externalId,
+        });
+      }
+      existingMatch.externalSource = source;
+      existingMatch.externalId = externalId;
+      byExternalId.set(externalKey!, existingMatch);
+      return;
+    }
+
+    if (externalId && !patient.dob && weakIdentityMatch) {
+      errors.push(
+        weakIdentityMatch === "ambiguous"
+          ? `Row ${index + 1}: More than one existing patient may match this external ID. Add a microchip or date of birth, or resolve the duplicate charts before importing.`
+          : `Row ${index + 1}: An existing patient may match this external ID, but a microchip or date of birth is needed before OpenVPM can connect it safely.`,
+      );
+      return;
+    }
+
+    const row: PatientImportRow = {
+      clientId: owner.clientId,
+      name: patient.name.trim(),
+      species: patient.species,
+      breed: patient.breed?.trim() || null,
+      sex: patient.sex || null,
+      dob: patient.dob?.trim() || null,
+      color: patient.color?.trim() || null,
+      microchipNumber: patient.microchipNumber?.trim() || null,
+      ...(externalId ? { externalSource: source, externalId } : {}),
+    };
+    rows.push(row);
+
+    const planned: ExistingPatientImportIdentity = {
+      id: `planned:${index}`,
+      clientId: owner.clientId,
+      name: row.name,
+      species: row.species,
+      dob: row.dob ?? null,
+      microchipNumber: row.microchipNumber ?? null,
+      externalSource: externalId ? source : null,
+      externalId,
+      deletedAt: null,
+      plannedRowIndex: rows.length - 1,
+    };
+    byIdentity.set(identityKey, planned);
+    byWeakIdentity.set(weakIdentityKey, planned);
+    if (chipKey) byMicrochip.set(chipKey, planned);
+    if (externalKey) byExternalId.set(externalKey, planned);
+  });
+
+  return {
+    rows,
+    identityUpdates,
+    errors,
+    duplicates,
+    unmatchedClient,
+  };
+}
+
+/** Legacy key linking a historical row to a pet: owner email + pet name. */
+function vaccinationPatientKey(
+  clientEmail: string,
+  patientName: string,
+): string {
   return `${normalizeImportEmail(clientEmail) ?? ""}|${normalizeImportText(patientName)}`;
+}
+
+function externalOwnerPatientKey(
+  source: string,
+  externalClientId: string,
+  patientName: string,
+): string {
+  return `${externalIdentityKey(source, externalClientId)}|${normalizeImportText(patientName)}`;
+}
+
+type PatientReferenceLookup = {
+  byExternalPatientId: Record<string, string>;
+  byEmailAndName: Record<string, string | "ambiguous">;
+  byExternalOwnerAndName: Record<string, string | "ambiguous">;
+};
+
+function addUniquePatientReference(
+  target: Record<string, string | "ambiguous">,
+  key: string,
+  patientId: string,
+) {
+  target[key] = target[key] ? "ambiguous" : patientId;
+}
+
+function createPatientReferenceLookup(
+  patientRows: Array<{
+    id: string;
+    name: string;
+    externalSource: string | null;
+    externalId: string | null;
+    clientEmail: string | null;
+    clientExternalSource: string | null;
+    clientExternalId: string | null;
+  }>,
+): PatientReferenceLookup {
+  const lookup: PatientReferenceLookup = {
+    byExternalPatientId: {},
+    byEmailAndName: {},
+    byExternalOwnerAndName: {},
+  };
+
+  for (const patient of patientRows) {
+    if (patient.externalSource && patient.externalId) {
+      lookup.byExternalPatientId[
+        externalIdentityKey(patient.externalSource, patient.externalId)
+      ] = patient.id;
+    }
+    if (patient.clientEmail) {
+      addUniquePatientReference(
+        lookup.byEmailAndName,
+        vaccinationPatientKey(patient.clientEmail, patient.name),
+        patient.id,
+      );
+    }
+    if (patient.clientExternalSource && patient.clientExternalId) {
+      addUniquePatientReference(
+        lookup.byExternalOwnerAndName,
+        externalOwnerPatientKey(
+          patient.clientExternalSource,
+          patient.clientExternalId,
+          patient.name,
+        ),
+        patient.id,
+      );
+    }
+  }
+
+  return lookup;
+}
+
+function resolvePatientReference(
+  record: Pick<
+    VaccinationImportRecord,
+    "clientEmail" | "externalClientId" | "externalPatientId" | "patientName"
+  >,
+  source: string,
+  lookup: PatientReferenceLookup,
+): string | "ambiguous" | undefined {
+  const externalPatientId = normalizeExternalId(record.externalPatientId);
+  const matches = new Set<string>();
+  let ambiguous = false;
+  if (externalPatientId) {
+    const directMatch =
+      lookup.byExternalPatientId[
+        externalIdentityKey(source, externalPatientId)
+      ];
+    if (!directMatch) return undefined;
+    matches.add(directMatch);
+  }
+
+  if (record.patientName && record.clientEmail) {
+    const match =
+      lookup.byEmailAndName[
+        vaccinationPatientKey(record.clientEmail, record.patientName)
+      ];
+    if (match === "ambiguous") ambiguous = true;
+    else if (match) matches.add(match);
+  }
+  const externalClientId = normalizeExternalId(record.externalClientId);
+  if (record.patientName && externalClientId) {
+    const match =
+      lookup.byExternalOwnerAndName[
+        externalOwnerPatientKey(source, externalClientId, record.patientName)
+      ];
+    if (match === "ambiguous") ambiguous = true;
+    else if (match) matches.add(match);
+  }
+
+  if (ambiguous || matches.size > 1) return "ambiguous";
+  return matches.values().next().value;
 }
 
 /** Identity of an administered dose: patient + vaccine + date given. */
@@ -382,12 +1028,13 @@ function vaccinationInstant(dateInput: string): Date {
 
 function dedupeVaccinationImport(
   records: VaccinationImportRecord[],
-  patientKeyToId: Record<string, string | "ambiguous">,
+  patientLookup: PatientReferenceLookup,
+  source: string,
   existingDoses: Array<{
     patientId: string;
     vaccineName: string;
     administeredAt: Date;
-  }>
+  }>,
 ): {
   rows: VaccinationImportRow[];
   errors: string[];
@@ -400,8 +1047,8 @@ function dedupeVaccinationImport(
         patientId: dose.patientId,
         vaccineName: dose.vaccineName,
         administeredDate: dose.administeredAt.toISOString().slice(0, 10),
-      })
-    )
+      }),
+    ),
   );
 
   const rows: VaccinationImportRow[] = [];
@@ -410,19 +1057,18 @@ function dedupeVaccinationImport(
   let unmatchedPatient = 0;
 
   records.forEach((record, index) => {
-    const key = vaccinationPatientKey(record.clientEmail, record.patientName);
-    const patientId = patientKeyToId[key];
+    const patientId = resolvePatientReference(record, source, patientLookup);
     if (!patientId) {
       unmatchedPatient++;
       errors.push(
-        `Row ${index + 1}: No pet named "${record.patientName}" found for client "${record.clientEmail}"`
+        `Row ${index + 1}: No matching patient was found for the supplied reference.`,
       );
       return;
     }
     if (patientId === "ambiguous") {
       unmatchedPatient++;
       errors.push(
-        `Row ${index + 1}: More than one pet named "${record.patientName}" belongs to "${record.clientEmail}"; add this dose by hand.`
+        `Row ${index + 1}: The supplied patient references are ambiguous or conflict. Nothing was changed.`,
       );
       return;
     }
@@ -434,9 +1080,7 @@ function dedupeVaccinationImport(
     });
     if (seen.has(identityKey)) {
       duplicates++;
-      errors.push(
-        `Row ${index + 1}: Skipped duplicate dose "${record.vaccineName}" for "${record.patientName}".`
-      );
+      errors.push(`Row ${index + 1}: Skipped a duplicate vaccine dose.`);
       return;
     }
     seen.add(identityKey);
@@ -457,7 +1101,7 @@ function dedupeVaccinationImport(
 }
 
 function parseVaccinationImportRecords(
-  records: VaccinationImportRecord[]
+  records: VaccinationImportRecord[],
 ): VaccinationImportRecord[] {
   const result = vaccinationImportRecordsInput.safeParse(records);
   if (!result.success) {
@@ -506,7 +1150,8 @@ function soapNoteInstant(dateInput: string): Date {
 
 function dedupeSoapNoteImport(
   records: SoapNoteImportRecord[],
-  patientKeyToId: Record<string, string | "ambiguous">,
+  patientLookup: PatientReferenceLookup,
+  source: string,
   existingNotes: Array<{
     patientId: string;
     createdAt: Date;
@@ -514,7 +1159,7 @@ function dedupeSoapNoteImport(
     objective: string | null;
     assessment: string | null;
     plan: string | null;
-  }>
+  }>,
 ): {
   rows: SoapNoteImportRow[];
   errors: string[];
@@ -527,8 +1172,8 @@ function dedupeSoapNoteImport(
         patientId: note.patientId,
         date: note.createdAt.toISOString().slice(0, 10),
         signature: soapNoteContentSignature(note),
-      })
-    )
+      }),
+    ),
   );
 
   const rows: SoapNoteImportRow[] = [];
@@ -537,20 +1182,18 @@ function dedupeSoapNoteImport(
   let unmatchedPatient = 0;
 
   records.forEach((record, index) => {
-    // Same owner-email + pet-name link key as the vaccination import.
-    const key = vaccinationPatientKey(record.clientEmail, record.patientName);
-    const patientId = patientKeyToId[key];
+    const patientId = resolvePatientReference(record, source, patientLookup);
     if (!patientId) {
       unmatchedPatient++;
       errors.push(
-        `Row ${index + 1}: No pet named "${record.patientName}" found for client "${record.clientEmail}"`
+        `Row ${index + 1}: No matching patient was found for the supplied reference.`,
       );
       return;
     }
     if (patientId === "ambiguous") {
       unmatchedPatient++;
       errors.push(
-        `Row ${index + 1}: More than one pet named "${record.patientName}" belongs to "${record.clientEmail}"; add this note by hand.`
+        `Row ${index + 1}: The supplied patient references are ambiguous or conflict. Nothing was changed.`,
       );
       return;
     }
@@ -562,9 +1205,7 @@ function dedupeSoapNoteImport(
     });
     if (seen.has(identityKey)) {
       duplicates++;
-      errors.push(
-        `Row ${index + 1}: Skipped duplicate note for "${record.patientName}" on ${record.date}.`
-      );
+      errors.push(`Row ${index + 1}: Skipped a duplicate medical note.`);
       return;
     }
     seen.add(identityKey);
@@ -585,7 +1226,7 @@ function dedupeSoapNoteImport(
 }
 
 function parseSoapNoteImportRecords(
-  records: SoapNoteImportRecord[]
+  records: SoapNoteImportRecord[],
 ): SoapNoteImportRecord[] {
   const result = soapNoteImportRecordsInput.safeParse(records);
   if (!result.success) {
@@ -598,7 +1239,7 @@ function parseSoapNoteImportRecords(
 }
 
 function parseClientImportRecords(
-  records: ClientImportRecord[]
+  records: ClientImportRecord[],
 ): ClientImportRecord[] {
   const result = clientImportRecordsInput.safeParse(records);
   if (!result.success) {
@@ -611,7 +1252,7 @@ function parseClientImportRecords(
 }
 
 function parsePatientImportRecords(
-  records: PatientImportRecord[]
+  records: PatientImportRecord[],
 ): PatientImportRecord[] {
   const result = patientImportRecordsInput.safeParse(records);
   if (!result.success) {
@@ -654,8 +1295,8 @@ export const dataRouter = createRouter({
         and(
           eq(clients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(clients.deletedAt)
-        )
+          isNull(clients.deletedAt),
+        ),
       );
     return rows;
   }),
@@ -684,15 +1325,15 @@ export const dataRouter = createRouter({
           eq(patients.clientId, clients.id),
           eq(clients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(clients.deletedAt)
-        )
+          isNull(clients.deletedAt),
+        ),
       )
       .where(
         and(
           eq(patients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(patients.deletedAt)
-        )
+          isNull(patients.deletedAt),
+        ),
       );
     return rows;
   }),
@@ -720,8 +1361,8 @@ export const dataRouter = createRouter({
           eq(patients.clientId, appointments.clientId),
           eq(patients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(patients.deletedAt)
-        )
+          isNull(patients.deletedAt),
+        ),
       )
       .leftJoin(
         clients,
@@ -729,8 +1370,8 @@ export const dataRouter = createRouter({
           eq(appointments.clientId, clients.id),
           eq(clients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(clients.deletedAt)
-        )
+          isNull(clients.deletedAt),
+        ),
       )
       .leftJoin(
         users,
@@ -738,8 +1379,8 @@ export const dataRouter = createRouter({
           eq(appointments.doctorId, users.id),
           eq(users.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(users.deletedAt)
-        )
+          isNull(users.deletedAt),
+        ),
       )
       .leftJoin(
         appointmentTypes,
@@ -747,15 +1388,15 @@ export const dataRouter = createRouter({
           eq(appointments.typeId, appointmentTypes.id),
           eq(appointmentTypes.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(appointmentTypes.deletedAt)
-        )
+          isNull(appointmentTypes.deletedAt),
+        ),
       )
       .where(
         and(
           eq(appointments.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(appointments.deletedAt)
-        )
+          isNull(appointments.deletedAt),
+        ),
       );
     return rows;
   }),
@@ -784,8 +1425,8 @@ export const dataRouter = createRouter({
           eq(invoices.clientId, clients.id),
           eq(clients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(clients.deletedAt)
-        )
+          isNull(clients.deletedAt),
+        ),
       )
       .leftJoin(
         patients,
@@ -794,20 +1435,28 @@ export const dataRouter = createRouter({
           eq(patients.clientId, invoices.clientId),
           eq(patients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(patients.deletedAt)
-        )
+          isNull(patients.deletedAt),
+        ),
       )
       .where(
         and(
           eq(invoices.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(invoices.deletedAt)
-        )
+          isNull(invoices.deletedAt),
+        ),
       );
 
     // Fetch items for each invoice
     const invoiceIds = invoiceRows.map((r) => r.invoiceId);
-    let itemsByInvoice: Record<string, { description: string; quantity: number; unitPrice: string; total: string }[]> = {};
+    let itemsByInvoice: Record<
+      string,
+      {
+        description: string;
+        quantity: number;
+        unitPrice: string;
+        total: string;
+      }[]
+    > = {};
 
     if (invoiceIds.length > 0) {
       const allItems = await ctx.db
@@ -830,8 +1479,8 @@ export const dataRouter = createRouter({
                 and ${invoices.deletedAt} is null
             )`,
             activePracticePredicate(ctx.practiceId),
-            isNull(invoiceItems.deletedAt)
-          )
+            isNull(invoiceItems.deletedAt),
+          ),
         );
 
       for (const item of allItems) {
@@ -862,11 +1511,11 @@ export const dataRouter = createRouter({
           .record(z.unknown())
           .refine(
             isPracticeBackupJsonSizeValid,
-            PRACTICE_BACKUP_JSON_SIZE_MESSAGE
+            PRACTICE_BACKUP_JSON_SIZE_MESSAGE,
           ),
         dryRun: z.boolean().optional().default(true),
         confirmFreshPractice: z.boolean().optional().default(false),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const summary = summarizePracticeExport(input.backup);
@@ -902,53 +1551,57 @@ export const dataRouter = createRouter({
         });
       }
 
-      const [existingClients, existingPatients, existingAppointments, existingInvoices] =
-        await Promise.all([
-          ctx.db
-            .select({ id: clients.id })
-            .from(clients)
-            .where(
-              and(
-                eq(clients.practiceId, ctx.practiceId),
-                activePracticePredicate(ctx.practiceId),
-                isNull(clients.deletedAt)
-              )
-            )
-            .limit(1),
-          ctx.db
-            .select({ id: patients.id })
-            .from(patients)
-            .where(
-              and(
-                eq(patients.practiceId, ctx.practiceId),
-                activePracticePredicate(ctx.practiceId),
-                isNull(patients.deletedAt)
-              )
-            )
-            .limit(1),
-          ctx.db
-            .select({ id: appointments.id })
-            .from(appointments)
-            .where(
-              and(
-                eq(appointments.practiceId, ctx.practiceId),
-                activePracticePredicate(ctx.practiceId),
-                isNull(appointments.deletedAt)
-              )
-            )
-            .limit(1),
-          ctx.db
-            .select({ id: invoices.id })
-            .from(invoices)
-            .where(
-              and(
-                eq(invoices.practiceId, ctx.practiceId),
-                activePracticePredicate(ctx.practiceId),
-                isNull(invoices.deletedAt)
-              )
-            )
-            .limit(1),
-        ]);
+      const [
+        existingClients,
+        existingPatients,
+        existingAppointments,
+        existingInvoices,
+      ] = await Promise.all([
+        ctx.db
+          .select({ id: clients.id })
+          .from(clients)
+          .where(
+            and(
+              eq(clients.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(clients.deletedAt),
+            ),
+          )
+          .limit(1),
+        ctx.db
+          .select({ id: patients.id })
+          .from(patients)
+          .where(
+            and(
+              eq(patients.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(patients.deletedAt),
+            ),
+          )
+          .limit(1),
+        ctx.db
+          .select({ id: appointments.id })
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(appointments.deletedAt),
+            ),
+          )
+          .limit(1),
+        ctx.db
+          .select({ id: invoices.id })
+          .from(invoices)
+          .where(
+            and(
+              eq(invoices.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(invoices.deletedAt),
+            ),
+          )
+          .limit(1),
+      ]);
 
       if (
         existingClients.length > 0 ||
@@ -963,7 +1616,11 @@ export const dataRouter = createRouter({
         });
       }
 
-      const result = await restorePracticeData(ctx.db, ctx.practiceId, input.backup);
+      const result = await restorePracticeData(
+        ctx.db,
+        ctx.practiceId,
+        input.backup,
+      );
       return { dryRun: false as const, ...result };
     }),
 
@@ -984,17 +1641,17 @@ export const dataRouter = createRouter({
           and(
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         );
       const existingEmails = new Set(
         existing
           .map((client) => normalizeImportEmail(client.email))
-          .filter((email): email is string => !!email)
+          .filter((email): email is string => !!email),
       );
       const { rows, errors } = dedupeClientImport(
         input.clients,
-        existingEmails
+        existingEmails,
       );
 
       if (rows.length > 0) {
@@ -1021,8 +1678,8 @@ export const dataRouter = createRouter({
           and(
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         );
 
       const emailToClientId: Record<string, string> = {};
@@ -1046,13 +1703,13 @@ export const dataRouter = createRouter({
           and(
             eq(patients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(patients.deletedAt)
-          )
+            isNull(patients.deletedAt),
+          ),
         );
       const { rows, errors } = dedupePatientImport(
         input.patients,
         emailToClientId,
-        existingPatients
+        existingPatients,
       );
 
       if (rows.length > 0) {
@@ -1081,68 +1738,89 @@ export const dataRouter = createRouter({
             dryRun: true as const,
             total: 0,
             willInsert: 0,
+            willReconcile: 0,
             duplicates: 0,
             errors,
           };
         }
-        return { imported: 0, errors };
+        return { imported: 0, reconciled: 0, errors };
       }
 
       await assertActivePractice(ctx);
 
-      if (input.dryRun) {
-        const existing = await ctx.db
-          .select({ email: clients.email })
-          .from(clients)
-          .where(
-            and(
-              eq(clients.practiceId, ctx.practiceId),
-              activePracticePredicate(ctx.practiceId),
-              isNull(clients.deletedAt)
-            )
-          );
-        const emails = new Set(
-          existing
-            .map((client) => normalizeImportEmail(client.email))
-            .filter((email): email is string => !!email)
-        );
-        const plan = planClientImport(validRecords, emails);
-        return { dryRun: true as const, ...plan, errors };
-      }
-
       const existing = await ctx.db
-        .select({ email: clients.email })
+        .select({
+          id: clients.id,
+          email: clients.email,
+          externalSource: clients.externalSource,
+          externalId: clients.externalId,
+          deletedAt: clients.deletedAt,
+        })
         .from(clients)
         .where(
           and(
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+          ),
         );
-      const existingEmails = new Set(
-        existing
-          .map((client) => normalizeImportEmail(client.email))
-          .filter((email): email is string => !!email)
-      );
-      const deduped = dedupeClientImport(validRecords, existingEmails);
+      const plan = planClientCsvImport(validRecords, input.source, existing);
 
-      if (deduped.rows.length > 0) {
-        await ctx.db.insert(clients).values(
-          deduped.rows.map((c) => ({
-            ...c,
-            practiceId: ctx.practiceId,
-          }))
-        );
+      if (input.dryRun) {
+        return {
+          dryRun: true as const,
+          total: validRecords.length,
+          willInsert: plan.rows.length,
+          willReconcile: plan.identityUpdates.length,
+          duplicates: plan.duplicates,
+          errors: [...errors, ...plan.errors],
+        };
       }
+
+      await ctx.db.transaction(async (tx) => {
+        for (const update of plan.identityUpdates) {
+          const updated = await tx
+            .update(clients)
+            .set({
+              externalSource: update.externalSource,
+              externalId: update.externalId,
+            })
+            .where(
+              and(
+                eq(clients.id, update.id),
+                eq(clients.practiceId, ctx.practiceId),
+                isNull(clients.deletedAt),
+                isNull(clients.externalSource),
+                isNull(clients.externalId),
+              ),
+            )
+            .returning({ id: clients.id });
+          if (updated.length !== 1) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "A client changed after the dry run. Check the file again before importing.",
+            });
+          }
+        }
+
+        if (plan.rows.length > 0) {
+          await tx.insert(clients).values(
+            plan.rows.map((client) => ({
+              ...client,
+              practiceId: ctx.practiceId,
+            })),
+          );
+        }
+      });
       return {
-        imported: deduped.rows.length,
-        errors: [...errors, ...deduped.errors],
+        imported: plan.rows.length,
+        reconciled: plan.identityUpdates.length,
+        errors: [...errors, ...plan.errors],
       };
     }),
 
   importPatientsCsv: adminProcedure
-    .input(importCsvInput)
+    .input(importPatientsCsvInput)
     .mutation(async ({ ctx, input }) => {
       const { records, errors } = csvToPatientRecords(input.csv);
       const validRecords = parsePatientImportRecords(records);
@@ -1153,81 +1831,140 @@ export const dataRouter = createRouter({
             dryRun: true as const,
             total: 0,
             willInsert: 0,
+            willReconcile: 0,
             unmatchedClient: 0,
             duplicates: 0,
             errors,
           };
         }
-        return { imported: 0, errors };
+        return { imported: 0, reconciled: 0, errors };
       }
 
       await assertActivePractice(ctx);
 
       const clientRows = await ctx.db
-        .select({ id: clients.id, email: clients.email })
+        .select({
+          id: clients.id,
+          email: clients.email,
+          externalSource: clients.externalSource,
+          externalId: clients.externalId,
+          deletedAt: clients.deletedAt,
+        })
         .from(clients)
         .where(
           and(
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+          ),
         );
-      const emailToClientId: Record<string, string> = {};
-      for (const c of clientRows) {
-        const email = normalizeImportEmail(c.email);
-        if (email) emailToClientId[email] = c.id;
+      if (input.dryRun && input.clientCsv) {
+        const clientCsv = csvToClientRecords(input.clientCsv);
+        const plannedClientRecords = parseClientImportRecords(
+          clientCsv.records,
+        );
+        const clientPlan = planClientCsvImport(
+          plannedClientRecords,
+          input.source,
+          clientRows,
+        );
+        clientRows.push(
+          ...clientPlan.rows.map((client, index) => ({
+            id: `planned-client:${index}`,
+            email: client.email ?? null,
+            externalSource: client.externalSource ?? null,
+            externalId: client.externalId ?? null,
+            deletedAt: null,
+          })),
+        );
       }
+      const clientLookup = createClientReferenceLookup(clientRows);
 
       const existingPatients = await ctx.db
         .select({
+          id: patients.id,
           clientId: patients.clientId,
           name: patients.name,
           species: patients.species,
           dob: patients.dob,
           microchipNumber: patients.microchipNumber,
+          externalSource: patients.externalSource,
+          externalId: patients.externalId,
+          deletedAt: patients.deletedAt,
         })
         .from(patients)
         .where(
           and(
             eq(patients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(patients.deletedAt)
-          )
+          ),
         );
 
-      const deduped = dedupePatientImport(
+      const plan = planPatientCsvImport(
         validRecords,
-        emailToClientId,
-        existingPatients
+        input.source,
+        clientLookup,
+        existingPatients,
       );
 
       if (input.dryRun) {
         return {
           dryRun: true as const,
           total: validRecords.length,
-          willInsert: deduped.rows.length,
-          unmatchedClient: deduped.unmatchedClient,
-          duplicates: deduped.duplicates,
-          errors: [...errors, ...deduped.errors],
+          willInsert: plan.rows.length,
+          willReconcile: plan.identityUpdates.length,
+          unmatchedClient: plan.unmatchedClient,
+          duplicates: plan.duplicates,
+          errors: [...errors, ...plan.errors],
         };
       }
 
-      if (deduped.rows.length > 0) {
-        await ctx.db.insert(patients).values(
-          deduped.rows.map((p) => ({ ...p, practiceId: ctx.practiceId }))
-        );
-      }
+      await ctx.db.transaction(async (tx) => {
+        for (const update of plan.identityUpdates) {
+          const updated = await tx
+            .update(patients)
+            .set({
+              externalSource: update.externalSource,
+              externalId: update.externalId,
+            })
+            .where(
+              and(
+                eq(patients.id, update.id),
+                eq(patients.practiceId, ctx.practiceId),
+                isNull(patients.deletedAt),
+                isNull(patients.externalSource),
+                isNull(patients.externalId),
+              ),
+            )
+            .returning({ id: patients.id });
+          if (updated.length !== 1) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "A patient changed after the dry run. Check the file again before importing.",
+            });
+          }
+        }
+
+        if (plan.rows.length > 0) {
+          await tx.insert(patients).values(
+            plan.rows.map((patient) => ({
+              ...patient,
+              practiceId: ctx.practiceId,
+            })),
+          );
+        }
+      });
       return {
-        imported: deduped.rows.length,
-        errors: [...errors, ...deduped.errors],
+        imported: plan.rows.length,
+        reconciled: plan.identityUpdates.length,
+        errors: [...errors, ...plan.errors],
       };
     }),
 
   /**
-   * Vaccination history import (migration): rows link to pets by owner
-   * email + pet name, so run it AFTER clients and patients. Historical
-   * doses power reminders and the overdue-vaccine views from day one.
+   * Vaccination history import (migration): rows prefer a source-scoped
+   * external patient ID and fall back to owner reference + pet name. Run it
+   * after clients and patients. Historical doses power reminders immediately.
    */
   importVaccinationsCsv: adminProcedure
     .input(importCsvInput)
@@ -1255,26 +1992,24 @@ export const dataRouter = createRouter({
         .select({
           id: patients.id,
           name: patients.name,
+          externalSource: patients.externalSource,
+          externalId: patients.externalId,
           clientEmail: clients.email,
+          clientExternalSource: clients.externalSource,
+          clientExternalId: clients.externalId,
         })
         .from(patients)
         .innerJoin(clients, eq(patients.clientId, clients.id))
         .where(
           and(
             eq(patients.practiceId, ctx.practiceId),
+            eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             isNull(patients.deletedAt),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         );
-      const patientKeyToId: Record<string, string | "ambiguous"> = {};
-      for (const p of patientRows) {
-        if (!p.clientEmail) continue;
-        const key = vaccinationPatientKey(p.clientEmail, p.name);
-        // Two pets with the same name under one owner cannot be told apart
-        // by a CSV row; flag instead of guessing which pet got the dose.
-        patientKeyToId[key] = patientKeyToId[key] ? "ambiguous" : p.id;
-      }
+      const patientLookup = createPatientReferenceLookup(patientRows);
 
       const existingDoses = await ctx.db
         .select({
@@ -1287,14 +2022,15 @@ export const dataRouter = createRouter({
           and(
             eq(vaccinationRecords.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(vaccinationRecords.deletedAt)
-          )
+            isNull(vaccinationRecords.deletedAt),
+          ),
         );
 
       const deduped = dedupeVaccinationImport(
         validRecords,
-        patientKeyToId,
-        existingDoses
+        patientLookup,
+        input.source,
+        existingDoses,
       );
 
       if (input.dryRun) {
@@ -1309,9 +2045,11 @@ export const dataRouter = createRouter({
       }
 
       if (deduped.rows.length > 0) {
-        await ctx.db.insert(vaccinationRecords).values(
-          deduped.rows.map((v) => ({ ...v, practiceId: ctx.practiceId }))
-        );
+        await ctx.db
+          .insert(vaccinationRecords)
+          .values(
+            deduped.rows.map((v) => ({ ...v, practiceId: ctx.practiceId })),
+          );
       }
       return {
         imported: deduped.rows.length,
@@ -1321,8 +2059,8 @@ export const dataRouter = createRouter({
 
   /**
    * Medical history import (migration): each row is one dated visit note,
-   * saved as a SOAP note and linked to a pet by owner email + pet name, so
-   * run it AFTER clients and patients. The visit date is preserved (the
+   * saved as a SOAP note and linked by external patient ID or owner reference
+   * + pet name, so run it after clients and patients. The visit date is preserved (the
    * history reads in order) and the note is attributed to the importing admin,
    * since historical records have no OpenVPM author. Re-running a file is
    * safe: the same pet + date + note text is skipped as a duplicate.
@@ -1353,26 +2091,24 @@ export const dataRouter = createRouter({
         .select({
           id: patients.id,
           name: patients.name,
+          externalSource: patients.externalSource,
+          externalId: patients.externalId,
           clientEmail: clients.email,
+          clientExternalSource: clients.externalSource,
+          clientExternalId: clients.externalId,
         })
         .from(patients)
         .innerJoin(clients, eq(patients.clientId, clients.id))
         .where(
           and(
             eq(patients.practiceId, ctx.practiceId),
+            eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             isNull(patients.deletedAt),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         );
-      const patientKeyToId: Record<string, string | "ambiguous"> = {};
-      for (const p of patientRows) {
-        if (!p.clientEmail) continue;
-        const key = vaccinationPatientKey(p.clientEmail, p.name);
-        // Two pets with the same name under one owner cannot be told apart
-        // by a CSV row; flag instead of guessing which pet the note is for.
-        patientKeyToId[key] = patientKeyToId[key] ? "ambiguous" : p.id;
-      }
+      const patientLookup = createPatientReferenceLookup(patientRows);
 
       const existingNotes = await ctx.db
         .select({
@@ -1388,14 +2124,15 @@ export const dataRouter = createRouter({
           and(
             eq(soapNotes.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(soapNotes.deletedAt)
-          )
+            isNull(soapNotes.deletedAt),
+          ),
         );
 
       const deduped = dedupeSoapNoteImport(
         validRecords,
-        patientKeyToId,
-        existingNotes
+        patientLookup,
+        input.source,
+        existingNotes,
       );
 
       if (input.dryRun) {
@@ -1418,7 +2155,7 @@ export const dataRouter = createRouter({
             // Mark as migrated so the record shows "Imported" rather than
             // implying the importing admin authored this historical note.
             imported: true,
-          }))
+          })),
         );
       }
       return {

--- a/packages/db/drizzle/0039_greedy_valeria_richards.sql
+++ b/packages/db/drizzle/0039_greedy_valeria_richards.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "clients" ADD COLUMN "external_source" varchar(64);--> statement-breakpoint
+ALTER TABLE "clients" ADD COLUMN "external_id" varchar(160);--> statement-breakpoint
+ALTER TABLE "patients" ADD COLUMN "external_source" varchar(64);--> statement-breakpoint
+ALTER TABLE "patients" ADD COLUMN "external_id" varchar(160);--> statement-breakpoint
+CREATE UNIQUE INDEX "clients_external_id_uq" ON "clients" USING btree ("practice_id","external_source","external_id") WHERE "clients"."external_source" is not null and "clients"."external_id" is not null;--> statement-breakpoint
+CREATE UNIQUE INDEX "patients_external_id_uq" ON "patients" USING btree ("practice_id","external_source","external_id") WHERE "patients"."external_source" is not null and "patients"."external_id" is not null;--> statement-breakpoint
+ALTER TABLE "clients" ADD CONSTRAINT "clients_external_identity_pair_check" CHECK (("clients"."external_source" is null) = ("clients"."external_id" is null));--> statement-breakpoint
+ALTER TABLE "patients" ADD CONSTRAINT "patients_external_identity_pair_check" CHECK (("patients"."external_source" is null) = ("patients"."external_id" is null));

--- a/packages/db/drizzle/meta/0039_snapshot.json
+++ b/packages/db/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,11088 @@
+{
+  "id": "52c0761b-f0e0-4962-881b-9cfda25276d6",
+  "prevId": "3d438631-3eba-482f-9c94-57718eefef02",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1786115753528,
       "tag": "0038_overconfident_power_pack",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1786121551230,
+      "tag": "0039_greedy_valeria_richards",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schema/clients.ts
+++ b/packages/db/schema/clients.ts
@@ -1,4 +1,5 @@
 import {
+  check,
   pgTable,
   pgEnum,
   uuid,
@@ -7,8 +8,9 @@ import {
   boolean,
   timestamp,
   index,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import { baseColumns } from "./common";
 import { practices } from "./practices";
 
@@ -28,6 +30,8 @@ export const clients = pgTable(
       .references(() => practices.id),
     firstName: varchar("first_name", { length: 128 }).notNull(),
     lastName: varchar("last_name", { length: 128 }).notNull(),
+    externalSource: varchar("external_source", { length: 64 }),
+    externalId: varchar("external_id", { length: 160 }),
     email: varchar("email", { length: 255 }),
     phone: varchar("phone", { length: 32 }),
     address: text("address"),
@@ -36,7 +40,9 @@ export const clients = pgTable(
     zip: varchar("zip", { length: 16 }),
     emergencyContact: varchar("emergency_contact", { length: 255 }),
     emergencyPhone: varchar("emergency_phone", { length: 32 }),
-    preferredContactMethod: contactMethodEnum("preferred_contact_method").default("phone"),
+    preferredContactMethod: contactMethodEnum(
+      "preferred_contact_method",
+    ).default("phone"),
     // SMS opt-in for TCPA: consent state + an audit trail of how/when it was
     // captured and the exact disclosure shown. Required before texting a client.
     smsConsent: boolean("sms_consent").notNull().default(false),
@@ -47,10 +53,25 @@ export const clients = pgTable(
     accessToken: varchar("access_token", { length: 64 }).unique(),
   },
   (table) => ({
-    practiceIdx: index("clients_practice_idx").on(table.practiceId, table.deletedAt),
-    nameTrgmIdx: index("clients_name_trgm_idx").on(table.firstName, table.lastName),
+    practiceIdx: index("clients_practice_idx").on(
+      table.practiceId,
+      table.deletedAt,
+    ),
+    nameTrgmIdx: index("clients_name_trgm_idx").on(
+      table.firstName,
+      table.lastName,
+    ),
     emailIdx: index("clients_email_idx").on(table.email),
-  })
+    externalIdUq: uniqueIndex("clients_external_id_uq")
+      .on(table.practiceId, table.externalSource, table.externalId)
+      .where(
+        sql`${table.externalSource} is not null and ${table.externalId} is not null`,
+      ),
+    externalIdentityPairCheck: check(
+      "clients_external_identity_pair_check",
+      sql`(${table.externalSource} is null) = (${table.externalId} is null)`,
+    ),
+  }),
 );
 
 export const clientsRelations = relations(clients, ({ one }) => ({

--- a/packages/db/schema/patients.ts
+++ b/packages/db/schema/patients.ts
@@ -1,4 +1,5 @@
 import {
+  check,
   pgTable,
   pgEnum,
   uuid,
@@ -8,8 +9,9 @@ import {
   timestamp,
   numeric,
   index,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import { baseColumns } from "./common";
 import { practices } from "./practices";
 import { clients } from "./clients";
@@ -54,6 +56,8 @@ export const patients = pgTable(
     clientId: uuid("client_id")
       .notNull()
       .references(() => clients.id),
+    externalSource: varchar("external_source", { length: 64 }),
+    externalId: varchar("external_id", { length: 160 }),
     name: varchar("name", { length: 128 }).notNull(),
     species: speciesEnum("species").notNull(),
     breed: varchar("breed", { length: 128 }),
@@ -65,10 +69,22 @@ export const patients = pgTable(
     status: patientStatusEnum("status").notNull().default("active"),
   },
   (table) => ({
-    practiceIdx: index("patients_practice_idx").on(table.practiceId, table.deletedAt),
+    practiceIdx: index("patients_practice_idx").on(
+      table.practiceId,
+      table.deletedAt,
+    ),
     clientIdx: index("patients_client_idx").on(table.clientId),
     nameIdx: index("patients_name_idx").on(table.name),
-  })
+    externalIdUq: uniqueIndex("patients_external_id_uq")
+      .on(table.practiceId, table.externalSource, table.externalId)
+      .where(
+        sql`${table.externalSource} is not null and ${table.externalId} is not null`,
+      ),
+    externalIdentityPairCheck: check(
+      "patients_external_identity_pair_check",
+      sql`(${table.externalSource} is null) = (${table.externalId} is null)`,
+    ),
+  }),
 );
 
 export const patientWeights = pgTable(
@@ -88,9 +104,9 @@ export const patientWeights = pgTable(
     patientRecordedIdx: index("patient_weights_patient_recorded_idx").on(
       table.patientId,
       table.deletedAt,
-      table.recordedAt
+      table.recordedAt,
     ),
-  })
+  }),
 );
 
 export const patientAllergies = pgTable(
@@ -111,9 +127,9 @@ export const patientAllergies = pgTable(
   (table) => ({
     patientIdx: index("patient_allergies_patient_idx").on(
       table.patientId,
-      table.deletedAt
+      table.deletedAt,
     ),
-  })
+  }),
 );
 
 export const patientsRelations = relations(patients, ({ one, many }) => ({
@@ -151,5 +167,5 @@ export const patientAllergiesRelations = relations(
       fields: [patientAllergies.notedBy],
       references: [users.id],
     }),
-  })
+  }),
 );


### PR DESCRIPTION
## Why
Clinics need to migrate real records without depending on owner email or risking duplicate/wrong-chart matches. This adds source-scoped external IDs as the durable link across client, patient, vaccine, and medical-history files.

## What changed
- adds tenant-scoped external identities for clients and patients, with pair constraints and unique indexes
- accepts common owner/client and patient/pet ID columns while preserving leading zeroes and case
- supports ID-only owners and pets, plus source selection in onboarding and Settings
- dry-runs insert/reconciliation counts before commit and applies client/patient changes transactionally
- fails closed for archived IDs, ambiguous matches, conflicting references, changed reconciliation targets, and stale file/preview responses
- redacts all CSV payloads, including onboarding `clientCsv`, from audit metadata

## Validation
- 115 focused import/privacy/UI tests passed
- workspace TypeScript checks passed
- production Next.js build passed
- full suite: 2,372 tests passed; 2 unrelated crypto-heavy tests timed out under concurrent load and both passed in a serial rerun (30/30)
- Drizzle reports no ungenerated schema changes
- independent release review completed with no remaining P0-P2 findings