### PR TITLE
Harden clinic texting readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,8 +32,9 @@ EMAIL_FROM=
 # preferred), or fall back to console logging in local dev.
 MESSAGING_PROVIDER=
 
-# Telnyx (recommended SMS provider). A messaging profile is preferred over a bare
-# from-number — it draws from the number pool and binds the A2P campaign.
+# Telnyx (recommended SMS provider). Clinic sends use the per-location profile
+# and number created during texting setup. The global profile/from values below
+# are optional fallbacks for legacy or development sends without a location.
 TELNYX_API_KEY=
 TELNYX_MESSAGING_PROFILE_ID=
 TELNYX_FROM_NUMBER=

--- a/apps/web/app/(dashboard)/clients/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/clients/[id]/edit/page.tsx
@@ -21,6 +21,11 @@ import {
   isOptionalClientTextValid,
   isRequiredClientTextValid,
 } from "@/lib/clients/policy";
+import { normalizeE164 } from "@/lib/messaging/phone";
+import {
+  phoneNumbersMatchForConsent,
+  SMS_CONSENT_DISCLOSURE,
+} from "@/lib/messaging/consent";
 
 function EditClientLoadingPanel() {
   return (
@@ -96,6 +101,7 @@ function EditClientForm() {
     zip: "",
   });
   const [smsConsent, setSmsConsent] = useState(false);
+  const [smsConsentTouched, setSmsConsentTouched] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const {
@@ -120,6 +126,7 @@ function EditClientForm() {
         zip: client.zip ?? "",
       });
       setSmsConsent(client.smsConsent ?? false);
+      setSmsConsentTouched(false);
     }
   }, [client]);
 
@@ -134,6 +141,10 @@ function EditClientForm() {
     },
   });
 
+  const smsPhoneValid = normalizeE164(form.phone) !== null;
+  const phoneChanged = client
+    ? !phoneNumbersMatchForConsent(client.phone, form.phone)
+    : false;
   const canSubmit =
     isRequiredClientTextValid(form.firstName, CLIENT_NAME_MAX_LENGTH) &&
     isRequiredClientTextValid(form.lastName, CLIENT_NAME_MAX_LENGTH) &&
@@ -142,7 +153,8 @@ function EditClientForm() {
     isOptionalClientTextValid(form.address, CLIENT_ADDRESS_MAX_LENGTH) &&
     isOptionalClientTextValid(form.city, CLIENT_CITY_MAX_LENGTH) &&
     isOptionalClientTextValid(form.state, CLIENT_STATE_MAX_LENGTH) &&
-    isOptionalClientTextValid(form.zip, CLIENT_ZIP_MAX_LENGTH);
+    isOptionalClientTextValid(form.zip, CLIENT_ZIP_MAX_LENGTH) &&
+    (!smsConsentTouched || !smsConsent || smsPhoneValid);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -150,6 +162,10 @@ function EditClientForm() {
 
     if (!client) {
       setError("Load the client before saving changes.");
+      return;
+    }
+    if (smsConsentTouched && smsConsent && !smsPhoneValid) {
+      setError("Enter a valid mobile phone number before recording SMS consent.");
       return;
     }
     if (!canSubmit) {
@@ -167,12 +183,22 @@ function EditClientForm() {
       city: form.city.trim() || undefined,
       state: form.state.trim() || undefined,
       zip: form.zip.trim() || undefined,
-      smsConsent,
+      ...(smsConsentTouched ? { smsConsent } : {}),
     });
   };
 
   const updateField = (field: keyof typeof form, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));
