### PR TITLE
Require auditable invoice settlement

### DIFF
--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -225,7 +225,7 @@ export default function BillingPage() {
   const handleStatusChange = (
     e: React.MouseEvent,
     id: string,
-    status: "sent" | "paid"
+    status: "sent"
   ) => {
     e.stopPropagation();
     updateStatus.mutate({ id, status });
@@ -657,7 +657,7 @@ function InvoiceRow({
   onStatusChange: (
     e: React.MouseEvent,
     id: string,
-    status: "sent" | "paid"
+    status: "sent"
   ) => void;
   onConvertEstimate: (e: React.MouseEvent, id: string) => void;
   onVoidInvoice: (e: React.MouseEvent, id: string) => void;
@@ -762,15 +762,6 @@ function InvoiceRow({
                       <Send className="h-3.5 w-3.5" />
                     </Button>
                   )}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    disabled={isMutating}
-                    onClick={(e) => onStatusChange(e, invoice.id, "paid")}
-                    title="Mark as Paid"
-                  >
-                    <CheckCircle className="h-3.5 w-3.5" />
-                  </Button>
                 </>
               )}
             {canManageBilling &&

--- a/apps/web/app/api-docs/page.tsx
+++ b/apps/web/app/api-docs/page.tsx
@@ -533,10 +533,11 @@ const sections: Section[] = [
       {
         name: "billing.updateInvoiceStatus",
         method: "POST",
-        description: "Update invoice status.",
+        description:
+          "Update a workflow status. Paid is derived from recorded payments or adjustments and cannot be set directly.",
         input: `{
   id: string,
-  status: "draft" | "sent" | "paid" | "overdue" | "void"
+  status: "draft" | "sent" | "overdue" | "void"
 }`,
         response: `Invoice`,
       },

--- a/apps/web/lib/__tests__/api-docs.test.ts
+++ b/apps/web/lib/__tests__/api-docs.test.ts
@@ -166,6 +166,24 @@ describe("API reference docs", () => {
     expect(appointmentSection).not.toContain('"completed"');
   });
 
+  it("documents paid invoices as payment-derived", () => {
+    const source = readFileSync("app/api-docs/page.tsx", "utf8");
+    const billingSection = source.slice(
+      source.indexOf('id: "billing"'),
+      source.indexOf('id: "inventory"')
+    );
+
+    expect(billingSection).toContain(
+      "Paid is derived from recorded payments or adjustments and cannot be set directly."
+    );
+    expect(billingSection).toContain(
+      'status: "draft" | "sent" | "overdue" | "void"'
+    );
+    expect(billingSection).not.toContain(
+      'status: "draft" | "sent" | "paid" | "overdue" | "void"'
+    );
+  });
+
   it("keeps inventory docs aligned to the live router contract", () => {
     const source = readFileSync("app/api-docs/page.tsx", "utf8");
     const inventorySection = source.slice(

--- a/apps/web/lib/__tests__/billing-ui.test.ts
+++ b/apps/web/lib/__tests__/billing-ui.test.ts
@@ -190,6 +190,13 @@ describe("billing invoice payment actions", () => {
     );
   });
 
+  it("does not offer a status-only path for settling an invoice", () => {
+    expect(source).not.toContain('title="Mark as Paid"');
+    expect(source).not.toContain('onStatusChange(e, invoice.id, "paid")');
+    expect(source).toContain("Record Payment");
+    expect(source).toContain("Take Card");
+  });
+
   it("disables card checkout when Stripe checkout is not configured", () => {
     expect(source).toContain("trpc.billing.cardPaymentStatus.useQuery");
     expect(source).toContain("const cardPaymentStatusMissing =");

--- a/apps/web/server/__tests__/billing-payments.test.ts
+++ b/apps/web/server/__tests__/billing-payments.test.ts
@@ -295,7 +295,7 @@ describe("billing payments", () => {
   });
 
   it("marks the invoice paid when payment reaches the balance", async () => {
-    const { db, updateSet } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [[baseInvoice]],
     });
 
@@ -309,6 +309,14 @@ describe("billing payments", () => {
       paidAmount: "100.00",
       status: "paid",
     });
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoiceId: INVOICE_ID,
+        amount: "80.00",
+        method: "credit_card",
+        receivedBy: USER_ID,
+      })
+    );
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
       PRACTICE_ID,
       "invoice.paid",
@@ -322,38 +330,8 @@ describe("billing payments", () => {
     );
   });
 
-  it("emits invoice.paid when manually marking an invoice paid", async () => {
-    const { db, updateSet } = createDb({
-      selectResults: [[baseInvoice], []],
-      updateReturns: [[{ id: INVOICE_ID, status: "paid" }]],
-    });
-
-    await callerWithDb(db).updateInvoiceStatus({
-      id: INVOICE_ID,
-      status: "paid",
-    });
-
-    expect(updateSet).toHaveBeenCalledWith({
-      status: "paid",
-      paidAmount: "100.00",
-    });
-    expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
-      PRACTICE_ID,
-      "invoice.paid",
-      {
-        id: INVOICE_ID,
-        paidAmount: "100.00",
-        total: "100.00",
-        source: "dashboard",
-      }
-    );
-  });
-
-  it("does not mark an invoice paid when the invoice changed concurrently", async () => {
-    const { db, updateSet } = createDb({
-      selectResults: [[baseInvoice], []],
-      updateReturns: [[]],
-    });
+  it("requires a payment or adjustment to settle an invoice", async () => {
+    const { db, updateSet } = createDb({ selectResults: [[baseInvoice]] });
 
     await expect(
       callerWithDb(db).updateInvoiceStatus({
@@ -362,38 +340,10 @@ describe("billing payments", () => {
       })
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
-      message:
-        "Invoice status changed while updating. Refresh and try again.",
+      message: "Record a payment or apply an adjustment to settle this invoice.",
     });
 
-    expect(updateSet).toHaveBeenCalledWith({
-      status: "paid",
-      paidAmount: "100.00",
-    });
-    expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
-  });
-
-  it("does not mark an invoice paid when adjustment history changed concurrently", async () => {
-    const { db, updateSet } = createDb({
-      selectResults: [[baseInvoice], [{ amount: "10.00", type: "write_off" }]],
-      updateReturns: [[]],
-    });
-
-    await expect(
-      callerWithDb(db).updateInvoiceStatus({
-        id: INVOICE_ID,
-        status: "paid",
-      })
-    ).rejects.toMatchObject({
-      code: "BAD_REQUEST",
-      message:
-        "Invoice status changed while updating. Refresh and try again.",
-    });
-
-    expect(updateSet).toHaveBeenCalledWith({
-      status: "paid",
-      paidAmount: "90.00",
-    });
+    expect(updateSet).not.toHaveBeenCalled();
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
   });
 
@@ -415,25 +365,6 @@ describe("billing payments", () => {
     });
 
     expect(updateSet).toHaveBeenCalledWith({ status: "void" });
-    expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
-  });
-
-  it("rejects marking draft invoices paid directly", async () => {
-    const { db, updateSet } = createDb({
-      selectResults: [[{ ...baseInvoice, status: "draft" }]],
-    });
-
-    await expect(
-      callerWithDb(db).updateInvoiceStatus({
-        id: INVOICE_ID,
-        status: "paid",
-      })
-    ).rejects.toMatchObject({
-      code: "BAD_REQUEST",
-      message: "Mark the invoice as sent before marking it paid.",
-    });
-
-    expect(updateSet).not.toHaveBeenCalled();
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
   });
 

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -1274,6 +1274,13 @@ export const billingRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const existing = await getInvoiceForPractice(ctx, input.id);
+      if (input.status === "paid") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Record a payment or apply an adjustment to settle this invoice.",
+        });
+      }
       if (existing.isEstimate && input.status !== "void") {
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -1289,13 +1296,6 @@ export const billingRouter = createRouter({
       if (existing.status === "void" && input.status === "void") {
         return existing;
       }
-      if (existing.status === "draft" && input.status === "paid") {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Mark the invoice as sent before marking it paid.",
-        });
-      }
-
       const updates: Record<string, any> = { status: input.status };
       const updateConditions: SQL[] = [
         eq(invoices.id, input.id),
@@ -1305,29 +1305,18 @@ export const billingRouter = createRouter({
         eq(invoices.isEstimate, existing.isEstimate),
         eq(invoices.paidAmount, existing.paidAmount ?? "0"),
       ];
-      if (input.status === "paid" || input.status === "void") {
+      if (input.status === "void") {
         const adjustedCents = await getInvoiceAdjustmentTotalCents(ctx, input.id);
-        if (
-          input.status === "void" &&
-          (moneyToCents(existing.paidAmount) > 0 || adjustedCents > 0)
-        ) {
+        if (moneyToCents(existing.paidAmount) > 0 || adjustedCents > 0) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: "Cannot void an invoice with payments or adjustments.",
           });
         }
-        if (input.status === "paid") {
-          updates.paidAmount = centsToMoney(
-            Math.max(0, moneyToCents(existing.total) - adjustedCents)
-          );
-          updateConditions.push(invoiceAdjustmentTotalMatches(adjustedCents));
-        }
-        if (input.status === "void") {
-          updateConditions.push(
-            noActivePaymentsForInvoice(),
-            noActiveAdjustmentsForInvoice()
-          );
-        }
+        updateConditions.push(
+          noActivePaymentsForInvoice(),
+          noActiveAdjustmentsForInvoice()
+        );
       }
 
       if (input.status === "void") {
@@ -1366,14 +1355,6 @@ export const billingRouter = createRouter({
           code: "BAD_REQUEST",
           message:
             "Invoice status changed while updating. Refresh and try again.",
-        });
-      }
-      if (input.status === "paid" && existing.status !== "paid") {
-        await dispatchWebhookEvent(ctx.practiceId, "invoice.paid", {
-          id: input.id,
-          paidAmount: updates.paidAmount,
-          total: existing.total,
-          source: "dashboard",
         });
       }
       return invoice!;


### PR DESCRIPTION
## What changed

- removed the dashboard's status-only **Mark as Paid** action
- reject direct `paid` status mutations on the server with guidance to record a payment or adjustment
- keep `paid` derived from auditable payment, adjustment, and Stripe reconciliation paths
- update the dashboard API reference to document the invariant
- replace tests that previously made phantom payments contractual with settlement-integrity coverage

## Why

The previous quick action set an invoice's paid amount and status without creating a payment row. That could remove a balance from receivables while leaving payment history, cashier attribution, receipts, and monthly collections empty.

## Impact

Clinic staff now settle invoices through **Record Payment**, **Take Card**, or a documented adjustment. These paths retain the payment method, staff attribution, receipt behavior, and collection reporting.

Production currently has no invoice rows, so no historical reconciliation or data migration is required.

## Validation

- 80 focused billing/UI/API-documentation tests passed
- 104 tests passed in independent billing/Stripe review coverage
- workspace type-check passed
- production build passed
- full suite: 2,421 tests passed; 3 unrelated CPU-heavy auth hashing tests timed out only under full-suite concurrency, then all 30 tests in those files passed on immediate isolated rerun
- independent reviewer approved the diff with no blocker
