### PR TITLE
Make assisted clinic migrations reviewable and retry-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,5 @@ jobs:
       - run: pnpm --filter @openpims/db db:rls
 
       - run: pnpm --filter @openpims/db db:rls:test
+
+      - run: pnpm --filter @openpims/db db:migration-runs:test

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -2768,6 +2768,7 @@ function downloadJSON(data: unknown, filename: string) {
 
 type ImportPreview = {
   requestKey: string;
+  previewToken: string;
   total: number;
   willInsert: number;
   willReconcile?: number;
@@ -2820,6 +2821,7 @@ function DataTab() {
     reconciled?: number;
     errors?: string[];
   } | null>(null);
+  const [importRecoveryMessage, setImportRecoveryMessage] = useState("");
   const [backupFileName, setBackupFileName] = useState("");
   const [backupPayload, setBackupPayload] = useState<Record<
     string,
@@ -2910,6 +2912,22 @@ function DataTab() {
     ? verifiedPracticeSettings.timezone
     : null;
 
+  function handleCsvImportError(err: {
+    data?: { code?: string | null } | null;
+    message: string;
+  }) {
+    if (err.data?.code === "CONFLICT") {
+      importRequestKeyRef.current = null;
+      setImportPreview(null);
+      setImportRecoveryMessage(
+        "This preview expired or the clinic data changed. Nothing new was imported by this attempt. Check the same file again.",
+      );
+      toast.error("Check the CSV again before importing.");
+      return;
+    }
+    toast.error(err.message);
+  }
+
   const importClientsCsv = trpc.data.importClientsCsv.useMutation({
     onSuccess: (data, variables) => {
       if ("dryRun" in data && data.dryRun) {
@@ -2921,12 +2939,14 @@ function DataTab() {
         if (importRequestKeyRef.current !== requestKey) return;
         setImportPreview({
           requestKey,
+          previewToken: data.previewToken,
           total: data.total,
           willInsert: data.willInsert,
           willReconcile: data.willReconcile,
           duplicates: data.duplicates,
           errors: data.errors,
         });
+        setImportRecoveryMessage("");
         setImportResult(null);
         toast.success("Client CSV checked");
         return;
@@ -2940,11 +2960,10 @@ function DataTab() {
       setImportPreview(null);
       setCsvText("");
       setCsvFileName("");
+      setImportRecoveryMessage("");
       toast.success("Clients imported");
     },
-    onError: (err) => {
-      toast.error(err.message);
-    },
+    onError: handleCsvImportError,
   });
   const importPatientsCsv = trpc.data.importPatientsCsv.useMutation({
     onSuccess: (data, variables) => {
@@ -2957,6 +2976,7 @@ function DataTab() {
         if (importRequestKeyRef.current !== requestKey) return;
         setImportPreview({
           requestKey,
+          previewToken: data.previewToken,
           total: data.total,
           willInsert: data.willInsert,
           willReconcile: data.willReconcile,
@@ -2964,6 +2984,7 @@ function DataTab() {
           unmatchedClient: data.unmatchedClient,
           errors: data.errors,
         });
+        setImportRecoveryMessage("");
         setImportResult(null);
         toast.success("Patient CSV checked");
         return;
@@ -2977,11 +2998,10 @@ function DataTab() {
       setImportPreview(null);
       setCsvText("");
       setCsvFileName("");
+      setImportRecoveryMessage("");
       toast.success("Patients imported");
     },
-    onError: (err) => {
-      toast.error(err.message);
-    },
+    onError: handleCsvImportError,
   });
   const importVaccinationsCsv = trpc.data.importVaccinationsCsv.useMutation({
     onSuccess: (data, variables) => {
@@ -2994,12 +3014,14 @@ function DataTab() {
         if (importRequestKeyRef.current !== requestKey) return;
         setImportPreview({
           requestKey,
+          previewToken: data.previewToken,
           total: data.total,
           willInsert: data.willInsert,
           duplicates: data.duplicates,
           unmatchedPatient: data.unmatchedPatient,
           errors: data.errors,
         });
+        setImportRecoveryMessage("");
         setImportResult(null);
         toast.success("Vaccination CSV checked");
         return;
@@ -3009,11 +3031,10 @@ function DataTab() {
       setImportPreview(null);
       setCsvText("");
       setCsvFileName("");
+      setImportRecoveryMessage("");
       toast.success("Vaccine history imported");
     },
-    onError: (err) => {
-      toast.error(err.message);
-    },
+    onError: handleCsvImportError,
   });
   const importSoapNotesCsv = trpc.data.importSoapNotesCsv.useMutation({
     onSuccess: (data, variables) => {
@@ -3026,12 +3047,14 @@ function DataTab() {
         if (importRequestKeyRef.current !== requestKey) return;
         setImportPreview({
           requestKey,
+          previewToken: data.previewToken,
           total: data.total,
           willInsert: data.willInsert,
           duplicates: data.duplicates,
           unmatchedPatient: data.unmatchedPatient,
           errors: data.errors,
         });
+        setImportRecoveryMessage("");
         setImportResult(null);
         toast.success("Medical history CSV checked");
         return;
@@ -3041,11 +3064,10 @@ function DataTab() {
       setImportPreview(null);
       setCsvText("");
       setCsvFileName("");
+      setImportRecoveryMessage("");
       toast.success("Medical history imported");
     },
-    onError: (err) => {
-      toast.error(err.message);
-    },
+    onError: handleCsvImportError,
   });
 
   const requestAccountDeletion =
@@ -3242,9 +3264,48 @@ function DataTab() {
     requestAccountDeletion,
   ]);
 
+  const runImportPreview = useCallback(
+    (text: string) => {
+      if (!importMode || !migrationSource) {
+        toast.error("Choose the system you are moving from first.");
+        return;
+      }
+      setImportPreview(null);
+      setImportResult(null);
+      setImportRecoveryMessage("");
+      importRequestKeyRef.current = importPreviewRequestKey(
+        importMode,
+        migrationSource,
+        text,
+      );
+      const input = {
+        csv: text,
+        dryRun: true as const,
+        source: migrationSource,
+        migrationProtocol: "reviewed-v1" as const,
+      };
+      if (importMode === "clients") importClientsCsv.mutate(input);
+      else if (importMode === "patients") importPatientsCsv.mutate(input);
+      else if (importMode === "vaccinations")
+        importVaccinationsCsv.mutate(input);
+      else importSoapNotesCsv.mutate(input);
+    },
+    [
+      importClientsCsv,
+      importMode,
+      importPatientsCsv,
+      importSoapNotesCsv,
+      importVaccinationsCsv,
+      migrationSource,
+    ],
+  );
+
   const handleFileSelect = useCallback(
     (file: File) => {
-      if (!importMode) return;
+      if (!importMode || !migrationSource) {
+        toast.error("Choose the system you are moving from first.");
+        return;
+      }
       const readVersion = ++importFileReadVersionRef.current;
       function clearImportFile() {
         importRequestKeyRef.current = null;
@@ -3252,6 +3313,7 @@ function DataTab() {
         setCsvText("");
         setImportPreview(null);
         setImportResult(null);
+        setImportRecoveryMessage("");
       }
 
       if (file.size > IMPORT_CSV_MAX_BYTES) {
@@ -3264,6 +3326,7 @@ function DataTab() {
       setCsvText("");
       setImportPreview(null);
       setImportResult(null);
+      setImportRecoveryMessage("");
       const reader = new FileReader();
       reader.onload = (e) => {
         if (importFileReadVersionRef.current !== readVersion) return;
@@ -3280,36 +3343,7 @@ function DataTab() {
         }
 
         setCsvText(text);
-        importRequestKeyRef.current = importPreviewRequestKey(
-          importMode,
-          importSource,
-          text,
-        );
-        if (importMode === "clients") {
-          importClientsCsv.mutate({
-            csv: text,
-            dryRun: true,
-            source: importSource,
-          });
-        } else if (importMode === "patients") {
-          importPatientsCsv.mutate({
-            csv: text,
-            dryRun: true,
-            source: importSource,
-          });
-        } else if (importMode === "vaccinations") {
-          importVaccinationsCsv.mutate({
-            csv: text,
-            dryRun: true,
-            source: importSource,
-          });
-        } else {
-          importSoapNotesCsv.mutate({
-            csv: text,
-            dryRun: true,
-            source: importSource,
-          });
-        }
+        runImportPreview(text);
       };
       reader.onerror = () => {
         if (importFileReadVersionRef.current !== readVersion) return;
@@ -3318,14 +3352,7 @@ function DataTab() {
       };
       reader.readAsText(file);
     },
-    [
-      importClientsCsv,
-      importSource,
-      importMode,
-      importPatientsCsv,
-      importVaccinationsCsv,
-      importSoapNotesCsv,
-    ],
+    [importMode, migrationSource, runImportPreview],
   );
 
   const handleDrop = useCallback(
@@ -3362,24 +3389,32 @@ function DataTab() {
         csv: csvText,
         dryRun: false,
         source: importSource,
+        previewToken: importPreview.previewToken,
+        migrationProtocol: "reviewed-v1",
       });
     } else if (importMode === "patients") {
       importPatientsCsv.mutate({
         csv: csvText,
         dryRun: false,
         source: importSource,
+        previewToken: importPreview.previewToken,
+        migrationProtocol: "reviewed-v1",
       });
     } else if (importMode === "vaccinations") {
       importVaccinationsCsv.mutate({
         csv: csvText,
         dryRun: false,
         source: importSource,
+        previewToken: importPreview.previewToken,
+        migrationProtocol: "reviewed-v1",
       });
     } else {
       importSoapNotesCsv.mutate({
         csv: csvText,
         dryRun: false,
         source: importSource,
+        previewToken: importPreview.previewToken,
+        migrationProtocol: "reviewed-v1",
       });
     }
   }, [
@@ -3827,9 +3862,10 @@ function DataTab() {
           Moving from another system? Import clients first, then patients, then
           vaccine history, then medical history (visit notes). Every file is
           dry-run first so you see duplicates and missing matches before
-          anything is saved. Common column names from AVImark, Cornerstone,
-          ezyVet, and Shepherd exports are understood automatically. Owner and
-          patient IDs stay linked across files, even when an owner has no email.
+          anything is saved. Common column names from AVImark, Cornerstone, and
+          ezyVet are recognized. Shepherd migrations are currently guided so we
+          can verify the clinic's exact export format. Owner and patient IDs
+          stay linked across files, even when an owner has no email.
         </p>
 
         {/* Where the data is coming from (export instructions per source) */}
@@ -3844,13 +3880,13 @@ function DataTab() {
               onClick={() => {
                 importFileReadVersionRef.current += 1;
                 importRequestKeyRef.current = null;
-                setMigrationSource(
-                  migrationSource === source.id ? null : source.id,
-                );
+                setMigrationSource(source.id);
+                setImportMode(null);
                 setCsvText("");
                 setCsvFileName("");
                 setImportPreview(null);
                 setImportResult(null);
+                setImportRecoveryMessage("");
               }}
               className={cn(
                 "rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
@@ -3864,13 +3900,27 @@ function DataTab() {
           ))}
         </div>
         {migrationSource ? (
-          <p className="mb-4 max-w-2xl rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-            {
-              MIGRATION_SOURCES.find((s) => s.id === migrationSource)!
-                .exportHint
-            }
+          <div className="mb-4 max-w-2xl rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+            <p>
+              {
+                MIGRATION_SOURCES.find((s) => s.id === migrationSource)!
+                  .exportHint
+              }
+            </p>
+            {migrationSource === "shepherd" ? (
+              <a
+                href="mailto:support@openvpm.com?subject=Assisted%20Shepherd%20migration"
+                className="mt-2 inline-flex font-medium text-primary hover:underline"
+              >
+                Request a migration review before the full import
+              </a>
+            ) : null}
+          </div>
+        ) : (
+          <p className="mb-4 text-xs font-medium text-amber-700">
+            Choose the system you are moving from before selecting an import.
           </p>
-        ) : null}
+        )}
 
         {/* Import mode selector */}
         <div className="flex flex-wrap gap-2 mb-4">
@@ -3890,14 +3940,15 @@ function DataTab() {
               key={mode}
               variant={importMode === mode ? "default" : "outline"}
               size="sm"
+              disabled={!migrationSource}
               onClick={() => {
                 importFileReadVersionRef.current += 1;
-                importRequestKeyRef.current = null;
                 setImportMode(mode);
                 setCsvText("");
                 setCsvFileName("");
                 setImportPreview(null);
                 setImportResult(null);
+                setImportRecoveryMessage("");
               }}
             >
               <Upload className="mr-2 h-4 w-4" />
@@ -3961,6 +4012,25 @@ function DataTab() {
                 <span className="font-medium">{csvFileName}</span>
               </p>
             )}
+
+            {importRecoveryMessage && csvText ? (
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+                <p>{importRecoveryMessage}</p>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="mt-2"
+                  disabled={isImportPending}
+                  onClick={() => runImportPreview(csvText)}
+                >
+                  {isImportPending ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : null}
+                  Check again
+                </Button>
+              </div>
+            ) : null}
 
             {importPreview && (
               <div className="space-y-3">
@@ -4030,6 +4100,13 @@ function DataTab() {
                       </ul>
                     </div>
                   )}
+                  <p className="mt-4 text-xs text-muted-foreground">
+                    Only the{" "}
+                    {importPreview.willInsert +
+                      (importPreview.willReconcile ?? 0)}{" "}
+                    listed changes will be saved. {importPreview.errors.length}{" "}
+                    issue row(s) will be skipped.
+                  </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   <Button
@@ -4061,6 +4138,7 @@ function DataTab() {
                       setCsvText("");
                       setCsvFileName("");
                       setImportPreview(null);
+                      setImportRecoveryMessage("");
                     }}
                   >
                     Cancel

--- a/apps/web/components/onboarding/journey-overlay.tsx
+++ b/apps/web/components/onboarding/journey-overlay.tsx
@@ -99,8 +99,7 @@ export function OnboardingJourneyProvider({
   children: React.ReactNode;
 }) {
   const { data: session, status } = useSession();
-  const isAdmin =
-    status === "authenticated" && session?.user?.role === "admin";
+  const isAdmin = status === "authenticated" && session?.user?.role === "admin";
 
   const onboardingStatus = trpc.settings.onboardingStatus.useQuery(undefined, {
     enabled: isAdmin,
@@ -149,7 +148,7 @@ export function OnboardingJourneyProvider({
     window.history.replaceState(
       null,
       "",
-      window.location.pathname + (rest ? `?${rest}` : "")
+      window.location.pathname + (rest ? `?${rest}` : ""),
     );
     setIndex(resumeIndex);
   }, [isAdmin, index, onboardingState.data, resumeIndex]);
@@ -162,11 +161,7 @@ export function OnboardingJourneyProvider({
     // restores this auto-open exactly.
     if (firstRunMode() === "welcome") return;
     // Wait until all gates are loaded so the step list + resume point are stable.
-    if (
-      !onboardingStatus.data ||
-      !onboardingState.data ||
-      !subscription.data
-    ) {
+    if (!onboardingStatus.data || !onboardingState.data || !subscription.data) {
       return;
     }
     const notFinished = onboardingStatus.data.completedAt == null;
@@ -193,7 +188,8 @@ export function OnboardingJourneyProvider({
     <OnboardingJourneyContext.Provider value={{ openJourney, isOpen }}>
       {children}
       {isOpen ? (
-        <JourneyShell steps={steps}
+        <JourneyShell
+          steps={steps}
           index={index!}
           setIndex={setIndex}
           initialIntent={onboardingIntent ?? DEFAULT_ONBOARDING_INTENT}
@@ -233,13 +229,17 @@ function JourneyShell({
   const setState = useCallback(
     (patch: Partial<JourneyState>) =>
       setStateRaw((prev) => ({ ...prev, ...patch })),
-    []
+    [],
   );
 
   // The active step registers its Continue handler here.
   const handleRef = useRef<StepHandle | null>(null);
+  const [continueLabel, setContinueLabel] = useState<string | null>(null);
+  const [continueDisabled, setContinueDisabled] = useState(false);
   const register = useCallback((h: StepHandle) => {
     handleRef.current = h;
+    setContinueLabel(h.continueLabel ?? null);
+    setContinueDisabled(h.continueDisabled ?? false);
   }, []);
 
   const [busy, setBusy] = useState(false);
@@ -251,11 +251,11 @@ function JourneyShell({
   const persistCursor = useCallback(
     (stepId: string) => {
       utils.settings.getOnboardingState.setData(undefined, (prev) =>
-        prev ? { ...prev, journeyStepId: stepId } : prev
+        prev ? { ...prev, journeyStepId: stepId } : prev,
       );
       setJourneyProgress.mutate({ stepId });
     },
-    [utils, setJourneyProgress]
+    [utils, setJourneyProgress],
   );
 
   const finish = useCallback(async () => {
@@ -287,7 +287,7 @@ function JourneyShell({
   ]);
 
   const handleContinue = useCallback(async () => {
-    if (busy) return;
+    if (busy || continueDisabled) return;
     setBusy(true);
     try {
       const advance = handleRef.current
@@ -298,38 +298,51 @@ function JourneyShell({
         await finish();
       } else {
         handleRef.current = null;
+        setContinueLabel(null);
+        setContinueDisabled(false);
         const next = index + 1;
         persistCursor(steps[next]!.id);
         setIndex(next);
       }
     } catch (err) {
       toast.error(
-        err instanceof Error ? err.message : "Something went wrong. Try again."
+        err instanceof Error ? err.message : "Something went wrong. Try again.",
       );
     } finally {
       setBusy(false);
     }
-  }, [busy, isLast, finish, index, steps, persistCursor, setIndex]);
+  }, [
+    busy,
+    continueDisabled,
+    isLast,
+    finish,
+    index,
+    steps,
+    persistCursor,
+    setIndex,
+  ]);
 
   const handleBack = useCallback(() => {
-    if (busy || index === 0) return;
+    if (busy || continueDisabled || index === 0) return;
     handleRef.current = null;
+    setContinueLabel(null);
+    setContinueDisabled(false);
     const prev = index - 1;
     persistCursor(steps[prev]!.id);
     setIndex(prev);
-  }, [busy, index, steps, persistCursor, setIndex]);
+  }, [busy, continueDisabled, index, steps, persistCursor, setIndex]);
 
   const handleFinishLater = useCallback(() => {
-    if (busy) return;
+    if (busy || continueDisabled) return;
     // Not the same as finishing: record where we are and that it was dismissed,
     // WITHOUT marking onboarding complete. The checklist keeps nudging and the
     // user can resume from here later.
     utils.settings.getOnboardingState.setData(undefined, (prev) =>
-      prev ? { ...prev, journeyStepId: step.id, journeyDismissed: true } : prev
+      prev ? { ...prev, journeyStepId: step.id, journeyDismissed: true } : prev,
     );
     setJourneyProgress.mutate({ stepId: step.id, dismissed: true });
     setIndex(null);
-  }, [busy, step.id, utils, setJourneyProgress, setIndex]);
+  }, [busy, continueDisabled, step.id, utils, setJourneyProgress, setIndex]);
 
   return (
     <div
@@ -357,7 +370,7 @@ function JourneyShell({
                 key={s.id}
                 className={cn(
                   "h-1.5 flex-1 rounded-full transition-colors",
-                  i <= index ? "bg-emerald-500" : "bg-slate-200"
+                  i <= index ? "bg-emerald-500" : "bg-slate-200",
                 )}
               />
             ))}
@@ -383,9 +396,7 @@ function JourneyShell({
             {step.id === "branding" ? (
               <BrandingStep register={register} />
             ) : null}
-            {step.id === "team" ? (
-              <InviteTeamStep register={register} />
-            ) : null}
+            {step.id === "team" ? <InviteTeamStep register={register} /> : null}
             {step.id === "data" ? (
               <BringDataStep
                 register={register}
@@ -393,9 +404,7 @@ function JourneyShell({
                 setState={setState}
               />
             ) : null}
-            {step.id === "agent" ? (
-              <TryAgentStep register={register} />
-            ) : null}
+            {step.id === "agent" ? <TryAgentStep register={register} /> : null}
             {step.id === "phone" ? (
               <SetUpTextingStep register={register} />
             ) : null}
@@ -403,7 +412,11 @@ function JourneyShell({
               <AddACardStep register={register} />
             ) : null}
             {step.id === "allSet" ? (
-              <AllSetStep register={register} state={state} setState={setState} />
+              <AllSetStep
+                register={register}
+                state={state}
+                setState={setState}
+              />
             ) : null}
           </div>
 
@@ -415,7 +428,7 @@ function JourneyShell({
                   type="button"
                   variant="ghost"
                   onClick={handleBack}
-                  disabled={busy}
+                  disabled={busy || continueDisabled}
                 >
                   <ArrowLeft className="mr-1.5 h-4 w-4" />
                   Back
@@ -425,7 +438,7 @@ function JourneyShell({
                 <button
                   type="button"
                   onClick={handleFinishLater}
-                  disabled={busy}
+                  disabled={busy || continueDisabled}
                   className="text-sm font-medium text-slate-500 hover:text-slate-700 disabled:opacity-50"
                 >
                   I&apos;ll finish later
@@ -433,11 +446,13 @@ function JourneyShell({
               ) : null}
             </div>
 
-            <Button type="button" onClick={handleContinue} disabled={busy}>
-              {busy ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : null}
-              {isLast ? "Finish" : "Continue"}
+            <Button
+              type="button"
+              onClick={handleContinue}
+              disabled={busy || continueDisabled}
+            >
+              {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {isLast ? "Finish" : (continueLabel ?? "Continue")}
               {!isLast && !busy ? (
                 <ArrowRight className="ml-2 h-4 w-4" />
               ) : null}

--- a/apps/web/components/onboarding/journey-types.ts
+++ b/apps/web/components/onboarding/journey-types.ts
@@ -12,6 +12,10 @@ export interface JourneyState {
 }
 
 export interface StepHandle {
+  /** Optional action label for steps that perform a material operation. */
+  continueLabel?: string;
+  /** Prevent advancing while a step is still preparing local input. */
+  continueDisabled?: boolean;
   /**
    * Runs when the user presses Continue (or Finish). Do the step's own server
    * work here and return true to advance. Returning false (or throwing) keeps

--- a/apps/web/components/onboarding/steps/bring-data.tsx
+++ b/apps/web/components/onboarding/steps/bring-data.tsx
@@ -24,11 +24,17 @@ import type { StepHandle, StepProps } from "../journey-types";
 
 type Choice = "import" | "api" | "keep";
 type CsvPreview = {
+  previewToken: string;
   total: number;
   willInsert: number;
   willReconcile?: number;
   duplicates?: number;
   unmatchedClient?: number;
+  errors: string[];
+};
+type CommittedCsvImport = {
+  imported: number;
+  reconciled: number;
   errors: string[];
 };
 
@@ -54,6 +60,29 @@ function readFileText(file: File): Promise<string> {
   });
 }
 
+function isPreviewConflict(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const data = "data" in error ? error.data : null;
+  return Boolean(
+    data &&
+    typeof data === "object" &&
+    "code" in data &&
+    data.code === "CONFLICT",
+  );
+}
+
+function downloadIssueReport(errors: string[], fileName: string) {
+  const blob = new Blob([`${errors.join("\n")}\n`], {
+    type: "text/plain;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
 /**
  * Step 4: choose how real data gets in. Import from a file now, connect by API
  * later, or keep the sample data for now (the default and the skip behavior).
@@ -72,19 +101,31 @@ export function BringDataStep({ register, state, setState }: StepProps) {
   const [petsFileName, setPetsFileName] = useState("");
   const [clientsPreview, setClientsPreview] = useState<CsvPreview | null>(null);
   const [petsPreview, setPetsPreview] = useState<CsvPreview | null>(null);
+  const [committedClients, setCommittedClients] =
+    useState<CommittedCsvImport | null>(null);
+  const [importRecoveryMessage, setImportRecoveryMessage] = useState("");
   const importReviewVersionRef = useRef(0);
   const fileReadVersionRef = useRef({ clients: 0, pets: 0 });
+  const [fileReadPending, setFileReadPending] = useState({
+    clients: false,
+    pets: false,
+  });
   const [result, setResult] = useState<{
     clients: number;
     pets: number;
     reconciled: number;
     errors: string[];
   } | null>(null);
+  const importing = importClientsCsv.isPending || importPatientsCsv.isPending;
+  const readingFiles = fileReadPending.clients || fileReadPending.pets;
+  const importInputsBusy = importing || readingFiles;
 
   function clearImportReview() {
     importReviewVersionRef.current += 1;
     setClientsPreview(null);
     setPetsPreview(null);
+    setCommittedClients(null);
+    setImportRecoveryMessage("");
     setResult(null);
   }
 
@@ -97,7 +138,14 @@ export function BringDataStep({ register, state, setState }: StepProps) {
   function updatePetsCsv(value: string) {
     fileReadVersionRef.current.pets += 1;
     setPetsCsv(value);
-    clearImportReview();
+    clearPetReview();
+  }
+
+  function clearPetReview() {
+    importReviewVersionRef.current += 1;
+    setPetsPreview(null);
+    setImportRecoveryMessage("");
+    setResult(null);
   }
 
   function invalidatePendingFileReads() {
@@ -112,12 +160,19 @@ export function BringDataStep({ register, state, setState }: StepProps) {
   ) {
     const file = e.target.files?.[0];
     if (!file) return;
+    if (which === "clients") clearImportReview();
+    else clearPetReview();
+    setFileReadPending((current) => ({ ...current, [which]: true }));
     const readVersion = ++fileReadVersionRef.current[which];
+    function finishFileRead() {
+      setFileReadPending((current) => ({ ...current, [which]: false }));
+    }
     function clearPickedFile() {
       setCsv("");
       if (which === "clients") setClientsFileName("");
       else setPetsFileName("");
       e.target.value = "";
+      finishFileRead();
     }
     if (file.size > IMPORT_CSV_MAX_BYTES) {
       clearPickedFile();
@@ -135,8 +190,10 @@ export function BringDataStep({ register, state, setState }: StepProps) {
       setCsv(text);
       if (which === "clients") setClientsFileName(file.name);
       else setPetsFileName(file.name);
+      finishFileRead();
     } catch {
       if (fileReadVersionRef.current[which] !== readVersion) return;
+      finishFileRead();
       toast.error("Could not read that file. Try again.");
     }
   }
@@ -153,24 +210,47 @@ export function BringDataStep({ register, state, setState }: StepProps) {
   const hasClientsCsv = clientsCsv.trim().length > 0;
   const hasPetsCsv = petsCsv.trim().length > 0;
   const hasImportCsv = choice === "import" && (hasClientsCsv || hasPetsCsv);
-  const needsDryRun =
-    (hasClientsCsv && !clientsPreview) || (hasPetsCsv && !petsPreview);
-  const previewReady = hasImportCsv && !needsDryRun;
+  const needsClientPreview =
+    hasClientsCsv && !clientsPreview && !committedClients;
+  const needsClientCommit =
+    hasClientsCsv && Boolean(clientsPreview) && !committedClients;
+  const needsPetsPreview = hasPetsCsv && !petsPreview;
+  const previewReady = Boolean(clientsPreview || petsPreview);
   const previewWillInsert =
     (clientsPreview?.willInsert ?? 0) + (petsPreview?.willInsert ?? 0);
   const previewWillReconcile =
     (clientsPreview?.willReconcile ?? 0) + (petsPreview?.willReconcile ?? 0);
+  const previewChangeCount = previewWillInsert + previewWillReconcile;
+  const continueLabel =
+    choice !== "import" || !hasImportCsv || result
+      ? "Continue"
+      : needsClientPreview
+        ? "Check client file"
+        : needsClientCommit
+          ? `Import ${previewChangeCount.toLocaleString()} client changes`
+          : needsPetsPreview
+            ? "Check pet file"
+            : previewChangeCount > 0
+              ? `Import ${previewChangeCount.toLocaleString()} pet changes`
+              : "Review import";
 
   // Finish only clears sample data after real rows have imported. Checking a
   // CSV or connecting later leaves the demo clinic intact.
   const hasImportedRows =
-    choice === "import" && Boolean(result && result.clients + result.pets > 0);
+    choice === "import" &&
+    Boolean(
+      (result && result.clients + result.pets + result.reconciled > 0) ||
+      (committedClients &&
+        committedClients.imported + committedClients.reconciled > 0),
+    );
   useEffect(() => {
     setState({ keepSampleData: !hasImportedRows });
   }, [hasImportedRows, setState]);
 
   useEffect(() => {
     register({
+      continueLabel,
+      continueDisabled: readingFiles,
       async onContinue() {
         // Only the file path does extra work on Continue; the others just move on.
         if (choice !== "import") return true;
@@ -181,35 +261,119 @@ export function BringDataStep({ register, state, setState }: StepProps) {
           return false;
         }
 
-        if (needsDryRun) {
+        if (needsClientPreview) {
           const reviewVersion = importReviewVersionRef.current;
-          if (hasClientsCsv) {
-            const r = await importClientsCsv.mutateAsync({
-              csv: clientsCsv.trim(),
-              dryRun: true,
-              source: migrationSource,
+          setImportRecoveryMessage("");
+          const r = await importClientsCsv.mutateAsync({
+            csv: clientsCsv.trim(),
+            dryRun: true,
+            source: migrationSource,
+            migrationProtocol: "reviewed-v1",
+          });
+          if (importReviewVersionRef.current !== reviewVersion) return false;
+          if ("dryRun" in r && r.dryRun) {
+            setClientsPreview({
+              previewToken: r.previewToken,
+              total: r.total,
+              willInsert: r.willInsert,
+              willReconcile: r.willReconcile,
+              duplicates: r.duplicates,
+              errors: r.errors,
             });
-            if (importReviewVersionRef.current !== reviewVersion) return false;
-            if ("dryRun" in r && r.dryRun) {
-              setClientsPreview({
-                total: r.total,
-                willInsert: r.willInsert,
-                willReconcile: r.willReconcile,
-                duplicates: r.duplicates,
-                errors: r.errors,
+          }
+          toast.success(
+            "Client CSV checked. Review the plan before importing.",
+          );
+          return false;
+        }
+
+        if (needsClientCommit) {
+          const preview = clientsPreview!;
+          if (preview.willInsert + (preview.willReconcile ?? 0) === 0) {
+            const committed = {
+              imported: 0,
+              reconciled: 0,
+              errors: preview.errors,
+            };
+            setCommittedClients(committed);
+            setClientsPreview(null);
+            if (hasPetsCsv) {
+              setImportRecoveryMessage(
+                "No client changes were needed. Check the pet file next.",
+              );
+            } else {
+              setResult({
+                clients: 0,
+                pets: 0,
+                reconciled: 0,
+                errors: [
+                  ...preview.errors,
+                  "No new client rows were found to import.",
+                ],
               });
             }
+            return false;
           }
-          if (hasPetsCsv) {
+
+          try {
+            const reviewVersion = importReviewVersionRef.current;
+            const r = await importClientsCsv.mutateAsync({
+              csv: clientsCsv.trim(),
+              dryRun: false,
+              source: migrationSource,
+              previewToken: preview.previewToken,
+              migrationProtocol: "reviewed-v1",
+            });
+            if (importReviewVersionRef.current !== reviewVersion) return false;
+            const committed = {
+              imported: r.imported ?? 0,
+              reconciled: r.reconciled ?? 0,
+              errors: r.errors ?? [],
+            };
+            setCommittedClients(committed);
+            setClientsPreview(null);
+            if (hasPetsCsv) {
+              setImportRecoveryMessage(
+                `Clients imported (${committed.imported}). Check the pet file next.`,
+              );
+            } else {
+              setResult({
+                clients: committed.imported,
+                pets: 0,
+                reconciled: committed.reconciled,
+                errors: committed.errors,
+              });
+              toast.success(`Added ${committed.imported} clients`);
+            }
+          } catch (error) {
+            if (isPreviewConflict(error)) {
+              setClientsPreview(null);
+              setImportRecoveryMessage(
+                "Nothing was imported because the client preview expired or changed. Check the same file again.",
+              );
+            } else {
+              setImportRecoveryMessage(
+                "We could not confirm the client import response. Retry the same import; it is safe and will not add the rows twice.",
+              );
+            }
+          }
+          return false;
+        }
+
+        if (needsPetsPreview) {
+          const reviewVersion = importReviewVersionRef.current;
+          setImportRecoveryMessage("");
+          try {
             const r = await importPatientsCsv.mutateAsync({
               csv: petsCsv.trim(),
               dryRun: true,
               source: migrationSource,
-              clientCsv: hasClientsCsv ? clientsCsv.trim() : undefined,
+              migrationProtocol: "reviewed-v1",
             });
             if (importReviewVersionRef.current !== reviewVersion) return false;
             if ("dryRun" in r && r.dryRun) {
               setPetsPreview({
+                previewToken: r.previewToken,
                 total: r.total,
                 willInsert: r.willInsert,
                 willReconcile: r.willReconcile,
@@ -217,16 +381,23 @@ export function BringDataStep({ register, state, setState }: StepProps) {
                 errors: r.errors,
               });
             }
+            toast.success("Pet CSV checked. Review the plan before importing.");
+          } catch {
+            setPetsPreview(null);
+            setImportRecoveryMessage(
+              committedClients
+                ? `Clients imported (${committedClients.imported}); pets were not checked. Try the pet file again.`
+                : "Pets were not checked. Try the pet file again.",
+            );
           }
-          toast.success("CSV checked. Review the plan before importing.");
           return false;
         }
 
-        if (previewWillInsert + previewWillReconcile === 0) {
+        if (previewChangeCount === 0) {
           setResult({
-            clients: 0,
+            clients: committedClients?.imported ?? 0,
             pets: 0,
-            reconciled: 0,
+            reconciled: committedClients?.reconciled ?? 0,
             errors: [
               "No new rows were found to import. You can adjust the CSV or continue with sample data.",
             ],
@@ -234,40 +405,46 @@ export function BringDataStep({ register, state, setState }: StepProps) {
           return false;
         }
 
-        const errors: string[] = [];
-        let clientsImported = 0;
-        let petsImported = 0;
-        let reconciled = 0;
-
-        if (hasClientsCsv) {
-          const r = await importClientsCsv.mutateAsync({
-            csv: clientsCsv.trim(),
-            dryRun: false,
-            source: migrationSource,
-          });
-          clientsImported = r.imported ?? 0;
-          reconciled += r.reconciled ?? 0;
-          if (r.errors?.length) errors.push(...r.errors);
-        }
-        if (hasPetsCsv) {
+        try {
+          const reviewVersion = importReviewVersionRef.current;
           const r = await importPatientsCsv.mutateAsync({
             csv: petsCsv.trim(),
             dryRun: false,
             source: migrationSource,
+            previewToken: petsPreview!.previewToken,
+            migrationProtocol: "reviewed-v1",
           });
-          petsImported = r.imported ?? 0;
-          reconciled += r.reconciled ?? 0;
-          if (r.errors?.length) errors.push(...r.errors);
+          if (importReviewVersionRef.current !== reviewVersion) return false;
+          const clientsImported = committedClients?.imported ?? 0;
+          const petsImported = r.imported ?? 0;
+          const reconciled =
+            (committedClients?.reconciled ?? 0) + (r.reconciled ?? 0);
+          setImportRecoveryMessage("");
+          setResult({
+            clients: clientsImported,
+            pets: petsImported,
+            reconciled,
+            errors: [...(committedClients?.errors ?? []), ...(r.errors ?? [])],
+          });
+          toast.success(
+            `Added ${clientsImported} clients and ${petsImported} pets${reconciled > 0 ? `; connected ${reconciled} IDs` : ""}`,
+          );
+        } catch (error) {
+          if (isPreviewConflict(error)) {
+            setPetsPreview(null);
+            setImportRecoveryMessage(
+              committedClients
+                ? `Clients imported (${committedClients.imported}); nothing was imported from the pet file because its preview expired or changed. Check the pet file again.`
+                : "Nothing was imported because the pet preview expired or changed. Check the pet file again.",
+            );
+          } else {
+            setImportRecoveryMessage(
+              committedClients
+                ? `Clients imported (${committedClients.imported}); we could not confirm the pet import response. Retry the same pet import—it is safe and will not add rows twice.`
+                : "We could not confirm the pet import response. Retry the same import; it is safe and will not add rows twice.",
+            );
+          }
         }
-        setResult({
-          clients: clientsImported,
-          pets: petsImported,
-          reconciled,
-          errors,
-        });
-        toast.success(
-          `Added ${clientsImported} clients and ${petsImported} pets${reconciled > 0 ? `; connected ${reconciled} IDs` : ""}`,
-        );
         // Stay on the step so they can see the result before moving on.
         return false;
       },
@@ -281,17 +458,25 @@ export function BringDataStep({ register, state, setState }: StepProps) {
     hasPetsCsv,
     hasImportCsvSizeError,
     importCsvSizeError,
-    needsDryRun,
-    previewWillInsert,
-    previewWillReconcile,
+    needsClientPreview,
+    needsClientCommit,
+    needsPetsPreview,
+    previewChangeCount,
+    continueLabel,
+    readingFiles,
+    clientsPreview,
+    petsPreview,
+    committedClients,
     migrationSource,
     result,
     importClientsCsv,
     importPatientsCsv,
   ]);
 
-  const importing = importClientsCsv.isPending || importPatientsCsv.isPending;
   const pathway = getOnboardingIntentOption(state.onboardingIntent);
+  const selectedMigrationSource = MIGRATION_SOURCES.find(
+    (source) => source.id === migrationSource,
+  )!;
   const pathwayIntro =
     pathway.value === "alongside"
       ? "Start small: bring in a few real clients and pets while your current PIMS stays in place."
@@ -314,10 +499,20 @@ export function BringDataStep({ register, state, setState }: StepProps) {
           title="Import from a file"
           subtitle="Paste your clients and pets from a spreadsheet."
           onClick={() => {
+            if (
+              importInputsBusy ||
+              choice === "import" ||
+              committedClients ||
+              result
+            )
+              return;
             invalidatePendingFileReads();
             setChoice("import");
             clearImportReview();
           }}
+          disabled={
+            importInputsBusy || Boolean(committedClients) || Boolean(result)
+          }
         />
         {choice === "import" ? (
           <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50/70 p-4">
@@ -333,6 +528,11 @@ export function BringDataStep({ register, state, setState }: StepProps) {
               <span>Which system are you moving from?</span>
               <select
                 value={migrationSource}
+                disabled={
+                  importInputsBusy ||
+                  Boolean(committedClients) ||
+                  Boolean(result)
+                }
                 onChange={(event) => {
                   invalidatePendingFileReads();
                   setMigrationSource(
@@ -350,6 +550,17 @@ export function BringDataStep({ register, state, setState }: StepProps) {
                 ))}
               </select>
             </label>
+            <div className="rounded-md border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600">
+              <p>{selectedMigrationSource.exportHint}</p>
+              {migrationSource === "shepherd" ? (
+                <a
+                  href="mailto:support@openvpm.com?subject=Assisted%20Shepherd%20migration"
+                  className="mt-2 inline-flex font-medium text-emerald-700 hover:underline"
+                >
+                  Request a migration review before the full import
+                </a>
+              ) : null}
+            </div>
             <div className="space-y-1.5">
               <span className="text-sm font-medium text-slate-700">
                 Clients
@@ -359,6 +570,11 @@ export function BringDataStep({ register, state, setState }: StepProps) {
               </p>
               <input
                 type="file"
+                disabled={
+                  importInputsBusy ||
+                  Boolean(committedClients) ||
+                  Boolean(result)
+                }
                 accept=".csv,text/csv"
                 onChange={(e) => onPickFile(e, updateClientsCsv, "clients")}
                 className={fileInputClass}
@@ -373,6 +589,11 @@ export function BringDataStep({ register, state, setState }: StepProps) {
                 rows={4}
                 className={textareaClass}
                 value={clientsCsv}
+                disabled={
+                  importInputsBusy ||
+                  Boolean(committedClients) ||
+                  Boolean(result)
+                }
                 maxLength={IMPORT_CSV_MAX_BYTES}
                 aria-invalid={clientsCsvTooLarge || undefined}
                 aria-describedby={
@@ -392,6 +613,7 @@ export function BringDataStep({ register, state, setState }: StepProps) {
               <p className="text-xs text-slate-500">Columns: {PET_COLUMNS}</p>
               <input
                 type="file"
+                disabled={importInputsBusy || Boolean(result)}
                 accept=".csv,text/csv"
                 onChange={(e) => onPickFile(e, updatePetsCsv, "pets")}
                 className={fileInputClass}
@@ -406,6 +628,7 @@ export function BringDataStep({ register, state, setState }: StepProps) {
                 rows={4}
                 className={textareaClass}
                 value={petsCsv}
+                disabled={importInputsBusy || Boolean(result)}
                 maxLength={IMPORT_CSV_MAX_BYTES}
                 aria-invalid={petsCsvTooLarge || undefined}
                 aria-describedby={
@@ -427,8 +650,8 @@ export function BringDataStep({ register, state, setState }: StepProps) {
                     Dry-run preview
                   </p>
                   <p className="mt-1 text-xs text-slate-500">
-                    No data has been imported yet. Review the counts, then press
-                    Continue again to import.
+                    No data in this preview has been imported yet. Only the
+                    listed changes will be saved; issue rows will be skipped.
                   </p>
                 </div>
                 {clientsPreview ? (
@@ -449,11 +672,21 @@ export function BringDataStep({ register, state, setState }: StepProps) {
                 ) : null}
               </div>
             ) : null}
-            {importing ? (
+            {readingFiles ? (
+              <p className="flex items-center gap-2 text-xs text-slate-500">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Reading the selected file
+              </p>
+            ) : importing ? (
               <p className="flex items-center gap-2 text-xs text-slate-500">
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 {previewReady ? "Importing your data" : "Checking your data"}
               </p>
+            ) : null}
+            {importRecoveryMessage ? (
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+                {importRecoveryMessage}
+              </div>
             ) : null}
             {result ? (
               <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-900">
@@ -465,14 +698,10 @@ export function BringDataStep({ register, state, setState }: StepProps) {
                 </p>
                 {result.errors.length > 0 ? (
                   <>
-                    <ul className="mt-2 list-disc space-y-0.5 pl-4 text-amber-800">
-                      {result.errors.slice(0, 5).map((e, i) => (
-                        <li key={i}>{e}</li>
-                      ))}
-                      {result.errors.length > 5 ? (
-                        <li>and {result.errors.length - 5} more</li>
-                      ) : null}
-                    </ul>
+                    <ImportIssues
+                      errors={result.errors}
+                      fileName="openvpm-import-issues.txt"
+                    />
                     <p className="mt-2">Press Continue when you are ready.</p>
                   </>
                 ) : (
@@ -480,7 +709,8 @@ export function BringDataStep({ register, state, setState }: StepProps) {
                 )}
               </div>
             ) : null}
-            {importClientsCsv.error || importPatientsCsv.error ? (
+            {!importRecoveryMessage &&
+            (importClientsCsv.error || importPatientsCsv.error) ? (
               <p className="text-xs text-red-700">
                 {importClientsCsv.error?.message ??
                   importPatientsCsv.error?.message}
@@ -495,10 +725,14 @@ export function BringDataStep({ register, state, setState }: StepProps) {
           title="Connect later by API"
           subtitle="Move data in from another system whenever you want."
           onClick={() => {
+            if (importInputsBusy || committedClients || result) return;
             invalidatePendingFileReads();
             setChoice("api");
             clearImportReview();
           }}
+          disabled={
+            importInputsBusy || Boolean(committedClients) || Boolean(result)
+          }
         />
         {choice === "api" ? (
           <div className="rounded-lg border border-slate-200 bg-slate-50/70 p-4 text-sm text-slate-600">
@@ -522,10 +756,14 @@ export function BringDataStep({ register, state, setState }: StepProps) {
           title="Keep the sample data for now"
           subtitle="Explore with the example pets we set up for you."
           onClick={() => {
+            if (importInputsBusy || committedClients || result) return;
             invalidatePendingFileReads();
             setChoice("keep");
             clearImportReview();
           }}
+          disabled={
+            importInputsBusy || Boolean(committedClients) || Boolean(result)
+          }
         />
       </div>
     </div>
@@ -547,10 +785,19 @@ function CsvPreviewCard({
     <div className="rounded-md border border-slate-200 bg-white p-3">
       <div className="flex items-center justify-between gap-3">
         <p className="text-sm font-medium text-slate-800">{title}</p>
-        <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700">
-          {preview.willInsert + (preview.willReconcile ?? 0) > 0
-            ? "Ready"
-            : "Review"}
+        <span
+          className={cn(
+            "rounded-full px-2 py-0.5 text-xs font-medium",
+            preview.errors.length > 0 || duplicateValue > 0
+              ? "bg-amber-50 text-amber-700"
+              : "bg-emerald-50 text-emerald-700",
+          )}
+        >
+          {preview.errors.length > 0 || duplicateValue > 0
+            ? "Ready with skipped rows"
+            : preview.willInsert + (preview.willReconcile ?? 0) > 0
+              ? "Ready"
+              : "Review"}
         </span>
       </div>
       <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
@@ -566,14 +813,38 @@ function CsvPreviewCard({
         <ImportStat label="Issues" value={preview.errors.length} />
       </div>
       {preview.errors.length > 0 ? (
-        <ul className="mt-3 max-h-24 space-y-0.5 overflow-y-auto text-xs text-amber-800">
-          {preview.errors.slice(0, 5).map((error, index) => (
-            <li key={index}>{error}</li>
-          ))}
-          {preview.errors.length > 5 ? (
-            <li>and {preview.errors.length - 5} more</li>
-          ) : null}
-        </ul>
+        <ImportIssues
+          errors={preview.errors}
+          fileName={`openvpm-${title.toLowerCase()}-preview-issues.txt`}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function ImportIssues({
+  errors,
+  fileName,
+}: {
+  errors: string[];
+  fileName: string;
+}) {
+  const visibleErrors = errors.slice(0, 5);
+  return (
+    <div className="mt-3 text-xs text-amber-800">
+      <ul className="max-h-24 list-disc space-y-0.5 overflow-y-auto pl-4">
+        {visibleErrors.map((error, index) => (
+          <li key={index}>{error}</li>
+        ))}
+      </ul>
+      {errors.length > visibleErrors.length ? (
+        <button
+          type="button"
+          className="mt-2 font-medium text-amber-900 underline underline-offset-2"
+          onClick={() => downloadIssueReport(errors, fileName)}
+        >
+          Download all {errors.length} issues
+        </button>
       ) : null}
     </div>
   );
@@ -596,19 +867,22 @@ function ChoiceCard({
   title,
   subtitle,
   onClick,
+  disabled = false,
 }: {
   active: boolean;
   icon: React.ReactNode;
   title: string;
   subtitle: string;
   onClick: () => void;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       className={cn(
-        "flex items-start gap-3 rounded-lg border bg-white p-4 text-left transition-colors",
+        "flex items-start gap-3 rounded-lg border bg-white p-4 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60",
         active
           ? "border-emerald-300 ring-1 ring-emerald-300"
           : "border-slate-200 hover:border-slate-300",

--- a/apps/web/lib/__tests__/api-auth.test.ts
+++ b/apps/web/lib/__tests__/api-auth.test.ts
@@ -17,12 +17,16 @@ describe("generateApiKey", () => {
     expect(await bcrypt.compare(raw, hash)).toBe(true);
   });
 
-  it("does not verify against a different key", async () => {
-    const a = await generateApiKey();
-    const b = await generateApiKey();
-    expect(await bcrypt.compare(b.raw, a.hash)).toBe(false);
-    expect(a.raw).not.toBe(b.raw);
-  });
+  it(
+    "does not verify against a different key",
+    async () => {
+      const a = await generateApiKey();
+      const b = await generateApiKey();
+      expect(await bcrypt.compare(b.raw, a.hash)).toBe(false);
+      expect(a.raw).not.toBe(b.raw);
+    },
+    15_000,
+  );
 });
 
 describe("extractApiKey", () => {

--- a/apps/web/lib/__tests__/audit.test.ts
+++ b/apps/web/lib/__tests__/audit.test.ts
@@ -77,9 +77,13 @@ describe("redactSecrets", () => {
     const onboarding = redactSecrets({
       csv: "patient rows",
       clientCsv: "client rows with PII",
+      previewToken: "opaque-migration-run-id",
+      source: "shepherd",
     })!;
     expect(onboarding.csv).toBe("[redacted-bulk-payload]");
     expect(onboarding.clientCsv).toBe("[redacted-bulk-payload]");
+    expect(onboarding.previewToken).toBe("[redacted]");
+    expect(onboarding.source).toBe("shepherd");
     expect(out.dryRun).toBe(true);
 
     const restore = redactSecrets({

--- a/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
@@ -106,7 +106,8 @@ describe("dashboard onboarding UI states", () => {
     expect(journeyProviderSource).toContain("if (!isAdmin) return;");
     expect(journeyProviderSource).toContain("const isOpen = isAdmin && index !== null");
     expect(journeyProviderSource).toContain("value={{ openJourney, isOpen }}");
-    expect(journeyProviderSource).toContain("<JourneyShell steps={steps}");
+    expect(journeyProviderSource).toMatch(/<JourneyShell\s+steps=\{steps\}/);
+    expect(journeyProviderSource).toContain("disabled={busy || continueDisabled}");
     expect(journeyProviderSource).toContain(
       "trpc.settings.completeOnboarding.useMutation"
     );

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -498,4 +498,33 @@ describe("committed Drizzle migrations", () => {
       'ON "email_suppressions" USING btree ("practice_id","deleted_at")'
     );
   });
+
+  it("commits the tenant-scoped exact-file migration run ledger", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json")
+    ) as { entries?: Array<{ tag?: string }> };
+    expect(journal.entries?.map((entry) => entry.tag)).toContain(
+      "0041_aromatic_rhino"
+    );
+
+    const sql = readRepoFile(
+      "packages/db/drizzle/0041_aromatic_rhino.sql"
+    );
+    expect(sql).toContain('CREATE TABLE "migration_runs"');
+    expect(sql).toContain(
+      'CREATE TYPE "public"."migration_run_mode" AS ENUM(\'clients\', \'patients\', \'vaccinations\', \'soap_notes\')'
+    );
+    expect(sql).toContain("'previewed', 'superseded', 'committing'");
+    expect(sql).toContain('CONSTRAINT "migration_runs_file_hash_check"');
+    expect(sql).toContain('CONSTRAINT "migration_runs_counts_check"');
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX "migration_runs_active_preview_uq"'
+    );
+    expect(sql).toContain(
+      'WHERE "migration_runs"."status" = \'previewed\' and "migration_runs"."deleted_at" is null'
+    );
+
+    const rls = readRepoFile("packages/db/rls/enable-rls.sql");
+    expect(rls).toContain("'migration_runs'");
+  });
 });

--- a/apps/web/lib/__tests__/onboarding-import-ui.test.ts
+++ b/apps/web/lib/__tests__/onboarding-import-ui.test.ts
@@ -23,14 +23,31 @@ describe("onboarding import UI", () => {
     expect(source).toContain("dryRun: false");
     expect(source).toContain("setClientsPreview");
     expect(source).toContain("setPetsPreview");
+    expect(source).toContain("previewToken: string;");
+    expect(source.match(/previewToken: r\.previewToken/g)).toHaveLength(2);
+    expect(source).toContain("previewToken: preview.previewToken");
+    expect(source).toContain("previewToken: petsPreview!.previewToken");
     expect(source).toContain("if (result) return true");
-    expect(source).toContain("Continue again to import.");
+    expect(source).toContain("Only the");
+    expect(source).toContain("issue rows will be skipped.");
     expect(source).toContain("source: migrationSource");
+    expect(source.match(/migrationProtocol: "reviewed-v1"/g)).toHaveLength(4);
     expect(source).toContain("Which system are you moving from?");
     expect(source).toContain("MIGRATION_SOURCES.map");
+    expect(source).not.toContain("clientCsv:");
+    expect(source).toContain('? "Check client file"');
+    expect(source).toContain('"Check pet file"');
+    expect(source).toContain("setCommittedClients(committed)");
+    expect(source).toContain("Retry the same import; it is safe");
+    expect(source).toContain("Download all {errors.length} issues");
     expect(source).toContain(
-      "clientCsv: hasClientsCsv ? clientsCsv.trim() : undefined",
+      "const importInputsBusy = importing || readingFiles",
     );
+    expect(source).toContain("continueDisabled: readingFiles");
+    expect(source).toContain("if (which === \"clients\") clearImportReview()");
+    expect(source).toContain("else clearPetReview()");
+    expect(source).toContain("setFileReadPending");
+    expect(source).toContain("Request a migration review before the full import");
     expect(source).toContain("willReconcile");
     expect(source).toContain(
       "const fileReadVersionRef = useRef({ clients: 0, pets: 0 })",

--- a/apps/web/lib/__tests__/settings-ui-states.test.ts
+++ b/apps/web/lib/__tests__/settings-ui-states.test.ts
@@ -359,6 +359,12 @@ describe("settings UI states", () => {
     expect(source).toContain("importClientsCsv.mutate({");
     expect(source).toContain("importPatientsCsv.mutate({");
     expect(source).toContain("source: importSource");
+    expect(source.match(/migrationProtocol: "reviewed-v1"/g)).toHaveLength(5);
+    expect(source).toContain("previewToken: string;");
+    expect(source.match(/previewToken: data\.previewToken/g)).toHaveLength(4);
+    expect(
+      source.match(/previewToken: importPreview\.previewToken/g),
+    ).toHaveLength(4);
     expect(source).toContain("duplicates: data.duplicates");
     expect(source).toContain('label="Row issues"');
     expect(source).toContain("IDs to connect");

--- a/apps/web/lib/import/__tests__/run-ledger.test.ts
+++ b/apps/web/lib/import/__tests__/run-ledger.test.ts
@@ -1,0 +1,334 @@
+import type { Database } from "@openpims/db/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  MIGRATION_PREVIEW_TTL_MS,
+  MigrationPreviewError,
+  claimMigrationPreview,
+  completeMigrationRun,
+  createMigrationPreview,
+  migrationFileHash,
+} from "../run-ledger";
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-0000000000bb";
+const PREVIEW_TOKEN = "00000000-0000-0000-0000-0000000000cc";
+const NOW = new Date("2026-08-08T12:00:00.000Z");
+
+function makeDb(
+  returningRows: Array<{ id: string }> = [],
+  runRows: unknown[] = [],
+) {
+  const selectResults = [[{ id: PRACTICE_ID }], runRows];
+  const selectFor = vi.fn(
+    async (_mode: unknown) => selectResults.shift() ?? [],
+  );
+  const selectLimit = vi.fn((_limit: number) => ({ for: selectFor }));
+  const selectWhere = vi.fn((_condition: unknown) => ({ limit: selectLimit }));
+  const selectFrom = vi.fn((_table: unknown) => ({ where: selectWhere }));
+  const select = vi.fn((_selection: unknown) => ({ from: selectFrom }));
+  const insertValues = vi.fn(async (_values: unknown) => undefined);
+  const insert = vi.fn((_table: unknown) => ({ values: insertValues }));
+  const returning = vi.fn(async (_selection: unknown) => returningRows);
+  const where = vi.fn((_condition: unknown) => ({ returning }));
+  const set = vi.fn((_values: unknown) => ({ where }));
+  const update = vi.fn((_table: unknown) => ({ set }));
+
+  return {
+    db: { insert, select, update } as unknown as Database,
+    insertValues,
+    returning,
+    where,
+    set,
+    selectFor,
+    selectWhere,
+  };
+}
+
+function conditionIncludesColumnValue(
+  value: unknown,
+  columnName: string,
+  expectedValue: unknown,
+): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const chunk = value as {
+    name?: unknown;
+    value?: unknown;
+    queryChunks?: unknown[];
+  };
+  if (
+    chunk.name === columnName &&
+    Object.prototype.hasOwnProperty.call(chunk, "value") &&
+    Object.is(chunk.value, expectedValue)
+  ) {
+    return true;
+  }
+  if (!Array.isArray(chunk.queryChunks)) {
+    return false;
+  }
+
+  const hasColumn = chunk.queryChunks.some(
+    (item) =>
+      !!item &&
+      typeof item === "object" &&
+      (item as { name?: unknown }).name === columnName,
+  );
+  const hasValue = chunk.queryChunks.some(
+    (item) =>
+      !!item &&
+      typeof item === "object" &&
+      Object.prototype.hasOwnProperty.call(item, "value") &&
+      Object.is((item as { value?: unknown }).value, expectedValue),
+  );
+
+  return (
+    (hasColumn && hasValue) ||
+    chunk.queryChunks.some((item) =>
+      conditionIncludesColumnValue(item, columnName, expectedValue),
+    )
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("migrationFileHash", () => {
+  it("binds a preview to the exact CSV bytes, including a trailing newline", () => {
+    const csv = "name,email\nAda,ada@example.com";
+
+    expect(migrationFileHash(csv)).toBe(
+      "11bcbfcb3959377b9274253d7fa710f8fcc4d35bfa3412b7a9e69101548561c6",
+    );
+    expect(migrationFileHash(`${csv}\n`)).toBe(
+      "1791357b12b2a8f87ed5c5f8f61adcdde1393decdecdaa86d0b2cce6f9320fb2",
+    );
+    expect(migrationFileHash(`${csv}\n`)).not.toBe(migrationFileHash(csv));
+  });
+});
+
+describe("createMigrationPreview", () => {
+  it("persists only a safe aggregate ledger with the exact hash, size, counts, and TTL", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { db, insertValues, set, where, selectFor } = makeDb();
+    const csv = "name,email\nZoë,secret@example.com";
+
+    const token = await createMigrationPreview(db, {
+      practiceId: PRACTICE_ID,
+      createdBy: USER_ID,
+      mode: "patients",
+      source: "shepherd",
+      csv,
+      summary: {
+        sourceRowCount: 17,
+        plannedInsertCount: 11,
+        plannedReconcileCount: 2,
+        duplicateCount: 3,
+        unmatchedCount: 1,
+        errorCount: 4,
+      },
+    });
+
+    expect(token).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(selectFor).toHaveBeenCalledWith("update");
+    expect(set).toHaveBeenCalledWith({
+      status: "superseded",
+      supersededAt: NOW,
+      updatedAt: NOW,
+    });
+    const supersedeCondition = where.mock.calls[0]?.[0];
+    expect(
+      conditionIncludesColumnValue(
+        supersedeCondition,
+        "practice_id",
+        PRACTICE_ID,
+      ),
+    ).toBe(true);
+    expect(
+      conditionIncludesColumnValue(supersedeCondition, "mode", "patients"),
+    ).toBe(true);
+    expect(
+      conditionIncludesColumnValue(supersedeCondition, "status", "previewed"),
+    ).toBe(true);
+    expect(insertValues).toHaveBeenCalledOnce();
+
+    const persisted = insertValues.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(persisted).toEqual({
+      id: token,
+      practiceId: PRACTICE_ID,
+      createdBy: USER_ID,
+      mode: "patients",
+      source: "shepherd",
+      fileHash: migrationFileHash(csv),
+      fileSizeBytes: Buffer.byteLength(csv, "utf8"),
+      sourceRowCount: 17,
+      plannedInsertCount: 11,
+      plannedReconcileCount: 2,
+      duplicateCount: 3,
+      unmatchedCount: 1,
+      errorCount: 4,
+      previewExpiresAt: new Date(NOW.getTime() + MIGRATION_PREVIEW_TTL_MS),
+    });
+    expect(persisted).not.toHaveProperty("csv");
+    expect(persisted).not.toHaveProperty("errors");
+    expect(JSON.stringify(persisted)).not.toContain("secret@example.com");
+  });
+});
+
+describe("claimMigrationPreview", () => {
+  const identity = {
+    practiceId: PRACTICE_ID,
+    previewToken: PREVIEW_TOKEN,
+    mode: "clients" as const,
+    source: "shepherd",
+    csv: "name,email\nAda,ada@example.com",
+    summary: {
+      sourceRowCount: 5,
+      plannedInsertCount: 3,
+      plannedReconcileCount: 1,
+      duplicateCount: 1,
+      unmatchedCount: 0,
+      errorCount: 0,
+    },
+  };
+  const previewRun = {
+    status: "previewed",
+    previewExpiresAt: new Date(NOW.getTime() + 60_000),
+    sourceRowCount: 5,
+    plannedInsertCount: 3,
+    plannedReconcileCount: 1,
+    duplicateCount: 1,
+    unmatchedCount: 0,
+    errorCount: 0,
+    importedCount: 0,
+    reconciledCount: 0,
+  };
+
+  it("atomically claims a matching unexpired preview", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { db, set, where, returning, selectWhere } = makeDb(
+      [{ id: PREVIEW_TOKEN }],
+      [previewRun],
+    );
+
+    await expect(claimMigrationPreview(db, identity)).resolves.toEqual({
+      alreadyCommitted: false,
+    });
+
+    expect(set).toHaveBeenCalledWith({ status: "committing", updatedAt: NOW });
+    expect(returning).toHaveBeenCalledOnce();
+    const identityCondition = selectWhere.mock.calls[1]?.[0];
+    expect(
+      conditionIncludesColumnValue(identityCondition, "id", PREVIEW_TOKEN),
+    ).toBe(true);
+    expect(
+      conditionIncludesColumnValue(
+        identityCondition,
+        "practice_id",
+        PRACTICE_ID,
+      ),
+    ).toBe(true);
+    expect(
+      conditionIncludesColumnValue(identityCondition, "mode", "clients"),
+    ).toBe(true);
+    expect(
+      conditionIncludesColumnValue(identityCondition, "source", "shepherd"),
+    ).toBe(true);
+    const claimCondition = where.mock.calls[0]?.[0];
+    expect(
+      conditionIncludesColumnValue(claimCondition, "status", "previewed"),
+    ).toBe(true);
+    expect(
+      conditionIncludesColumnValue(claimCondition, "practice_id", PRACTICE_ID),
+    ).toBe(true);
+  });
+
+  it("rejects a preview that could not be claimed", async () => {
+    const { db } = makeDb([]);
+
+    await expect(claimMigrationPreview(db, identity)).rejects.toEqual(
+      new MigrationPreviewError(
+        "The import preview expired or no longer matches this file and practice.",
+      ),
+    );
+  });
+
+  it("returns saved counts without claiming an exact committed retry", async () => {
+    const { db, set } = makeDb(
+      [],
+      [
+        {
+          ...previewRun,
+          status: "committed",
+          importedCount: 3,
+          reconciledCount: 1,
+        },
+      ],
+    );
+
+    await expect(claimMigrationPreview(db, identity)).resolves.toEqual({
+      alreadyCommitted: true,
+      importedCount: 3,
+      reconciledCount: 1,
+      errorCount: 0,
+    });
+    expect(set).not.toHaveBeenCalled();
+  });
+});
+
+describe("completeMigrationRun", () => {
+  const completion = {
+    practiceId: PRACTICE_ID,
+    previewToken: PREVIEW_TOKEN,
+    importedCount: 13,
+    reconciledCount: 4,
+    committedBy: USER_ID,
+  };
+
+  it("records the actor, final counts, and one completion timestamp", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { db, set, where, returning } = makeDb([{ id: PREVIEW_TOKEN }]);
+
+    await expect(completeMigrationRun(db, completion)).resolves.toBeUndefined();
+
+    expect(set).toHaveBeenCalledWith({
+      status: "committed",
+      importedCount: 13,
+      reconciledCount: 4,
+      committedAt: NOW,
+      committedBy: USER_ID,
+      updatedAt: NOW,
+    });
+    expect(returning).toHaveBeenCalledOnce();
+    const condition = where.mock.calls[0]?.[0];
+    expect(conditionIncludesColumnValue(condition, "id", PREVIEW_TOKEN)).toBe(
+      true,
+    );
+    expect(
+      conditionIncludesColumnValue(condition, "practice_id", PRACTICE_ID),
+    ).toBe(true);
+    expect(
+      conditionIncludesColumnValue(condition, "status", "committing"),
+    ).toBe(true);
+  });
+
+  it("rejects a run that is no longer in the committing state", async () => {
+    const { db } = makeDb([]);
+
+    await expect(completeMigrationRun(db, completion)).rejects.toEqual(
+      new MigrationPreviewError(
+        "The migration run could not be completed safely.",
+      ),
+    );
+  });
+});

--- a/apps/web/lib/import/run-ledger.ts
+++ b/apps/web/lib/import/run-ledger.ts
@@ -1,0 +1,234 @@
+import { createHash, randomUUID } from "node:crypto";
+import { and, eq, isNull } from "drizzle-orm";
+import { migrationRuns, practices } from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+
+export const MIGRATION_PREVIEW_TTL_MS = 24 * 60 * 60 * 1000;
+
+export class MigrationPreviewError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MigrationPreviewError";
+  }
+}
+
+export type MigrationRunMode =
+  | "clients"
+  | "patients"
+  | "vaccinations"
+  | "soap_notes";
+
+export type MigrationPreviewSummary = {
+  sourceRowCount: number;
+  plannedInsertCount: number;
+  plannedReconcileCount?: number;
+  duplicateCount?: number;
+  unmatchedCount?: number;
+  errorCount: number;
+};
+
+export type MigrationClaimResult =
+  | { alreadyCommitted: false }
+  | {
+      alreadyCommitted: true;
+      importedCount: number;
+      reconciledCount: number;
+      errorCount: number;
+    };
+
+type MigrationPreviewIdentity = {
+  practiceId: string;
+  mode: MigrationRunMode;
+  source: string;
+  csv: string;
+  summary: MigrationPreviewSummary;
+};
+
+export async function lockMigrationPractice(
+  db: Database,
+  practiceId: string,
+): Promise<void> {
+  const [practice] = await db
+    .select({ id: practices.id })
+    .from(practices)
+    .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
+    .limit(1)
+    .for("update");
+
+  if (!practice) {
+    throw new MigrationPreviewError("The practice is no longer available.");
+  }
+}
+
+export function migrationFileHash(csv: string): string {
+  return createHash("sha256").update(csv, "utf8").digest("hex");
+}
+
+export async function createMigrationPreview(
+  db: Database,
+  input: MigrationPreviewIdentity & { createdBy: string },
+): Promise<string> {
+  const id = randomUUID();
+  const supersededAt = new Date();
+  await lockMigrationPractice(db, input.practiceId);
+  await db
+    .update(migrationRuns)
+    .set({
+      status: "superseded",
+      supersededAt,
+      updatedAt: supersededAt,
+    })
+    .where(
+      and(
+        eq(migrationRuns.practiceId, input.practiceId),
+        eq(migrationRuns.mode, input.mode),
+        eq(migrationRuns.status, "previewed"),
+        isNull(migrationRuns.deletedAt),
+      ),
+    );
+  await db.insert(migrationRuns).values({
+    id,
+    practiceId: input.practiceId,
+    createdBy: input.createdBy,
+    mode: input.mode,
+    source: input.source,
+    fileHash: migrationFileHash(input.csv),
+    fileSizeBytes: Buffer.byteLength(input.csv, "utf8"),
+    sourceRowCount: input.summary.sourceRowCount,
+    plannedInsertCount: input.summary.plannedInsertCount,
+    plannedReconcileCount: input.summary.plannedReconcileCount ?? 0,
+    duplicateCount: input.summary.duplicateCount ?? 0,
+    unmatchedCount: input.summary.unmatchedCount ?? 0,
+    errorCount: input.summary.errorCount,
+    previewExpiresAt: new Date(Date.now() + MIGRATION_PREVIEW_TTL_MS),
+  });
+  return id;
+}
+
+export async function claimMigrationPreview(
+  db: Database,
+  input: MigrationPreviewIdentity & { previewToken: string },
+): Promise<MigrationClaimResult> {
+  await lockMigrationPractice(db, input.practiceId);
+  const [run] = await db
+    .select({
+      status: migrationRuns.status,
+      previewExpiresAt: migrationRuns.previewExpiresAt,
+      sourceRowCount: migrationRuns.sourceRowCount,
+      plannedInsertCount: migrationRuns.plannedInsertCount,
+      plannedReconcileCount: migrationRuns.plannedReconcileCount,
+      duplicateCount: migrationRuns.duplicateCount,
+      unmatchedCount: migrationRuns.unmatchedCount,
+      errorCount: migrationRuns.errorCount,
+      importedCount: migrationRuns.importedCount,
+      reconciledCount: migrationRuns.reconciledCount,
+    })
+    .from(migrationRuns)
+    .where(
+      and(
+        eq(migrationRuns.id, input.previewToken),
+        eq(migrationRuns.practiceId, input.practiceId),
+        eq(migrationRuns.mode, input.mode),
+        eq(migrationRuns.source, input.source),
+        eq(migrationRuns.fileHash, migrationFileHash(input.csv)),
+        isNull(migrationRuns.deletedAt),
+      ),
+    )
+    .limit(1)
+    .for("update");
+
+  if (!run) {
+    throw new MigrationPreviewError(
+      "The import preview expired or no longer matches this file and practice.",
+    );
+  }
+  if (run.status === "committed") {
+    return {
+      alreadyCommitted: true,
+      importedCount: run.importedCount,
+      reconciledCount: run.reconciledCount,
+      errorCount: run.errorCount,
+    };
+  }
+
+  const expected = {
+    sourceRowCount: input.summary.sourceRowCount,
+    plannedInsertCount: input.summary.plannedInsertCount,
+    plannedReconcileCount: input.summary.plannedReconcileCount ?? 0,
+    duplicateCount: input.summary.duplicateCount ?? 0,
+    unmatchedCount: input.summary.unmatchedCount ?? 0,
+    errorCount: input.summary.errorCount,
+  };
+  const previewMatches =
+    run.status === "previewed" &&
+    run.previewExpiresAt.getTime() > Date.now() &&
+    run.sourceRowCount === expected.sourceRowCount &&
+    run.plannedInsertCount === expected.plannedInsertCount &&
+    run.plannedReconcileCount === expected.plannedReconcileCount &&
+    run.duplicateCount === expected.duplicateCount &&
+    run.unmatchedCount === expected.unmatchedCount &&
+    run.errorCount === expected.errorCount;
+  if (!previewMatches) {
+    throw new MigrationPreviewError(
+      "The import preview expired or no longer matches this file and practice.",
+    );
+  }
+
+  const [claimed] = await db
+    .update(migrationRuns)
+    .set({ status: "committing", updatedAt: new Date() })
+    .where(
+      and(
+        eq(migrationRuns.id, input.previewToken),
+        eq(migrationRuns.practiceId, input.practiceId),
+        eq(migrationRuns.status, "previewed"),
+        isNull(migrationRuns.deletedAt),
+      ),
+    )
+    .returning({ id: migrationRuns.id });
+
+  if (!claimed) {
+    throw new MigrationPreviewError(
+      "The import preview expired or no longer matches this file and practice.",
+    );
+  }
+  return { alreadyCommitted: false };
+}
+
+export async function completeMigrationRun(
+  db: Database,
+  input: {
+    practiceId: string;
+    previewToken: string;
+    importedCount: number;
+    reconciledCount?: number;
+    committedBy: string;
+  },
+): Promise<void> {
+  const committedAt = new Date();
+  const [completed] = await db
+    .update(migrationRuns)
+    .set({
+      status: "committed",
+      importedCount: input.importedCount,
+      reconciledCount: input.reconciledCount ?? 0,
+      committedAt,
+      committedBy: input.committedBy,
+      updatedAt: committedAt,
+    })
+    .where(
+      and(
+        eq(migrationRuns.id, input.previewToken),
+        eq(migrationRuns.practiceId, input.practiceId),
+        eq(migrationRuns.status, "committing"),
+        isNull(migrationRuns.deletedAt),
+      ),
+    )
+    .returning({ id: migrationRuns.id });
+
+  if (!completed) {
+    throw new MigrationPreviewError(
+      "The migration run could not be completed safely.",
+    );
+  }
+}

--- a/apps/web/lib/import/sources.ts
+++ b/apps/web/lib/import/sources.ts
@@ -42,7 +42,7 @@ export const MIGRATION_SOURCES: MigrationSource[] = [
     id: "other",
     name: "Another system or spreadsheet",
     exportHint:
-      "Any CSV works. We read the common column names automatically, and the dry run shows exactly what will import before anything is saved.",
+      "Use a CSV with the columns shown below. The dry run shows exactly what will import before anything is saved.",
   },
 ];
 

--- a/apps/web/server/__tests__/data-import-dedup.test.ts
+++ b/apps/web/server/__tests__/data-import-dedup.test.ts
@@ -4,11 +4,32 @@ vi.mock("@/lib/audit", () => ({
   recordAuditLog: vi.fn(async () => undefined),
 }));
 
-const { IMPORT_CSV_MAX_BYTES, dataRouter } = await import("../routers/data");
+const migrationRunMocks = vi.hoisted(() => ({
+  createMigrationPreview: vi.fn(
+    async () => "00000000-0000-0000-0000-0000000000f1",
+  ),
+  claimMigrationPreview: vi.fn(async () => ({
+    alreadyCommitted: false,
+    importedCount: 0,
+    reconciledCount: 0,
+    errorCount: 0,
+  })),
+  completeMigrationRun: vi.fn(async () => undefined),
+  lockMigrationPractice: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/import/run-ledger", () => ({
+  MigrationPreviewError: class MigrationPreviewError extends Error {},
+  ...migrationRunMocks,
+}));
+
+const { IMPORT_CSV_MAX_BYTES, dataRouter, legacyImportCompatibilityOpen } =
+  await import("../routers/data");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const CLIENT_ID = "00000000-0000-0000-0000-0000000000c1";
+const PREVIEW_TOKEN = "00000000-0000-0000-0000-0000000000f1";
 
 function callerWithDb(db: Record<string, unknown>) {
   const session = {
@@ -74,6 +95,40 @@ afterEach(() => {
 });
 
 describe("data import duplicate handling", () => {
+  it("bounds compatibility for pre-deploy import tabs", () => {
+    expect(
+      legacyImportCompatibilityOpen(
+        Date.parse("2026-08-14T23:59:59Z"),
+        "production",
+      ),
+    ).toBe(true);
+    expect(
+      legacyImportCompatibilityOpen(
+        Date.parse("2026-08-15T00:00:00Z"),
+        "production",
+      ),
+    ).toBe(false);
+  });
+
+  it("requires old two-file onboarding tabs to refresh before pet review", async () => {
+    const { db, insertValues, select } = createDb([]);
+
+    await expect(
+      callerWithDb(db).importPatientsCsv({
+        csv: "clientEmail,name,species\nowner@example.com,Rex,canine",
+        clientCsv: "firstName,lastName,email\nAda,Client,owner@example.com",
+        dryRun: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message:
+        "This onboarding import session is out of date. Refresh OpenVPM to check clients before pets.",
+    });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid client import fields before DB work", async () => {
     const { db, insertValues } = createDb([]);
 
@@ -137,6 +192,52 @@ describe("data import duplicate handling", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
+  it("rejects any commit that has not supplied a server preview token", async () => {
+    const { db, insertValues, select } = createDb([]);
+
+    await expect(
+      callerWithDb(db).importClientsCsv({
+        csv: "firstName,lastName,email\nAda,Client,ada@example.com",
+        dryRun: false,
+        migrationProtocol: "reviewed-v1",
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Check this exact CSV first, then confirm its import.",
+    });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("returns the saved result when an exact committed request is retried", async () => {
+    migrationRunMocks.claimMigrationPreview.mockResolvedValueOnce({
+      alreadyCommitted: true,
+      importedCount: 7,
+      reconciledCount: 2,
+      errorCount: 0,
+    });
+    const { db, insertValues } = createDb([[]]);
+
+    await expect(
+      callerWithDb(db).importClientsCsv({
+        csv: "firstName,lastName,email\nAda,Client,ada@example.com",
+        source: "shepherd",
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
+      }),
+    ).resolves.toEqual({
+      imported: 7,
+      reconciled: 2,
+      errors: [],
+      alreadyCommitted: true,
+      migrationRunId: PREVIEW_TOKEN,
+    });
+
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(migrationRunMocks.completeMigrationRun).not.toHaveBeenCalled();
+  });
+
   it("rejects imports when the practice is missing or deleted", async () => {
     const { db, insertValues } = createDb([], []);
 
@@ -164,20 +265,25 @@ describe("data import duplicate handling", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("reports malformed client CSV before DB work", async () => {
+  it("records malformed client CSV as a preview without domain writes", async () => {
     const { db, insertValues, select } = createDb([]);
 
     await expect(
       callerWithDb(db).importClientsCsv({
         csv: 'firstName,lastName,email\n"Jane,Doe,jane@example.com',
+        dryRun: true,
       }),
     ).resolves.toEqual({
-      imported: 0,
-      reconciled: 0,
+      dryRun: true,
+      previewToken: PREVIEW_TOKEN,
+      total: 0,
+      willInsert: 0,
+      willReconcile: 0,
+      duplicates: 0,
       errors: ["CSV has an unterminated quoted field."],
     });
 
-    expect(select).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalledTimes(1);
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -255,6 +361,8 @@ describe("data import duplicate handling", () => {
           "New,Client,new@example.com",
           "Again,Client, New@example.com ",
         ].join("\n"),
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
       }),
     ).resolves.toMatchObject({
       imported: 1,
@@ -297,6 +405,7 @@ describe("data import duplicate handling", () => {
       }),
     ).resolves.toEqual({
       dryRun: true,
+      previewToken: PREVIEW_TOKEN,
       total: 3,
       willInsert: 1,
       willReconcile: 0,
@@ -317,6 +426,8 @@ describe("data import duplicate handling", () => {
       callerWithDb(db).importClientsCsv({
         csv: "Owner ID,First Name,Last Name\n00AbC-19,Jane,Doe",
         source: "shepherd",
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
       }),
     ).resolves.toMatchObject({ imported: 1, reconciled: 0, errors: [] });
 
@@ -342,6 +453,8 @@ describe("data import duplicate handling", () => {
         "C-42,Jane,Doe,jane@example.com",
       ].join("\n"),
       source: "shepherd",
+      dryRun: false,
+      previewToken: PREVIEW_TOKEN,
     });
 
     expect(result).toMatchObject({ imported: 1, reconciled: 0, errors: [] });
@@ -391,6 +504,8 @@ describe("data import duplicate handling", () => {
       callerWithDb(commitDb.db).importClientsCsv({
         csv: "Client ID,First Name,Last Name,Email\nC-42,Ada,Client,owner@example.com",
         source: "shepherd",
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
       }),
     ).resolves.toMatchObject({ imported: 0, reconciled: 1, errors: [] });
     expect(commitDb.updateSet).toHaveBeenCalledWith({
@@ -418,6 +533,8 @@ describe("data import duplicate handling", () => {
       callerWithDb(db).importClientsCsv({
         csv: "Client ID,First Name,Last Name,Email\nC-42,Ada,Client,owner@example.com",
         source: "shepherd",
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
       }),
     ).rejects.toMatchObject({
       code: "CONFLICT",
@@ -568,6 +685,7 @@ describe("data import duplicate handling", () => {
       }),
     ).resolves.toEqual({
       dryRun: true,
+      previewToken: PREVIEW_TOKEN,
       total: 2,
       willInsert: 1,
       willReconcile: 0,
@@ -599,6 +717,8 @@ describe("data import duplicate handling", () => {
       callerWithDb(db).importPatientsCsv({
         csv: "Client ID,Patient ID,Patient Name,Species\nC-42,P-9,Rex,Dog",
         source: "shepherd",
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
       }),
     ).resolves.toMatchObject({ imported: 1, reconciled: 0, errors: [] });
 
@@ -614,12 +734,11 @@ describe("data import duplicate handling", () => {
     ]);
   });
 
-  it("previews patients against clients planned by the same onboarding import", async () => {
+  it("requires clients to be committed before a patient preview can match them", async () => {
     const { db, insertValues } = createDb([[], []]);
 
     const result = await callerWithDb(db).importPatientsCsv({
       csv: "Client ID,Patient ID,Patient Name,Species\nC-42,P-9,Rex,Dog",
-      clientCsv: "Client ID,First Name,Last Name\nC-42,Jane,Doe",
       source: "other",
       dryRun: true,
     });
@@ -627,9 +746,11 @@ describe("data import duplicate handling", () => {
     expect(result).toMatchObject({
       dryRun: true,
       total: 1,
-      willInsert: 1,
-      unmatchedClient: 0,
-      errors: [],
+      willInsert: 0,
+      unmatchedClient: 1,
+      errors: [
+        "Row 1: No matching client was found for the supplied owner reference.",
+      ],
     });
     expect(insertValues).not.toHaveBeenCalled();
   });
@@ -655,6 +776,8 @@ describe("data import duplicate handling", () => {
         "owner@example.com,P-9,Rex,Dog",
       ].join("\n"),
       source: "shepherd",
+      dryRun: false,
+      previewToken: PREVIEW_TOKEN,
     });
 
     expect(result).toMatchObject({ imported: 1, reconciled: 0, errors: [] });
@@ -873,20 +996,26 @@ describe("data import duplicate handling", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("reports malformed patient CSV before DB work", async () => {
+  it("records malformed patient CSV as a preview without domain writes", async () => {
     const { db, insertValues, select } = createDb([]);
 
     await expect(
       callerWithDb(db).importPatientsCsv({
         csv: 'clientEmail,name,species\n"owner@example.com,Rex,canine',
+        dryRun: true,
       }),
     ).resolves.toEqual({
-      imported: 0,
-      reconciled: 0,
+      dryRun: true,
+      previewToken: PREVIEW_TOKEN,
+      total: 0,
+      willInsert: 0,
+      willReconcile: 0,
+      unmatchedClient: 0,
+      duplicates: 0,
       errors: ["CSV has an unterminated quoted field."],
     });
 
-    expect(select).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalledTimes(1);
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -916,6 +1045,7 @@ describe("data import duplicate handling", () => {
       }),
     ).resolves.toEqual({
       dryRun: true,
+      previewToken: PREVIEW_TOKEN,
       total: 3,
       willInsert: 1,
       willReconcile: 0,

--- a/apps/web/server/__tests__/data-import-soap.test.ts
+++ b/apps/web/server/__tests__/data-import-soap.test.ts
@@ -4,11 +4,31 @@ vi.mock("@/lib/audit", () => ({
   recordAuditLog: vi.fn(async () => undefined),
 }));
 
+const migrationRunMocks = vi.hoisted(() => ({
+  createMigrationPreview: vi.fn(
+    async () => "00000000-0000-0000-0000-0000000000f1",
+  ),
+  claimMigrationPreview: vi.fn(async () => ({
+    alreadyCommitted: false,
+    importedCount: 0,
+    reconciledCount: 0,
+    errorCount: 0,
+  })),
+  completeMigrationRun: vi.fn(async () => undefined),
+  lockMigrationPractice: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/import/run-ledger", () => ({
+  MigrationPreviewError: class MigrationPreviewError extends Error {},
+  ...migrationRunMocks,
+}));
+
 const { IMPORT_CSV_MAX_BYTES, dataRouter } = await import("../routers/data");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const PATIENT_ID = "00000000-0000-0000-0000-0000000000p1";
+const PREVIEW_TOKEN = "00000000-0000-0000-0000-0000000000f1";
 
 function callerWithDb(db: Record<string, unknown>, role = "admin") {
   const session = {
@@ -100,16 +120,22 @@ describe("medical history (SOAP notes) import", () => {
     expect(select).not.toHaveBeenCalled();
   });
 
-  it("returns parse errors for malformed CSV without touching the DB", async () => {
+  it("records malformed CSV as a preview without domain writes", async () => {
     const { db, select, insertValues } = createDb([]);
     const result = await callerWithDb(db).importSoapNotesCsv({
       csv: `${HEADER}\n"jane@x.com,Rex`,
+      dryRun: true,
     });
     expect(result).toEqual({
-      imported: 0,
+      dryRun: true,
+      previewToken: PREVIEW_TOKEN,
+      total: 0,
+      willInsert: 0,
+      unmatchedPatient: 0,
+      duplicates: 0,
       errors: ["CSV has an unterminated quoted field."],
     });
-    expect(select).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalledTimes(1);
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -153,6 +179,8 @@ describe("medical history (SOAP notes) import", () => {
 
     const result = await callerWithDb(db).importSoapNotesCsv({
       csv: `${HEADER}\n${REX_ROW}`,
+      dryRun: false,
+      previewToken: PREVIEW_TOKEN,
     });
 
     expect(result).toMatchObject({ imported: 1 });
@@ -184,6 +212,8 @@ describe("medical history (SOAP notes) import", () => {
       csv:
         "clientEmail,patientName,date,notes\n" +
         "jane@x.com,Rex,2024-03-05,Wellness exam. All normal.",
+      dryRun: false,
+      previewToken: PREVIEW_TOKEN,
     });
 
     expect(result).toMatchObject({ imported: 1 });
@@ -263,6 +293,8 @@ describe("medical history (SOAP notes) import", () => {
     const result = await callerWithDb(db).importSoapNotesCsv({
       csv: "Patient ID,Visit Date,Notes\nP-9,2025-02-03,Annual exam",
       source: "shepherd",
+      dryRun: false,
+      previewToken: PREVIEW_TOKEN,
     });
 
     expect(result).toMatchObject({ imported: 1, errors: [] });

--- a/apps/web/server/__tests__/data-import-vaccinations.test.ts
+++ b/apps/web/server/__tests__/data-import-vaccinations.test.ts
@@ -4,11 +4,31 @@ vi.mock("@/lib/audit", () => ({
   recordAuditLog: vi.fn(async () => undefined),
 }));
 
+const migrationRunMocks = vi.hoisted(() => ({
+  createMigrationPreview: vi.fn(
+    async () => "00000000-0000-0000-0000-0000000000f1",
+  ),
+  claimMigrationPreview: vi.fn(async () => ({
+    alreadyCommitted: false,
+    importedCount: 0,
+    reconciledCount: 0,
+    errorCount: 0,
+  })),
+  completeMigrationRun: vi.fn(async () => undefined),
+  lockMigrationPractice: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/import/run-ledger", () => ({
+  MigrationPreviewError: class MigrationPreviewError extends Error {},
+  ...migrationRunMocks,
+}));
+
 const { IMPORT_CSV_MAX_BYTES, dataRouter } = await import("../routers/data");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const PATIENT_ID = "00000000-0000-0000-0000-0000000000p1";
+const PREVIEW_TOKEN = "00000000-0000-0000-0000-0000000000f1";
 
 function callerWithDb(db: Record<string, unknown>, role = "admin") {
   const session = {
@@ -100,16 +120,22 @@ describe("vaccination history import", () => {
     expect(select).not.toHaveBeenCalled();
   });
 
-  it("returns parse errors for malformed CSV without touching the DB", async () => {
+  it("records malformed CSV as a preview without domain writes", async () => {
     const { db, select, insertValues } = createDb([]);
     const result = await callerWithDb(db).importVaccinationsCsv({
       csv: `${HEADER}\n"jane@x.com,Rex`,
+      dryRun: true,
     });
     expect(result).toEqual({
-      imported: 0,
+      dryRun: true,
+      previewToken: PREVIEW_TOKEN,
+      total: 0,
+      willInsert: 0,
+      unmatchedPatient: 0,
+      duplicates: 0,
       errors: ["CSV has an unterminated quoted field."],
     });
-    expect(select).not.toHaveBeenCalled();
+    expect(select).toHaveBeenCalledTimes(1);
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -150,6 +176,8 @@ describe("vaccination history import", () => {
 
     const result = await callerWithDb(db).importVaccinationsCsv({
       csv: `${HEADER}\n${REX_ROW}`,
+      dryRun: false,
+      previewToken: PREVIEW_TOKEN,
     });
 
     expect(result).toMatchObject({ imported: 1 });
@@ -223,6 +251,8 @@ describe("vaccination history import", () => {
     const result = await callerWithDb(db).importVaccinationsCsv({
       csv: "Patient ID,Vaccine,Date Given\nP-2,Rabies,2025-01-01",
       source: "shepherd",
+      dryRun: false,
+      previewToken: PREVIEW_TOKEN,
     });
 
     expect(result).toMatchObject({ imported: 1, errors: [] });

--- a/apps/web/server/routers/data.ts
+++ b/apps/web/server/routers/data.ts
@@ -45,6 +45,16 @@ import {
   isImportCsvSizeValid,
 } from "@/lib/import/policy";
 import { clinicalDateInput } from "@/lib/records/clinical-inputs";
+import {
+  MigrationPreviewError,
+  claimMigrationPreview,
+  completeMigrationRun,
+  createMigrationPreview,
+  lockMigrationPractice,
+  type MigrationClaimResult,
+  type MigrationPreviewSummary,
+  type MigrationRunMode,
+} from "@/lib/import/run-ledger";
 
 const adminProcedure = protectedProcedure.use(requireRole("admin"));
 export { IMPORT_CSV_MAX_BYTES, IMPORT_MAX_ROWS } from "@/lib/import/policy";
@@ -239,19 +249,133 @@ const soapNoteImportRecordsInput = z
   );
 const importCsvTextInput = z
   .string()
-  .min(1)
+  .min(1, "Choose a non-empty CSV file.")
   .max(IMPORT_CSV_MAX_BYTES, "CSV imports must be 5 MB or less.")
   .refine(isImportCsvSizeValid, "CSV imports must be 5 MB or less.");
 const importCsvInput = z.object({
   csv: importCsvTextInput,
+  // Keep the pre-ledger default during the compatibility rollout so a browser
+  // tab loaded before this deploy does not silently switch a commit to preview.
   dryRun: z.boolean().optional().default(false),
   source: importSourceInput,
-});
-const importPatientsCsvInput = importCsvInput.extend({
-  /** Optional during dry-run so a two-file onboarding preview can resolve pets
-   * against owners that the client file will create without writing either file. */
+  previewToken: z.string().uuid().optional(),
+  migrationProtocol: z.literal("reviewed-v1").optional(),
+  // Accepted only so a pre-deploy onboarding tab receives an explicit refresh
+  // instruction instead of a misleading pet preview.
   clientCsv: importCsvTextInput.optional(),
 });
+
+type CsvImportIntent = z.infer<typeof importCsvInput>;
+
+const LEGACY_IMPORT_COMPATIBILITY_END_MS = Date.parse("2026-08-15T00:00:00Z");
+
+export function legacyImportCompatibilityOpen(
+  now = Date.now(),
+  nodeEnv = process.env.NODE_ENV,
+): boolean {
+  return nodeEnv === "test" || now < LEGACY_IMPORT_COMPATIBILITY_END_MS;
+}
+
+function requireValidImportIntent(input: CsvImportIntent): void {
+  if (
+    input.migrationProtocol !== "reviewed-v1" &&
+    !input.previewToken &&
+    !legacyImportCompatibilityOpen()
+  ) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message:
+        "This import session is out of date. Refresh OpenVPM and check the file again.",
+    });
+  }
+  if (input.dryRun && input.previewToken) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Start a new preview without an existing preview token.",
+    });
+  }
+  if (
+    input.migrationProtocol === "reviewed-v1" &&
+    !input.dryRun &&
+    !input.previewToken
+  ) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Check this exact CSV first, then confirm its import.",
+    });
+  }
+}
+
+async function createCsvImportPreview(
+  ctx: DataContext & { user: { id: string } },
+  input: CsvImportIntent,
+  mode: MigrationRunMode,
+  summary: MigrationPreviewSummary,
+): Promise<string> {
+  return createMigrationPreview(ctx.db, {
+    practiceId: ctx.practiceId,
+    createdBy: ctx.user.id,
+    mode,
+    source: input.source,
+    csv: input.csv,
+    summary,
+  });
+}
+
+async function claimCsvImportPreview(
+  db: Database,
+  practiceId: string,
+  input: CsvImportIntent,
+  mode: MigrationRunMode,
+  summary: MigrationPreviewSummary,
+): Promise<MigrationClaimResult> {
+  // One rollout keeps legacy, already-loaded browser bundles working. Every
+  // newly shipped caller identifies the reviewed protocol and must provide the
+  // exact preview token. Remove this branch after the compatibility window.
+  if (input.migrationProtocol !== "reviewed-v1" && !input.previewToken) {
+    return { alreadyCommitted: false };
+  }
+  try {
+    return await claimMigrationPreview(db, {
+      practiceId,
+      previewToken: input.previewToken!,
+      mode,
+      source: input.source,
+      csv: input.csv,
+      summary,
+    });
+  } catch (error) {
+    if (error instanceof MigrationPreviewError) {
+      throw new TRPCError({ code: "CONFLICT", message: error.message });
+    }
+    throw error;
+  }
+}
+
+async function finishCsvImportRun(
+  db: Database,
+  practiceId: string,
+  previewToken: string | undefined,
+  importedCount: number,
+  committedBy: string,
+  reconciledCount = 0,
+): Promise<void> {
+  if (!previewToken) return;
+  try {
+    await completeMigrationRun(db, {
+      practiceId,
+      previewToken,
+      importedCount,
+      reconciledCount,
+      committedBy,
+    });
+  } catch (error) {
+    if (error instanceof MigrationPreviewError) {
+      throw new TRPCError({ code: "CONFLICT", message: error.message });
+    }
+    throw error;
+  }
+}
 
 function activePracticeWhere(practiceId: string) {
   return and(eq(practices.id, practiceId), isNull(practices.deletedAt));
@@ -1729,13 +1853,27 @@ export const dataRouter = createRouter({
   importClientsCsv: adminProcedure
     .input(importCsvInput)
     .mutation(async ({ ctx, input }) => {
+      requireValidImportIntent(input);
       const { records, errors } = csvToClientRecords(input.csv);
       const validRecords = parseClientImportRecords(records);
 
       if (validRecords.length === 0 && errors.length > 0) {
         if (input.dryRun) {
+          await assertActivePractice(ctx);
+          const summary: MigrationPreviewSummary = {
+            sourceRowCount: 0,
+            plannedInsertCount: 0,
+            errorCount: errors.length,
+          };
+          const previewToken = await createCsvImportPreview(
+            ctx,
+            input,
+            "clients",
+            summary,
+          );
           return {
             dryRun: true as const,
+            previewToken,
             total: 0,
             willInsert: 0,
             willReconcile: 0,
@@ -1743,10 +1881,14 @@ export const dataRouter = createRouter({
             errors,
           };
         }
-        return { imported: 0, reconciled: 0, errors };
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "This CSV has no importable client rows. Check it again.",
+        });
       }
 
       await assertActivePractice(ctx);
+      await lockMigrationPractice(ctx.db, ctx.practiceId);
 
       const existing = await ctx.db
         .select({
@@ -1764,19 +1906,49 @@ export const dataRouter = createRouter({
           ),
         );
       const plan = planClientCsvImport(validRecords, input.source, existing);
+      const combinedErrors = [...errors, ...plan.errors];
+      const summary: MigrationPreviewSummary = {
+        sourceRowCount: validRecords.length,
+        plannedInsertCount: plan.rows.length,
+        plannedReconcileCount: plan.identityUpdates.length,
+        duplicateCount: plan.duplicates,
+        errorCount: combinedErrors.length,
+      };
 
       if (input.dryRun) {
+        const previewToken = await createCsvImportPreview(
+          ctx,
+          input,
+          "clients",
+          summary,
+        );
         return {
           dryRun: true as const,
+          previewToken,
           total: validRecords.length,
           willInsert: plan.rows.length,
           willReconcile: plan.identityUpdates.length,
           duplicates: plan.duplicates,
-          errors: [...errors, ...plan.errors],
+          errors: combinedErrors,
         };
       }
 
+      let replay:
+        | Extract<MigrationClaimResult, { alreadyCommitted: true }>
+        | undefined;
       await ctx.db.transaction(async (tx) => {
+        const migrationDb = tx as unknown as Database;
+        const claim = await claimCsvImportPreview(
+          migrationDb,
+          ctx.practiceId,
+          input,
+          "clients",
+          summary,
+        );
+        if (claim.alreadyCommitted) {
+          replay = claim;
+          return;
+        }
         for (const update of plan.identityUpdates) {
           const updated = await tx
             .update(clients)
@@ -1811,24 +1983,62 @@ export const dataRouter = createRouter({
             })),
           );
         }
+        await finishCsvImportRun(
+          migrationDb,
+          ctx.practiceId,
+          input.previewToken!,
+          plan.rows.length,
+          ctx.user.id,
+          plan.identityUpdates.length,
+        );
       });
+      if (replay) {
+        return {
+          imported: replay.importedCount,
+          reconciled: replay.reconciledCount,
+          errors: [] as string[],
+          alreadyCommitted: true as const,
+          migrationRunId: input.previewToken!,
+        };
+      }
       return {
         imported: plan.rows.length,
         reconciled: plan.identityUpdates.length,
-        errors: [...errors, ...plan.errors],
+        errors: combinedErrors,
       };
     }),
 
   importPatientsCsv: adminProcedure
-    .input(importPatientsCsvInput)
+    .input(importCsvInput)
     .mutation(async ({ ctx, input }) => {
+      requireValidImportIntent(input);
+      if (input.clientCsv) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "This onboarding import session is out of date. Refresh OpenVPM to check clients before pets.",
+        });
+      }
       const { records, errors } = csvToPatientRecords(input.csv);
       const validRecords = parsePatientImportRecords(records);
 
       if (validRecords.length === 0 && errors.length > 0) {
         if (input.dryRun) {
+          await assertActivePractice(ctx);
+          const summary: MigrationPreviewSummary = {
+            sourceRowCount: 0,
+            plannedInsertCount: 0,
+            errorCount: errors.length,
+          };
+          const previewToken = await createCsvImportPreview(
+            ctx,
+            input,
+            "patients",
+            summary,
+          );
           return {
             dryRun: true as const,
+            previewToken,
             total: 0,
             willInsert: 0,
             willReconcile: 0,
@@ -1837,10 +2047,14 @@ export const dataRouter = createRouter({
             errors,
           };
         }
-        return { imported: 0, reconciled: 0, errors };
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "This CSV has no importable patient rows. Check it again.",
+        });
       }
 
       await assertActivePractice(ctx);
+      await lockMigrationPractice(ctx.db, ctx.practiceId);
 
       const clientRows = await ctx.db
         .select({
@@ -1857,26 +2071,6 @@ export const dataRouter = createRouter({
             activePracticePredicate(ctx.practiceId),
           ),
         );
-      if (input.dryRun && input.clientCsv) {
-        const clientCsv = csvToClientRecords(input.clientCsv);
-        const plannedClientRecords = parseClientImportRecords(
-          clientCsv.records,
-        );
-        const clientPlan = planClientCsvImport(
-          plannedClientRecords,
-          input.source,
-          clientRows,
-        );
-        clientRows.push(
-          ...clientPlan.rows.map((client, index) => ({
-            id: `planned-client:${index}`,
-            email: client.email ?? null,
-            externalSource: client.externalSource ?? null,
-            externalId: client.externalId ?? null,
-            deletedAt: null,
-          })),
-        );
-      }
       const clientLookup = createClientReferenceLookup(clientRows);
 
       const existingPatients = await ctx.db
@@ -1905,20 +2099,51 @@ export const dataRouter = createRouter({
         clientLookup,
         existingPatients,
       );
+      const combinedErrors = [...errors, ...plan.errors];
+      const summary: MigrationPreviewSummary = {
+        sourceRowCount: validRecords.length,
+        plannedInsertCount: plan.rows.length,
+        plannedReconcileCount: plan.identityUpdates.length,
+        duplicateCount: plan.duplicates,
+        unmatchedCount: plan.unmatchedClient,
+        errorCount: combinedErrors.length,
+      };
 
       if (input.dryRun) {
+        const previewToken = await createCsvImportPreview(
+          ctx,
+          input,
+          "patients",
+          summary,
+        );
         return {
           dryRun: true as const,
+          previewToken,
           total: validRecords.length,
           willInsert: plan.rows.length,
           willReconcile: plan.identityUpdates.length,
           unmatchedClient: plan.unmatchedClient,
           duplicates: plan.duplicates,
-          errors: [...errors, ...plan.errors],
+          errors: combinedErrors,
         };
       }
 
+      let replay:
+        | Extract<MigrationClaimResult, { alreadyCommitted: true }>
+        | undefined;
       await ctx.db.transaction(async (tx) => {
+        const migrationDb = tx as unknown as Database;
+        const claim = await claimCsvImportPreview(
+          migrationDb,
+          ctx.practiceId,
+          input,
+          "patients",
+          summary,
+        );
+        if (claim.alreadyCommitted) {
+          replay = claim;
+          return;
+        }
         for (const update of plan.identityUpdates) {
           const updated = await tx
             .update(patients)
@@ -1953,11 +2178,28 @@ export const dataRouter = createRouter({
             })),
           );
         }
+        await finishCsvImportRun(
+          migrationDb,
+          ctx.practiceId,
+          input.previewToken!,
+          plan.rows.length,
+          ctx.user.id,
+          plan.identityUpdates.length,
+        );
       });
+      if (replay) {
+        return {
+          imported: replay.importedCount,
+          reconciled: replay.reconciledCount,
+          errors: [] as string[],
+          alreadyCommitted: true as const,
+          migrationRunId: input.previewToken!,
+        };
+      }
       return {
         imported: plan.rows.length,
         reconciled: plan.identityUpdates.length,
-        errors: [...errors, ...plan.errors],
+        errors: combinedErrors,
       };
     }),
 
@@ -1969,13 +2211,27 @@ export const dataRouter = createRouter({
   importVaccinationsCsv: adminProcedure
     .input(importCsvInput)
     .mutation(async ({ ctx, input }) => {
+      requireValidImportIntent(input);
       const { records, errors } = csvToVaccinationRecords(input.csv);
       const validRecords = parseVaccinationImportRecords(records);
 
       if (validRecords.length === 0 && errors.length > 0) {
         if (input.dryRun) {
+          await assertActivePractice(ctx);
+          const summary: MigrationPreviewSummary = {
+            sourceRowCount: 0,
+            plannedInsertCount: 0,
+            errorCount: errors.length,
+          };
+          const previewToken = await createCsvImportPreview(
+            ctx,
+            input,
+            "vaccinations",
+            summary,
+          );
           return {
             dryRun: true as const,
+            previewToken,
             total: 0,
             willInsert: 0,
             unmatchedPatient: 0,
@@ -1983,10 +2239,15 @@ export const dataRouter = createRouter({
             errors,
           };
         }
-        return { imported: 0, errors };
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "This CSV has no importable vaccination rows. Check it again.",
+        });
       }
 
       await assertActivePractice(ctx);
+      await lockMigrationPractice(ctx.db, ctx.practiceId);
 
       const patientRows = await ctx.db
         .select({
@@ -2032,28 +2293,75 @@ export const dataRouter = createRouter({
         input.source,
         existingDoses,
       );
+      const combinedErrors = [...errors, ...deduped.errors];
+      const summary: MigrationPreviewSummary = {
+        sourceRowCount: validRecords.length,
+        plannedInsertCount: deduped.rows.length,
+        duplicateCount: deduped.duplicates,
+        unmatchedCount: deduped.unmatchedPatient,
+        errorCount: combinedErrors.length,
+      };
 
       if (input.dryRun) {
+        const previewToken = await createCsvImportPreview(
+          ctx,
+          input,
+          "vaccinations",
+          summary,
+        );
         return {
           dryRun: true as const,
+          previewToken,
           total: validRecords.length,
           willInsert: deduped.rows.length,
           unmatchedPatient: deduped.unmatchedPatient,
           duplicates: deduped.duplicates,
-          errors: [...errors, ...deduped.errors],
+          errors: combinedErrors,
         };
       }
 
-      if (deduped.rows.length > 0) {
-        await ctx.db
-          .insert(vaccinationRecords)
-          .values(
-            deduped.rows.map((v) => ({ ...v, practiceId: ctx.practiceId })),
-          );
+      let replay:
+        | Extract<MigrationClaimResult, { alreadyCommitted: true }>
+        | undefined;
+      await ctx.db.transaction(async (tx) => {
+        const migrationDb = tx as unknown as Database;
+        const claim = await claimCsvImportPreview(
+          migrationDb,
+          ctx.practiceId,
+          input,
+          "vaccinations",
+          summary,
+        );
+        if (claim.alreadyCommitted) {
+          replay = claim;
+          return;
+        }
+        if (deduped.rows.length > 0) {
+          await tx
+            .insert(vaccinationRecords)
+            .values(
+              deduped.rows.map((v) => ({ ...v, practiceId: ctx.practiceId })),
+            );
+        }
+        await finishCsvImportRun(
+          migrationDb,
+          ctx.practiceId,
+          input.previewToken!,
+          deduped.rows.length,
+          ctx.user.id,
+        );
+      });
+      if (replay) {
+        return {
+          imported: replay.importedCount,
+          errors: [] as string[],
+          alreadyCommitted: true as const,
+          migrationRunId: input.previewToken!,
+        };
       }
       return {
         imported: deduped.rows.length,
-        errors: [...errors, ...deduped.errors],
+        errors: combinedErrors,
       };
     }),
 
@@ -2068,13 +2376,27 @@ export const dataRouter = createRouter({
   importSoapNotesCsv: adminProcedure
     .input(importCsvInput)
     .mutation(async ({ ctx, input }) => {
+      requireValidImportIntent(input);
       const { records, errors } = csvToSoapNoteRecords(input.csv);
       const validRecords = parseSoapNoteImportRecords(records);
 
       if (validRecords.length === 0 && errors.length > 0) {
         if (input.dryRun) {
+          await assertActivePractice(ctx);
+          const summary: MigrationPreviewSummary = {
+            sourceRowCount: 0,
+            plannedInsertCount: 0,
+            errorCount: errors.length,
+          };
+          const previewToken = await createCsvImportPreview(
+            ctx,
+            input,
+            "soap_notes",
+            summary,
+          );
           return {
             dryRun: true as const,
+            previewToken,
             total: 0,
             willInsert: 0,
             unmatchedPatient: 0,
@@ -2082,10 +2404,15 @@ export const dataRouter = createRouter({
             errors,
           };
         }
-        return { imported: 0, errors };
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "This CSV has no importable medical history rows. Check it again.",
+        });
       }
 
       await assertActivePractice(ctx);
+      await lockMigrationPractice(ctx.db, ctx.practiceId);
 
       const patientRows = await ctx.db
         .select({
@@ -2134,33 +2461,80 @@ export const dataRouter = createRouter({
         input.source,
         existingNotes,
       );
+      const combinedErrors = [...errors, ...deduped.errors];
+      const summary: MigrationPreviewSummary = {
+        sourceRowCount: validRecords.length,
+        plannedInsertCount: deduped.rows.length,
+        duplicateCount: deduped.duplicates,
+        unmatchedCount: deduped.unmatchedPatient,
+        errorCount: combinedErrors.length,
+      };
 
       if (input.dryRun) {
+        const previewToken = await createCsvImportPreview(
+          ctx,
+          input,
+          "soap_notes",
+          summary,
+        );
         return {
           dryRun: true as const,
+          previewToken,
           total: validRecords.length,
           willInsert: deduped.rows.length,
           unmatchedPatient: deduped.unmatchedPatient,
           duplicates: deduped.duplicates,
-          errors: [...errors, ...deduped.errors],
+          errors: combinedErrors,
         };
       }
 
-      if (deduped.rows.length > 0) {
-        await ctx.db.insert(soapNotes).values(
-          deduped.rows.map((n) => ({
-            ...n,
-            practiceId: ctx.practiceId,
-            authorId: ctx.user.id,
-            // Mark as migrated so the record shows "Imported" rather than
-            // implying the importing admin authored this historical note.
-            imported: true,
-          })),
+      let replay:
+        | Extract<MigrationClaimResult, { alreadyCommitted: true }>
+        | undefined;
+      await ctx.db.transaction(async (tx) => {
+        const migrationDb = tx as unknown as Database;
+        const claim = await claimCsvImportPreview(
+          migrationDb,
+          ctx.practiceId,
+          input,
+          "soap_notes",
+          summary,
         );
+        if (claim.alreadyCommitted) {
+          replay = claim;
+          return;
+        }
+        if (deduped.rows.length > 0) {
+          await tx.insert(soapNotes).values(
+            deduped.rows.map((n) => ({
+              ...n,
+              practiceId: ctx.practiceId,
+              authorId: ctx.user.id,
+              // Mark as migrated so the record shows "Imported" rather than
+              // implying the importing admin authored this historical note.
+              imported: true,
+            })),
+          );
+        }
+        await finishCsvImportRun(
+          migrationDb,
+          ctx.practiceId,
+          input.previewToken!,
+          deduped.rows.length,
+          ctx.user.id,
+        );
+      });
+      if (replay) {
+        return {
+          imported: replay.importedCount,
+          errors: [] as string[],
+          alreadyCommitted: true as const,
+          migrationRunId: input.previewToken!,
+        };
       }
       return {
         imported: deduped.rows.length,
-        errors: [...errors, ...deduped.errors],
+        errors: combinedErrors,
       };
     }),
 });

--- a/packages/db/drizzle/0041_aromatic_rhino.sql
+++ b/packages/db/drizzle/0041_aromatic_rhino.sql
@@ -1,0 +1,50 @@
+CREATE TYPE "public"."migration_run_mode" AS ENUM('clients', 'patients', 'vaccinations', 'soap_notes');--> statement-breakpoint
+CREATE TYPE "public"."migration_run_status" AS ENUM('previewed', 'superseded', 'committing', 'committed');--> statement-breakpoint
+CREATE TABLE "migration_runs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	"practice_id" uuid NOT NULL,
+	"created_by" uuid NOT NULL,
+	"mode" "migration_run_mode" NOT NULL,
+	"source" varchar(64) NOT NULL,
+	"file_hash" varchar(64) NOT NULL,
+	"file_size_bytes" integer NOT NULL,
+	"status" "migration_run_status" DEFAULT 'previewed' NOT NULL,
+	"source_row_count" integer DEFAULT 0 NOT NULL,
+	"planned_insert_count" integer DEFAULT 0 NOT NULL,
+	"planned_reconcile_count" integer DEFAULT 0 NOT NULL,
+	"duplicate_count" integer DEFAULT 0 NOT NULL,
+	"unmatched_count" integer DEFAULT 0 NOT NULL,
+	"error_count" integer DEFAULT 0 NOT NULL,
+	"imported_count" integer DEFAULT 0 NOT NULL,
+	"reconciled_count" integer DEFAULT 0 NOT NULL,
+	"preview_expires_at" timestamp with time zone NOT NULL,
+	"superseded_at" timestamp with time zone,
+	"committed_at" timestamp with time zone,
+	"committed_by" uuid,
+	CONSTRAINT "migration_runs_file_hash_check" CHECK ("migration_runs"."file_hash" ~ '^[0-9a-f]{64}$'),
+	CONSTRAINT "migration_runs_file_size_check" CHECK ("migration_runs"."file_size_bytes" between 1 and 5000000),
+	CONSTRAINT "migration_runs_source_check" CHECK ("migration_runs"."source" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'),
+	CONSTRAINT "migration_runs_preview_expiry_check" CHECK ("migration_runs"."preview_expires_at" > "migration_runs"."created_at"),
+	CONSTRAINT "migration_runs_committed_state_check" CHECK (("migration_runs"."status" <> 'committed' or ("migration_runs"."committed_at" is not null and "migration_runs"."committed_by" is not null))),
+	CONSTRAINT "migration_runs_superseded_state_check" CHECK (("migration_runs"."status" <> 'superseded' or ("migration_runs"."superseded_at" is not null and "migration_runs"."committed_at" is null and "migration_runs"."committed_by" is null))),
+	CONSTRAINT "migration_runs_counts_check" CHECK ("migration_runs"."source_row_count" >= 0
+        and "migration_runs"."planned_insert_count" >= 0
+        and "migration_runs"."planned_reconcile_count" >= 0
+        and "migration_runs"."duplicate_count" >= 0
+        and "migration_runs"."unmatched_count" >= 0
+        and "migration_runs"."error_count" >= 0
+        and "migration_runs"."imported_count" >= 0
+        and "migration_runs"."reconciled_count" >= 0)
+);
+--> statement-breakpoint
+ALTER TABLE "migration_runs" ADD CONSTRAINT "migration_runs_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "migration_runs" ADD CONSTRAINT "migration_runs_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "migration_runs" ADD CONSTRAINT "migration_runs_committed_by_users_id_fk" FOREIGN KEY ("committed_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "migration_runs_active_preview_uq" ON "migration_runs" USING btree ("practice_id","mode") WHERE "migration_runs"."status" = 'previewed' and "migration_runs"."deleted_at" is null;--> statement-breakpoint
+CREATE INDEX "migration_runs_practice_status_idx" ON "migration_runs" USING btree ("practice_id","status","updated_at");--> statement-breakpoint
+CREATE INDEX "migration_runs_created_by_idx" ON "migration_runs" USING btree ("created_by");--> statement-breakpoint
+CREATE INDEX "migration_runs_committed_by_idx" ON "migration_runs" USING btree ("committed_by");--> statement-breakpoint
+CREATE INDEX "migration_runs_pending_expiry_idx" ON "migration_runs" USING btree ("preview_expires_at") WHERE "migration_runs"."status" = 'previewed';

--- a/packages/db/drizzle/meta/0041_snapshot.json
+++ b/packages/db/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,11443 @@
+{
+  "id": "87d8db3f-9f64-48fd-aa64-c6c5d3c5bea1",
+  "prevId": "dcb2403a-867c-4202-8c73-5d67e9a67a3f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1786174822039,
       "tag": "0040_eager_vargas",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1786186474122,
+      "tag": "0041_aromatic_rhino",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,7 @@
     "db:reset": "tsx reset.ts",
     "db:rls": "tsx apply-rls.ts",
     "db:rls:test": "tsx test-rls.ts",
+    "db:migration-runs:test": "tsx test-migration-runs.ts",
     "db:drift": "tsx check-drift.ts",
     "db:baseline": "tsx baseline.ts",
     "db:studio": "drizzle-kit studio"

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -53,7 +53,7 @@ DECLARE
   tbls text[] := array[
     'api_keys','appointment_types','appointment_waitlist','appointments','audit_log','booking_pages',
     'capture_sessions','cases','clients','clinical_notes','communications','consent_forms','consent_requests','controlled_substance_log','email_suppressions',
-    'files','insurance_claims','insurance_policies','invoices','lab_results','location_messaging','messaging_registrations',
+    'files','insurance_claims','insurance_policies','invoices','lab_results','location_messaging','messaging_registrations','migration_runs',
     'locations','patients','practice_payment_accounts','prescriptions','problem_list','procedures','products','purchase_orders',
     'recurring_series','rooms','services','sms_suppressions','soap_notes','staff_schedules','suppliers',
     'treatment_plans','treatment_templates','usage_records','users','vaccination_records',

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -20,3 +20,4 @@ export * from "./messaging";
 export * from "./demo-access";
 export * from "./booking";
 export * from "./funnel-events";
+export * from "./migrations";

--- a/packages/db/schema/migrations.ts
+++ b/packages/db/schema/migrations.ts
@@ -1,0 +1,134 @@
+import { relations, sql } from "drizzle-orm";
+import {
+  check,
+  index,
+  integer,
+  pgEnum,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { baseColumns } from "./common";
+import { practices } from "./practices";
+import { users } from "./users";
+
+export const migrationRunModeEnum = pgEnum("migration_run_mode", [
+  "clients",
+  "patients",
+  "vaccinations",
+  "soap_notes",
+]);
+
+export const migrationRunStatusEnum = pgEnum("migration_run_status", [
+  "previewed",
+  "superseded",
+  "committing",
+  "committed",
+]);
+
+/**
+ * Privacy-safe ledger for supervised clinic migrations.
+ *
+ * Raw files and row-level errors never belong here. The ledger stores only a
+ * SHA-256 file identity, aggregate counts, lifecycle state, and actor. That is
+ * enough to prove what was reviewed and committed without making another copy
+ * of clinic data.
+ */
+export const migrationRuns = pgTable(
+  "migration_runs",
+  {
+    ...baseColumns(),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    createdBy: uuid("created_by")
+      .notNull()
+      .references(() => users.id),
+    mode: migrationRunModeEnum("mode").notNull(),
+    source: varchar("source", { length: 64 }).notNull(),
+    fileHash: varchar("file_hash", { length: 64 }).notNull(),
+    fileSizeBytes: integer("file_size_bytes").notNull(),
+    status: migrationRunStatusEnum("status").notNull().default("previewed"),
+    sourceRowCount: integer("source_row_count").notNull().default(0),
+    plannedInsertCount: integer("planned_insert_count").notNull().default(0),
+    plannedReconcileCount: integer("planned_reconcile_count")
+      .notNull()
+      .default(0),
+    duplicateCount: integer("duplicate_count").notNull().default(0),
+    unmatchedCount: integer("unmatched_count").notNull().default(0),
+    errorCount: integer("error_count").notNull().default(0),
+    importedCount: integer("imported_count").notNull().default(0),
+    reconciledCount: integer("reconciled_count").notNull().default(0),
+    previewExpiresAt: timestamp("preview_expires_at", {
+      withTimezone: true,
+    }).notNull(),
+    supersededAt: timestamp("superseded_at", { withTimezone: true }),
+    committedAt: timestamp("committed_at", { withTimezone: true }),
+    committedBy: uuid("committed_by").references(() => users.id),
+  },
+  (table) => ({
+    activePreviewUq: uniqueIndex("migration_runs_active_preview_uq")
+      .on(table.practiceId, table.mode)
+      .where(sql`${table.status} = 'previewed' and ${table.deletedAt} is null`),
+    practiceStatusIdx: index("migration_runs_practice_status_idx").on(
+      table.practiceId,
+      table.status,
+      table.updatedAt,
+    ),
+    createdByIdx: index("migration_runs_created_by_idx").on(table.createdBy),
+    committedByIdx: index("migration_runs_committed_by_idx").on(
+      table.committedBy,
+    ),
+    pendingExpiryIdx: index("migration_runs_pending_expiry_idx")
+      .on(table.previewExpiresAt)
+      .where(sql`${table.status} = 'previewed'`),
+    fileHashCheck: check(
+      "migration_runs_file_hash_check",
+      sql`${table.fileHash} ~ '^[0-9a-f]{64}$'`,
+    ),
+    fileSizeCheck: check(
+      "migration_runs_file_size_check",
+      sql`${table.fileSizeBytes} between 1 and 5000000`,
+    ),
+    sourceCheck: check(
+      "migration_runs_source_check",
+      sql`${table.source} ~ '^[a-z0-9][a-z0-9_-]{0,63}$'`,
+    ),
+    previewExpiryCheck: check(
+      "migration_runs_preview_expiry_check",
+      sql`${table.previewExpiresAt} > ${table.createdAt}`,
+    ),
+    committedStateCheck: check(
+      "migration_runs_committed_state_check",
+      sql`(${table.status} <> 'committed' or (${table.committedAt} is not null and ${table.committedBy} is not null))`,
+    ),
+    supersededStateCheck: check(
+      "migration_runs_superseded_state_check",
+      sql`(${table.status} <> 'superseded' or (${table.supersededAt} is not null and ${table.committedAt} is null and ${table.committedBy} is null))`,
+    ),
+    countsCheck: check(
+      "migration_runs_counts_check",
+      sql`${table.sourceRowCount} >= 0
+        and ${table.plannedInsertCount} >= 0
+        and ${table.plannedReconcileCount} >= 0
+        and ${table.duplicateCount} >= 0
+        and ${table.unmatchedCount} >= 0
+        and ${table.errorCount} >= 0
+        and ${table.importedCount} >= 0
+        and ${table.reconciledCount} >= 0`,
+    ),
+  }),
+);
+
+export const migrationRunsRelations = relations(migrationRuns, ({ one }) => ({
+  practice: one(practices, {
+    fields: [migrationRuns.practiceId],
+    references: [practices.id],
+  }),
+  creator: one(users, {
+    fields: [migrationRuns.createdBy],
+    references: [users.id],
+  }),
+}));

--- a/packages/db/test-migration-runs.ts
+++ b/packages/db/test-migration-runs.ts
@@ -1,0 +1,232 @@
+/**
+ * Real-Postgres migration-run concurrency and rollback verification.
+ * Run after committed migrations and RLS have been applied.
+ */
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "./schema/index";
+import type { Database } from "./client";
+import { clients, migrationRuns } from "./schema/index";
+const importedRunLedger =
+  (await import("../../apps/web/lib/import/run-ledger")) as unknown as Record<
+    string,
+    unknown
+  >;
+const runLedgerModule = (importedRunLedger.default ??
+  importedRunLedger["module.exports"] ??
+  importedRunLedger) as typeof import("../../apps/web/lib/import/run-ledger");
+const {
+  claimMigrationPreview,
+  completeMigrationRun,
+  createMigrationPreview,
+  lockMigrationPractice,
+} = runLedgerModule;
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} not set`);
+  return value;
+}
+
+function appRoleUrl(ownerUrl: string): string {
+  const url = new URL(ownerUrl);
+  url.username = "openpims_app";
+  url.password = process.env.OPENPIMS_APP_DB_PASSWORD?.trim() || "openpims_app";
+  return url.toString();
+}
+
+const ownerSql = postgres(requiredEnv("DATABASE_URL"), { max: 1 });
+const appSql = postgres(appRoleUrl(requiredEnv("DATABASE_URL")), { max: 4 });
+const appDb = drizzle(appSql, { schema });
+const practiceId = randomUUID();
+const userId = randomUUID();
+const csv = "firstName,lastName,email\nAda,Clinic,ada@example.com";
+const summary = {
+  sourceRowCount: 1,
+  plannedInsertCount: 1,
+  errorCount: 0,
+};
+
+async function tenantTransaction<T>(
+  fn: (tx: Database) => Promise<T>,
+): Promise<T> {
+  return appDb.transaction(async (tx) => {
+    await tx.execute(
+      sql`select set_config('app.current_practice_id', ${practiceId}, true)`,
+    );
+    return fn(tx as unknown as Database);
+  });
+}
+
+function check(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+try {
+  await ownerSql`insert into practices (id, name) values (${practiceId}, 'Migration Run Integration')`;
+  await ownerSql`insert into users (id, email, password_hash, name, role, practice_id)
+    values (${userId}, ${`migration-${userId}@example.com`}, 'not-a-real-hash', 'Migration Admin', 'admin', ${practiceId})`;
+
+  const [firstPreview, secondPreview] = await Promise.all([
+    tenantTransaction((tx) =>
+      createMigrationPreview(tx, {
+        practiceId,
+        createdBy: userId,
+        mode: "clients",
+        source: "other",
+        csv,
+        summary,
+      }),
+    ),
+    tenantTransaction((tx) =>
+      createMigrationPreview(tx, {
+        practiceId,
+        createdBy: userId,
+        mode: "clients",
+        source: "other",
+        csv,
+        summary,
+      }),
+    ),
+  ]);
+  const previewRows = await ownerSql`
+    select id, status from migration_runs
+    where id in (${firstPreview}, ${secondPreview})
+    order by created_at, id`;
+  check(previewRows.length === 2, "both concurrent previews must be recorded");
+  check(
+    previewRows.filter((row) => row.status === "previewed").length === 1,
+    "exactly one same-kind preview must remain active",
+  );
+  check(
+    previewRows.filter((row) => row.status === "superseded").length === 1,
+    "the older concurrent preview must be superseded",
+  );
+  const activePreview = previewRows.find((row) => row.status === "previewed")!;
+
+  async function commitOnce() {
+    return tenantTransaction(async (tx) => {
+      await lockMigrationPractice(tx, practiceId);
+      await tx
+        .select({ id: clients.id })
+        .from(clients)
+        .where(eq(clients.practiceId, practiceId));
+      const claim = await claimMigrationPreview(tx, {
+        practiceId,
+        previewToken: activePreview.id,
+        mode: "clients",
+        source: "other",
+        csv,
+        summary,
+      });
+      if (claim.alreadyCommitted) return claim;
+      await tx.insert(clients).values({
+        practiceId,
+        firstName: "Migration",
+        lastName: "Concurrency",
+      });
+      await completeMigrationRun(tx, {
+        practiceId,
+        previewToken: activePreview.id,
+        importedCount: 1,
+        committedBy: userId,
+      });
+      return claim;
+    });
+  }
+
+  const commitResults = await Promise.all([commitOnce(), commitOnce()]);
+  check(
+    commitResults.filter((result) => result.alreadyCommitted).length === 1,
+    "one concurrent retry must return the saved committed result",
+  );
+  const inserted = await ownerSql`
+    select id from clients
+    where practice_id = ${practiceId} and first_name = 'Migration' and last_name = 'Concurrency'`;
+  check(
+    inserted.length === 1,
+    "concurrent exact commits must write domain rows once",
+  );
+  const [committedRun] = await ownerSql`
+    select status, imported_count from migration_runs where id = ${activePreview.id}`;
+  check(
+    committedRun?.status === "committed" && committedRun.imported_count === 1,
+    "the migration run must commit exactly once",
+  );
+
+  const rollbackPreview = await tenantTransaction((tx) =>
+    createMigrationPreview(tx, {
+      practiceId,
+      createdBy: userId,
+      mode: "patients",
+      source: "other",
+      csv,
+      summary,
+    }),
+  );
+  let failedWriteRolledBack = false;
+  try {
+    await tenantTransaction(async (tx) => {
+      const claim = await claimMigrationPreview(tx, {
+        practiceId,
+        previewToken: rollbackPreview,
+        mode: "patients",
+        source: "other",
+        csv,
+        summary,
+      });
+      check(
+        !claim.alreadyCommitted,
+        "fresh rollback test preview must be claimable",
+      );
+      await tx.execute(
+        sql`insert into clients (practice_id, last_name) values (${practiceId}, 'Invalid')`,
+      );
+    });
+  } catch {
+    failedWriteRolledBack = true;
+  }
+  check(
+    failedWriteRolledBack,
+    "the forced domain constraint failure must throw",
+  );
+  const [rolledBackRun] = await ownerSql`
+    select status from migration_runs where id = ${rollbackPreview}`;
+  check(
+    rolledBackRun?.status === "previewed",
+    "a failed domain write must roll the preview claim back",
+  );
+
+  let mismatchRejected = false;
+  try {
+    await tenantTransaction((tx) =>
+      claimMigrationPreview(tx, {
+        practiceId,
+        previewToken: activePreview.id,
+        mode: "clients",
+        source: "other",
+        csv: `${csv}\n`,
+        summary,
+      }),
+    );
+  } catch {
+    mismatchRejected = true;
+  }
+  check(
+    mismatchRejected,
+    "an exact-byte mismatch must reject the committed token",
+  );
+
+  console.log(
+    "✓ migration preview concurrency, idempotency, rollback, and exact-file checks passed",
+  );
+} finally {
+  await ownerSql`delete from clients where practice_id = ${practiceId}`;
+  await ownerSql`delete from migration_runs where practice_id = ${practiceId}`;
+  await ownerSql`delete from users where id = ${userId}`;
+  await ownerSql`delete from practices where id = ${practiceId}`;
+  await appSql.end();
+  await ownerSql.end();
+}

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -37,6 +37,10 @@ const aId = randomUUID();
 const bId = randomUUID();
 const aInvoice = randomUUID();
 const bInvoice = randomUUID();
+const aUser = randomUUID();
+const bUser = randomUUID();
+const aMigrationRun = randomUUID();
+const bMigrationRun = randomUUID();
 const funnelEventId = randomUUID();
 let failures = 0;
 
@@ -56,6 +60,14 @@ try {
   await owner`insert into practices (id, name) values (${aId}, 'RLS Test A'), (${bId}, 'RLS Test B')`;
   await owner`insert into clients (practice_id, first_name, last_name) values
     (${aId}, 'Alice', 'A'), (${bId}, 'Bob', 'B')`;
+  await owner`insert into users (id, email, password_hash, name, role, practice_id) values
+    (${aUser}, ${`rls-${aUser}@example.com`}, 'not-a-real-hash', 'RLS Admin A', 'admin', ${aId}),
+    (${bUser}, ${`rls-${bUser}@example.com`}, 'not-a-real-hash', 'RLS Admin B', 'admin', ${bId})`;
+  await owner`insert into migration_runs
+    (id, practice_id, created_by, mode, source, file_hash, file_size_bytes, preview_expires_at)
+    values
+    (${aMigrationRun}, ${aId}, ${aUser}, 'clients', 'other', ${"a".repeat(64)}, 10, now() + interval '1 day'),
+    (${bMigrationRun}, ${bId}, ${bUser}, 'clients', 'other', ${"b".repeat(64)}, 10, now() + interval '1 day')`;
   await owner`insert into funnel_events (id, event_name, practice_id)
     values (${funnelEventId}, 'registration', ${aId})`;
 
@@ -64,14 +76,53 @@ try {
     await tx`select set_config('app.current_practice_id', ${aId}, true)`;
     return tx`select practice_id from clients where practice_id in (${aId}, ${bId})`;
   });
-  check("tenant A sees only A's clients", aRows.length === 1 && aRows[0]!.practice_id === aId);
+  check(
+    "tenant A sees only A's clients",
+    aRows.length === 1 && aRows[0]!.practice_id === aId,
+  );
 
   // Tenant B context sees only B's rows.
   const bRows = await appTransaction(async (tx) => {
     await tx`select set_config('app.current_practice_id', ${bId}, true)`;
     return tx`select practice_id from clients where practice_id in (${aId}, ${bId})`;
   });
-  check("tenant B sees only B's clients", bRows.length === 1 && bRows[0]!.practice_id === bId);
+  check(
+    "tenant B sees only B's clients",
+    bRows.length === 1 && bRows[0]!.practice_id === bId,
+  );
+
+  const aMigrationRows = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id, practice_id from migration_runs where id in (${aMigrationRun}, ${bMigrationRun})`;
+  });
+  check(
+    "tenant A sees only A's migration run",
+    aMigrationRows.length === 1 &&
+      aMigrationRows[0]!.id === aMigrationRun &&
+      aMigrationRows[0]!.practice_id === aId,
+  );
+
+  const hiddenMigrationUpdate = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`update migration_runs set source = 'hidden-update' where id = ${bMigrationRun} returning id`;
+  });
+  check(
+    "tenant A cannot update B's migration run",
+    hiddenMigrationUpdate.length === 0,
+  );
+
+  let migrationInsertBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into migration_runs
+        (practice_id, created_by, mode, source, file_hash, file_size_bytes, preview_expires_at)
+        values (${bId}, ${bUser}, 'patients', 'other', ${"c".repeat(64)}, 10, now() + interval '1 day')`;
+    });
+  } catch {
+    migrationInsertBlocked = true;
+  }
+  check("cross-tenant migration run INSERT is blocked", migrationInsertBlocked);
 
   // Child tables without practice_id isolate via the parent join policy.
   // invoice_adjustments is the representative (regression: it was missing
@@ -104,8 +155,15 @@ try {
   check("cross-tenant INSERT is blocked", writeBlocked);
 
   // No tenant context → deny by default.
-  const noneRows = await app`select practice_id from clients where practice_id in (${aId}, ${bId})`;
+  const noneRows =
+    await app`select practice_id from clients where practice_id in (${aId}, ${bId})`;
   check("no tenant context → zero rows", noneRows.length === 0);
+  const noContextMigrationRows =
+    await app`select id from migration_runs where id in (${aMigrationRun}, ${bMigrationRun})`;
+  check(
+    "no tenant context hides migration runs",
+    noContextMigrationRows.length === 0,
+  );
 
   // Product analytics is system-only even with a valid tenant context. The
   // public ingestion route writes under an explicit system transaction.
@@ -124,14 +182,19 @@ try {
     return tx`select practice_id from clients where practice_id in (${aId}, ${bId})`;
   });
   check("system bypass sees both practices", allRows.length === 2);
+  const allMigrationRows = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`select id from migration_runs where id in (${aMigrationRun}, ${bMigrationRun})`;
+  });
+  check(
+    "system bypass sees both migration runs",
+    allMigrationRows.length === 2,
+  );
   const systemFunnelRows = await appTransaction(async (tx) => {
     await tx`select set_config('app.rls_bypass', 'on', true)`;
     return tx`select id from funnel_events where id = ${funnelEventId}`;
   });
-  check(
-    "system bypass can read funnel events",
-    systemFunnelRows.length === 1,
-  );
+  check("system bypass can read funnel events", systemFunnelRows.length === 1);
 } catch (err) {
   console.error("Unexpected error:", err);
   failures++;
@@ -140,7 +203,9 @@ try {
   await owner`delete from invoice_adjustments where invoice_id in (${aInvoice}, ${bInvoice})`;
   await owner`delete from funnel_events where id = ${funnelEventId}`;
   await owner`delete from invoices where id in (${aInvoice}, ${bInvoice})`;
+  await owner`delete from migration_runs where id in (${aMigrationRun}, ${bMigrationRun})`;
   await owner`delete from clients where practice_id in (${aId}, ${bId})`;
+  await owner`delete from users where id in (${aUser}, ${bUser})`;
   await owner`delete from practices where id in (${aId}, ${bId})`;
   await owner.end();
   await app.end();


### PR DESCRIPTION
## Outcome

Makes assisted clinic imports reviewable, exact-file-bound, tenant-isolated, and safe to retry before OpenVPM takes a design partner live.

## What changed

- adds a privacy-safe migration run ledger with a 24-hour preview token, aggregate-only audit data, RLS, and schema constraints
- serializes planning and commits per practice, performs the claim and domain writes transactionally, and returns saved results for exact retries
- stages onboarding as clients first, then pets against committed owners
- adds explicit Check → Import actions, source selection, Shepherd migration help, recovery copy, skipped-row issue downloads, and file-read/input locking
- keeps already-open browser bundles compatible through a bounded rollout ending 2026-08-15T00:00Z; stale two-file onboarding tabs are told to refresh before database work
- adds real-Postgres concurrency, idempotency, exact-file, rollback, migration, and RLS coverage to CI
- stabilizes the CPU-heavy bcrypt negative-key test under full parallel load

## Release evidence

- 2,437/2,437 web tests accounted for; 2,436 passed in the full parallel run and the sole 5.09s timeout passes 13/13 after its test budget was corrected
- focused migration/onboarding gate: 88/88
- workspace type-check: pass
- production Next.js build: pass
- Drizzle schema generation: no drift
- disposable Postgres 16: migrations pass; RLS pass; tenant isolation pass; concurrent preview/commit, retry idempotency, transactional rollback, and exact-file rejection pass
- two independent final reviews: no release blockers
- diff check and secret scan: pass

## Production verification

After merge:
1. verify migration 0041 and RLS deployment
2. verify Vercel production build and /api/health
3. smoke Settings and onboarding preview/commit/retry recovery
4. remove the compatibility bridge after the cutoff