+    if (field === "phone" && client) {
+      // Consent belongs to the destination. Any material phone change requires
+      // a fresh, explicit check after the new number is entered.
+      setSmsConsent(
+        phoneNumbersMatchForConsent(client.phone, value)
+          ? (client.smsConsent ?? false)
+          : false
+      );
+      setSmsConsentTouched(false);
+    }
   };
 
   if (isLoading) {
@@ -285,16 +311,28 @@ function EditClientForm() {
         <label className="flex items-start gap-2 rounded-md border border-border p-3 text-sm">
           <Checkbox
             checked={smsConsent}
-            onChange={(e) => setSmsConsent(e.target.checked)}
+            onChange={(e) => {
+              setSmsConsent(e.target.checked);
+              setSmsConsentTouched(true);
+            }}
+            disabled={!smsPhoneValid && !smsConsent}
             className="mt-0.5"
           />
           <span>
             <span className="font-medium">
-              Client agrees to receive text messages
+              I confirm the client explicitly consented to SMS
             </span>
             <span className="block text-xs text-muted-foreground">
-              Appointment and care reminders by SMS. They can reply STOP to opt out
-              anytime.
+              {SMS_CONSENT_DISCLOSURE.snapshot}
+            </span>
+            <span className="mt-1 block text-xs text-muted-foreground">
+              Saving other details does not renew consent. Only check this after
+              the client has read this disclosure or you have read it to them.
+              {phoneChanged
+                ? " The phone number changed, so prior SMS consent will be removed unless the client explicitly re-consents."
+                : !smsPhoneValid && !smsConsent
+                  ? " Enter a valid mobile phone number to record consent."
+                  : ""}
             </span>
           </span>
         </label>

--- a/apps/web/app/(dashboard)/clients/new/page.tsx
+++ b/apps/web/app/(dashboard)/clients/new/page.tsx
@@ -21,6 +21,8 @@ import {
   isOptionalClientTextValid,
   isRequiredClientTextValid,
 } from "@/lib/clients/policy";
+import { normalizeE164 } from "@/lib/messaging/phone";
+import { SMS_CONSENT_DISCLOSURE } from "@/lib/messaging/consent";
 
 function canManageClientFormRole(role?: string | null): boolean {
   return (
@@ -100,6 +102,7 @@ function NewClientForm() {
     },
   });
 
+  const smsPhoneValid = normalizeE164(form.phone) !== null;
   const canSubmit =
     isRequiredClientTextValid(form.firstName, CLIENT_NAME_MAX_LENGTH) &&
     isRequiredClientTextValid(form.lastName, CLIENT_NAME_MAX_LENGTH) &&
@@ -108,12 +111,17 @@ function NewClientForm() {
     isOptionalClientTextValid(form.address, CLIENT_ADDRESS_MAX_LENGTH) &&
     isOptionalClientTextValid(form.city, CLIENT_CITY_MAX_LENGTH) &&
     isOptionalClientTextValid(form.state, CLIENT_STATE_MAX_LENGTH) &&
-    isOptionalClientTextValid(form.zip, CLIENT_ZIP_MAX_LENGTH);
+    isOptionalClientTextValid(form.zip, CLIENT_ZIP_MAX_LENGTH) &&
+    (!smsConsent || smsPhoneValid);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
 
+    if (smsConsent && !smsPhoneValid) {
+      setError("Enter a valid mobile phone number before recording SMS consent.");
+      return;
+    }
     if (!canSubmit) {
       setError("Check required fields and field lengths.");
       return;
@@ -134,6 +142,9 @@ function NewClientForm() {
 
   const updateField = (field: keyof typeof form, value: string) => {
     setForm((prev) => ({ ...prev, [field]: value }));
+    if (field === "phone" && !normalizeE164(value)) {
+      setSmsConsent(false);
+    }
   };
 
   return (
@@ -225,15 +236,22 @@ function NewClientForm() {
           <Checkbox
             checked={smsConsent}
             onChange={(e) => setSmsConsent(e.target.checked)}
+            disabled={!smsPhoneValid}
             className="mt-0.5"
           />
           <span>
             <span className="font-medium">
-              Client agrees to receive text messages
+              I confirm the client explicitly consented to SMS
             </span>
             <span className="block text-xs text-muted-foreground">
-              Appointment and care reminders by SMS. They can reply STOP to opt out
-              anytime.
+              {SMS_CONSENT_DISCLOSURE.snapshot}
+            </span>
+            <span className="mt-1 block text-xs text-muted-foreground">
+              Only check this after the client has read this disclosure or you
+              have read it to them.
+              {!smsPhoneValid
+                ? " Enter a valid mobile phone number to record consent."
+                : ""}
             </span>
           </span>
         </label>

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -5,8 +5,8 @@ const mocks = vi.hoisted(() => ({
   billingEnforced: vi.fn(() => false),
   requiredMessagingEnvNames: vi.fn(() => [
     "TELNYX_API_KEY",
-    "TELNYX_MESSAGING_PROFILE_ID",
     "TELNYX_PUBLIC_KEY",
+    "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
   ]),
   shouldAssertHostedRlsRole: vi.fn(() => false),
   inspectHostedRlsRole: vi.fn(async () => ({
@@ -107,8 +107,8 @@ afterEach(() => {
   mocks.billingEnforced.mockReturnValue(false);
   mocks.requiredMessagingEnvNames.mockReturnValue([
     "TELNYX_API_KEY",
-    "TELNYX_MESSAGING_PROFILE_ID",
     "TELNYX_PUBLIC_KEY",
+    "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
   ]);
   mocks.shouldAssertHostedRlsRole.mockReturnValue(false);
   mocks.hostedRlsRoleViolations.mockReturnValue([]);
@@ -260,6 +260,7 @@ describe("health route", () => {
     expect(body).not.toContain("GOOGLE_GENERATIVE_AI_API_KEY");
     expect(body).not.toContain("TELNYX_API_KEY");
     expect(body).not.toContain("TELNYX_PUBLIC_KEY");
+    expect(body).not.toContain("MESSAGING_REGISTRATION_ENCRYPTION_KEY");
     expect(json.checks.hostedSms).toEqual({
       ok: false,
       detail: "3 required hosted configuration values are missing",

--- a/apps/web/app/api/webhooks/telnyx/route.test.ts
+++ b/apps/web/app/api/webhooks/telnyx/route.test.ts
@@ -92,6 +92,9 @@ vi.mock("@/lib/messaging/telnyx-signature", () => ({
 
 const { POST } = await import("./route");
 const { communications } = await import("@openpims/db");
+const { inboundSmsOptInEvidence, SMS_INBOUND_OPT_IN } = await import(
+  "@/lib/messaging/consent"
+);
 const { MESSAGING_WEBHOOK_BODY_MAX_BYTES } = await import(
   "@/lib/messaging-webhook-limits"
 );
@@ -748,7 +751,9 @@ describe("Telnyx webhook", () => {
     );
     expect(mocks.updateSet).toHaveBeenCalledWith({
       smsConsent: false,
-      smsConsentAt: expect.any(Date),
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
     });
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -811,6 +816,8 @@ describe("Telnyx webhook", () => {
     expect(mocks.updateSet).toHaveBeenCalledWith({
       smsConsent: true,
       smsConsentAt: expect.any(Date),
+      smsConsentSource: SMS_INBOUND_OPT_IN.source,
+      smsConsentDisclosure: inboundSmsOptInEvidence("START"),
     });
     const condition = mocks.updateWhere.mock.calls[0]?.[0];
     expect(sqlIncludesColumnParamPair(condition, "id", clientId)).toBe(true);
@@ -943,7 +950,7 @@ describe("Telnyx webhook", () => {
     expect(inserted.dedupeKey?.length).toBeLessThanOrEqual(160);
   });
 
-  it("suppresses SMS recipients after failed delivery receipts", async () => {
+  it("updates generic failed delivery receipts without suppressing recipients", async () => {
     process.env.TELNYX_PUBLIC_KEY = "test-public-key";
     mocks.selectResults.push([
       {
@@ -975,16 +982,8 @@ describe("Telnyx webhook", () => {
 
     await expect(response.json()).resolves.toEqual({ ok: true });
     expect(mocks.updateSet).toHaveBeenCalledWith({ status: "failed" });
-    expect(mocks.insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-        locationId: "00000000-0000-0000-0000-000000000002",
-        phone: "+15555550199",
-        reason: "bounce",
-        detail: "Delivery failed for provider message msg-failed",
-      })
-    );
-    expect(mocks.insertConflict).toHaveBeenCalled();
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+    expect(mocks.insertConflict).not.toHaveBeenCalled();
   });
 
   it("does not suppress recipients when a failed delivery receipt matches no outbound communication", async () => {

--- a/apps/web/app/api/webhooks/telnyx/route.ts
+++ b/apps/web/app/api/webhooks/telnyx/route.ts
@@ -12,7 +12,7 @@ import {
   MESSAGING_WEBHOOK_BODY_MAX_BYTES,
   messagingWebhookContentLengthTooLarge,
 } from "@/lib/messaging-webhook-limits";
-import { addSuppression, normalizeE164 } from "@/lib/messaging";
+import { normalizeE164 } from "@/lib/messaging";
 import {
   findMessagingLocationForWebhook,
   handleInboundSmsReply,
@@ -37,17 +37,6 @@ function payloadTooLargeResponse() {
     { error: "Messaging webhook payload too large" },
     { status: 413 }
   );
-}
-
-function firstPayloadToPhone(payload: {
-  to?:
-    | Array<{ phone_number?: string; status?: string }>
-    | { phone_number?: string; status?: string };
-}): string | null {
-  const raw = Array.isArray(payload.to)
-    ? payload.to[0]?.phone_number
-    : payload.to?.phone_number;
-  return normalizeE164(raw);
 }
 
 function payloadString(value: unknown): string | null {
@@ -317,7 +306,7 @@ export async function POST(request: Request) {
     });
 
     if (loc) {
-      const updatedCommunications = await withTenant(db, loc.practiceId, (tx) =>
+      await withTenant(db, loc.practiceId, (tx) =>
         tx
           .update(communications)
           .set({ status: deliveryStatus })
@@ -334,18 +323,9 @@ export async function POST(request: Request) {
           .returning({ id: communications.id })
       );
 
-      if (deliveryStatus === "failed" && updatedCommunications.length > 0) {
-        const failedRecipient = firstPayloadToPhone(payload);
-        if (failedRecipient) {
-          await addSuppression({
-            practiceId: loc.practiceId,
-            locationId: loc.locationId,
-            phone: failedRecipient,
-            reason: "bounce",
-            detail: `Delivery failed for provider message ${providerMessageId}`,
-          });
-        }
-      }
+      // Generic Telnyx failure events do not distinguish a permanently invalid
+      // recipient from transient carrier/provider failures. Preserve delivery
+      // status, but leave automatic suppression to explicit STOP/opt-out events.
     }
 
     return NextResponse.json({ ok: true });

--- a/apps/web/app/api/webhooks/twilio/route.test.ts
+++ b/apps/web/app/api/webhooks/twilio/route.test.ts
@@ -85,6 +85,9 @@ vi.mock("twilio", () => ({
 
 const { POST } = await import("./route");
 const { communications } = await import("@openpims/db");
+const { inboundSmsOptInEvidence, SMS_INBOUND_OPT_IN } = await import(
+  "@/lib/messaging/consent"
+);
 const { MESSAGING_WEBHOOK_BODY_MAX_BYTES } = await import(
   "@/lib/messaging-webhook-limits"
 );
@@ -410,7 +413,9 @@ describe("Twilio webhook", () => {
     );
     expect(mocks.updateSet).toHaveBeenCalledWith({
       smsConsent: false,
-      smsConsentAt: expect.any(Date),
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
     });
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -460,6 +465,8 @@ describe("Twilio webhook", () => {
     expect(mocks.updateSet).toHaveBeenCalledWith({
       smsConsent: true,
       smsConsentAt: expect.any(Date),
+      smsConsentSource: SMS_INBOUND_OPT_IN.source,
+      smsConsentDisclosure: inboundSmsOptInEvidence("START"),
     });
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -479,7 +486,7 @@ describe("Twilio webhook", () => {
     });
   });
 
-  it("updates failed delivery callbacks and suppresses bounced recipients", async () => {
+  it("updates transient failed delivery callbacks without suppressing recipients", async () => {
     process.env.TWILIO_AUTH_TOKEN = "test-token";
     mocks.selectResults.push([
       {
@@ -494,6 +501,7 @@ describe("Twilio webhook", () => {
         To: "+15555550199",
         MessageSid: "SM-failed",
         MessageStatus: "undelivered",
+        ErrorCode: "30008",
       })
     );
 
@@ -501,15 +509,7 @@ describe("Twilio webhook", () => {
     expect(mocks.updateSet).toHaveBeenCalledWith({ status: "failed" });
     const condition = mocks.updateWhere.mock.calls[0]?.[0];
     expect(sqlIncludesColumnName(condition, "deleted_at")).toBe(true);
-    expect(mocks.insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-        locationId: "00000000-0000-0000-0000-000000000002",
-        phone: "+15555550199",
-        reason: "bounce",
-        detail: "Delivery failed for provider message SM-failed",
-      })
-    );
+    expect(mocks.insertValues).not.toHaveBeenCalled();
   });
 
   it("routes delivery callbacks by MessagingServiceSid when no sender number is stored", async () => {
@@ -542,14 +542,6 @@ describe("Twilio webhook", () => {
     );
     expect(sqlIncludesValue(profileCondition, "MG123")).toBe(true);
     expect(mocks.updateSet).toHaveBeenCalledWith({ status: "failed" });
-    expect(mocks.insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-        locationId: "00000000-0000-0000-0000-000000000002",
-        phone: "+15555550199",
-        reason: "bounce",
-        detail: "Delivery failed for provider message SM-profile-failed",
-      })
-    );
+    expect(mocks.insertValues).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/webhooks/twilio/route.ts
+++ b/apps/web/app/api/webhooks/twilio/route.ts
@@ -10,7 +10,7 @@ import {
   MESSAGING_WEBHOOK_BODY_MAX_BYTES,
   messagingWebhookContentLengthTooLarge,
 } from "@/lib/messaging-webhook-limits";
-import { addSuppression, normalizeE164 } from "@/lib/messaging";
+import { normalizeE164 } from "@/lib/messaging";
 import {
   findMessagingLocationForWebhook,
   handleInboundSmsReply,
@@ -133,7 +133,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: true });
   }
 
-  const updatedCommunications = await withTenant(db, loc.practiceId, (tx) =>
+  await withTenant(db, loc.practiceId, (tx) =>
     tx
       .update(communications)
       .set({ status: deliveryStatus })
@@ -150,15 +150,10 @@ export async function POST(request: Request) {
       .returning({ id: communications.id })
   );
 
-  if (deliveryStatus === "failed" && updatedCommunications.length > 0 && toPhone) {
-    await addSuppression({
-      practiceId: loc.practiceId,
-      locationId: loc.locationId,
-      phone: toPhone,
-      reason: "bounce",
-      detail: `Delivery failed for provider message ${providerMessageId}`,
-    });
-  }
+  // A failed/undelivered DLR is not proof that the recipient is permanently
+  // invalid: carrier congestion, filtering, and provider errors share these
+  // statuses. Keep STOP/opt-out webhooks as the only automatic SMS suppression
+  // until a provider-specific permanent-recipient signal is classified safely.
 
   return NextResponse.json({ ok: true });
 }

--- a/apps/web/lib/__tests__/client-sms-consent-ui.test.ts
+++ b/apps/web/lib/__tests__/client-sms-consent-ui.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+const NEW_CLIENT_SOURCE = readFileSync(
+  new URL("../../app/(dashboard)/clients/new/page.tsx", import.meta.url),
+  "utf8"
+);
+const EDIT_CLIENT_SOURCE = readFileSync(
+  new URL("../../app/(dashboard)/clients/[id]/edit/page.tsx", import.meta.url),
+  "utf8"
+);
+
+describe("client SMS consent forms", () => {
+  it("renders the shared server-owned disclosure in both forms", () => {
+    for (const source of [NEW_CLIENT_SOURCE, EDIT_CLIENT_SOURCE]) {
+      expect(source).toContain("SMS_CONSENT_DISCLOSURE.snapshot");
+      expect(source).toContain(
+        "I confirm the client explicitly consented to SMS"
+      );
+      expect(source).toContain("read this disclosure");
+    }
+  });
+
+  it("does not resubmit persisted edit consent on unrelated saves", () => {
+    expect(EDIT_CLIENT_SOURCE).toContain("smsConsentTouched");
+    expect(EDIT_CLIENT_SOURCE).toContain(
+      "...(smsConsentTouched ? { smsConsent } : {})"
+    );
+    expect(EDIT_CLIENT_SOURCE).toContain("phoneNumbersMatchForConsent");
+    expect(EDIT_CLIENT_SOURCE).toContain("setSmsConsentTouched(false)");
+  });
+});

--- a/apps/web/lib/__tests__/self-hosting-ops.test.ts
+++ b/apps/web/lib/__tests__/self-hosting-ops.test.ts
@@ -84,8 +84,6 @@ describe("self-hosting operations docs", () => {
 
     expect(requiredHostedEnvBlock).toContain("MESSAGING_PROVIDER=telnyx");
     expect(requiredHostedEnvBlock).toContain("TELNYX_API_KEY=...");
-    expect(requiredHostedEnvBlock).toContain("TELNYX_MESSAGING_PROFILE_ID=...");
-    expect(requiredHostedEnvBlock).toContain("TELNYX_FROM_NUMBER=...");
     expect(requiredHostedEnvBlock).toContain("TELNYX_PUBLIC_KEY=...");
     expect(requiredHostedEnvBlock).toContain("RESEND_WEBHOOK_SECRET=...");
     expect(requiredHostedEnvBlock).toContain("EMAIL_SUPPORT_ADDRESS=");
@@ -100,6 +98,8 @@ describe("self-hosting operations docs", () => {
       "`STRIPE_PRICE_CLOUD_USER` and `STRIPE_PRICE_CLOUD` are legacy-only"
     );
     expect(envExample).toContain("TELNYX_PUBLIC_KEY=");
+    expect(envExample).toContain("TELNYX_MESSAGING_PROFILE_ID=");
+    expect(envExample).toContain("TELNYX_FROM_NUMBER=");
     expect(envExample).toContain("RESEND_WEBHOOK_SECRET=");
     expect(envExample).toContain("EMAIL_SUPPORT_ADDRESS=");
     expect(envExample).toContain("EMAIL_COMPANY_ADDRESS=");

--- a/apps/web/lib/__tests__/sms.test.ts
+++ b/apps/web/lib/__tests__/sms.test.ts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => {
       send: providerSend,
     })),
     providerSend,
-    resolveSender: vi.fn(),
+    resolveMessagingTransport: vi.fn(),
     isSuppressed: vi.fn(),
     recordUsage: vi.fn(),
     billingEnforced: vi.fn(() => false),
@@ -41,7 +41,7 @@ vi.mock("@/lib/messaging", async (importOriginal) => {
   return {
     ...actual,
     getMessagingProvider: mocks.getMessagingProvider,
-    resolveSender: mocks.resolveSender,
+    resolveMessagingTransport: mocks.resolveMessagingTransport,
     isSuppressed: mocks.isSuppressed,
   };
 });
@@ -58,6 +58,17 @@ function deferred<T = void>() {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+function transport(
+  sender: { messagingServiceId?: string; from?: string },
+  name: "telnyx" | "twilio" | "console" = "telnyx",
+  send = mocks.providerSend
+) {
+  return {
+    provider: { name, isConfigured: () => true, send },
+    sender,
+  };
 }
 
 afterEach(() => {
@@ -102,7 +113,9 @@ describe("sendSms", () => {
 
   it("meters successful real provider sends for hosted usage billing", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveSender.mockResolvedValue({ from: "+15555550100" });
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
     mocks.providerSend.mockResolvedValue({ success: true, id: "sms-1" });
 
     await expect(
@@ -121,7 +134,9 @@ describe("sendSms", () => {
 
   it("normalizes recipients before suppression checks and provider sends", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveSender.mockResolvedValue({ from: "+15555550100" });
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
     mocks.providerSend.mockResolvedValue({ success: true, id: "sms-1" });
 
     await expect(
@@ -156,7 +171,7 @@ describe("sendSms", () => {
     });
 
     expect(mocks.isSuppressed).not.toHaveBeenCalled();
-    expect(mocks.resolveSender).not.toHaveBeenCalled();
+    expect(mocks.resolveMessagingTransport).not.toHaveBeenCalled();
     expect(mocks.providerSend).not.toHaveBeenCalled();
     expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
@@ -164,7 +179,9 @@ describe("sendSms", () => {
   it("waits for hosted usage recording before returning a successful real send", async () => {
     const usage = deferred();
     mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveSender.mockResolvedValue({ from: "+15555550100" });
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
     mocks.providerSend.mockResolvedValue({ success: true, id: "sms-1" });
     mocks.recordUsage.mockReturnValueOnce(usage.promise);
 
@@ -191,7 +208,9 @@ describe("sendSms", () => {
 
   it("keeps provider message ids on appointment reminder helper results", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveSender.mockResolvedValue({ from: "+15555550100" });
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
     mocks.providerSend.mockResolvedValue({ success: true, id: "sms-reminder-1" });
 
     await expect(
@@ -211,7 +230,9 @@ describe("sendSms", () => {
 
   it("keeps provider message ids on vaccination reminder helper results", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveSender.mockResolvedValue({ from: "+15555550100" });
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
     mocks.providerSend.mockResolvedValue({ success: true, id: "sms-vax-1" });
 
     await expect(
@@ -230,7 +251,9 @@ describe("sendSms", () => {
 
   it("does not meter failed provider sends", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveSender.mockResolvedValue({ from: "+15555550100" });
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
     mocks.providerSend.mockResolvedValue({
       success: false,
       error: "Provider rejected",
@@ -258,7 +281,7 @@ describe("sendSms", () => {
       send: mocks.providerSend,
     });
     mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveSender.mockResolvedValue({});
+    mocks.resolveMessagingTransport.mockResolvedValue(transport({}, "console"));
     mocks.providerSend.mockResolvedValue({ success: true, id: "console-1" });
 
     await expect(
@@ -295,7 +318,7 @@ describe("sendSms", () => {
       error: "SMS provider is not configured for hosted sending.",
     });
 
-    expect(mocks.resolveSender).not.toHaveBeenCalled();
+    expect(mocks.resolveMessagingTransport).not.toHaveBeenCalled();
     expect(mocks.providerSend).not.toHaveBeenCalled();
     expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
@@ -309,7 +332,7 @@ describe("sendSms", () => {
       send: mocks.providerSend,
     });
     mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveSender.mockResolvedValue({});
+    mocks.resolveMessagingTransport.mockResolvedValue(transport({}, "console"));
     mocks.providerSend.mockResolvedValue({ success: true, id: "console-1" });
 
     await expect(
@@ -360,14 +383,14 @@ describe("sendSms", () => {
 
     expect(mocks.hasHostedFullAccess).not.toHaveBeenCalled();
     expect(mocks.isSuppressed).not.toHaveBeenCalled();
-    expect(mocks.resolveSender).not.toHaveBeenCalled();
+    expect(mocks.resolveMessagingTransport).not.toHaveBeenCalled();
     expect(mocks.providerSend).not.toHaveBeenCalled();
     expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
 
   it("fails closed for explicit locations without an active sender", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveSender.mockResolvedValue({});
+    mocks.resolveMessagingTransport.mockResolvedValue(undefined);
 
     await expect(
       sendSms({
@@ -381,7 +404,43 @@ describe("sendSms", () => {
       error: "No active texting sender is configured for this location.",
     });
 
+    expect(mocks.getMessagingProvider).not.toHaveBeenCalled();
     expect(mocks.providerSend).not.toHaveBeenCalled();
     expect(mocks.recordUsage).not.toHaveBeenCalled();
+  });
+
+  it("dispatches an explicit location through its persisted provider, not the global provider", async () => {
+    const twilioSend = vi.fn().mockResolvedValue({ success: true, id: "SM-location" });
+    mocks.isSuppressed.mockResolvedValue(false);
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport(
+        {
+          messagingServiceId: "MG-location",
+          from: "+15555550122",
+        },
+        "twilio",
+        twilioSend
+      )
+    );
+
+    await expect(
+      sendSms({
+        to: "+15555550199",
+        body: "Location-bound message",
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        locationId: "00000000-0000-0000-0000-000000000002",
+      })
+    ).resolves.toEqual({ success: true, sid: "SM-location", error: undefined });
+
+    expect(mocks.getMessagingProvider).not.toHaveBeenCalled();
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+    expect(twilioSend).toHaveBeenCalledWith({
+      to: "+15555550199",
+      body: "Location-bound message",
+      sender: {
+        messagingServiceId: "MG-location",
+        from: "+15555550122",
+      },
+    });
   });
 });

--- a/apps/web/lib/messaging/__tests__/consent.test.ts
+++ b/apps/web/lib/messaging/__tests__/consent.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  inboundSmsOptInEvidence,
+  phoneNumbersMatchForConsent,
+  SMS_CONSENT_DISCLOSURE,
+  SMS_INBOUND_OPT_IN,
+} from "../consent";
+
+describe("SMS consent evidence policy", () => {
+  it("keeps a versioned source alongside the exact disclosure snapshot", () => {
+    expect(SMS_CONSENT_DISCLOSURE.version).toBe("v1");
+    expect(SMS_CONSENT_DISCLOSURE.source).toContain(
+      SMS_CONSENT_DISCLOSURE.version
+    );
+    expect(SMS_CONSENT_DISCLOSURE.snapshot).toContain(
+      "appointment reminders"
+    );
+    expect(SMS_CONSENT_DISCLOSURE.snapshot).toContain(
+      "Consent is not a condition of purchase"
+    );
+    expect(SMS_CONSENT_DISCLOSURE.snapshot).toContain("Reply STOP");
+    expect(SMS_CONSENT_DISCLOSURE.snapshot).toContain("HELP for help");
+  });
+
+  it("records carrier-keyword opt-in evidence under its own versioned source", () => {
+    expect(SMS_INBOUND_OPT_IN.source).toContain(SMS_INBOUND_OPT_IN.version);
+    expect(inboundSmsOptInEvidence("START")).toContain('keyword "START"');
+    expect(inboundSmsOptInEvidence("START")).toContain("Reply STOP");
+    expect(inboundSmsOptInEvidence("START")).toContain("HELP for help");
+  });
+
+  it("treats formatting-only edits as the same valid destination", () => {
+    expect(
+      phoneNumbersMatchForConsent("+1 555 555 0123", "(555) 555-0123")
+    ).toBe(true);
+  });
+
+  it("does not collapse unrelated invalid values into one null identity", () => {
+    expect(phoneNumbersMatchForConsent("12345", "67890")).toBe(false);
+    expect(phoneNumbersMatchForConsent("12345", " 12345 ")).toBe(true);
+    expect(phoneNumbersMatchForConsent("", null)).toBe(true);
+  });
+});

--- a/apps/web/lib/messaging/__tests__/index.test.ts
+++ b/apps/web/lib/messaging/__tests__/index.test.ts
@@ -33,6 +33,7 @@ vi.mock("@/lib/tenant-db", () => ({
 import {
   getMessagingProvider,
   requiredMessagingEnvNames,
+  resolveMessagingTransport,
   resolveSender,
 } from "../index";
 
@@ -125,7 +126,6 @@ describe("requiredMessagingEnvNames", () => {
     vi.stubEnv("TELNYX_API_KEY", "KEY123");
     expect(requiredMessagingEnvNames()).toEqual([
       "TELNYX_API_KEY",
-      "TELNYX_MESSAGING_PROFILE_ID",
       "TELNYX_PUBLIC_KEY",
       "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
     ]);
@@ -183,7 +183,11 @@ describe("resolveSender", () => {
     vi.stubEnv("TELNYX_API_KEY", "KEY123");
     vi.stubEnv("TELNYX_MESSAGING_PROFILE_ID", "env-profile");
     mocks.senderRows.push([
-      { messagingProfileId: "loc-profile", senderE164: "+15555550122" },
+      {
+        provider: "telnyx",
+        messagingProfileId: "loc-profile",
+        senderE164: "+15555550122",
+      },
     ]);
 
     await expect(
@@ -204,7 +208,7 @@ describe("resolveSender", () => {
     vi.stubEnv("TELNYX_MESSAGING_PROFILE_ID", "env-profile");
     vi.stubEnv("TELNYX_FROM_NUMBER", "+15555550100");
     mocks.senderRows.push([
-      { messagingProfileId: "   ", senderE164: "\n" },
+      { provider: "telnyx", messagingProfileId: "   ", senderE164: "\n" },
     ]);
 
     await expect(
@@ -228,5 +232,110 @@ describe("resolveSender", () => {
         locationId: "00000000-0000-0000-0000-000000000099",
       })
     ).resolves.toEqual({});
+  });
+});
+
+describe("resolveMessagingTransport", () => {
+  it("fails closed before DB work when a location has no practice scope", async () => {
+    clearMessagingEnv();
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    vi.stubEnv("TELNYX_MESSAGING_PROFILE_ID", "env-profile");
+
+    await expect(
+      resolveMessagingTransport({
+        locationId: "00000000-0000-0000-0000-000000000002",
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.selectInnerJoin).not.toHaveBeenCalled();
+  });
+
+  it("binds an explicit location's persisted provider and sender in one lookup", async () => {
+    clearMessagingEnv();
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    vi.stubEnv("MESSAGING_PROVIDER", "telnyx");
+    mocks.senderRows.push([
+      {
+        provider: "twilio",
+        messagingProfileId: "MG-location",
+        senderE164: "+15555550122",
+      },
+    ]);
+
+    const transport = await resolveMessagingTransport({
+      practiceId: "00000000-0000-0000-0000-0000000000aa",
+      locationId: "00000000-0000-0000-0000-000000000002",
+    });
+
+    expect(transport).toEqual({
+      provider: expect.objectContaining({ name: "twilio" }),
+      sender: {
+        messagingServiceId: "MG-location",
+        from: "+15555550122",
+      },
+    });
+    expect(mocks.selectInnerJoin).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed for an unsupported persisted provider instead of using the global provider", async () => {
+    clearMessagingEnv();
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    vi.stubEnv("TELNYX_MESSAGING_PROFILE_ID", "env-profile");
+    mocks.senderRows.push([
+      {
+        provider: "unknown-provider",
+        messagingProfileId: "location-profile",
+        senderE164: "+15555550122",
+      },
+    ]);
+
+    await expect(
+      resolveMessagingTransport({
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        locationId: "00000000-0000-0000-0000-000000000002",
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("forces explicit location sends through console in demo mode", async () => {
+    clearMessagingEnv();
+    vi.stubEnv("NEXT_PUBLIC_DEMO_MODE", "true");
+    mocks.senderRows.push([
+      {
+        provider: "twilio",
+        messagingProfileId: "MG-location",
+        senderE164: "+15555550122",
+      },
+    ]);
+
+    await expect(
+      resolveMessagingTransport({
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        locationId: "00000000-0000-0000-0000-000000000002",
+      })
+    ).resolves.toEqual({
+      provider: expect.objectContaining({ name: "console" }),
+      sender: {
+        messagingServiceId: "MG-location",
+        from: "+15555550122",
+      },
+    });
+  });
+
+  it("keeps the env-selected provider and sender for locationless dev sends", async () => {
+    clearMessagingEnv();
+    vi.stubEnv("MESSAGING_PROVIDER", "twilio");
+    vi.stubEnv("TWILIO_MESSAGING_SERVICE_SID", "MG-env");
+    vi.stubEnv("TWILIO_PHONE_NUMBER", "+15555550111");
+
+    await expect(resolveMessagingTransport({ practiceId: "p1" })).resolves.toEqual({
+      provider: expect.objectContaining({ name: "twilio" }),
+      sender: {
+        messagingServiceId: "MG-env",
+        from: "+15555550111",
+      },
+    });
+    expect(mocks.selectInnerJoin).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/messaging/__tests__/telnyx-provisioning.test.ts
+++ b/apps/web/lib/messaging/__tests__/telnyx-provisioning.test.ts
@@ -4,6 +4,7 @@ import {
   parseAvailableNumbers,
   searchAvailableNumbers,
   TelnyxNotConfiguredError,
+  createMessagingProfile,
   createA2pBrand,
   createA2pCampaign,
   ensureA2pNumberAssignment,
@@ -101,6 +102,41 @@ describe("Telnyx provisioning requests", () => {
       TelnyxNotConfiguredError
     );
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a US-scoped messaging profile with the production webhook format", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    const fetchMock = vi.fn(
+      async (
+        _url: Parameters<typeof fetch>[0],
+        _init?: Parameters<typeof fetch>[1]
+      ) =>
+        new Response(
+          JSON.stringify({ data: { id: "3fa85f64-5717-4562-b3fc-2c963f66afa6" } })
+        )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      createMessagingProfile({
+        name: "Healthy Pets — OpenVPM",
+        webhookUrl: "https://app.openvpm.com/api/webhooks/telnyx",
+      })
+    ).resolves.toEqual({ id: "3fa85f64-5717-4562-b3fc-2c963f66afa6" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telnyx.com/v2/messaging_profiles",
+      expect.objectContaining({ method: "POST" })
+    );
+    const body = JSON.parse(
+      String(fetchMock.mock.calls[0]?.[1]?.body)
+    ) as Record<string, unknown>;
+    expect(body).toEqual({
+      name: "Healthy Pets — OpenVPM",
+      webhook_url: "https://app.openvpm.com/api/webhooks/telnyx",
+      webhook_api_version: "2",
+      whitelisted_destinations: ["US"],
+    });
   });
 
   it("aborts hung hosted eligibility checks", async () => {

--- a/apps/web/lib/messaging/__tests__/telnyx-signature.test.ts
+++ b/apps/web/lib/messaging/__tests__/telnyx-signature.test.ts
@@ -43,8 +43,21 @@ describe("verifyTelnyxSignature", () => {
     ).toBe(false);
   });
 
-  it("rejects a stale timestamp (replay)", () => {
-    const oldTs = String(Math.floor(nowMs / 1000) - 1000); // > tolerance
+  it("accepts a signature at the five-minute boundary", () => {
+    const boundaryTs = String(Math.floor(nowMs / 1000) - 300);
+    expect(
+      verifyTelnyxSignature({
+        rawBody: body,
+        signatureB64: signPayload(boundaryTs, body),
+        timestamp: boundaryTs,
+        publicKeyB64,
+        nowMs,
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a signature beyond the five-minute replay window", () => {
+    const oldTs = String(Math.floor(nowMs / 1000) - 301);
     expect(
       verifyTelnyxSignature({
         rawBody: body,

--- a/apps/web/lib/messaging/consent.ts
+++ b/apps/web/lib/messaging/consent.ts
@@ -1,0 +1,56 @@
+import { normalizeE164 } from "./phone";
+
+/**
+ * The disclosure a staff member must show or read to a client before recording
+ * SMS consent. The server owns this value: clients submit only the explicit
+ * consent decision, never the evidence snapshot or its source.
+ *
+ * Keep `source` versioned because the existing client schema has no separate
+ * disclosure-version column. `snapshot` is stored verbatim and rendered by the
+ * staff-facing client forms so the persisted evidence matches what was shown.
+ */
+export const SMS_CONSENT_DISCLOSURE = Object.freeze({
+  version: "v1",
+  source: "staff_attested_form:v1",
+  snapshot:
+    "The client agrees that this veterinary practice may send appointment reminders, vaccination and care updates, and two-way service messages by text, including automated messages, to the mobile number provided. Message frequency varies. Message and data rates may apply. Consent is not a condition of purchase. Reply STOP to opt out or HELP for help.",
+});
+
+/**
+ * Evidence recorded when a client re-subscribes from their own phone with an
+ * accepted carrier keyword. The inbound communication retains the original
+ * message; this concise snapshot makes the current consent row self-describing.
+ */
+export const SMS_INBOUND_OPT_IN = Object.freeze({
+  version: "v1",
+  source: "inbound_keyword:v1",
+});
+
+export function inboundSmsOptInEvidence(keyword: string): string {
+  return `Client sent the accepted SMS opt-in keyword "${keyword}" to resume transactional text messages from this veterinary practice. Reply STOP to opt out or HELP for help.`;
+}
+
+function trimmedPhone(raw: string | null | undefined): string | null {
+  const value = raw?.trim();
+  return value ? value : null;
+}
+
+/**
+ * Compare the destination represented by two phone strings. Valid numbers use
+ * their E.164 identity so formatting-only edits preserve consent. Invalid or
+ * ambiguous values compare exactly after trimming, which fails safe instead of
+ * treating two unrelated invalid numbers as the same `null` identity.
+ */
+export function phoneNumbersMatchForConsent(
+  left: string | null | undefined,
+  right: string | null | undefined
+): boolean {
+  const normalizedLeft = normalizeE164(left);
+  const normalizedRight = normalizeE164(right);
+
+  if (normalizedLeft || normalizedRight) {
+    return normalizedLeft !== null && normalizedLeft === normalizedRight;
+  }
+
+  return trimmedPhone(left) === trimmedPhone(right);
+}

--- a/apps/web/lib/messaging/inbound.ts
+++ b/apps/web/lib/messaging/inbound.ts
@@ -11,6 +11,10 @@ import {
 import { withSystem, withTenant } from "@/lib/tenant-db";
 import { normalizeE164 } from "./phone";
 import { addSuppression, removeSuppression } from "./suppression";
+import {
+  inboundSmsOptInEvidence,
+  SMS_INBOUND_OPT_IN,
+} from "./consent";
 import { latestAssignedToForClient } from "@/lib/communications/assignment";
 
 export type InboundSmsProvider = "telnyx" | "twilio";
@@ -152,7 +156,8 @@ export async function setClientSmsConsentByPhone(
   practiceId: string,
   e164: string,
   consent: boolean,
-  matchedClientId?: string | null
+  matchedClientId?: string | null,
+  optInKeyword?: string
 ): Promise<void> {
   const digits = e164.replace(/\D/g, "").slice(-10);
   if (digits.length < 10) return;
@@ -167,7 +172,14 @@ export async function setClientSmsConsentByPhone(
     await withSystem(db, (tx) =>
       tx
         .update(clients)
-        .set({ smsConsent: true, smsConsentAt: new Date() })
+        .set({
+          smsConsent: true,
+          smsConsentAt: new Date(),
+          smsConsentSource: SMS_INBOUND_OPT_IN.source,
+          smsConsentDisclosure: inboundSmsOptInEvidence(
+            optInKeyword ?? "START"
+          ),
+        })
         .where(
           and(
             eq(clients.id, clientId),
@@ -182,7 +194,12 @@ export async function setClientSmsConsentByPhone(
   await withSystem(db, (tx) =>
     tx
       .update(clients)
-      .set({ smsConsent: false, smsConsentAt: new Date() })
+      .set({
+        smsConsent: false,
+        smsConsentAt: null,
+        smsConsentSource: null,
+        smsConsentDisclosure: null,
+      })
       .where(
         and(
           eq(clients.practiceId, practiceId),
@@ -275,7 +292,13 @@ export async function handleInboundSmsReply(opts: {
 
   if (START_KEYWORDS.has(keyword)) {
     await removeSuppression(loc.practiceId, fromPhone);
-    await setClientSmsConsentByPhone(loc.practiceId, fromPhone, true, clientId);
+    await setClientSmsConsentByPhone(
+      loc.practiceId,
+      fromPhone,
+      true,
+      clientId,
+      keyword
+    );
     await logInboundSmsCommunication({
       practiceId: loc.practiceId,
       clientId,

--- a/apps/web/lib/messaging/index.ts
+++ b/apps/web/lib/messaging/index.ts
@@ -7,7 +7,12 @@ import { envValue, nonBlank } from "./env";
 import { hasNonBlankMessagingSender } from "./sender-query";
 import { telnyxProvider } from "./telnyx";
 import { twilioProvider } from "./twilio";
-import type { MessagingProvider, MessagingSender } from "./types";
+import type {
+  MessagingProvider,
+  MessagingProviderName,
+  MessagingSender,
+  ResolvedMessagingTransport,
+} from "./types";
 
 export * from "./types";
 export { normalizeE164 } from "./phone";
@@ -37,15 +42,14 @@ export function requiredMessagingEnvNames(): string[] {
     ? ["TWILIO_ACCOUNT_SID", "TWILIO_AUTH_TOKEN", "TWILIO_PHONE_NUMBER"]
     : [
         "TELNYX_API_KEY",
-        "TELNYX_MESSAGING_PROFILE_ID",
         "TELNYX_PUBLIC_KEY",
         "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
       ];
 }
 
 /** Platform-wide env default sender for the active provider (dev + fallback). */
-function envSender(): MessagingSender {
-  if (getMessagingProvider().name === "twilio") {
+function envSender(providerName: MessagingProviderName): MessagingSender {
+  if (providerName === "twilio") {
     return {
       messagingServiceId: envValue("TWILIO_MESSAGING_SERVICE_SID"),
       from: envValue("TWILIO_PHONE_NUMBER"),
@@ -57,21 +61,32 @@ function envSender(): MessagingSender {
   };
 }
 
+/** Resolve a persisted provider name without consulting global provider env. */
+function providerByName(name: string): MessagingProvider | undefined {
+  if (name === "telnyx") return telnyxProvider;
+  if (name === "twilio") return twilioProvider;
+  return undefined;
+}
+
 /**
- * Resolve the sender for a practice/location. Calls with a location id must use
- * that location's active texting setup; calls without a location id fall back to
- * the platform-wide env default for dev / not-yet-provisioned workflows. A DB
- * error falls back to env only when there was no explicit location target.
+ * Resolve the provider and sender for a practice/location as one transport.
+ * Calls with a location id must use that location's active texting setup; calls
+ * without a location id fall back to the platform-wide env defaults for dev.
+ * Explicit locations never fall back after a missing, invalid, or failed lookup.
  */
-export async function resolveSender(opts: {
+export async function resolveMessagingTransport(opts: {
   practiceId?: string;
   locationId?: string;
-}): Promise<MessagingSender> {
+}): Promise<ResolvedMessagingTransport | undefined> {
   if (opts.locationId) {
+    // A location UUID is not an authorization boundary. Never resolve an
+    // explicit clinic sender unless its owning practice is supplied too.
+    if (!opts.practiceId) return undefined;
     try {
       const [row] = await withSystem(db, (tx) =>
         tx
           .select({
+            provider: locationMessaging.provider,
             messagingProfileId: locationMessaging.messagingProfileId,
             senderE164: locationMessaging.senderE164,
           })
@@ -80,48 +95,59 @@ export async function resolveSender(opts: {
             locations,
             and(
               eq(locations.id, locationMessaging.locationId),
-              opts.practiceId
-                ? eq(locations.practiceId, opts.practiceId)
-                : eq(locations.practiceId, locationMessaging.practiceId),
+              eq(locations.practiceId, opts.practiceId!),
               isNull(locations.deletedAt)
             )
           )
           .where(
-            opts.practiceId
-              ? and(
-                  eq(locationMessaging.locationId, opts.locationId!),
-                  eq(locationMessaging.practiceId, opts.practiceId),
-                  isNull(locationMessaging.deletedAt),
-                  eq(locations.practiceId, opts.practiceId),
-                  isNull(locations.deletedAt),
-                  eq(locationMessaging.enabled, true),
-                  eq(locationMessaging.registrationStatus, "active"),
-                  hasNonBlankMessagingSender()
-                )
-              : and(
-                  eq(locationMessaging.locationId, opts.locationId!),
-                  isNull(locationMessaging.deletedAt),
-                  isNull(locations.deletedAt),
-                  eq(locationMessaging.enabled, true),
-                  eq(locationMessaging.registrationStatus, "active"),
-                  hasNonBlankMessagingSender()
-                )
+            and(
+              eq(locationMessaging.locationId, opts.locationId!),
+              eq(locationMessaging.practiceId, opts.practiceId!),
+              isNull(locationMessaging.deletedAt),
+              eq(locations.practiceId, opts.practiceId!),
+              isNull(locations.deletedAt),
+              eq(locationMessaging.enabled, true),
+              eq(locationMessaging.registrationStatus, "active"),
+              hasNonBlankMessagingSender()
+            )
           )
           .limit(1)
       );
       if (row) {
         const messagingServiceId = nonBlank(row.messagingProfileId);
         const from = nonBlank(row.senderE164);
-        if (!messagingServiceId && !from) return {};
+        if (!messagingServiceId && !from) return undefined;
+        // Demo is the only permitted override for an explicit location: it must
+        // never send externally even if that location has live provider config.
+        const provider =
+          envValue("NEXT_PUBLIC_DEMO_MODE") === "true"
+            ? consoleProvider
+            : providerByName(row.provider);
+        if (!provider) return undefined;
         return {
-          messagingServiceId,
-          from,
+          provider,
+          sender: {
+            messagingServiceId,
+            from,
+          },
         };
       }
     } catch (e) {
-      console.error("[messaging] resolveSender lookup failed", e);
+      console.error("[messaging] resolveMessagingTransport lookup failed", e);
     }
-    return {};
+    return undefined;
   }
-  return envSender();
+  const provider = getMessagingProvider();
+  return { provider, sender: envSender(provider.name) };
+}
+
+/**
+ * Backwards-compatible sender-only lookup. Outbound sends should use
+ * `resolveMessagingTransport` so provider and sender cannot be separated.
+ */
+export async function resolveSender(opts: {
+  practiceId?: string;
+  locationId?: string;
+}): Promise<MessagingSender> {
+  return (await resolveMessagingTransport(opts))?.sender ?? {};
 }

--- a/apps/web/lib/messaging/telnyx-provisioning.ts
+++ b/apps/web/lib/messaging/telnyx-provisioning.ts
@@ -161,6 +161,9 @@ export async function createMessagingProfile(opts: {
       name: opts.name,
       webhook_url: opts.webhookUrl,
       webhook_api_version: "2",
+      // Telnyx rejects new profiles without an explicit destination allowlist.
+      // OpenVPM's supported hosted launch market is the United States.
+      whitelisted_destinations: ["US"],
     }
   );
   const id = json.data?.id;

--- a/apps/web/lib/messaging/telnyx-signature.ts
+++ b/apps/web/lib/messaging/telnyx-signature.ts
@@ -1,6 +1,8 @@
 import { createPublicKey, verify } from "node:crypto";
 
-const SIGNATURE_TOLERANCE_SECONDS = 600;
+// Match Telnyx's current webhook guidance: reject signatures older than five
+// minutes so a captured request has a narrow replay window.
+const SIGNATURE_TOLERANCE_SECONDS = 300;
 
 /** Build a Node public key from Telnyx's base64 raw Ed25519 key (wrap in SPKI). */
 function ed25519PublicKey(b64: string) {

--- a/apps/web/lib/messaging/types.ts
+++ b/apps/web/lib/messaging/types.ts
@@ -42,3 +42,13 @@ export interface MessagingProvider {
   isConfigured(): boolean;
   send(input: SendMessageInput): Promise<SendMessageResult>;
 }
+
+/**
+ * The provider and sender that must be used together for one outbound message.
+ * Location-scoped sends resolve this pair from the same `location_messaging`
+ * row so a global provider setting cannot route a clinic's sender elsewhere.
+ */
+export interface ResolvedMessagingTransport {
+  provider: MessagingProvider;
+  sender: MessagingSender;
+}

--- a/apps/web/lib/sms.ts
+++ b/apps/web/lib/sms.ts
@@ -7,7 +7,7 @@ import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
 import {
   getMessagingProvider,
   normalizeE164,
-  resolveSender,
+  resolveMessagingTransport,
   isSuppressed,
 } from "@/lib/messaging";
 import { envFlagEnabled } from "@/lib/env-bool";
@@ -15,10 +15,10 @@ import { envFlagEnabled } from "@/lib/env-bool";
 // ---------------------------------------------------------------------------
 // Core send function
 //
-// Transport is provider-agnostic (lib/messaging): the active provider (Telnyx
-// preferred, Twilio fallback, console in dev) is chosen by env. This module
-// keeps the hosted entitlement gate and usage metering; the per-location sender
-// is resolved by lib/messaging (env default today, per-location config in P1).
+// Transport is provider-agnostic (lib/messaging): explicit locations bind the
+// persisted provider and sender from one active location_messaging row. Calls
+// without a location retain the env-selected provider/sender fallback for dev.
+// This module keeps the hosted entitlement gate and usage metering.
 // ---------------------------------------------------------------------------
 
 export async function sendSms(options: {
@@ -26,10 +26,9 @@ export async function sendSms(options: {
   body: string;
   /** When set (and a real send occurs), meters the SMS for hosted billing. */
   practiceId?: string;
-  /** Future: selects the location's own number/messaging profile (P1). */
+  /** Selects the location's bound provider and number/messaging profile. */
   locationId?: string;
 }): Promise<{ success: boolean; sid?: string; error?: string }> {
-  const provider = getMessagingProvider();
   const hostedBilling = billingEnforced();
   const recipient = normalizeE164(options.to);
 
@@ -40,8 +39,11 @@ export async function sendSms(options: {
     };
   }
 
+  // Preserve the locationless hosted guard without consulting the global
+  // provider for explicit locations. Their provider comes only from the DB row.
   if (
-    provider.name === "console" &&
+    !options.locationId &&
+    getMessagingProvider().name === "console" &&
     hostedBilling &&
     !envFlagEnabled("NEXT_PUBLIC_DEMO_MODE")
   ) {
@@ -101,18 +103,30 @@ export async function sendSms(options: {
     }
   }
 
-  const sender = await resolveSender({
+  const transport = await resolveMessagingTransport({
     practiceId: options.practiceId,
     locationId: options.locationId,
   });
-  if (
-    options.locationId &&
-    !sender.messagingServiceId &&
-    !sender.from
-  ) {
+  if (options.locationId && !transport) {
     return {
       success: false,
       error: "No active texting sender is configured for this location.",
+    };
+  }
+
+  if (!transport) {
+    return { success: false, error: "SMS provider is not configured." };
+  }
+
+  const { provider, sender } = transport;
+  if (
+    provider.name === "console" &&
+    hostedBilling &&
+    !envFlagEnabled("NEXT_PUBLIC_DEMO_MODE")
+  ) {
+    return {
+      success: false,
+      error: "SMS provider is not configured for hosted sending.",
     };
   }
 

--- a/apps/web/server/__tests__/clients-safety.test.ts
+++ b/apps/web/server/__tests__/clients-safety.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/lib/webhook-dispatcher", () => ({
 
 const { clientsRouter } = await import("../routers/clients");
 const { LIST_OFFSET_MAX } = await import("../routers/pagination");
+const { SMS_CONSENT_DISCLOSURE } = await import("@/lib/messaging/consent");
 const CLIENTS_SOURCE = readFileSync(
   new URL("../routers/clients.ts", import.meta.url),
   "utf8"
@@ -55,6 +56,7 @@ function createDb(opts?: {
       where: vi.fn(() => builder),
       orderBy: vi.fn(() => builder),
       limit: vi.fn(() => builder),
+      for: vi.fn(() => builder),
       offset: vi.fn(async () => result),
       then: (
         resolve: (value: unknown[]) => unknown,
@@ -337,6 +339,58 @@ describe("clients mutation safety", () => {
     );
   });
 
+  it("stores the current server-owned disclosure only on explicit creation consent", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [[{ id: PRACTICE_ID }]],
+      insertedRows: [
+        {
+          id: CLIENT_ID,
+          firstName: "Ada",
+          lastName: "Lovelace",
+          phone: "+15555550123",
+        },
+      ],
+    });
+
+    await callerWithDb(db).create({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      phone: "(555) 555-0123",
+      smsConsent: true,
+    });
+
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        smsConsent: true,
+        smsConsentAt: expect.any(Date),
+        smsConsentSource: SMS_CONSENT_DISCLOSURE.source,
+        smsConsentDisclosure: SMS_CONSENT_DISCLOSURE.snapshot,
+      })
+    );
+    expect(SMS_CONSENT_DISCLOSURE.source).toContain(
+      SMS_CONSENT_DISCLOSURE.version
+    );
+  });
+
+  it("rejects explicit creation consent without a valid SMS destination", async () => {
+    const { db, select, insertValues } = createDb();
+
+    await expect(
+      callerWithDb(db).create({
+        firstName: "Ada",
+        lastName: "Lovelace",
+        phone: "12345",
+        smsConsent: true,
+      })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "A valid mobile phone number is required for SMS consent",
+    });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("rejects client creation before insert when the practice is missing or deleted", async () => {
     const { db, insertValues } = createDb({ selectResults: [[]] });
 
@@ -372,6 +426,82 @@ describe("clients mutation safety", () => {
       firstName: "Ada",
       address: undefined,
       notes: "Prefers morning appointments.",
+    });
+  });
+
+  it("preserves consent evidence across formatting-only phone edits", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [[{ id: CLIENT_ID, phone: "+15555550123" }]],
+      updatedRows: [{ id: CLIENT_ID, phone: "(555) 555-0123" }],
+    });
+
+    await callerWithDb(db).update({
+      id: CLIENT_ID,
+      phone: "(555) 555-0123",
+    });
+
+    expect(updateSet).toHaveBeenCalledWith({
+      phone: "(555) 555-0123",
+    });
+  });
+
+  it("clears consent evidence when the normalized phone destination changes", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [[{ id: CLIENT_ID, phone: "+15555550123" }]],
+      updatedRows: [{ id: CLIENT_ID, phone: "+15555550999" }],
+    });
+
+    await callerWithDb(db).update({
+      id: CLIENT_ID,
+      phone: "+15555550999",
+    });
+
+    expect(updateSet).toHaveBeenCalledWith({
+      phone: "+15555550999",
+      smsConsent: false,
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
+    });
+  });
+
+  it("stores fresh current evidence when a phone edit explicitly re-consents", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [[{ id: CLIENT_ID, phone: "+15555550123" }]],
+      updatedRows: [{ id: CLIENT_ID, phone: "+15555550999" }],
+    });
+
+    await callerWithDb(db).update({
+      id: CLIENT_ID,
+      phone: "+15555550999",
+      smsConsent: true,
+    });
+
+    expect(updateSet).toHaveBeenCalledWith({
+      phone: "+15555550999",
+      smsConsent: true,
+      smsConsentAt: expect.any(Date),
+      smsConsentSource: SMS_CONSENT_DISCLOSURE.source,
+      smsConsentDisclosure: SMS_CONSENT_DISCLOSURE.snapshot,
+    });
+  });
+
+  it("clears prior evidence when staff explicitly withdraws SMS consent", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [[{ id: CLIENT_ID, phone: "+15555550123" }]],
+      updatedRows: [{ id: CLIENT_ID, smsConsent: false }],
+    });
+
+    await callerWithDb(db).update({
+      id: CLIENT_ID,
+      smsConsent: false,
+    });
+
+    expect(updateSet).toHaveBeenCalledWith({
+      smsConsent: false,
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
     });
   });
 

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -664,11 +664,15 @@ describe("messaging location sender join scoping", () => {
     );
   });
 
-  it("scopes shared sender resolution to active locations with or without practice context", () => {
+  it("requires practice context and scopes shared sender resolution to that active location", () => {
     const source = readSource("lib/messaging/index.ts");
 
+    expect(source).toContain("if (!opts.practiceId) return undefined");
     expect(source).toMatch(
-      /innerJoin\(\s*locations,\s*and\(\s*eq\(locations\.id, locationMessaging\.locationId\),\s*opts\.practiceId\s*\?\s*eq\(locations\.practiceId, opts\.practiceId\)\s*:\s*eq\(locations\.practiceId, locationMessaging\.practiceId\),\s*isNull\(locations\.deletedAt\)\s*\)\s*\)/s
+      /innerJoin\(\s*locations,\s*and\(\s*eq\(locations\.id, locationMessaging\.locationId\),\s*eq\(locations\.practiceId, opts\.practiceId!\),\s*isNull\(locations\.deletedAt\)\s*\)\s*\)/s
+    );
+    expect(source).toContain(
+      "eq(locationMessaging.practiceId, opts.practiceId!)"
     );
   });
 });

--- a/apps/web/server/__tests__/notifications-safety.test.ts
+++ b/apps/web/server/__tests__/notifications-safety.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 
 const mocks = vi.hoisted(() => ({
@@ -121,6 +121,12 @@ function createDb(opts?: {
   return { db, select, insertValues };
 }
 
+beforeEach(() => {
+  vi.useFakeTimers();
+  // Noon in Los Angeles / 3 PM in New York: outside SMS quiet hours.
+  vi.setSystemTime(new Date("2026-07-01T19:00:00Z"));
+});
+
 afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
@@ -234,6 +240,78 @@ describe("notification target safety", () => {
         status: "sent",
         providerMessageId: "sms-manual-1",
       })
+    );
+  });
+
+  it("blocks an SMS-only manual reminder during the clinic's quiet hours", async () => {
+    vi.setSystemTime(new Date("2026-07-02T05:00:00Z")); // 10 PM in Los Angeles
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            startTime: new Date("2026-07-03T19:00:00Z"),
+            patientName: "Miso",
+            clientId: CLIENT_ID,
+            clientFirstName: "Ada",
+            clientLastName: "Lovelace",
+            clientEmail: null,
+            clientPhone: "(555) 555-0100",
+            preferredContactMethod: "sms",
+            smsConsent: true,
+            practiceName: "Neighborhood Veterinary",
+            practicePhone: "555-0100",
+            practiceTimezone: "America/Los_Angeles",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "SMS reminders cannot be sent during quiet hours (9 PM–8 AM local time). Try again after 8 AM.",
+    });
+
+    expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
+    expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("falls back to email instead of texting during quiet hours", async () => {
+    vi.setSystemTime(new Date("2026-07-02T05:00:00Z")); // 10 PM in Los Angeles
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            startTime: new Date("2026-07-03T19:00:00Z"),
+            patientName: "Miso",
+            clientId: CLIENT_ID,
+            clientFirstName: "Ada",
+            clientLastName: "Lovelace",
+            clientEmail: "ada@example.com",
+            clientPhone: "(555) 555-0100",
+            preferredContactMethod: "sms",
+            smsConsent: true,
+            practiceName: "Neighborhood Veterinary",
+            practicePhone: "555-0100",
+            practiceTimezone: "America/Los_Angeles",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+    ).resolves.toEqual({ success: true, channel: "email" });
+
+    expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
+    expect(mocks.sendAppointmentReminder).toHaveBeenCalledOnce();
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "email", status: "sent" })
     );
   });
 

--- a/apps/web/server/routers/clients.ts
+++ b/apps/web/server/routers/clients.ts
@@ -24,6 +24,11 @@ import {
   CLIENT_STATE_MAX_LENGTH,
   CLIENT_ZIP_MAX_LENGTH,
 } from "@/lib/clients/policy";
+import { normalizeE164 } from "@/lib/messaging/phone";
+import {
+  phoneNumbersMatchForConsent,
+  SMS_CONSENT_DISCLOSURE,
+} from "@/lib/messaging/consent";
 
 const clientNameInput = z.string().trim().min(1).max(CLIENT_NAME_MAX_LENGTH);
 const clientEmailInput = z
@@ -261,10 +266,22 @@ export const clientsRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      await assertActivePractice(ctx);
       const { smsConsent, ...rest } = input;
+      if (smsConsent && !normalizeE164(rest.phone)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "A valid mobile phone number is required for SMS consent",
+        });
+      }
+
+      await assertActivePractice(ctx);
       const consent = smsConsent
-        ? { smsConsent: true, smsConsentAt: new Date(), smsConsentSource: "intake" }
+        ? {
+            smsConsent: true,
+            smsConsentAt: new Date(),
+            smsConsentSource: SMS_CONSENT_DISCLOSURE.source,
+            smsConsentDisclosure: SMS_CONSENT_DISCLOSURE.snapshot,
+          }
         : {};
       const [client] = await ctx.db
         .insert(clients)
@@ -303,32 +320,90 @@ export const clientsRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const { id, smsConsent, ...rest } = input;
-      const data: Record<string, unknown> = { ...rest };
-      // Record consent transitions with an audit timestamp + source.
-      if (smsConsent !== undefined) {
-        data.smsConsent = smsConsent;
-        if (smsConsent) {
-          data.smsConsentAt = new Date();
-          data.smsConsentSource = "intake";
+      return ctx.db.transaction(async (tx) => {
+        const phoneWasProvided = Object.prototype.hasOwnProperty.call(
+          input,
+          "phone"
+        );
+        const { id, smsConsent, phone, ...rest } = input;
+        const data: Record<string, unknown> = { ...rest };
+
+        if (phoneWasProvided) {
+          // Drizzle ignores undefined values. Use null so an explicitly cleared
+          // phone field is actually removed from the client record.
+          data.phone = phone ?? null;
         }
-      }
-      const [client] = await ctx.db
-        .update(clients)
-        .set(data)
-        .where(
-          and(
-            eq(clients.id, id),
-            eq(clients.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
+
+        if (phoneWasProvided || smsConsent !== undefined) {
+          // Keep the consent decision and destination update under one row lock.
+          // Without the surrounding transaction, FOR UPDATE would release before
+          // the write and a concurrent phone edit could attach consent to the
+          // wrong destination.
+          const [existingClient] = await tx
+            .select({ id: clients.id, phone: clients.phone })
+            .from(clients)
+            .where(
+              and(
+                eq(clients.id, id),
+                eq(clients.practiceId, ctx.practiceId),
+                activePracticePredicate(ctx.practiceId),
+                isNull(clients.deletedAt)
+              )
+            )
+            .limit(1)
+            .for("update");
+
+          if (!existingClient) {
+            throw new TRPCError({ code: "NOT_FOUND", message: "Client not found" });
+          }
+
+          const nextPhone = phoneWasProvided ? phone : existingClient.phone;
+          const phoneChanged = !phoneNumbersMatchForConsent(
+            existingClient.phone,
+            nextPhone
+          );
+
+          if (smsConsent === true) {
+            if (!normalizeE164(nextPhone)) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message: "A valid mobile phone number is required for SMS consent",
+              });
+            }
+
+            // A true value is an explicit staff attestation under the current,
+            // server-owned disclosure. Unrelated edits omit this field entirely.
+            data.smsConsent = true;
+            data.smsConsentAt = new Date();
+            data.smsConsentSource = SMS_CONSENT_DISCLOSURE.source;
+            data.smsConsentDisclosure = SMS_CONSENT_DISCLOSURE.snapshot;
+          } else if (phoneChanged || smsConsent === false) {
+            // Consent belongs to one destination. Changing that destination (or
+            // explicitly withdrawing consent) invalidates all prior evidence.
+            data.smsConsent = false;
+            data.smsConsentAt = null;
+            data.smsConsentSource = null;
+            data.smsConsentDisclosure = null;
+          }
+        }
+
+        const [client] = await tx
+          .update(clients)
+          .set(data)
+          .where(
+            and(
+              eq(clients.id, id),
+              eq(clients.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(clients.deletedAt)
+            )
           )
-        )
-        .returning();
-      if (!client) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Client not found" });
-      }
-      return client;
+          .returning();
+        if (!client) {
+          throw new TRPCError({ code: "NOT_FOUND", message: "Client not found" });
+        }
+        return client;
+      });
     }),
 
   rotatePortalAccessToken: clientManagerProcedure

--- a/apps/web/server/routers/notifications.ts
+++ b/apps/web/server/routers/notifications.ts
@@ -34,7 +34,10 @@ import {
   sendAppointmentReminderSms,
   sendVaccinationReminderSms,
 } from "@/lib/sms";
-import { pickReminderChannel } from "@/lib/messaging/reminders";
+import {
+  isQuietHours,
+  pickReminderChannel,
+} from "@/lib/messaging/reminders";
 import { formatCurrency } from "@/lib/locale/format";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
 import { formatClinicalDate } from "@/lib/records/clinical-dates";
@@ -328,7 +331,7 @@ export const notificationsRouter = createRouter({
         phone: appt.clientPhone,
         smsConsent: appt.smsConsent ?? false,
         hasEmail: Boolean(normalizeEmailSuppressionAddress(appt.clientEmail)),
-        quietHours: false,
+        quietHours: isQuietHours(new Date(), appt.practiceTimezone),
       });
 
       if (channel === "none") {
@@ -336,6 +339,14 @@ export const notificationsRouter = createRouter({
           code: "BAD_REQUEST",
           message:
             "Client has no email and no SMS-consented phone number on file",
+        });
+      }
+
+      if (channel === "skip") {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            "SMS reminders cannot be sent during quiet hours (9 PM–8 AM local time). Try again after 8 AM.",
         });
       }
 
@@ -682,7 +693,7 @@ export const notificationsRouter = createRouter({
           phone: appt.clientPhone,
           smsConsent: appt.smsConsent ?? false,
           hasEmail: Boolean(normalizeEmailSuppressionAddress(appt.clientEmail)),
-          quietHours: false,
+          quietHours: isQuietHours(new Date(), appt.practiceTimezone),
         });
 
         if (channel === "sms") {
@@ -991,7 +1002,7 @@ export const notificationsRouter = createRouter({
           phone: data.clientPhone,
           smsConsent: data.smsConsent ?? false,
           hasEmail: Boolean(normalizeEmailSuppressionAddress(data.clientEmail)),
-          quietHours: false,
+          quietHours: isQuietHours(new Date(), practice.timezone),
         });
 
         if (channel === "sms") {

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -84,11 +84,9 @@ EMAIL_SUPPORT_ADDRESS=support@openvpm.com
 EMAIL_COMPANY_ADDRESS=...
 MESSAGING_PROVIDER=telnyx
 TELNYX_API_KEY=...
-TELNYX_MESSAGING_PROFILE_ID=...
-TELNYX_FROM_NUMBER=...
 TELNYX_PUBLIC_KEY=...
 MESSAGING_REGISTRATION_ENCRYPTION_KEY=... # openssl rand -base64 32
-MESSAGING_PROVISIONING_ENABLED=true
+MESSAGING_PROVISIONING_ENABLED=false
 AI_MODEL=claude-sonnet-4-6
 ANTHROPIC_API_KEY=...
 OPS_ALERT_WEBHOOK_URL=...
@@ -103,6 +101,11 @@ Telnyx is the hosted SMS default. `TELNYX_PUBLIC_KEY` is required for the
 public webhook to verify inbound SMS and delivery-status callbacks. For a
 hosted Telnyx deployment, set a dedicated 32-byte
 `MESSAGING_REGISTRATION_ENCRYPTION_KEY` before collecting clinic A2P details.
+Normal clinic sends use the per-location profile and number stored after the
+location completes texting setup. `TELNYX_MESSAGING_PROFILE_ID` and
+`TELNYX_FROM_NUMBER` are optional platform fallback sender values for legacy or
+development calls that do not specify a location; do not point them at an
+individual clinic merely to satisfy readiness checks.
 Keep `MESSAGING_PROVISIONING_ENABLED=false` until the Telnyx account, webhook,
 operator queue, and budget controls have been verified; changing it to `true`
 opens the explicitly confirmed fee-bearing provisioning actions. For a

--- a/packages/db/schema/clients.ts
+++ b/packages/db/schema/clients.ts
@@ -47,7 +47,8 @@ export const clients = pgTable(
     // captured and the exact disclosure shown. Required before texting a client.
     smsConsent: boolean("sms_consent").notNull().default(false),
     smsConsentAt: timestamp("sms_consent_at", { withTimezone: true }),
-    smsConsentSource: varchar("sms_consent_source", { length: 32 }), // intake|verbal|import|portal
+    // Versioned capture source, for example staff_attested_form:v1.
+    smsConsentSource: varchar("sms_consent_source", { length: 32 }),
     smsConsentDisclosure: text("sms_consent_disclosure"),
     notes: text("notes"),
     accessToken: varchar("access_token", { length: 64 }).unique(),


### PR DESCRIPTION
## Summary

- bind outbound provider and sender atomically to each active clinic location and fail closed across missing or cross-practice scope
- add versioned, server-owned SMS consent evidence for staff attestation and inbound opt-in keywords; clear stale evidence on phone changes and STOP
- enforce 9 PM–8 AM local quiet hours for manual appointment and vaccination reminders with email fallback where available
- stop turning ambiguous transient carrier failures into practice-wide SMS suppression
- align Telnyx profile creation with the required US destination allowlist and narrow webhook replay tolerance to five minutes
- make global Telnyx profile/from values optional fallbacks because normal clinic sends use per-location configuration

## Safety posture

- self-service messaging provisioning remains disabled
- no Telnyx profile or phone number was purchased
- no real SMS was sent
- no database migration is required
- explicit location sends never fall back to a global clinic sender

## Verification

- 2,426 web tests passed
- web TypeScript check passed
- production Next.js build passed
- git diff check passed
- independent tenant/consent/security review passed after correcting inbound START/STOP evidence handling
