### PR TITLE
Make visit closeout durable and retry-safe

### DIFF
--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -1124,6 +1124,8 @@ function PaymentSection({
   );
   const [adjustmentAmount, setAdjustmentAmount] = useState("");
   const [adjustmentReason, setAdjustmentReason] = useState("");
+  const paymentOperationId = useRef<string | null>(null);
+  const adjustmentOperationId = useRef<string | null>(null);
 
   const utils = trpc.useUtils();
 
@@ -1144,6 +1146,7 @@ function PaymentSection({
       setPaymentAmount("");
       setPaymentMethod("cash");
       setPaymentNotes("");
+      paymentOperationId.current = null;
     },
     onError: (err) => {
       toast.error(err.message);
@@ -1160,6 +1163,7 @@ function PaymentSection({
       setAdjustmentType("credit");
       setAdjustmentAmount("");
       setAdjustmentReason("");
+      adjustmentOperationId.current = null;
     },
     onError: (err) => {
       toast.error(err.message);
@@ -1231,19 +1235,23 @@ function PaymentSection({
     !applyAdjustment.isPending;
 
   const handleOpenForm = () => {
+    paymentOperationId.current = null;
     setPaymentAmount(remaining.toFixed(2));
     setShowPaymentForm(true);
   };
 
   const handleOpenAdjustmentForm = () => {
+    adjustmentOperationId.current = null;
     setAdjustmentAmount(remaining.toFixed(2));
     setShowAdjustmentForm(true);
   };
 
   const handleRecordPayment = () => {
     if (!canRecordPayment) return;
+    paymentOperationId.current ??= crypto.randomUUID();
     recordPayment.mutate({
       invoiceId,
+      operationId: paymentOperationId.current,
       amount: paymentAmount.trim(),
       method: paymentMethod as any,
       notes: paymentNotes.trim() || undefined,
@@ -1252,8 +1260,10 @@ function PaymentSection({
 
   const handleApplyAdjustment = () => {
     if (!canApplyAdjustment) return;
+    adjustmentOperationId.current ??= crypto.randomUUID();
     applyAdjustment.mutate({
       invoiceId,
+      operationId: adjustmentOperationId.current,
       type: adjustmentType,
       amount: adjustmentAmount.trim(),
       reason: adjustmentReason.trim() || undefined,
@@ -1373,7 +1383,10 @@ function PaymentSection({
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setShowPaymentForm(false)}
+              onClick={() => {
+                paymentOperationId.current = null;
+                setShowPaymentForm(false);
+              }}
             >
               Cancel
             </Button>
@@ -1441,7 +1454,10 @@ function PaymentSection({
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => setShowAdjustmentForm(false)}
+              onClick={() => {
+                adjustmentOperationId.current = null;
+                setShowAdjustmentForm(false);
+              }}
             >
               Cancel
             </Button>

--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -1,21 +1,26 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useSession } from "next-auth/react";
+import type { inferRouterOutputs } from "@trpc/server";
 import {
   AlertCircle,
   ArrowLeft,
   CalendarClock,
   Check,
+  ClipboardCheck,
   ClipboardList,
+  Download,
   FileText,
   Loader2,
   Package,
+  Pill,
   Plus,
   Receipt,
   Stethoscope,
+  Save,
   Trash2,
   UserRound,
 } from "lucide-react";
@@ -40,7 +45,21 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { EmptyState } from "@/components/common/empty-state";
+import type { AppRouter } from "@/server/routers/_app";
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+type CloseoutQueryState = {
+  data: RouterOutputs["encounters"]["getCloseout"] | undefined;
+  error: { message: string } | null;
+  isLoading: boolean;
+};
+type InvoiceQueryState = {
+  data: RouterOutputs["billing"]["listInvoices"] | undefined;
+  error: { message: string } | null;
+  isLoading: boolean;
+};
 
 type ChargeItem = {
   key: string;
@@ -49,6 +68,7 @@ type ChargeItem = {
   unitPrice: string;
   itemType: "service" | "product";
   itemId?: string;
+  sourcePrescriptionId?: string;
 };
 
 const APPOINTMENT_STATUS_LABELS: Record<string, string> = {
@@ -80,7 +100,7 @@ function canManageBilling(role?: string | null): boolean {
 
 function nextVisitAction(status: string): {
   label: string;
-  status: "checked_in" | "in_exam" | "checked_out";
+  status: "checked_in" | "in_exam";
 } | null {
   if (status === "scheduled" || status === "confirmed") {
     return { label: "Check in", status: "checked_in" };
@@ -88,15 +108,12 @@ function nextVisitAction(status: string): {
   if (status === "checked_in") {
     return { label: "Start exam", status: "in_exam" };
   }
-  if (status === "in_exam") {
-    return { label: "Check out", status: "checked_out" };
-  }
   return null;
 }
 
 function formatAppointmentTime(
   value: Date | string,
-  timeZone?: string | null
+  timeZone?: string | null,
 ): string {
   try {
     return new Date(value).toLocaleString("en-US", {
@@ -118,6 +135,19 @@ function formatAppointmentTime(
   }
 }
 
+function formatClinicDate(value: string): string {
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(Date.UTC(year!, month! - 1, day!)).toLocaleDateString(
+    "en-US",
+    {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      timeZone: "UTC",
+    },
+  );
+}
+
 function EncounterLoading() {
   return (
     <div className="flex items-center justify-center gap-2 rounded-lg border border-border bg-card p-12 text-sm text-muted-foreground">
@@ -135,19 +165,23 @@ export default function EncounterWorkspacePage() {
 
   const appointmentQuery = trpc.appointments.getById.useQuery(
     { id: appointmentId },
-    { enabled: Boolean(appointmentId) }
+    { enabled: Boolean(appointmentId) },
   );
   const appointment = appointmentQuery.data;
   const patientQuery = trpc.patients.getById.useQuery(
     { id: appointment?.patientId ?? "" },
-    { enabled: Boolean(appointment?.patientId) }
+    { enabled: Boolean(appointment?.patientId) },
   );
   const taxConfigQuery = trpc.billing.getTaxConfig.useQuery(undefined, {
     staleTime: 5 * 60 * 1000,
   });
   const invoicesQuery = trpc.billing.listInvoices.useQuery(
     { appointmentId, limit: 25, offset: 0 },
-    { enabled: Boolean(appointmentId) }
+    { enabled: Boolean(appointmentId) },
+  );
+  const closeoutQuery = trpc.encounters.getCloseout.useQuery(
+    { appointmentId },
+    { enabled: Boolean(appointmentId) },
   );
 
   const updateStatus = trpc.appointments.updateStatus.useMutation({
@@ -189,7 +223,7 @@ export default function EncounterWorkspacePage() {
   const nextAction = nextVisitAction(appointment.status);
   const activeInvoices =
     invoicesQuery.data?.items.filter(
-      (invoice) => !invoice.isEstimate && invoice.status !== "void"
+      (invoice) => !invoice.isEstimate && invoice.status !== "void",
     ) ?? [];
   const visitInvoices = invoicesQuery.data?.items ?? [];
 
@@ -228,7 +262,7 @@ export default function EncounterWorkspacePage() {
                 <CalendarClock className="h-4 w-4" />
                 {formatAppointmentTime(
                   appointment.startTime,
-                  taxConfigQuery.data?.timezone
+                  taxConfigQuery.data?.timezone,
                 )}
               </span>
               <span className="inline-flex items-center gap-1.5">
@@ -259,6 +293,17 @@ export default function EncounterWorkspacePage() {
               <Check className="mr-2 h-4 w-4" />
             )}
             {nextAction.label}
+          </Button>
+        ) : appointment.status === "in_exam" && canManageVisit(role) ? (
+          <Button
+            onClick={() => {
+              const closeout = document.getElementById("visit-closeout");
+              closeout?.scrollIntoView({ behavior: "smooth", block: "start" });
+              closeout?.focus({ preventScroll: true });
+            }}
+          >
+            <ClipboardCheck className="mr-2 h-4 w-4" />
+            Review closeout
           </Button>
         ) : null}
       </header>
@@ -320,13 +365,31 @@ export default function EncounterWorkspacePage() {
                   </div>
 
                   <div className="flex flex-wrap gap-2">
-                    {canCreateSoap(role) ? (
+                    {canCreateSoap(role) &&
+                    appointment.status === "in_exam" &&
+                    closeoutQuery.data?.closeout?.status !==
+                      "clinical_finalized" &&
+                    closeoutQuery.data?.closeout?.status !== "completed" ? (
                       <Button size="sm" asChild>
                         <Link
                           href={`/records/new-soap/${appointment.patientId}?appointmentId=${appointmentId}`}
                         >
                           <FileText className="mr-2 h-4 w-4" />
                           Write SOAP note
+                        </Link>
+                      </Button>
+                    ) : null}
+                    {canCreateSoap(role) &&
+                    appointment.status === "in_exam" &&
+                    closeoutQuery.data?.closeout?.status !==
+                      "clinical_finalized" &&
+                    closeoutQuery.data?.closeout?.status !== "completed" ? (
+                      <Button size="sm" variant="outline" asChild>
+                        <Link
+                          href={`/records?patientId=${appointment.patientId}&appointmentId=${appointmentId}&tab=prescriptions&new=1`}
+                        >
+                          <Pill className="mr-2 h-4 w-4" />
+                          Prescribe
                         </Link>
                       </Button>
                     ) : null}
@@ -360,32 +423,1496 @@ export default function EncounterWorkspacePage() {
             </CardContent>
           </Card>
 
+          <VisitCloseout
+            appointment={appointment}
+            appointmentId={appointmentId}
+            role={role}
+            closeoutQuery={closeoutQuery}
+            invoicesQuery={invoicesQuery}
+          />
+
           <EncounterInvoices
             appointmentId={appointmentId}
             invoicesQuery={invoicesQuery}
             visitInvoices={visitInvoices}
-            canManage={canManageBilling(role)}
+            canManage={
+              canManageBilling(role) &&
+              closeoutQuery.data?.closeout?.status !== "completed"
+            }
           />
         </div>
 
-        <ChargeCapture
-          appointmentId={appointmentId}
-          clientId={appointment.clientId}
-          patientId={appointment.patientId}
-          canManage={canManageBilling(role)}
-          activeInvoice={
-            activeInvoices[0]
-              ? {
-                  id: activeInvoices[0].id,
-                  status: activeInvoices[0].status,
-                }
-              : null
-          }
-          invoiceStateReady={
-            Boolean(invoicesQuery.data) && !invoicesQuery.error
-          }
-          invoiceStateLoading={invoicesQuery.isLoading}
+        <div id="charge-capture" className="scroll-mt-4">
+          <ChargeCapture
+            appointmentId={appointmentId}
+            clientId={appointment.clientId}
+            patientId={appointment.patientId}
+            canManage={
+              canManageBilling(role) &&
+              appointment.status === "in_exam" &&
+              closeoutQuery.data?.closeout?.status !== "completed"
+            }
+            activeInvoice={
+              activeInvoices[0]
+                ? {
+                    id: activeInvoices[0].id,
+                    status: activeInvoices[0].status,
+                  }
+                : null
+            }
+            invoiceStateReady={
+              Boolean(invoicesQuery.data) && !invoicesQuery.error
+            }
+            invoiceStateLoading={invoicesQuery.isLoading}
+            linkedPrescriptions={closeoutQuery.data?.medications ?? []}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function splitOwnerInstructions(value: string | null | undefined): string[] {
+  return (value ?? "")
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function VisitCloseout({
+  appointment,
+  appointmentId,
+  role,
+  closeoutQuery,
+  invoicesQuery,
+}: {
+  appointment: {
+    status: string;
+    patientName: string | null;
+    patientSpecies: string | null;
+    clientFirstName: string | null;
+    clientLastName: string | null;
+    doctorName: string | null;
+    startTime: Date | string;
+    typeRequiresDoctor: number | null;
+  };
+  appointmentId: string;
+  role?: string | null;
+  closeoutQuery: CloseoutQueryState;
+  invoicesQuery: InvoiceQueryState;
+}) {
+  const utils = trpc.useUtils();
+  const data = closeoutQuery.data;
+  const closeout = data?.closeout ?? null;
+  const hydratedRevision = useRef<string | null>(null);
+  const [diagnosisSummary, setDiagnosisSummary] = useState("");
+  const [dischargeInstructions, setDischargeInstructions] = useState("");
+  const [warningSigns, setWarningSigns] = useState("");
+  const [noInstructionsReason, setNoInstructionsReason] = useState("");
+  const [prescriptionDisposition, setPrescriptionDisposition] = useState<
+    "" | "prescribed" | "not_needed"
+  >("");
+  const [followUpDisposition, setFollowUpDisposition] = useState<
+    "" | "none" | "needed" | "scheduled"
+  >("");
+  const [followUpNotes, setFollowUpNotes] = useState("");
+  const [followUpAppointmentId, setFollowUpAppointmentId] = useState("");
+  const [followUpDueDate, setFollowUpDueDate] = useState("");
+  const [followUpAssignedTo, setFollowUpAssignedTo] = useState("");
+  const [documentationExceptionReason, setDocumentationExceptionReason] =
+    useState("");
+  const [chargeDisposition, setChargeDisposition] = useState<
+    "" | "paid" | "accounts_receivable" | "no_charge"
+  >("");
+  const [noChargeReason, setNoChargeReason] = useState("");
+  const [handoffMethod, setHandoffMethod] = useState<
+    "" | "print" | "verbal" | "declined"
+  >("");
+  const [amendmentReason, setAmendmentReason] = useState("");
+  const [followUpResolution, setFollowUpResolution] = useState<
+    "" | "scheduled" | "completed" | "not_needed"
+  >("");
+  const [resolutionAppointmentId, setResolutionAppointmentId] = useState("");
+  const [resolutionNotes, setResolutionNotes] = useState("");
+
+  useEffect(() => {
+    if (!data) return;
+    const key = closeout ? `${closeout.id}:${closeout.revision}` : "empty";
+    if (hydratedRevision.current === key) return;
+    const clinicalSource = closeout?.amendmentDraft ?? closeout;
+    setDiagnosisSummary(clinicalSource?.diagnosisSummary ?? "");
+    setDischargeInstructions(clinicalSource?.dischargeInstructions ?? "");
+    setWarningSigns(clinicalSource?.warningSigns ?? "");
+    setNoInstructionsReason(clinicalSource?.noInstructionsReason ?? "");
+    setPrescriptionDisposition(clinicalSource?.prescriptionDisposition ?? "");
+    setFollowUpDisposition(clinicalSource?.followUpDisposition ?? "");
+    setFollowUpNotes(clinicalSource?.followUpNotes ?? "");
+    setFollowUpAppointmentId(clinicalSource?.followUpAppointmentId ?? "");
+    setFollowUpDueDate(clinicalSource?.followUpDueDate ?? "");
+    setFollowUpAssignedTo(clinicalSource?.followUpAssignedTo ?? "");
+    setDocumentationExceptionReason(
+      clinicalSource?.documentationExceptionReason ?? "",
+    );
+    setChargeDisposition(closeout?.chargeDisposition ?? "");
+    setNoChargeReason(closeout?.noChargeReason ?? "");
+    setHandoffMethod(closeout?.handoffMethod ?? "");
+    hydratedRevision.current = key;
+  }, [closeout, data]);
+
+  const refresh = async () => {
+    await Promise.all([
+      utils.encounters.getCloseout.invalidate({ appointmentId }),
+      utils.appointments.getById.invalidate({ id: appointmentId }),
+      utils.appointments.list.invalidate(),
+      utils.whiteboard.getActive.invalidate(),
+    ]);
+  };
+
+  const saveDraft = trpc.encounters.saveDraft.useMutation({
+    onSuccess: async () => {
+      toast.success("Clinical closeout draft saved");
+      await refresh();
+    },
+    onError: (error) => toast.error(error.message),
+  });
+  const finalizeClinical = trpc.encounters.finalizeClinical.useMutation({
+    onSuccess: async () => {
+      toast.success("Clinical handoff finalized");
+      await refresh();
+    },
+    onError: (error) => toast.error(error.message),
+  });
+  const completeVisit = trpc.encounters.completeVisit.useMutation({
+    onSuccess: async () => {
+      toast.success("Visit completed safely");
+      await refresh();
+    },
+    onError: (error) => toast.error(error.message),
+  });
+  const reopenClinical = trpc.encounters.reopenClinical.useMutation({
+    onSuccess: async () => {
+      toast.success(
+        "Amendment draft started; the signed handoff remains active",
+      );
+      setAmendmentReason("");
+      await refresh();
+    },
+    onError: (error) => toast.error(error.message),
+  });
+  const resolveNeededFollowUp =
+    trpc.encounters.resolveNeededFollowUp.useMutation({
+      onSuccess: async () => {
+        toast.success("Follow-up obligation resolved with attribution");
+        setFollowUpResolution("");
+        setResolutionAppointmentId("");
+        setResolutionNotes("");
+        await refresh();
+        await utils.encounters.listPendingFollowUps.invalidate();
+      },
+      onError: (error) => toast.error(error.message),
+    });
+
+  const canDraftClinical =
+    role === "admin" || role === "veterinarian" || role === "technician";
+  const canFinalizeClinical =
+    role === "veterinarian" ||
+    (appointment.typeRequiresDoctor === 0 &&
+      (role === "admin" || role === "technician"));
+  const signedClinical =
+    closeout?.status === "clinical_finalized" ||
+    closeout?.status === "completed";
+  const amendingClinical = Boolean(closeout?.amendmentDraft);
+  const clinicalLocked = signedClinical && !amendingClinical;
+  const isCompleted = closeout?.status === "completed";
+  const clinicalInput = {
+    appointmentId,
+    expectedRevision: closeout?.revision ?? 0,
+    diagnosisSummary: diagnosisSummary || null,
+    dischargeInstructions: dischargeInstructions || null,
+    warningSigns: warningSigns || null,
+    noInstructionsReason: noInstructionsReason || null,
+    prescriptionDisposition: prescriptionDisposition || null,
+    followUpDisposition: followUpDisposition || null,
+    followUpNotes: followUpNotes || null,
+    followUpAppointmentId: followUpAppointmentId || null,
+    followUpDueDate: followUpDueDate || null,
+    followUpAssignedTo: followUpAssignedTo || null,
+    documentationExceptionReason: documentationExceptionReason || null,
+  } as const;
+  const activeInvoice = data?.invoices[0] ?? null;
+  const clientName = [appointment.clientFirstName, appointment.clientLastName]
+    .filter(Boolean)
+    .join(" ");
+
+  async function downloadDischarge() {
+    if (!data || !signedClinical) return;
+    try {
+      const { generateDischargeInstructions } = await import("@/lib/pdf");
+      const followUpDate = closeout?.followUpScheduledAt
+        ? new Date(closeout.followUpScheduledAt).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            timeZone: data.practice.timezone ?? undefined,
+          })
+        : closeout?.followUpDisposition === "needed" && closeout.followUpDueDate
+          ? `Needed by ${formatClinicDate(closeout.followUpDueDate)}`
+          : undefined;
+      const instructions = closeout?.dischargeInstructions
+        ? splitOwnerInstructions(closeout.dischargeInstructions)
+        : closeout?.noInstructionsReason
+          ? [
+              `No additional home-care instructions: ${closeout.noInstructionsReason}`,
+            ]
+          : [];
+      generateDischargeInstructions({
+        practiceName: data.practice.name,
+        practicePhone: data.practice.phone ?? undefined,
+        patientName: appointment.patientName ?? "Patient",
+        species: appointment.patientSpecies ?? "",
+        clientName: clientName || "Owner",
+        visitDate: formatAppointmentTime(
+          appointment.startTime,
+          data.practice.timezone,
+        ),
+        doctorName: closeout?.clinicalFinalizerName ?? undefined,
+        diagnosis: closeout?.diagnosisSummary ?? undefined,
+        medications: (closeout?.medicationSnapshot ?? []).map((medication) => ({
+          name: medication.medicationName,
+          dosage: medication.dosage,
+          frequency: medication.frequency,
+          instructions: medication.instructions ?? undefined,
+        })),
+        instructions,
+        followUpDate,
+        followUpNotes: closeout?.followUpNotes ?? undefined,
+        emergencyNotes: closeout?.warningSigns ?? undefined,
+      }).save(
+        `discharge_${(appointment.patientName ?? "patient").replace(/\s+/g, "_")}.pdf`,
+      );
+      toast.success("Discharge instructions downloaded");
+    } catch {
+      toast.error("Discharge instructions could not be generated");
+    }
+  }
+
+  type HistoricalCloseout = NonNullable<
+    typeof closeout
+  >["amendmentHistory"][number];
+
+  async function downloadHistoricalDischarge(amendment: HistoricalCloseout) {
+    if (!data) return;
+    try {
+      const { generateDischargeInstructions } = await import("@/lib/pdf");
+      const followUpDate = amendment.followUpScheduledAt
+        ? new Date(amendment.followUpScheduledAt).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            timeZone: data.practice.timezone ?? undefined,
+          })
+        : amendment.followUpDisposition === "needed" &&
+            amendment.followUpDueDate
+          ? `Needed by ${formatClinicDate(amendment.followUpDueDate)}`
+          : undefined;
+      const instructions = amendment.dischargeInstructions
+        ? splitOwnerInstructions(amendment.dischargeInstructions)
+        : amendment.noInstructionsReason
+          ? [
+              `No additional home-care instructions: ${amendment.noInstructionsReason}`,
+            ]
+          : [];
+      generateDischargeInstructions({
+        practiceName: data.practice.name,
+        practicePhone: data.practice.phone ?? undefined,
+        patientName: appointment.patientName ?? "Patient",
+        species: appointment.patientSpecies ?? "",
+        clientName: clientName || "Owner",
+        visitDate: formatAppointmentTime(
+          appointment.startTime,
+          data.practice.timezone,
+        ),
+        doctorName: amendment.clinicalFinalizerName,
+        diagnosis: amendment.diagnosisSummary ?? undefined,
+        medications: amendment.medicationSnapshot.map((medication) => ({
+          name: medication.medicationName,
+          dosage: medication.dosage,
+          frequency: medication.frequency,
+          instructions: medication.instructions ?? undefined,
+        })),
+        instructions,
+        followUpDate,
+        followUpNotes: amendment.followUpNotes ?? undefined,
+        emergencyNotes: amendment.warningSigns ?? undefined,
+      }).save(
+        `discharge_${(appointment.patientName ?? "patient").replace(/\s+/g, "_")}_revision_${amendment.priorRevision}.pdf`,
+      );
+      toast.success(`Discharge revision ${amendment.priorRevision} downloaded`);
+    } catch {
+      toast.error("Prior discharge instructions could not be generated");
+    }
+  }
+
+  if (closeoutQuery.isLoading) {
+    return (
+      <Card id="visit-closeout">
+        <CardContent className="flex items-center gap-2 p-6 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading closeout readiness...
+        </CardContent>
+      </Card>
+    );
+  }
+  if (closeoutQuery.error || !data) {
+    return (
+      <Card id="visit-closeout" className="border-destructive">
+        <CardHeader>
+          <CardTitle>Visit closeout unavailable</CardTitle>
+          <CardDescription className="text-destructive">
+            {closeoutQuery.error?.message ??
+              "Readiness could not be verified. The visit cannot be checked out."}
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card id="visit-closeout" className="scroll-mt-4" tabIndex={-1}>
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle>Visit closeout</CardTitle>
+            <CardDescription>
+              Finalize clinical instructions, then verify billing and owner
+              handoff before checkout.
+            </CardDescription>
+          </div>
+          <Badge variant={isCompleted ? "success" : "outline"}>
+            {amendingClinical
+              ? isCompleted
+                ? "Completed · amendment draft"
+                : "Signed · amendment draft"
+              : isCompleted
+                ? "Completed"
+                : clinicalLocked
+                  ? "Clinical handoff finalized"
+                  : closeout
+                    ? "Draft saved"
+                    : "Not started"}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-3 sm:grid-cols-3">
+          <ReadinessTile
+            label="Clinical note"
+            value={
+              data.linkedSoapCount > 0
+                ? `${data.linkedSoapCount} linked SOAP note${data.linkedSoapCount === 1 ? "" : "s"}`
+                : closeout?.documentationExceptionReason
+                  ? "Documented exception"
+                  : "Missing"
+            }
+          />
+          <ReadinessTile
+            label="Visit medications"
+            value={
+              data.medications.length > 0
+                ? `${data.medications.length} linked prescription${data.medications.length === 1 ? "" : "s"}`
+                : "None linked"
+            }
+          />
+          <ReadinessTile
+            label="Billing"
+            value={
+              activeInvoice
+                ? `${activeInvoice.status} · ${activeInvoice.itemCount} line${activeInvoice.itemCount === 1 ? "" : "s"}`
+                : "No active invoice"
+            }
+          />
+        </div>
+
+        {!clinicalLocked ? (
+          appointment.status !== "in_exam" && !amendingClinical ? (
+            <div className="rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+              Check the patient in and start the exam before preparing the
+              clinical closeout.
+            </div>
+          ) : canDraftClinical ? (
+            <ClinicalCloseoutForm
+              diagnosisSummary={diagnosisSummary}
+              setDiagnosisSummary={setDiagnosisSummary}
+              dischargeInstructions={dischargeInstructions}
+              setDischargeInstructions={setDischargeInstructions}
+              warningSigns={warningSigns}
+              setWarningSigns={setWarningSigns}
+              noInstructionsReason={noInstructionsReason}
+              setNoInstructionsReason={setNoInstructionsReason}
+              prescriptionDisposition={prescriptionDisposition}
+              setPrescriptionDisposition={setPrescriptionDisposition}
+              followUpDisposition={followUpDisposition}
+              setFollowUpDisposition={setFollowUpDisposition}
+              followUpNotes={followUpNotes}
+              setFollowUpNotes={setFollowUpNotes}
+              followUpAppointmentId={followUpAppointmentId}
+              setFollowUpAppointmentId={setFollowUpAppointmentId}
+              followUpDueDate={followUpDueDate}
+              setFollowUpDueDate={setFollowUpDueDate}
+              followUpAssignedTo={followUpAssignedTo}
+              setFollowUpAssignedTo={setFollowUpAssignedTo}
+              documentationExceptionReason={documentationExceptionReason}
+              setDocumentationExceptionReason={setDocumentationExceptionReason}
+              linkedSoapCount={data.linkedSoapCount}
+              linkedMedicationCount={data.medications.length}
+              followUpAppointments={data.followUpAppointments}
+              followUpAssignees={data.followUpAssignees}
+              timeZone={data.practice.timezone}
+              isAmendment={amendingClinical}
+              isSaving={saveDraft.isPending || finalizeClinical.isPending}
+              isFinalizing={finalizeClinical.isPending}
+              canFinalize={canFinalizeClinical}
+              onSave={() => saveDraft.mutate(clinicalInput)}
+              onFinalize={() => finalizeClinical.mutate(clinicalInput)}
+            />
+          ) : (
+            <div className="rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+              Your role cannot prepare clinical closeout instructions.
+            </div>
+          )
+        ) : null}
+
+        {signedClinical ? (
+          <div className="space-y-3 rounded-md border border-border bg-muted/20 p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <h3 className="font-medium">1. Clinical handoff finalized</h3>
+                <p className="text-sm text-muted-foreground">
+                  {closeout?.medicationSnapshot.length ?? 0} visit medication
+                  {closeout?.medicationSnapshot.length === 1 ? "" : "s"} ·{" "}
+                  {closeout?.followUpDisposition?.replace("_", " ")}
+                </p>
+              </div>
+              <Button variant="outline" size="sm" onClick={downloadDischarge}>
+                <Download className="mr-2 h-4 w-4" />
+                Download discharge
+              </Button>
+            </div>
+            <dl className="grid gap-3 rounded-md border border-border bg-background p-3 text-sm sm:grid-cols-2">
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Finalized by
+                </dt>
+                <dd className="mt-1">
+                  {closeout?.clinicalFinalizerName ?? "Unknown clinician"}
+                  {closeout?.clinicalFinalizedAt
+                    ? ` · ${formatAppointmentTime(
+                        closeout.clinicalFinalizedAt,
+                        data.practice.timezone,
+                      )}`
+                    : ""}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Follow-up
+                </dt>
+                <dd className="mt-1">
+                  {closeout?.followUpDisposition === "scheduled" &&
+                  closeout.followUpScheduledAt
+                    ? `Scheduled ${formatAppointmentTime(
+                        closeout.followUpScheduledAt,
+                        data.practice.timezone,
+                      )}`
+                    : closeout?.followUpDisposition === "needed" &&
+                        closeout.followUpDueDate
+                      ? `Needed by ${formatClinicDate(closeout.followUpDueDate)} · Assigned to ${closeout.followUpAssigneeName ?? "clinic team"}`
+                      : "No follow-up needed"}
+                </dd>
+              </div>
+              <div className="sm:col-span-2">
+                <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Diagnosis or visit summary
+                </dt>
+                <dd className="mt-1 whitespace-pre-wrap">
+                  {closeout?.diagnosisSummary || "Not recorded"}
+                </dd>
+              </div>
+            </dl>
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium">Medications</h4>
+              {closeout?.medicationSnapshot.length ? (
+                <ul className="space-y-2">
+                  {closeout.medicationSnapshot.map((medication) => (
+                    <li
+                      key={medication.prescriptionId}
+                      className="rounded-md border border-border bg-background p-3 text-sm"
+                    >
+                      <p className="font-medium">{medication.medicationName}</p>
+                      <p className="text-muted-foreground">
+                        {medication.dosage} · {medication.frequency}
+                        {medication.quantity
+                          ? ` · Quantity ${medication.quantity}`
+                          : ""}
+                      </p>
+                      {medication.instructions ? (
+                        <p className="mt-1 whitespace-pre-wrap">
+                          {medication.instructions}
+                        </p>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  No visit medications.
+                </p>
+              )}
+            </div>
+            <div className="space-y-3 rounded-md border border-border bg-background p-3 text-sm">
+              <div>
+                <h4 className="font-medium">Home care</h4>
+                {closeout?.dischargeInstructions ? (
+                  <p className="mt-1 whitespace-pre-wrap">
+                    {closeout.dischargeInstructions}
+                  </p>
+                ) : (
+                  <p className="mt-1 text-muted-foreground">
+                    No additional instructions: {closeout?.noInstructionsReason}
+                  </p>
+                )}
+              </div>
+              {closeout?.warningSigns ? (
+                <div>
+                  <h4 className="font-medium">
+                    Warning signs and when to call
+                  </h4>
+                  <p className="mt-1 whitespace-pre-wrap">
+                    {closeout.warningSigns}
+                  </p>
+                </div>
+              ) : null}
+              {closeout?.followUpNotes ? (
+                <div>
+                  <h4 className="font-medium">Follow-up notes</h4>
+                  <p className="mt-1 whitespace-pre-wrap">
+                    {closeout.followUpNotes}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+            {closeout?.amendmentHistory.length ? (
+              <div className="space-y-2">
+                <p className="text-sm font-medium">
+                  Prior finalized versions ({closeout.amendmentHistory.length})
+                </p>
+                {closeout.amendmentHistory.map((amendment) => (
+                  <details
+                    key={`${amendment.priorRevision}:${amendment.reopenedAt}`}
+                    className="rounded-md border border-border bg-background p-3 text-sm"
+                  >
+                    <summary className="cursor-pointer font-medium">
+                      Revision {amendment.priorRevision} · {amendment.reason}
+                    </summary>
+                    <div className="mt-3 space-y-2 text-muted-foreground">
+                      <p>
+                        Finalized by {amendment.clinicalFinalizerName} on{" "}
+                        {formatAppointmentTime(
+                          amendment.clinicalFinalizedAt,
+                          data.practice.timezone,
+                        )}
+                        . Correction opened by {amendment.reopenedByName} on{" "}
+                        {formatAppointmentTime(
+                          amendment.reopenedAt,
+                          data.practice.timezone,
+                        )}
+                        .
+                      </p>
+                      <p className="whitespace-pre-wrap">
+                        {amendment.dischargeInstructions ||
+                          `No additional instructions: ${amendment.noInstructionsReason}`}
+                      </p>
+                      {amendment.diagnosisSummary ? (
+                        <p className="whitespace-pre-wrap">
+                          <span className="font-medium text-foreground">
+                            {"Visit summary: "}
+                          </span>
+                          {amendment.diagnosisSummary}
+                        </p>
+                      ) : null}
+                      {amendment.warningSigns ? (
+                        <p className="whitespace-pre-wrap">
+                          <span className="font-medium text-foreground">
+                            {"Warning signs: "}
+                          </span>
+                          {amendment.warningSigns}
+                        </p>
+                      ) : null}
+                      <p>
+                        <span className="font-medium text-foreground">
+                          {"Follow-up: "}
+                        </span>
+                        {amendment.followUpDisposition === "scheduled" &&
+                        amendment.followUpScheduledAt
+                          ? formatAppointmentTime(
+                              amendment.followUpScheduledAt,
+                              data.practice.timezone,
+                            )
+                          : amendment.followUpDisposition === "needed" &&
+                              amendment.followUpDueDate
+                            ? `Needed by ${formatClinicDate(amendment.followUpDueDate)} · Assigned to ${amendment.followUpAssigneeName ?? "clinic team"}`
+                            : "None needed"}
+                        {amendment.followUpNotes
+                          ? ` · ${amendment.followUpNotes}`
+                          : ""}
+                      </p>
+                      {amendment.medicationSnapshot.length ? (
+                        <ul className="list-disc pl-5">
+                          {amendment.medicationSnapshot.map((medication) => (
+                            <li key={medication.prescriptionId}>
+                              {medication.medicationName} · {medication.dosage}{" "}
+                              · {medication.frequency}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : null}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => downloadHistoricalDischarge(amendment)}
+                      >
+                        <Download className="mr-2 h-4 w-4" />
+                        Download revision {amendment.priorRevision}
+                      </Button>
+                    </div>
+                  </details>
+                ))}
+              </div>
+            ) : null}
+            {(role === "admin" || role === "veterinarian") &&
+            !amendingClinical ? (
+              <div className="flex flex-col gap-2 rounded-md border border-border bg-background p-3">
+                <label
+                  className="text-sm font-medium"
+                  htmlFor="closeout-amendment-reason"
+                >
+                  Create an attributed correction
+                </label>
+                <Input
+                  id="closeout-amendment-reason"
+                  value={amendmentReason}
+                  onChange={(event) => setAmendmentReason(event.target.value)}
+                  placeholder="Reason this signed handoff needs correction"
+                />
+                <div className="flex justify-end">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={
+                      amendmentReason.trim().length < 5 ||
+                      reopenClinical.isPending
+                    }
+                    onClick={() =>
+                      reopenClinical.mutate({
+                        appointmentId,
+                        expectedRevision: closeout!.revision,
+                        reason: amendmentReason,
+                      })
+                    }
+                  >
+                    {reopenClinical.isPending ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Save className="mr-2 h-4 w-4" />
+                    )}
+                    Start amendment
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {signedClinical && closeout?.followUpDisposition === "needed" ? (
+          <FollowUpResolutionPanel
+            dueDate={closeout.followUpDueDate}
+            assigneeName={closeout.followUpAssigneeName}
+            resolution={closeout.followUpResolution}
+            resolutionNotes={closeout.followUpResolutionNotes}
+            resolutionScheduledAt={closeout.followUpResolutionScheduledAt}
+            resolvedAt={closeout.followUpResolvedAt}
+            resolverName={closeout.followUpResolverName}
+            selectedResolution={followUpResolution}
+            setSelectedResolution={setFollowUpResolution}
+            resolutionAppointmentId={resolutionAppointmentId}
+            setResolutionAppointmentId={setResolutionAppointmentId}
+            notes={resolutionNotes}
+            setNotes={setResolutionNotes}
+            followUpAppointments={data.followUpAppointments}
+            timeZone={data.practice.timezone}
+            canResolve={canManageVisit(role)}
+            isPending={resolveNeededFollowUp.isPending}
+            onResolve={() => {
+              if (!followUpResolution || !closeout) return;
+              resolveNeededFollowUp.mutate({
+                appointmentId,
+                expectedRevision: closeout.revision,
+                resolution: followUpResolution,
+                resolutionAppointmentId:
+                  followUpResolution === "scheduled"
+                    ? resolutionAppointmentId || null
+                    : null,
+                notes: resolutionNotes || null,
+              });
+            }}
+          />
+        ) : null}
+
+        {clinicalLocked && !isCompleted && canManageVisit(role) ? (
+          <OperationalCloseoutForm
+            activeInvoice={activeInvoice}
+            chargeDisposition={chargeDisposition}
+            setChargeDisposition={setChargeDisposition}
+            noChargeReason={noChargeReason}
+            setNoChargeReason={setNoChargeReason}
+            handoffMethod={handoffMethod}
+            setHandoffMethod={setHandoffMethod}
+            isPending={completeVisit.isPending || invoicesQuery.isLoading}
+            onDownload={downloadDischarge}
+            onComplete={() => {
+              if (!chargeDisposition || !handoffMethod || !closeout) return;
+              completeVisit.mutate({
+                appointmentId,
+                expectedRevision: closeout.revision,
+                chargeDisposition,
+                noChargeReason:
+                  chargeDisposition === "no_charge"
+                    ? noChargeReason || null
+                    : null,
+                handoffMethod,
+              });
+            }}
+          />
+        ) : null}
+
+        {isCompleted ? (
+          <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm">
+            <p className="font-medium">
+              Visit completed with a durable closeout.
+            </p>
+            <p className="mt-1 text-muted-foreground">
+              Billing: {closeout?.chargeDisposition?.replace("_", " ")} · Owner
+              handoff: {closeout?.handoffMethod}
+            </p>
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ReadinessTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border p-3">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-1 text-sm font-medium">{value}</p>
+    </div>
+  );
+}
+
+type ClinicalCloseoutFormProps = {
+  diagnosisSummary: string;
+  setDiagnosisSummary: (value: string) => void;
+  dischargeInstructions: string;
+  setDischargeInstructions: (value: string) => void;
+  warningSigns: string;
+  setWarningSigns: (value: string) => void;
+  noInstructionsReason: string;
+  setNoInstructionsReason: (value: string) => void;
+  prescriptionDisposition: "" | "prescribed" | "not_needed";
+  setPrescriptionDisposition: (value: "" | "prescribed" | "not_needed") => void;
+  followUpDisposition: "" | "none" | "needed" | "scheduled";
+  setFollowUpDisposition: (value: "" | "none" | "needed" | "scheduled") => void;
+  followUpNotes: string;
+  setFollowUpNotes: (value: string) => void;
+  followUpAppointmentId: string;
+  setFollowUpAppointmentId: (value: string) => void;
+  followUpDueDate: string;
+  setFollowUpDueDate: (value: string) => void;
+  followUpAssignedTo: string;
+  setFollowUpAssignedTo: (value: string) => void;
+  documentationExceptionReason: string;
+  setDocumentationExceptionReason: (value: string) => void;
+  linkedSoapCount: number;
+  linkedMedicationCount: number;
+  followUpAppointments: Array<{ id: string; startTime: Date | string }>;
+  followUpAssignees: Array<{
+    id: string;
+    name: string;
+    email: string;
+    role: string;
+  }>;
+  timeZone?: string | null;
+  isAmendment: boolean;
+  isSaving: boolean;
+  isFinalizing: boolean;
+  canFinalize: boolean;
+  onSave: () => void;
+  onFinalize: () => void;
+};
+
+function ClinicalCloseoutForm(props: ClinicalCloseoutFormProps) {
+  const finalizationIssues = [
+    !props.dischargeInstructions.trim() && !props.noInstructionsReason.trim()
+      ? "Enter home-care instructions or a clinical reason why none are needed."
+      : null,
+    !props.prescriptionDisposition
+      ? "Confirm the prescription disposition."
+      : props.linkedMedicationCount > 0 &&
+          props.prescriptionDisposition !== "prescribed"
+        ? "Linked visit prescriptions must be included in the handoff."
+        : props.linkedMedicationCount === 0 &&
+            props.prescriptionDisposition !== "not_needed"
+          ? "No active visit prescription is linked."
+          : null,
+    !props.followUpDisposition
+      ? "Choose a follow-up disposition."
+      : props.followUpDisposition === "scheduled" &&
+          !props.followUpAppointmentId
+        ? "Choose the scheduled follow-up appointment."
+        : props.followUpDisposition === "needed" && !props.followUpDueDate
+          ? "Set the date by which follow-up is needed."
+          : props.followUpDisposition === "needed" && !props.followUpAssignedTo
+            ? "Assign a staff member to own the follow-up."
+            : null,
+    props.linkedSoapCount === 0 && !props.documentationExceptionReason.trim()
+      ? "Link a SOAP note or document why one is not required."
+      : null,
+  ].filter((issue): issue is string => Boolean(issue));
+  const canFinalizeNow =
+    props.canFinalize && finalizationIssues.length === 0 && !props.isSaving;
+
+  return (
+    <div className="space-y-4 rounded-md border border-border p-4">
+      <div>
+        <h3 className="font-medium">
+          1. Clinical owner handoff{props.isAmendment ? " amendment" : ""}
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          {props.isAmendment
+            ? "The current signed discharge remains active until this attributed replacement is finalized."
+            : "Finalized content becomes the durable discharge record and cannot be silently edited."}
+        </p>
+      </div>
+      <div>
+        <label className="text-sm font-medium" htmlFor="closeout-diagnosis">
+          Diagnosis or visit summary{" "}
+          <span className="text-muted-foreground">(optional)</span>
+        </label>
+        <Textarea
+          id="closeout-diagnosis"
+          value={props.diagnosisSummary}
+          onChange={(event) => props.setDiagnosisSummary(event.target.value)}
+          rows={3}
+          className="mt-1"
         />
+      </div>
+      <div>
+        <label className="text-sm font-medium" htmlFor="closeout-instructions">
+          Home-care instructions <span aria-hidden="true">*</span>
+        </label>
+        <Textarea
+          id="closeout-instructions"
+          value={props.dischargeInstructions}
+          onChange={(event) => {
+            props.setDischargeInstructions(event.target.value);
+            if (event.target.value) props.setNoInstructionsReason("");
+          }}
+          rows={5}
+          className="mt-1"
+          placeholder="Medication administration, diet, activity, wound care, or monitoring instructions reviewed with the owner."
+        />
+      </div>
+      <div>
+        <label
+          className="text-sm font-medium"
+          htmlFor="closeout-no-instructions"
+        >
+          If none, clinical reason <span aria-hidden="true">*</span>
+        </label>
+        <Input
+          id="closeout-no-instructions"
+          value={props.noInstructionsReason}
+          onChange={(event) => {
+            props.setNoInstructionsReason(event.target.value);
+            if (event.target.value) props.setDischargeInstructions("");
+          }}
+          className="mt-1"
+          placeholder="Example: No additional home care needed for this technician visit"
+        />
+      </div>
+      <div>
+        <label className="text-sm font-medium" htmlFor="closeout-warning-signs">
+          Warning signs and when to call{" "}
+          <span className="text-muted-foreground">(optional)</span>
+        </label>
+        <Textarea
+          id="closeout-warning-signs"
+          value={props.warningSigns}
+          onChange={(event) => props.setWarningSigns(event.target.value)}
+          rows={3}
+          className="mt-1"
+        />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label
+            className="text-sm font-medium"
+            htmlFor="closeout-prescriptions"
+          >
+            Prescriptions <span aria-hidden="true">*</span>
+          </label>
+          <select
+            id="closeout-prescriptions"
+            value={props.prescriptionDisposition}
+            onChange={(event) =>
+              props.setPrescriptionDisposition(
+                event.target.value as typeof props.prescriptionDisposition,
+              )
+            }
+            className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+          >
+            <option value="">Choose...</option>
+            <option
+              value="prescribed"
+              disabled={props.linkedMedicationCount === 0}
+            >
+              Prescription created for this visit
+            </option>
+            <option
+              value="not_needed"
+              disabled={props.linkedMedicationCount > 0}
+            >
+              No prescription needed
+            </option>
+          </select>
+        </div>
+        <div>
+          <label className="text-sm font-medium" htmlFor="closeout-follow-up">
+            Follow-up <span aria-hidden="true">*</span>
+          </label>
+          <select
+            id="closeout-follow-up"
+            value={props.followUpDisposition}
+            onChange={(event) => {
+              const next = event.target
+                .value as typeof props.followUpDisposition;
+              props.setFollowUpDisposition(next);
+              if (next !== "scheduled") props.setFollowUpAppointmentId("");
+              if (next !== "needed") {
+                props.setFollowUpDueDate("");
+                props.setFollowUpAssignedTo("");
+              }
+            }}
+            className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+          >
+            <option value="">Choose...</option>
+            <option value="none">No follow-up needed</option>
+            <option value="needed">Needed — not scheduled yet</option>
+            <option value="scheduled">Already scheduled</option>
+          </select>
+        </div>
+      </div>
+      {props.followUpDisposition === "scheduled" ? (
+        <div>
+          <label
+            className="text-sm font-medium"
+            htmlFor="closeout-follow-up-appointment"
+          >
+            Scheduled appointment
+          </label>
+          <select
+            id="closeout-follow-up-appointment"
+            value={props.followUpAppointmentId}
+            onChange={(event) =>
+              props.setFollowUpAppointmentId(event.target.value)
+            }
+            className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+          >
+            <option value="">Choose...</option>
+            {props.followUpAppointments.map((candidate) => (
+              <option key={candidate.id} value={candidate.id}>
+                {formatAppointmentTime(candidate.startTime, props.timeZone)}
+              </option>
+            ))}
+          </select>
+          {props.followUpAppointments.length === 0 ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              No future appointment is scheduled. Save this draft, create the
+              follow-up from the schedule, then return to finalize.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+      {props.followUpDisposition === "needed" ? (
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label
+              className="text-sm font-medium"
+              htmlFor="closeout-follow-up-due-date"
+            >
+              Follow-up due date <span aria-hidden="true">*</span>
+            </label>
+            <Input
+              id="closeout-follow-up-due-date"
+              type="date"
+              value={props.followUpDueDate}
+              onChange={(event) => props.setFollowUpDueDate(event.target.value)}
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <label
+              className="text-sm font-medium"
+              htmlFor="closeout-follow-up-assignee"
+            >
+              Accountable staff owner <span aria-hidden="true">*</span>
+            </label>
+            <select
+              id="closeout-follow-up-assignee"
+              value={props.followUpAssignedTo}
+              onChange={(event) =>
+                props.setFollowUpAssignedTo(event.target.value)
+              }
+              className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="">Choose...</option>
+              {props.followUpAssignees.map((assignee) => (
+                <option key={assignee.id} value={assignee.id}>
+                  {assignee.name || assignee.email} ·{" "}
+                  {assignee.role.replace("_", " ")}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      ) : null}
+      {props.followUpDisposition && props.followUpDisposition !== "none" ? (
+        <div>
+          <label
+            className="text-sm font-medium"
+            htmlFor="closeout-follow-up-notes"
+          >
+            Follow-up notes{" "}
+            <span className="text-muted-foreground">(optional)</span>
+          </label>
+          <Textarea
+            id="closeout-follow-up-notes"
+            value={props.followUpNotes}
+            onChange={(event) => props.setFollowUpNotes(event.target.value)}
+            rows={2}
+            className="mt-1"
+          />
+        </div>
+      ) : null}
+      {props.linkedSoapCount === 0 ? (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
+          <p className="text-sm font-medium">No SOAP note is linked</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Link a SOAP note, or document the bounded exception below.
+          </p>
+          <Input
+            aria-label="SOAP documentation exception"
+            value={props.documentationExceptionReason}
+            onChange={(event) =>
+              props.setDocumentationExceptionReason(event.target.value)
+            }
+            className="mt-2"
+            placeholder="Why a SOAP note is not required"
+          />
+        </div>
+      ) : null}
+      {finalizationIssues.length > 0 ? (
+        <div
+          className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3"
+          role="status"
+        >
+          <p className="text-sm font-medium">Before finalizing</p>
+          <ul className="mt-1 list-disc space-y-1 pl-5 text-xs text-muted-foreground">
+            {finalizationIssues.map((issue) => (
+              <li key={issue}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      <div className="flex flex-wrap justify-end gap-2">
+        <Button
+          variant="outline"
+          disabled={props.isSaving}
+          onClick={props.onSave}
+        >
+          <Save className="mr-2 h-4 w-4" />
+          Save draft
+        </Button>
+        <Button disabled={!canFinalizeNow} onClick={props.onFinalize}>
+          {props.isFinalizing ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <ClipboardCheck className="mr-2 h-4 w-4" />
+          )}
+          Finalize clinical handoff
+        </Button>
+      </div>
+      {!props.canFinalize ? (
+        <p className="text-right text-xs text-muted-foreground">
+          A veterinarian must finalize doctor-required visit instructions.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function FollowUpResolutionPanel({
+  dueDate,
+  assigneeName,
+  resolution,
+  resolutionNotes,
+  resolutionScheduledAt,
+  resolvedAt,
+  resolverName,
+  selectedResolution,
+  setSelectedResolution,
+  resolutionAppointmentId,
+  setResolutionAppointmentId,
+  notes,
+  setNotes,
+  followUpAppointments,
+  timeZone,
+  canResolve,
+  isPending,
+  onResolve,
+}: {
+  dueDate: string | null;
+  assigneeName: string | null;
+  resolution: "scheduled" | "completed" | "not_needed" | null;
+  resolutionNotes: string | null;
+  resolutionScheduledAt: Date | string | null;
+  resolvedAt: Date | string | null;
+  resolverName: string | null;
+  selectedResolution: "" | "scheduled" | "completed" | "not_needed";
+  setSelectedResolution: (
+    value: "" | "scheduled" | "completed" | "not_needed",
+  ) => void;
+  resolutionAppointmentId: string;
+  setResolutionAppointmentId: (value: string) => void;
+  notes: string;
+  setNotes: (value: string) => void;
+  followUpAppointments: Array<{ id: string; startTime: Date | string }>;
+  timeZone?: string | null;
+  canResolve: boolean;
+  isPending: boolean;
+  onResolve: () => void;
+}) {
+  const ready = Boolean(
+    selectedResolution &&
+    (selectedResolution === "scheduled"
+      ? resolutionAppointmentId
+      : notes.trim()),
+  );
+
+  return (
+    <div className="space-y-4 rounded-md border border-amber-500/40 bg-amber-500/10 p-4">
+      <div>
+        <h3 className="font-medium">Follow-up obligation</h3>
+        <p className="text-sm text-muted-foreground">
+          Due {dueDate ? formatClinicDate(dueDate) : "date unavailable"} ·
+          Assigned to {assigneeName ?? "clinic team"}. This queue state is
+          audited separately from the signed discharge.
+        </p>
+      </div>
+      {resolvedAt && resolution ? (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm">
+          <p className="font-medium">
+            Resolved as {resolution.replace("_", " ")}
+          </p>
+          <p className="mt-1 text-muted-foreground">
+            {resolverName ?? "Clinic staff"} ·{" "}
+            {formatAppointmentTime(resolvedAt, timeZone)}
+            {resolutionScheduledAt
+              ? ` · Scheduled ${formatAppointmentTime(
+                  resolutionScheduledAt,
+                  timeZone,
+                )}`
+              : ""}
+          </p>
+          {resolutionNotes ? (
+            <p className="mt-2 whitespace-pre-wrap">{resolutionNotes}</p>
+          ) : null}
+        </div>
+      ) : canResolve ? (
+        <>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label
+                className="text-sm font-medium"
+                htmlFor="closeout-follow-up-resolution"
+              >
+                Resolution
+              </label>
+              <select
+                id="closeout-follow-up-resolution"
+                value={selectedResolution}
+                onChange={(event) => {
+                  const next = event.target.value as typeof selectedResolution;
+                  setSelectedResolution(next);
+                  if (next !== "scheduled") setResolutionAppointmentId("");
+                }}
+                className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+              >
+                <option value="">Choose...</option>
+                <option value="scheduled">Follow-up scheduled</option>
+                <option value="completed">
+                  Follow-up completed another way
+                </option>
+                <option value="not_needed">Clinically no longer needed</option>
+              </select>
+            </div>
+            {selectedResolution === "scheduled" ? (
+              <div>
+                <label
+                  className="text-sm font-medium"
+                  htmlFor="closeout-resolution-appointment"
+                >
+                  Scheduled appointment
+                </label>
+                <select
+                  id="closeout-resolution-appointment"
+                  value={resolutionAppointmentId}
+                  onChange={(event) =>
+                    setResolutionAppointmentId(event.target.value)
+                  }
+                  className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                >
+                  <option value="">Choose...</option>
+                  {followUpAppointments.map((appointment) => (
+                    <option key={appointment.id} value={appointment.id}>
+                      {formatAppointmentTime(appointment.startTime, timeZone)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : null}
+          </div>
+          {selectedResolution && selectedResolution !== "scheduled" ? (
+            <div>
+              <label
+                className="text-sm font-medium"
+                htmlFor="closeout-resolution-notes"
+              >
+                Resolution notes
+              </label>
+              <Textarea
+                id="closeout-resolution-notes"
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
+                rows={2}
+                className="mt-1"
+                placeholder="Document the owner contact or clinical reason."
+              />
+            </div>
+          ) : null}
+          <div className="flex justify-end">
+            <Button disabled={!ready || isPending} onClick={onResolve}>
+              {isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="mr-2 h-4 w-4" />
+              )}
+              Resolve follow-up
+            </Button>
+          </div>
+        </>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          A clinic staff member must resolve this obligation from the visit.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function OperationalCloseoutForm({
+  activeInvoice,
+  chargeDisposition,
+  setChargeDisposition,
+  noChargeReason,
+  setNoChargeReason,
+  handoffMethod,
+  setHandoffMethod,
+  isPending,
+  onDownload,
+  onComplete,
+}: {
+  activeInvoice: {
+    id: string;
+    status: string;
+    itemCount: number;
+    balanceDueCents: number;
+    dueDate: Date | string | null;
+  } | null;
+  chargeDisposition: "" | "paid" | "accounts_receivable" | "no_charge";
+  setChargeDisposition: (
+    value: "" | "paid" | "accounts_receivable" | "no_charge",
+  ) => void;
+  noChargeReason: string;
+  setNoChargeReason: (value: string) => void;
+  handoffMethod: "" | "print" | "verbal" | "declined";
+  setHandoffMethod: (value: "" | "print" | "verbal" | "declined") => void;
+  isPending: boolean;
+  onDownload: () => void;
+  onComplete: () => void;
+}) {
+  const paidReady = Boolean(
+    activeInvoice &&
+    activeInvoice.itemCount > 0 &&
+    activeInvoice.status === "paid" &&
+    activeInvoice.balanceDueCents === 0,
+  );
+  const accountsReceivableReady = Boolean(
+    activeInvoice &&
+    activeInvoice.itemCount > 0 &&
+    (activeInvoice.status === "sent" || activeInvoice.status === "overdue") &&
+    activeInvoice.dueDate &&
+    activeInvoice.balanceDueCents > 0,
+  );
+  const noChargeReady = !activeInvoice;
+  const selectedDispositionReady =
+    (chargeDisposition === "paid" && paidReady) ||
+    (chargeDisposition === "accounts_receivable" && accountsReceivableReady) ||
+    (chargeDisposition === "no_charge" &&
+      noChargeReady &&
+      noChargeReason.trim().length > 0);
+  const canComplete =
+    selectedDispositionReady && Boolean(handoffMethod) && !isPending;
+
+  return (
+    <div className="space-y-4 rounded-md border border-border p-4">
+      <div>
+        <h3 className="font-medium">2. Billing and owner handoff</h3>
+        <p className="text-sm text-muted-foreground">
+          Resolve payment or explicitly place the invoice in accounts receivable
+          before completing the visit.
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label
+            className="text-sm font-medium"
+            htmlFor="closeout-charge-state"
+          >
+            Billing disposition
+          </label>
+          <select
+            id="closeout-charge-state"
+            value={chargeDisposition}
+            onChange={(event) =>
+              setChargeDisposition(
+                event.target.value as typeof chargeDisposition,
+              )
+            }
+            className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+          >
+            <option value="">Choose...</option>
+            <option value="paid" disabled={!paidReady}>
+              Invoice fully paid{paidReady ? "" : " — not ready"}
+            </option>
+            <option
+              value="accounts_receivable"
+              disabled={!accountsReceivableReady}
+            >
+              Pay later — sent with due date
+            </option>
+            <option value="no_charge" disabled={!noChargeReady}>
+              No charge for this visit{noChargeReady ? "" : " — invoice exists"}
+            </option>
+          </select>
+        </div>
+        <div>
+          <label className="text-sm font-medium" htmlFor="closeout-handoff">
+            Owner handoff
+          </label>
+          <select
+            id="closeout-handoff"
+            value={handoffMethod}
+            onChange={(event) =>
+              setHandoffMethod(event.target.value as typeof handoffMethod)
+            }
+            className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+          >
+            <option value="">Choose...</option>
+            <option value="print">Printed or downloaded for owner</option>
+            <option value="verbal">Reviewed verbally with owner</option>
+            <option value="declined">Owner declined instructions</option>
+          </select>
+        </div>
+      </div>
+      {chargeDisposition === "no_charge" ? (
+        <div>
+          <label className="text-sm font-medium" htmlFor="closeout-no-charge">
+            No-charge reason
+          </label>
+          <Input
+            id="closeout-no-charge"
+            value={noChargeReason}
+            onChange={(event) => setNoChargeReason(event.target.value)}
+            className="mt-1"
+          />
+        </div>
+      ) : null}
+      {activeInvoice ? (
+        <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
+          Invoice is <strong>{activeInvoice.status}</strong>, has{" "}
+          {activeInvoice.itemCount} line
+          {activeInvoice.itemCount === 1 ? "" : "s"}, and a balance of{" "}
+          {formatCurrency(activeInvoice.balanceDueCents / 100)}.{" "}
+          {paidReady
+            ? "Ready for paid checkout. "
+            : accountsReceivableReady
+              ? "Ready for accounts-receivable checkout. "
+              : "Resolve the invoice status, balance, and due date before checkout. "}
+          <Button variant="link" size="sm" asChild className="h-auto p-0">
+            <Link href={`/billing?expand=${activeInvoice.id}`}>
+              Open billing
+            </Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+          <p>
+            No active invoice exists. Choose no charge with a reason, or save
+            visit charges first.
+          </p>
+          <Button variant="outline" size="sm" asChild>
+            <a href="#charge-capture">Capture visit charges</a>
+          </Button>
+        </div>
+      )}
+      <div className="flex flex-wrap justify-end gap-2">
+        <Button variant="outline" onClick={onDownload}>
+          <Download className="mr-2 h-4 w-4" />
+          Download discharge
+        </Button>
+        <Button disabled={!canComplete} onClick={onComplete}>
+          {isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Check className="mr-2 h-4 w-4" />
+          )}
+          Complete visit
+        </Button>
       </div>
     </div>
   );
@@ -398,7 +1925,7 @@ function EncounterInvoices({
   canManage,
 }: {
   appointmentId: string;
-  invoicesQuery: ReturnType<typeof trpc.billing.listInvoices.useQuery>;
+  invoicesQuery: InvoiceQueryState;
   visitInvoices: Array<{
     id: string;
     status: string;
@@ -448,7 +1975,7 @@ function EncounterInvoices({
               const adjusted = Number(invoice.adjustedAmount ?? 0);
               const balance = Math.max(
                 0,
-                Number(invoice.total ?? 0) - paid - adjusted
+                Number(invoice.total ?? 0) - paid - adjusted,
               );
               return (
                 <div
@@ -496,7 +2023,7 @@ function useCurrencyFormatterWithConfig() {
     formatCurrency(
       value,
       config.data?.currency ?? "usd",
-      config.data?.country ?? "US"
+      config.data?.country ?? "US",
     );
 }
 
@@ -508,6 +2035,7 @@ function ChargeCapture({
   activeInvoice,
   invoiceStateReady,
   invoiceStateLoading,
+  linkedPrescriptions,
 }: {
   appointmentId: string;
   clientId: string | null;
@@ -516,6 +2044,15 @@ function ChargeCapture({
   activeInvoice: { id: string; status: string } | null;
   invoiceStateReady: boolean;
   invoiceStateLoading: boolean;
+  linkedPrescriptions: Array<{
+    id: string;
+    medicationName: string;
+    dosage: string;
+    quantity: number | null;
+    productId: string | null;
+    productName: string | null;
+    productUnitPrice: string | null;
+  }>;
 }) {
   const utils = trpc.useUtils();
   const [selectedCatalogId, setSelectedCatalogId] = useState("");
@@ -529,10 +2066,9 @@ function ChargeCapture({
   const activeInvoiceIsDraft = activeInvoice?.status === "draft";
   const invoiceDetailQuery = trpc.billing.getInvoice.useQuery(
     {
-      id:
-        activeInvoice?.id ?? "00000000-0000-0000-0000-000000000000",
+      id: activeInvoice?.id ?? "00000000-0000-0000-0000-000000000000",
     },
-    { enabled: Boolean(canManage && activeInvoiceIsDraft) }
+    { enabled: Boolean(canManage && activeInvoiceIsDraft) },
   );
   const invoiceDetailReady =
     !activeInvoice ||
@@ -552,7 +2088,7 @@ function ChargeCapture({
         configReady &&
         invoiceStateReady &&
         (!activeInvoice || (activeInvoiceIsDraft && invoiceDetailReady)),
-    }
+    },
   );
 
   useEffect(() => {
@@ -576,7 +2112,8 @@ function ChargeCapture({
           unitPrice: item.unitPrice,
           itemType: item.itemType,
           itemId: item.itemId ?? undefined,
-        }))
+          sourcePrescriptionId: item.sourcePrescriptionId ?? undefined,
+        })),
       );
       setLoadedInvoiceId(activeInvoice.id);
     }
@@ -597,23 +2134,56 @@ function ChargeCapture({
       category: ["Service", service.category].filter(Boolean).join(" · "),
       defaultPrice: service.defaultPrice,
       stockQuantity: null as number | null,
+      quantity: null as number | null,
+      sourcePrescriptionId: undefined as string | undefined,
     }));
-    const products = (productsQuery.data ?? []).map((product) => ({
-      id: `product:${product.id}`,
-      itemId: product.id,
-      itemType: "product" as const,
-      name: product.name,
-      category: `Product · ${product.stockQuantity} in stock`,
-      defaultPrice: product.unitPrice,
-      stockQuantity: product.stockQuantity,
-    }));
-    return [...services, ...products];
-  }, [productsQuery.data, servicesQuery.data]);
+    const linkedProductIds = new Set(
+      linkedPrescriptions
+        .map((prescription) => prescription.productId)
+        .filter((id): id is string => Boolean(id)),
+    );
+    const prescriptionCharges = linkedPrescriptions
+      .filter(
+        (prescription) =>
+          prescription.productId &&
+          prescription.productName &&
+          prescription.productUnitPrice &&
+          prescription.quantity,
+      )
+      .map((prescription) => ({
+        id: `prescription:${prescription.id}`,
+        itemId: prescription.productId!,
+        itemType: "product" as const,
+        name: `${prescription.productName} — ${prescription.medicationName}`,
+        category: "Visit prescription · inventory already dispensed",
+        defaultPrice: prescription.productUnitPrice!,
+        stockQuantity: null as number | null,
+        quantity: prescription.quantity!,
+        sourcePrescriptionId: prescription.id,
+      }));
+    const products = (productsQuery.data ?? [])
+      .filter((product) => !linkedProductIds.has(product.id))
+      .map((product) => ({
+        id: `product:${product.id}`,
+        itemId: product.id,
+        itemType: "product" as const,
+        name: product.name,
+        category: `Product · ${product.stockQuantity} in stock`,
+        defaultPrice: product.unitPrice,
+        stockQuantity: product.stockQuantity,
+        quantity: null as number | null,
+        sourcePrescriptionId: undefined as string | undefined,
+      }));
+    return [...prescriptionCharges, ...services, ...products];
+  }, [linkedPrescriptions, productsQuery.data, servicesQuery.data]);
 
   const selected = catalog.find((entry) => entry.id === selectedCatalogId);
+  useEffect(() => {
+    setQuantity(selected?.quantity ?? 1);
+  }, [selected?.id, selected?.quantity]);
   const subtotal = items.reduce(
     (sum, item) => sum + item.quantity * Number(item.unitPrice),
-    0
+    0,
   );
   const taxRate = Number(configQuery.data?.taxRatePercent ?? 0) / 100;
   const tax = Math.round(subtotal * taxRate * 100) / 100;
@@ -622,10 +2192,11 @@ function ChargeCapture({
     formatCurrency(
       value,
       configQuery.data?.currency ?? "usd",
-      configQuery.data?.country ?? "US"
+      configQuery.data?.country ?? "US",
     );
   const selectedHasStock =
     selected?.itemType !== "product" ||
+    Boolean(selected.sourcePrescriptionId) ||
     (selected.stockQuantity !== null && quantity <= selected.stockQuantity);
   const canAdd =
     Boolean(selected) &&
@@ -637,7 +2208,7 @@ function ChargeCapture({
     Boolean(clientId && patientId) &&
     items.length > 0 &&
     items.every((item) =>
-      isBillingInvoiceLineTotalValid(item.unitPrice, item.quantity)
+      isBillingInvoiceLineTotalValid(item.unitPrice, item.quantity),
     ) &&
     isBillingInvoiceSubtotalValid(items) &&
     configReady &&
@@ -656,6 +2227,7 @@ function ChargeCapture({
         limit: 25,
         offset: 0,
       });
+      utils.encounters.getCloseout.invalidate({ appointmentId });
     },
     onError: (error) => toast.error(error.message),
   });
@@ -667,6 +2239,7 @@ function ChargeCapture({
         limit: 25,
         offset: 0,
       });
+      utils.encounters.getCloseout.invalidate({ appointmentId });
       if (activeInvoice) {
         utils.billing.getInvoice.invalidate({ id: activeInvoice.id });
       }
@@ -686,6 +2259,7 @@ function ChargeCapture({
         unitPrice: selected.defaultPrice,
         itemType: selected.itemType,
         itemId: selected.itemId,
+        sourcePrescriptionId: selected.sourcePrescriptionId,
       },
     ]);
     setSelectedCatalogId("");
@@ -695,16 +2269,29 @@ function ChargeCapture({
   function saveCharges() {
     if (!clientId || !patientId || !canSubmit) return;
     const lineItems = items.map(
-      ({ description, quantity, unitPrice, itemType, itemId }) => ({
+      ({
         description,
         quantity,
         unitPrice,
         itemType,
         itemId,
-      })
+        sourcePrescriptionId,
+      }) => ({
+        description,
+        quantity,
+        unitPrice,
+        itemType,
+        itemId,
+        sourcePrescriptionId,
+      }),
     );
     if (activeInvoice) {
-      updateInvoiceItems.mutate({ id: activeInvoice.id, items: lineItems });
+      if (!invoiceDetailQuery.data) return;
+      updateInvoiceItems.mutate({
+        id: activeInvoice.id,
+        expectedUpdatedAt: invoiceDetailQuery.data.updatedAt,
+        items: lineItems,
+      });
       return;
     }
     createInvoice.mutate({
@@ -867,11 +2454,11 @@ function ChargeCapture({
                                       ...candidate,
                                       quantity: Math.max(
                                         1,
-                                        Number(event.target.value) || 1
+                                        Number(event.target.value) || 1,
                                       ),
                                     }
-                                  : candidate
-                              )
+                                  : candidate,
+                              ),
                             )
                           }
                         />
@@ -894,8 +2481,8 @@ function ChargeCapture({
                                       ...candidate,
                                       unitPrice: event.target.value,
                                     }
-                                  : candidate
-                              )
+                                  : candidate,
+                              ),
                             )
                           }
                         />
@@ -916,8 +2503,8 @@ function ChargeCapture({
                         onClick={() =>
                           setItems((current) =>
                             current.filter(
-                              (candidate) => candidate.key !== item.key
-                            )
+                              (candidate) => candidate.key !== item.key,
+                            ),
                           )
                         }
                       >
@@ -948,10 +2535,7 @@ function ChargeCapture({
               </div>
             ) : null}
 
-            <Button
-              disabled={!canSubmit || isSaving}
-              onClick={saveCharges}
-            >
+            <Button disabled={!canSubmit || isSaving} onClick={saveCharges}>
               {isSaving ? (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               ) : (
@@ -963,8 +2547,8 @@ function ChargeCapture({
             </Button>
             <p className="text-xs text-muted-foreground">
               {activeInvoiceIsDraft
-                ? "Product stock is restored and re-deducted atomically when draft charges change."
-                : "This creates a draft linked to the appointment. Product stock is deducted atomically when the invoice is created."}
+                ? "Unsourced product stock is restored and re-deducted atomically when draft charges change. Visit-prescription stock was already dispensed and is not moved twice."
+                : "This creates a draft linked to the appointment. Product stock is deducted atomically; visit prescriptions retain their original dispensation."}
             </p>
           </div>
         )}

--- a/apps/web/app/(dashboard)/page.tsx
+++ b/apps/web/app/(dashboard)/page.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
+  AlertTriangle,
+  ArrowRight,
   Calendar,
   CalendarPlus,
   Clock,
@@ -48,12 +51,12 @@ function DashboardChartsChunkLoading() {
 const DashboardCharts = dynamic(
   () =>
     import("@/components/dashboard/dashboard-charts").then(
-      (mod) => mod.DashboardCharts
+      (mod) => mod.DashboardCharts,
     ),
   {
     ssr: false,
     loading: DashboardChartsChunkLoading,
-  }
+  },
 );
 
 function formatTime(date: Date | string, timeZone?: string | null) {
@@ -72,6 +75,19 @@ function formatTime(date: Date | string, timeZone?: string | null) {
   }
 }
 
+function formatDueDate(dateInput: string) {
+  const [year, month, day] = dateInput.split("-").map(Number);
+  return new Date(Date.UTC(year!, month! - 1, day!)).toLocaleDateString(
+    "en-US",
+    {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    },
+  );
+}
+
 function addDateInputDays(dateInput: string, days: number): string {
   const [year, month, day] = dateInput.split("-").map(Number) as [
     number,
@@ -81,7 +97,7 @@ function addDateInputDays(dateInput: string, days: number): string {
   const date = new Date(Date.UTC(year, month - 1, day + days));
   return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(
     2,
-    "0"
+    "0",
   )}-${String(date.getUTCDate()).padStart(2, "0")}`;
 }
 
@@ -154,6 +170,7 @@ export default function DashboardPage() {
   const router = useRouter();
   const stats = trpc.dashboard.getStats.useQuery();
   const charts = trpc.dashboard.getCharts.useQuery();
+  const pendingFollowUps = trpc.encounters.listPendingFollowUps.useQuery();
   const taxConfig = trpc.billing.getTaxConfig.useQuery(undefined, {
     staleTime: 5 * 60 * 1000,
   });
@@ -191,7 +208,7 @@ export default function DashboardPage() {
     },
     {
       enabled: verifiedCalendarSettings !== null,
-    }
+    },
   );
   const upcomingError = calendarSettingsQuery.error ?? upcoming.error;
   const isUpcomingLoading =
@@ -226,7 +243,7 @@ export default function DashboardPage() {
       (a) =>
         a.status !== "checked_out" &&
         a.status !== "cancelled" &&
-        a.status !== "no_show"
+        a.status !== "no_show",
     )
     .slice(0, 5);
 
@@ -240,7 +257,7 @@ export default function DashboardPage() {
     !!chartData &&
     (chartData.speciesDistribution.length > 0 ||
       chartData.appointmentsByDay.some(
-        (d) => d.completed + d.scheduled + d.cancelled > 0
+        (d) => d.completed + d.scheduled + d.cancelled > 0,
       ) ||
       chartData.revenueByDay.some((d) => d.revenue > 0) ||
       chartData.productionByDoctor.some((d) => d.production > 0));
@@ -275,9 +292,7 @@ export default function DashboardPage() {
                     <Icon className="h-5 w-5" />
                   </div>
                   <div>
-                    <p className="text-sm text-muted-foreground">
-                      {kpi.label}
-                    </p>
+                    <p className="text-sm text-muted-foreground">{kpi.label}</p>
                     <p className="font-heading text-2xl font-bold">
                       {kpi.isCurrency ? fmtMoney(value) : String(value)}
                     </p>
@@ -291,6 +306,90 @@ export default function DashboardPage() {
           })}
         </div>
       ) : null}
+
+      <section
+        className="rounded-lg border border-border bg-card"
+        aria-labelledby="pending-follow-ups-heading"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-6 py-4">
+          <div>
+            <h2
+              id="pending-follow-ups-heading"
+              className="font-heading text-lg font-semibold"
+            >
+              Follow-up work queue
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Signed visit obligations that still need an owner.
+            </p>
+          </div>
+          {pendingFollowUps.data?.length ? (
+            <span className="rounded-full bg-amber-500/15 px-2.5 py-1 text-xs font-medium text-amber-700 dark:text-amber-300">
+              {pendingFollowUps.data.length} open
+            </span>
+          ) : null}
+        </div>
+        <div className="space-y-2 p-4">
+          {pendingFollowUps.error ? (
+            <div className="rounded-lg border border-destructive bg-destructive/10 p-4 text-sm text-destructive">
+              Follow-up obligations could not be loaded. Refresh before ending
+              the shift.
+            </div>
+          ) : pendingFollowUps.isLoading ? (
+            Array.from({ length: 2 }).map((_, index) => (
+              <AppointmentRowSkeleton key={index} />
+            ))
+          ) : pendingFollowUps.data?.length ? (
+            pendingFollowUps.data.map((followUp) => {
+              const dueDate = followUp.dueDate!;
+              const overdue = dueDate < todayStr;
+              return (
+                <div
+                  key={followUp.closeoutId}
+                  className="flex flex-col gap-3 rounded-md border border-border px-4 py-3 sm:flex-row sm:items-center"
+                >
+                  <div className="flex min-w-0 flex-1 items-start gap-3">
+                    <AlertTriangle
+                      className={cn(
+                        "mt-0.5 h-4 w-4 shrink-0",
+                        overdue ? "text-destructive" : "text-amber-600",
+                      )}
+                    />
+                    <div className="min-w-0">
+                      <p className="font-medium">
+                        {followUp.patientName} · due {formatDueDate(dueDate)}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        Owner: {followUp.clientFirstName}{" "}
+                        {followUp.clientLastName}
+                        {followUp.assigneeName
+                          ? ` · Assigned to ${followUp.assigneeName}`
+                          : ""}
+                      </p>
+                      {followUp.followUpNotes ? (
+                        <p className="mt-1 line-clamp-2 text-sm">
+                          {followUp.followUpNotes}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+                  <Link
+                    href={`/encounters/${followUp.appointmentId}#visit-closeout`}
+                    className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-primary hover:underline"
+                  >
+                    Resolve follow-up
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                </div>
+              );
+            })
+          ) : (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              No pending follow-up obligations.
+            </p>
+          )}
+        </div>
+      </section>
 
       {/* Recent Appointments */}
       <div className="rounded-lg border border-border bg-card">
@@ -356,7 +455,7 @@ export default function DashboardPage() {
                         ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
                         : appt.status === "in_exam"
                           ? "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400"
-                          : "bg-muted text-muted-foreground"
+                          : "bg-muted text-muted-foreground",
                   )}
                 >
                   {appt.status.replace("_", " ")}

--- a/apps/web/app/(dashboard)/records/page.tsx
+++ b/apps/web/app/(dashboard)/records/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import {
   Search,
@@ -480,9 +480,18 @@ function RecordsLoadingPanel({ label }: { label: string }) {
   );
 }
 
-export default function RecordsPage() {
+function RecordsPageContent() {
   const router = useRouter();
+  const utils = trpc.useUtils();
+  const searchParams = useSearchParams();
   const { data: session } = useSession();
+  const linkedPatientId = searchParams.get("patientId") ?? "";
+  const linkedAppointmentId = searchParams.get("appointmentId") ?? "";
+  const shouldOpenPrescription =
+    searchParams.get("tab") === "prescriptions" &&
+    searchParams.get("new") === "1";
+  const appliedVisitLink = useRef(false);
+  const prescriptionOperationId = useRef<string | null>(null);
   const userRole = session?.user?.role;
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedPatient, setSelectedPatient] = useState<{
@@ -517,6 +526,32 @@ export default function RecordsPage() {
   );
   const trimmedSearchQuery = searchQuery.trim();
   const canSearchPatients = isPatientSearchInputValid(searchQuery);
+
+  const linkedPatientQuery = trpc.patients.getById.useQuery(
+    { id: linkedPatientId || "00000000-0000-0000-0000-000000000000" },
+    { enabled: Boolean(linkedPatientId) }
+  );
+
+  useEffect(() => {
+    if (appliedVisitLink.current || !linkedPatientQuery.data) return;
+    const linkedPatient = linkedPatientQuery.data;
+    setSelectedPatient({
+      id: linkedPatient.id,
+      name: linkedPatient.name,
+      species: linkedPatient.species,
+      breed: linkedPatient.breed,
+      clientFirstName: linkedPatient.clientFirstName,
+      clientLastName: linkedPatient.clientLastName,
+    });
+    setSearchQuery(linkedPatient.name);
+    if (searchParams.get("tab") === "prescriptions") {
+      setActiveTab("prescriptions");
+    }
+    if (shouldOpenPrescription) {
+      setShowPrescriptionForm(true);
+    }
+    appliedVisitLink.current = true;
+  }, [linkedPatientQuery.data, searchParams, shouldOpenPrescription]);
 
   const {
     data: searchResults,
@@ -787,8 +822,14 @@ export default function RecordsPage() {
     onSuccess: () => {
       toast.success("Prescription created");
       refetchPrescriptions();
+      if (linkedAppointmentId) {
+        utils.encounters.getCloseout.invalidate({
+          appointmentId: linkedAppointmentId,
+        });
+      }
       setShowPrescriptionForm(false);
       setPrescriptionForm(initialPrescriptionForm(recordsTimeZone));
+      prescriptionOperationId.current = null;
     },
     onError: (err) => {
       toast.error(err.message);
@@ -1439,6 +1480,7 @@ export default function RecordsPage() {
                       variant={showPrescriptionForm ? "outline" : "default"}
                       onClick={() => {
                         if (showPrescriptionForm) {
+                          prescriptionOperationId.current = null;
                           setShowPrescriptionForm(false);
                           setPrescriptionForm((current) => ({
                             ...current,
@@ -1446,6 +1488,7 @@ export default function RecordsPage() {
                           }));
                           return;
                         }
+                        prescriptionOperationId.current = null;
                         setShowPrescriptionForm(true);
                         setPrescriptionForm(
                           initialPrescriptionForm(recordsTimeZone)
@@ -1478,8 +1521,14 @@ export default function RecordsPage() {
                       }
                       if (!canSubmitPrescription) return;
 
+                      prescriptionOperationId.current ??= crypto.randomUUID();
                       createPrescription.mutate({
                         patientId,
+                        operationId: prescriptionOperationId.current,
+                        appointmentId:
+                          linkedAppointmentId && linkedPatientId === patientId
+                            ? linkedAppointmentId
+                            : undefined,
                         medicationName:
                           prescriptionForm.medicationName.trim(),
                         productId: prescriptionForm.productId || undefined,
@@ -1746,6 +1795,7 @@ export default function RecordsPage() {
                         variant="ghost"
                         size="sm"
                         onClick={() => {
+                          prescriptionOperationId.current = null;
                           setShowPrescriptionForm(false);
                           setPrescriptionForm(
                             initialPrescriptionForm(recordsTimeZone)
@@ -2697,5 +2747,13 @@ export default function RecordsPage() {
         />
       )}
     </div>
+  );
+}
+
+export default function RecordsPage() {
+  return (
+    <Suspense fallback={<RecordsLoadingPanel label="Loading records..." />}>
+      <RecordsPageContent />
+    </Suspense>
   );
 }

--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState, useRef, useEffect, useId, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import {
@@ -67,6 +67,25 @@ const HOUR_HEIGHT = 60; // px per hour
 const TOTAL_HOURS = END_HOUR - START_HOUR;
 const CALENDAR_HEIGHT = TOTAL_HOURS * HOUR_HEIGHT;
 const DEFAULT_APPOINTMENT_COLOR = "#0d9488";
+const DIALOG_FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function focusElementAfterNavigation(elementId: string) {
+  const startedAt = performance.now();
+  function moveFocus() {
+    const target = document.getElementById(elementId);
+    if (target) {
+      if (!target.hasAttribute("tabindex"))
+        target.setAttribute("tabindex", "-1");
+      target.focus({ preventScroll: true });
+      return;
+    }
+    if (performance.now() - startedAt < 5_000) {
+      window.requestAnimationFrame(moveFocus);
+    }
+  }
+  window.requestAnimationFrame(moveFocus);
+}
 
 type AppointmentStatus =
   | "scheduled"
@@ -877,6 +896,9 @@ function AppointmentDetailPopover({
   isCancellingSeries: boolean;
 }) {
   const popoverRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  const restoreFocusRef = useRef(true);
+  const dialogTitleId = useId();
   const start = new Date(appointment.startTime);
   const end = new Date(appointment.endTime);
   const [showRescheduleForm, setShowRescheduleForm] = useState(false);
@@ -891,21 +913,75 @@ function AppointmentDetailPopover({
   );
 
   useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    const previouslyFocusedElement =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const focusFrame = window.requestAnimationFrame(() => {
+      popoverRef.current?.focus();
+    });
+
     function handleClickOutside(e: MouseEvent) {
       if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-        onClose();
+        onCloseRef.current();
       }
     }
-    function handleEscape(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+      if (e.key !== "Tab" || !popoverRef.current) return;
+
+      const focusableElements = Array.from(
+        popoverRef.current.querySelectorAll<HTMLElement>(
+          DIALOG_FOCUSABLE_SELECTOR,
+        ),
+      );
+      if (focusableElements.length === 0) {
+        e.preventDefault();
+        popoverRef.current.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0]!;
+      const lastElement = focusableElements[focusableElements.length - 1]!;
+      const activeElement = document.activeElement;
+      if (activeElement === popoverRef.current) {
+        e.preventDefault();
+        (e.shiftKey ? lastElement : firstElement).focus();
+      } else if (
+        e.shiftKey &&
+        (activeElement === firstElement ||
+          !popoverRef.current.contains(activeElement))
+      ) {
+        e.preventDefault();
+        lastElement.focus();
+      } else if (
+        !e.shiftKey &&
+        (activeElement === lastElement ||
+          !popoverRef.current.contains(activeElement))
+      ) {
+        e.preventDefault();
+        firstElement.focus();
+      }
     }
     document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleEscape);
+    document.addEventListener("keydown", handleKeyDown);
     return () => {
+      window.cancelAnimationFrame(focusFrame);
       document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscape);
+      document.removeEventListener("keydown", handleKeyDown);
+      if (restoreFocusRef.current && previouslyFocusedElement?.isConnected) {
+        previouslyFocusedElement.focus();
+      }
     };
-  }, [onClose]);
+  }, []);
 
   useEffect(() => {
     setShowRescheduleForm(false);
@@ -926,11 +1002,8 @@ function AppointmentDetailPopover({
     statusActions.push({ label: "Check In", status: "checked_in", variant: "default" });
     statusActions.push({ label: "No Show", status: "no_show", variant: "outline" });
     statusActions.push({ label: "Cancel", status: "cancelled", variant: "destructive" });
-  } else if (current === "checked_in" || current === "in_exam") {
-    statusActions.push({ label: "Check Out", status: "checked_out", variant: "default" });
-    if (current === "checked_in") {
-      statusActions.push({ label: "In Exam", status: "in_exam", variant: "outline" });
-    }
+  } else if (current === "checked_in") {
+    statusActions.push({ label: "In Exam", status: "in_exam", variant: "default" });
     statusActions.push({ label: "No Show", status: "no_show", variant: "outline" });
   } else if (current === "no_show" || current === "cancelled") {
     statusActions.push({ label: "Reopen", status: "scheduled", variant: "outline" });
@@ -960,6 +1033,10 @@ function AppointmentDetailPopover({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
       <div
         ref={popoverRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={dialogTitleId}
+        tabIndex={-1}
         className="w-full max-w-sm rounded-lg border border-border bg-card shadow-lg"
       >
         {/* Header */}
@@ -972,6 +1049,7 @@ function AppointmentDetailPopover({
           </div>
           <button
             type="button"
+            aria-label="Close appointment details"
             onClick={onClose}
             className="rounded-md p-1 hover:bg-muted transition-colors"
           >
@@ -982,7 +1060,7 @@ function AppointmentDetailPopover({
         {/* Body */}
         <div className="px-4 py-3 space-y-3">
           <div>
-            <h3 className="font-semibold text-base">
+            <h3 id={dialogTitleId} className="font-semibold text-base">
               {appointment.patientName || "Unknown Patient"}
             </h3>
             {appointment.patientSpecies && (
@@ -1112,14 +1190,35 @@ function AppointmentDetailPopover({
             (current === "scheduled" || current === "confirmed"))) && (
           <div className="flex flex-wrap gap-2 border-t border-border px-4 py-3">
             <Button size="sm" asChild>
-              <Link href={`/encounters/${appointment.id}`}>
+              <Link
+                href={
+                  current === "in_exam"
+                    ? `/encounters/${appointment.id}#visit-closeout`
+                    : `/encounters/${appointment.id}`
+                }
+                onNavigate={() => {
+                  restoreFocusRef.current = false;
+                  if (current === "in_exam") {
+                    focusElementAfterNavigation("visit-closeout");
+                  }
+                }}
+              >
                 <Stethoscope className="mr-1.5 h-3 w-3" />
-                Open visit
+                {current === "in_exam"
+                  ? "Review closeout"
+                  : "Open visit"}
               </Link>
             </Button>
             {appointment.patientId && (
               <Button size="sm" variant="outline" asChild>
-                <Link href={`/patients/${appointment.patientId}`}>View chart</Link>
+                <Link
+                  href={`/patients/${appointment.patientId}`}
+                  onNavigate={() => {
+                    restoreFocusRef.current = false;
+                  }}
+                >
+                  View chart
+                </Link>
               </Button>
             )}
             {canManageSchedule && canMoveAppointment && (

--- a/apps/web/app/(dashboard)/whiteboard/page.tsx
+++ b/apps/web/app/(dashboard)/whiteboard/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useId, useRef } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import {
   CalendarPlus,
   ClipboardList,
   Clock,
-  FileText,
   Loader2,
   MapPin,
   User,
@@ -45,6 +45,26 @@ type WhiteboardAppointment = {
   typeName: string | null;
   typeColor: string | null;
 };
+
+const DIALOG_FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function focusElementAfterNavigation(elementId: string) {
+  const startedAt = performance.now();
+  function moveFocus() {
+    const target = document.getElementById(elementId);
+    if (target) {
+      if (!target.hasAttribute("tabindex"))
+        target.setAttribute("tabindex", "-1");
+      target.focus({ preventScroll: true });
+      return;
+    }
+    if (performance.now() - startedAt < 5_000) {
+      window.requestAnimationFrame(moveFocus);
+    }
+  }
+  window.requestAnimationFrame(moveFocus);
+}
 
 // --- Constants ---
 
@@ -192,16 +212,6 @@ function formatAppointmentTime(date: Date, timeZone?: string | null): string {
   }
 }
 
-function formatVisitDate(date: Date, timeZone?: string | null): string {
-  try {
-    return date.toLocaleDateString("en-US", {
-      timeZone: timeZone ?? undefined,
-    });
-  } catch {
-    return date.toLocaleDateString("en-US");
-  }
-}
-
 // --- Components ---
 
 function LiveIndicator() {
@@ -303,8 +313,6 @@ function WhiteboardCard({
 function AppointmentDetailModal({
   appointment,
   timeZone,
-  practiceName,
-  practicePhone,
   onClose,
   onStatusChange,
   canUpdateStatus,
@@ -312,32 +320,87 @@ function AppointmentDetailModal({
 }: {
   appointment: WhiteboardAppointment;
   timeZone?: string | null;
-  practiceName: string;
-  practicePhone?: string | null;
   onClose: () => void;
   onStatusChange: (id: string, status: AppointmentStatus) => void;
   canUpdateStatus: boolean;
   isUpdating: boolean;
 }) {
   const modalRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  const restoreFocusRef = useRef(true);
+  const dialogTitleId = useId();
   const start = new Date(appointment.startTime);
 
   useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    const previouslyFocusedElement =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const focusFrame = window.requestAnimationFrame(() => {
+      modalRef.current?.focus();
+    });
+
     function handleClickOutside(e: MouseEvent) {
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-        onClose();
+        onCloseRef.current();
       }
     }
-    function handleEscape(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+      if (e.key !== "Tab" || !modalRef.current) return;
+
+      const focusableElements = Array.from(
+        modalRef.current.querySelectorAll<HTMLElement>(
+          DIALOG_FOCUSABLE_SELECTOR,
+        ),
+      );
+      if (focusableElements.length === 0) {
+        e.preventDefault();
+        modalRef.current.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0]!;
+      const lastElement = focusableElements[focusableElements.length - 1]!;
+      const activeElement = document.activeElement;
+      if (activeElement === modalRef.current) {
+        e.preventDefault();
+        (e.shiftKey ? lastElement : firstElement).focus();
+      } else if (
+        e.shiftKey &&
+        (activeElement === firstElement ||
+          !modalRef.current.contains(activeElement))
+      ) {
+        e.preventDefault();
+        lastElement.focus();
+      } else if (
+        !e.shiftKey &&
+        (activeElement === lastElement ||
+          !modalRef.current.contains(activeElement))
+      ) {
+        e.preventDefault();
+        firstElement.focus();
+      }
     }
     document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleEscape);
+    document.addEventListener("keydown", handleKeyDown);
     return () => {
+      window.cancelAnimationFrame(focusFrame);
       document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEscape);
+      document.removeEventListener("keydown", handleKeyDown);
+      if (restoreFocusRef.current && previouslyFocusedElement?.isConnected) {
+        previouslyFocusedElement.focus();
+      }
     };
-  }, [onClose]);
+  }, []);
 
   const clientName =
     [appointment.clientFirstName, appointment.clientLastName]
@@ -358,45 +421,17 @@ function AppointmentDetailModal({
     statusActions.push({ label: "Cancel", status: "cancelled", variant: "destructive" });
   } else if (current === "checked_in") {
     statusActions.push({ label: "Start Exam", status: "in_exam", variant: "default" });
-    statusActions.push({ label: "Check Out", status: "checked_out", variant: "outline" });
-  } else if (current === "in_exam") {
-    statusActions.push({ label: "Check Out", status: "checked_out", variant: "default" });
   }
   const visibleStatusActions = canUpdateStatus ? statusActions : [];
-
-  const handlePrintDischarge = async () => {
-    try {
-      const { generateDischargeInstructions } = await import("@/lib/pdf");
-      generateDischargeInstructions({
-        practiceName,
-        practicePhone: practicePhone ?? undefined,
-        patientName: appointment.patientName || "Unknown",
-        species: appointment.patientSpecies || "unknown",
-        clientName: clientName,
-        visitDate: formatVisitDate(new Date(appointment.startTime), timeZone),
-        doctorName: appointment.doctorName || undefined,
-        medications: [],
-        instructions: [
-          "Monitor your pet for any changes in behavior or appetite",
-          "Administer all prescribed medications as directed",
-          "Keep the follow-up appointment if one was scheduled",
-          "Ensure fresh water is available at all times",
-        ],
-        emergencyNotes:
-          "If your pet shows signs of difficulty breathing, excessive bleeding, seizures, collapse, or inability to urinate, seek emergency veterinary care immediately.",
-      }).save(
-        `discharge_${(appointment.patientName || "patient").replace(/\s+/g, "_")}.pdf`
-      );
-      toast.success("Discharge instructions downloaded");
-    } catch {
-      toast.error("Failed to generate discharge instructions");
-    }
-  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
       <div
         ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={dialogTitleId}
+        tabIndex={-1}
         className="w-full max-w-sm rounded-lg border border-border bg-card shadow-lg"
       >
         {/* Header */}
@@ -409,6 +444,7 @@ function AppointmentDetailModal({
           </div>
           <button
             type="button"
+            aria-label="Close appointment details"
             onClick={onClose}
             className="rounded-md p-1 hover:bg-muted transition-colors"
           >
@@ -423,7 +459,7 @@ function AppointmentDetailModal({
               {getSpeciesEmoji(appointment.patientSpecies)}
             </span>
             <div>
-              <h3 className="font-semibold text-base">
+              <h3 id={dialogTitleId} className="font-semibold text-base">
                 {appointment.patientName || "Unknown Patient"}
               </h3>
               {appointment.patientSpecies && (
@@ -478,8 +514,27 @@ function AppointmentDetailModal({
         </div>
 
         {/* Actions */}
-        {(visibleStatusActions.length > 0 || current === "checked_out") && (
+        {(visibleStatusActions.length > 0 || appointment.id) && (
           <div className="flex flex-wrap gap-2 border-t border-border px-4 py-3">
+            <Button size="sm" asChild>
+              <Link
+                href={
+                  current === "in_exam"
+                    ? `/encounters/${appointment.id}#visit-closeout`
+                    : `/encounters/${appointment.id}`
+                }
+                onNavigate={() => {
+                  restoreFocusRef.current = false;
+                  if (current === "in_exam") {
+                    focusElementAfterNavigation("visit-closeout");
+                  }
+                }}
+              >
+                 {current === "in_exam"
+                   ? "Review closeout"
+                   : "Open visit"}
+              </Link>
+            </Button>
             {visibleStatusActions.map((action) => (
               <Button
                 key={action.status}
@@ -494,16 +549,6 @@ function AppointmentDetailModal({
                 {action.label}
               </Button>
             ))}
-            {current === "checked_out" && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handlePrintDischarge}
-              >
-                <FileText className="mr-1.5 h-3 w-3" />
-                Print Discharge
-              </Button>
-            )}
           </div>
         )}
       </div>
@@ -731,8 +776,6 @@ export default function WhiteboardPage() {
           <AppointmentDetailModal
             appointment={selectedAppointmentFromList}
             timeZone={verifiedPracticeSettings.timezone}
-            practiceName={verifiedPracticeSettings.name}
-            practicePhone={verifiedPracticeSettings.phone}
             onClose={() => setSelectedAppointment(null)}
             onStatusChange={handleStatusChange}
             canUpdateStatus={canUpdateStatus}

--- a/apps/web/components/ui/textarea.tsx
+++ b/apps/web/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 aria-[invalid=true]:border-destructive aria-[invalid=true]:ring-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/apps/web/lib/__tests__/appointment-overlays-accessibility.test.ts
+++ b/apps/web/lib/__tests__/appointment-overlays-accessibility.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const scheduleSource = readFileSync(
+  "app/(dashboard)/schedule/page.tsx",
+  "utf8",
+);
+const whiteboardSource = readFileSync(
+  "app/(dashboard)/whiteboard/page.tsx",
+  "utf8",
+);
+
+const overlaySources = [
+  ["schedule", scheduleSource],
+  ["whiteboard", whiteboardSource],
+] as const;
+
+describe("appointment detail overlay accessibility", () => {
+  it.each(overlaySources)(
+    "%s exposes a named modal dialog with an accessible close control",
+    (_surface, source) => {
+      expect(source).toContain('role="dialog"');
+      expect(source).toContain('aria-modal="true"');
+      expect(source).toContain("aria-labelledby={dialogTitleId}");
+      expect(source).toContain("id={dialogTitleId}");
+      expect(source).toContain('aria-label="Close appointment details"');
+      expect(source).toContain("tabIndex={-1}");
+    },
+  );
+
+  it.each(overlaySources)(
+    "%s places, traps, and restores keyboard focus",
+    (_surface, source) => {
+      expect(source).toContain("DIALOG_FOCUSABLE_SELECTOR");
+      expect(source).toContain("previouslyFocusedElement");
+      expect(source).toContain("document.activeElement");
+      expect(source).toContain('e.key !== "Tab"');
+      expect(source).toContain("lastElement.focus()");
+      expect(source).toContain("firstElement.focus()");
+      expect(source).toContain("previouslyFocusedElement.focus()");
+      expect(source).toContain("onCloseRef.current()");
+    },
+  );
+
+  it.each(overlaySources)(
+    "%s sends in-exam users directly to the focused closeout region",
+    (_surface, source) => {
+      expect(source).toContain(
+        "`/encounters/${appointment.id}#visit-closeout`",
+      );
+      expect(source).toContain('focusElementAfterNavigation("visit-closeout")');
+      expect(source).toContain("target.focus({ preventScroll: true })");
+      expect(source).toContain("onNavigate={() => {");
+    },
+  );
+});

--- a/apps/web/lib/__tests__/billing-ui.test.ts
+++ b/apps/web/lib/__tests__/billing-ui.test.ts
@@ -197,6 +197,15 @@ describe("billing invoice payment actions", () => {
     expect(source).toContain("Take Card");
   });
 
+  it("keeps one operation ID across payment and adjustment retries", () => {
+    expect(source).toContain("paymentOperationId.current ??= crypto.randomUUID()");
+    expect(source).toContain("operationId: paymentOperationId.current");
+    expect(source).toContain(
+      "adjustmentOperationId.current ??= crypto.randomUUID()"
+    );
+    expect(source).toContain("operationId: adjustmentOperationId.current");
+  });
+
   it("disables card checkout when Stripe checkout is not configured", () => {
     expect(source).toContain("trpc.billing.cardPaymentStatus.useQuery");
     expect(source).toContain("const cardPaymentStatusMissing =");

--- a/apps/web/lib/__tests__/dashboard-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-ui.test.ts
@@ -7,7 +7,7 @@ describe("dashboard analytics UI", () => {
 
     expect(source).toContain("chartData.productionByDoctor.some");
     expect(source).toContain(
-      "productionByDoctor={chartData.productionByDoctor}"
+      "productionByDoctor={chartData.productionByDoctor}",
     );
   });
 
@@ -22,28 +22,32 @@ describe("dashboard analytics UI", () => {
     expect(source).toContain("const verifiedCalendarSettings =");
     expect(source).toContain("const verifiedUpcomingAppointments =");
     expect(source).toContain(
-      "upcomingError || isUpcomingLoading || isUpcomingMissing || !upcoming.data"
+      "upcomingError || isUpcomingLoading || isUpcomingMissing || !upcoming.data",
     );
     expect(source).toContain(
-      "const upcomingAppointments = (verifiedUpcomingAppointments ?? [])"
+      "const upcomingAppointments = (verifiedUpcomingAppointments ?? [])",
     );
     expect(source).toContain("const dashboardStats =");
-    expect(source).toContain("const statsError = stats.error ?? taxConfig.error");
-    expect(source).toContain("const chartsError = charts.error ?? taxConfig.error");
+    expect(source).toContain(
+      "const statsError = stats.error ?? taxConfig.error",
+    );
+    expect(source).toContain(
+      "const chartsError = charts.error ?? taxConfig.error",
+    );
     expect(source).toContain("statsError || statsDisplayMissing");
     expect(source).toContain("upcomingError || isUpcomingMissing");
     expect(source).toContain("chartsError || chartsDisplayMissing");
     expect(source.indexOf("statsError || statsDisplayMissing")).toBeLessThan(
       source.indexOf(
         "isStatsLoading",
-        source.indexOf("statsError || statsDisplayMissing")
-      )
+        source.indexOf("statsError || statsDisplayMissing"),
+      ),
     );
     expect(source.indexOf("upcomingError || isUpcomingMissing")).toBeLessThan(
-      source.indexOf("No visits booked yet")
+      source.indexOf("No visits booked yet"),
     );
     expect(source.indexOf("chartsError || chartsDisplayMissing")).toBeLessThan(
-      source.indexOf("Your charts show up once you start")
+      source.indexOf("Your charts show up once you start"),
     );
     expect(source).toContain("const value = dashboardStats[kpi.key] ?? 0");
     expect(source).not.toContain("charts.data?.appointmentsByDay ?? []");
@@ -53,13 +57,15 @@ describe("dashboard analytics UI", () => {
     expect(source).not.toContain("stats.data?.");
     expect(source).not.toContain("taxConfig.data?.");
     expect(source).not.toContain("calendarSettings?.timezone");
-    expect(source).not.toContain("const upcomingAppointments = (upcoming.data ?? [])");
+    expect(source).not.toContain(
+      "const upcomingAppointments = (upcoming.data ?? [])",
+    );
   });
 
   it("renders a month-to-date production by doctor chart", () => {
     const source = readFileSync(
       "components/dashboard/dashboard-charts.tsx",
-      "utf8"
+      "utf8",
     );
 
     expect(source).toContain("type ProductionByDoctorPoint");
@@ -67,7 +73,19 @@ describe("dashboard analytics UI", () => {
     expect(source).toContain('dataKey="doctorName"');
     expect(source).toContain('dataKey="production"');
     expect(source).toContain(
-      'formatter={(value: number) => [fmtMoney(value), "Production"]}'
+      'formatter={(value: number) => [fmtMoney(value), "Production"]}',
     );
+  });
+
+  it("surfaces signed follow-up obligations as an actionable work queue", () => {
+    const source = readFileSync("app/(dashboard)/page.tsx", "utf8");
+
+    expect(source).toContain("trpc.encounters.listPendingFollowUps.useQuery");
+    expect(source).toContain("Follow-up work queue");
+    expect(source).toContain("No pending follow-up obligations.");
+    expect(source).toContain(
+      "`/encounters/${followUp.appointmentId}#visit-closeout`",
+    );
+    expect(source).toContain("Resolve follow-up");
   });
 });

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -18,80 +18,80 @@ describe("committed Drizzle migrations", () => {
 
   it("includes a baseline migration registered in the Drizzle journal", () => {
     const journal = JSON.parse(
-      readRepoFile("packages/db/drizzle/meta/_journal.json")
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
     ) as { entries?: Array<{ tag?: string }> };
 
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0000_baseline"
+      "0000_baseline",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0001_wellness_enrollment_indexes"
+      "0001_wellness_enrollment_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0002_location_messaging_sender_index"
+      "0002_location_messaging_sender_index",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0003_product_inventory_indexes"
+      "0003_product_inventory_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0004_auth_expiry_indexes"
+      "0004_auth_expiry_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0005_rate_limit_bucket_reset_index"
+      "0005_rate_limit_bucket_reset_index",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0006_practice_billing_indexes"
+      "0006_practice_billing_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0007_patient_chart_indexes"
+      "0007_patient_chart_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0008_payment_invoice_index"
+      "0008_payment_invoice_index",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0009_scheduling_configuration_indexes"
+      "0009_scheduling_configuration_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0010_webhook_dispatch_index"
+      "0010_webhook_dispatch_index",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0011_catalog_lookup_indexes"
+      "0011_catalog_lookup_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0012_wellness_plan_list_index"
+      "0012_wellness_plan_list_index",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0013_api_key_practice_index"
+      "0013_api_key_practice_index",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0014_clinical_child_indexes"
+      "0014_clinical_child_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0015_waitlist_target_indexes"
+      "0015_waitlist_target_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0016_appointment_target_indexes"
+      "0016_appointment_target_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0017_location_guard_indexes"
+      "0017_location_guard_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0018_invoice_item_active_index"
+      "0018_invoice_item_active_index",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0019_invoice_list_index"
+      "0019_invoice_list_index",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0020_invoice_target_indexes"
+      "0020_invoice_target_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0021_communications_active_indexes"
+      "0021_communications_active_indexes",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0022_email_suppressions"
+      "0022_email_suppressions",
     );
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0025_practice_payment_accounts"
+      "0025_practice_payment_accounts",
     );
   });
 
@@ -136,18 +136,18 @@ describe("committed Drizzle migrations", () => {
 
   it("commits wellness enrollment indexes used by billing automation", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0001_wellness_enrollment_indexes.sql"
+      "packages/db/drizzle/0001_wellness_enrollment_indexes.sql",
     );
 
     expect(sql).toContain(
-      'CREATE INDEX "wellness_enrollments_billing_due_idx"'
+      'CREATE INDEX "wellness_enrollments_billing_due_idx"',
     );
     expect(sql).toContain('CREATE INDEX "wellness_enrollments_target_idx"');
   });
 
   it("commits the location messaging sender index used by SMS webhooks", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0002_location_messaging_sender_index.sql"
+      "packages/db/drizzle/0002_location_messaging_sender_index.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "location_messaging_sender_idx"');
@@ -157,219 +157,211 @@ describe("committed Drizzle migrations", () => {
 
   it("commits product indexes used by inventory list and alert workflows", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0003_product_inventory_indexes.sql"
+      "packages/db/drizzle/0003_product_inventory_indexes.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "products_practice_name_idx"');
     expect(sql).toContain(
-      'ON "products" USING btree ("practice_id","deleted_at","name")'
+      'ON "products" USING btree ("practice_id","deleted_at","name")',
     );
     expect(sql).toContain('CREATE INDEX "products_stock_alert_idx"');
     expect(sql).toContain(
-      'ON "products" USING btree ("practice_id","deleted_at","stock_quantity")'
+      'ON "products" USING btree ("practice_id","deleted_at","stock_quantity")',
     );
   });
 
   it("commits auth expiry indexes used by cleanup automation", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0004_auth_expiry_indexes.sql"
+      "packages/db/drizzle/0004_auth_expiry_indexes.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "sessions_expires_idx"');
     expect(sql).toContain('ON "sessions" USING btree ("expires")');
     expect(sql).toContain('CREATE INDEX "verification_tokens_expires_idx"');
-    expect(sql).toContain(
-      'ON "verification_tokens" USING btree ("expires")'
-    );
+    expect(sql).toContain('ON "verification_tokens" USING btree ("expires")');
     expect(sql).toContain('CREATE INDEX "auth_tokens_expires_idx"');
     expect(sql).toContain('ON "auth_tokens" USING btree ("expires_at")');
   });
 
   it("commits the rate-limit reset index used by cleanup automation", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0005_rate_limit_bucket_reset_index.sql"
+      "packages/db/drizzle/0005_rate_limit_bucket_reset_index.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "rate_limit_buckets_reset_at_idx"');
-    expect(sql).toContain(
-      'ON "rate_limit_buckets" USING btree ("reset_at")'
-    );
+    expect(sql).toContain('ON "rate_limit_buckets" USING btree ("reset_at")');
   });
 
   it("commits practice indexes used by hosted billing automation", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0006_practice_billing_indexes.sql"
+      "packages/db/drizzle/0006_practice_billing_indexes.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "practices_billing_trial_idx"');
     expect(sql).toContain(
-      'ON "practices" USING btree ("billing_status","trial_ends_at","deleted_at")'
+      'ON "practices" USING btree ("billing_status","trial_ends_at","deleted_at")',
     );
     expect(sql).toContain('CREATE INDEX "practices_stripe_customer_idx"');
     expect(sql).toContain(
-      'ON "practices" USING btree ("stripe_customer_id","deleted_at")'
+      'ON "practices" USING btree ("stripe_customer_id","deleted_at")',
     );
     expect(sql).toContain('CREATE INDEX "practices_stripe_subscription_idx"');
     expect(sql).toContain(
-      'ON "practices" USING btree ("stripe_subscription_id","deleted_at")'
+      'ON "practices" USING btree ("stripe_subscription_id","deleted_at")',
     );
   });
 
   it("commits patient chart indexes used by weight and allergy lookups", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0007_patient_chart_indexes.sql"
+      "packages/db/drizzle/0007_patient_chart_indexes.sql",
     );
 
-    expect(sql).toContain('CREATE INDEX "patient_weights_patient_recorded_idx"');
     expect(sql).toContain(
-      'ON "patient_weights" USING btree ("patient_id","deleted_at","recorded_at")'
+      'CREATE INDEX "patient_weights_patient_recorded_idx"',
+    );
+    expect(sql).toContain(
+      'ON "patient_weights" USING btree ("patient_id","deleted_at","recorded_at")',
     );
     expect(sql).toContain('CREATE INDEX "patient_allergies_patient_idx"');
     expect(sql).toContain(
-      'ON "patient_allergies" USING btree ("patient_id","deleted_at")'
+      'ON "patient_allergies" USING btree ("patient_id","deleted_at")',
     );
   });
 
   it("commits the payment invoice index used by billing history lookups", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0008_payment_invoice_index.sql"
+      "packages/db/drizzle/0008_payment_invoice_index.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "payments_invoice_idx"');
     expect(sql).toContain(
-      'ON "payments" USING btree ("invoice_id","deleted_at","received_at")'
+      'ON "payments" USING btree ("invoice_id","deleted_at","received_at")',
     );
   });
 
   it("commits Stripe Connect practice payment account storage", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0025_practice_payment_accounts.sql"
+      "packages/db/drizzle/0025_practice_payment_accounts.sql",
     );
 
     expect(sql).toContain('CREATE TABLE "practice_payment_accounts"');
     expect(sql).toContain('"stripe_account_id" varchar(128) NOT NULL');
     expect(sql).toContain(
-      'CREATE UNIQUE INDEX "practice_payment_accounts_practice_provider_uq"'
+      'CREATE UNIQUE INDEX "practice_payment_accounts_practice_provider_uq"',
     );
     expect(sql).toContain(
-      'CREATE INDEX "practice_payment_accounts_status_idx"'
+      'CREATE INDEX "practice_payment_accounts_status_idx"',
     );
   });
 
   it("commits scheduling indexes used by settings and booking lookups", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0009_scheduling_configuration_indexes.sql"
+      "packages/db/drizzle/0009_scheduling_configuration_indexes.sql",
     );
 
+    expect(sql).toContain('CREATE INDEX "appointment_types_practice_name_idx"');
     expect(sql).toContain(
-      'CREATE INDEX "appointment_types_practice_name_idx"'
-    );
-    expect(sql).toContain(
-      'ON "appointment_types" USING btree ("practice_id","deleted_at","name")'
+      'ON "appointment_types" USING btree ("practice_id","deleted_at","name")',
     );
     expect(sql).toContain('CREATE INDEX "rooms_practice_name_idx"');
     expect(sql).toContain(
-      'ON "rooms" USING btree ("practice_id","deleted_at","name")'
+      'ON "rooms" USING btree ("practice_id","deleted_at","name")',
     );
     expect(sql).toContain('CREATE INDEX "rooms_location_idx"');
     expect(sql).toContain(
-      'ON "rooms" USING btree ("practice_id","location_id","deleted_at")'
+      'ON "rooms" USING btree ("practice_id","location_id","deleted_at")',
     );
     expect(sql).toContain('CREATE INDEX "staff_schedules_location_idx"');
     expect(sql).toContain(
-      'ON "staff_schedules" USING btree ("practice_id","location_id","deleted_at")'
+      'ON "staff_schedules" USING btree ("practice_id","location_id","deleted_at")',
     );
     expect(sql).toContain('CREATE INDEX "staff_schedules_user_idx"');
     expect(sql).toContain(
-      'ON "staff_schedules" USING btree ("practice_id","user_id","deleted_at")'
+      'ON "staff_schedules" USING btree ("practice_id","user_id","deleted_at")',
     );
   });
 
   it("commits the webhook dispatch index used by integration delivery", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0010_webhook_dispatch_index.sql"
+      "packages/db/drizzle/0010_webhook_dispatch_index.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "webhooks_practice_active_idx"');
     expect(sql).toContain(
-      'ON "webhooks" USING btree ("practice_id","deleted_at","active")'
+      'ON "webhooks" USING btree ("practice_id","deleted_at","active")',
     );
   });
 
   it("commits catalog indexes used by service and supplier pickers", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0011_catalog_lookup_indexes.sql"
+      "packages/db/drizzle/0011_catalog_lookup_indexes.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "services_practice_name_idx"');
     expect(sql).toContain(
-      'ON "services" USING btree ("practice_id","deleted_at","name")'
+      'ON "services" USING btree ("practice_id","deleted_at","name")',
     );
     expect(sql).toContain('CREATE INDEX "suppliers_practice_name_idx"');
     expect(sql).toContain(
-      'ON "suppliers" USING btree ("practice_id","deleted_at","name")'
+      'ON "suppliers" USING btree ("practice_id","deleted_at","name")',
     );
   });
 
   it("commits the wellness plan index used by plan lists", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0012_wellness_plan_list_index.sql"
+      "packages/db/drizzle/0012_wellness_plan_list_index.sql",
     );
 
+    expect(sql).toContain('CREATE INDEX "wellness_plans_practice_created_idx"');
     expect(sql).toContain(
-      'CREATE INDEX "wellness_plans_practice_created_idx"'
-    );
-    expect(sql).toContain(
-      'ON "wellness_plans" USING btree ("practice_id","deleted_at","created_at")'
+      'ON "wellness_plans" USING btree ("practice_id","deleted_at","created_at")',
     );
   });
 
   it("commits the API key index used by admin key lists", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0013_api_key_practice_index.sql"
+      "packages/db/drizzle/0013_api_key_practice_index.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "api_keys_practice_created_idx"');
     expect(sql).toContain(
-      'ON "api_keys" USING btree ("practice_id","deleted_at","created_at")'
+      'ON "api_keys" USING btree ("practice_id","deleted_at","created_at")',
     );
   });
 
   it("commits clinical child indexes used by plan and export lookups", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0014_clinical_child_indexes.sql"
+      "packages/db/drizzle/0014_clinical_child_indexes.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "case_entries_case_idx"');
     expect(sql).toContain(
-      'ON "case_entries" USING btree ("case_id","deleted_at")'
+      'ON "case_entries" USING btree ("case_id","deleted_at")',
     );
+    expect(sql).toContain('CREATE INDEX "treatment_plan_items_plan_order_idx"');
     expect(sql).toContain(
-      'CREATE INDEX "treatment_plan_items_plan_order_idx"'
-    );
-    expect(sql).toContain(
-      'ON "treatment_plan_items" USING btree ("plan_id","deleted_at","sort_order")'
+      'ON "treatment_plan_items" USING btree ("plan_id","deleted_at","sort_order")',
     );
   });
 
   it("commits waitlist target indexes used by delete safety checks", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0015_waitlist_target_indexes.sql"
+      "packages/db/drizzle/0015_waitlist_target_indexes.sql",
     );
 
     expect(sql).toContain('CREATE INDEX "waitlist_client_status_idx"');
     expect(sql).toContain(
-      'ON "appointment_waitlist" USING btree ("practice_id","client_id","status","deleted_at")'
+      'ON "appointment_waitlist" USING btree ("practice_id","client_id","status","deleted_at")',
     );
     expect(sql).toContain('CREATE INDEX "waitlist_patient_status_idx"');
     expect(sql).toContain(
-      'ON "appointment_waitlist" USING btree ("practice_id","patient_id","status","deleted_at")'
+      'ON "appointment_waitlist" USING btree ("practice_id","patient_id","status","deleted_at")',
     );
   });
 
   it("commits appointment target indexes used by active appointment guards", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0016_appointment_target_indexes.sql"
+      "packages/db/drizzle/0016_appointment_target_indexes.sql",
     );
 
     for (const [indexName, targetColumn] of [
@@ -381,71 +373,69 @@ describe("committed Drizzle migrations", () => {
     ]) {
       expect(sql).toContain(`CREATE INDEX "${indexName}"`);
       expect(sql).toContain(
-        `ON "appointments" USING btree ("practice_id","${targetColumn}","status","deleted_at")`
+        `ON "appointments" USING btree ("practice_id","${targetColumn}","status","deleted_at")`,
       );
     }
   });
 
   it("commits tenant-scoped location guard indexes for staff and products", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0017_location_guard_indexes.sql"
+      "packages/db/drizzle/0017_location_guard_indexes.sql",
     );
 
     expect(sql).toContain('DROP INDEX "users_location_idx"');
     expect(sql).toContain('DROP INDEX "products_location_idx"');
     expect(sql).toContain('CREATE INDEX "users_location_idx"');
     expect(sql).toContain(
-      'ON "users" USING btree ("practice_id","location_id","deleted_at")'
+      'ON "users" USING btree ("practice_id","location_id","deleted_at")',
     );
     expect(sql).toContain('CREATE INDEX "products_location_idx"');
     expect(sql).toContain(
-      'ON "products" USING btree ("practice_id","location_id","deleted_at")'
+      'ON "products" USING btree ("practice_id","location_id","deleted_at")',
     );
   });
 
   it("commits the active invoice-item index used by billing lookups", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0018_invoice_item_active_index.sql"
+      "packages/db/drizzle/0018_invoice_item_active_index.sql",
     );
 
     expect(sql).toContain('DROP INDEX "invoice_items_item_idx"');
     expect(sql).toContain('CREATE INDEX "invoice_items_item_idx"');
     expect(sql).toContain(
-      'ON "invoice_items" USING btree ("item_type","deleted_at","item_id")'
+      'ON "invoice_items" USING btree ("item_type","deleted_at","item_id")',
     );
   });
 
   it("commits the invoice list index used by newest-first billing pages", () => {
-    const sql = readRepoFile(
-      "packages/db/drizzle/0019_invoice_list_index.sql"
-    );
+    const sql = readRepoFile("packages/db/drizzle/0019_invoice_list_index.sql");
 
     expect(sql).toContain('DROP INDEX "invoices_practice_idx"');
     expect(sql).toContain('CREATE INDEX "invoices_practice_idx"');
     expect(sql).toContain(
-      'ON "invoices" USING btree ("practice_id","deleted_at","created_at")'
+      'ON "invoices" USING btree ("practice_id","deleted_at","created_at")',
     );
   });
 
   it("commits invoice target indexes used by client and patient workflows", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0020_invoice_target_indexes.sql"
+      "packages/db/drizzle/0020_invoice_target_indexes.sql",
     );
 
     expect(sql).toContain('DROP INDEX "invoices_client_idx"');
     expect(sql).toContain('CREATE INDEX "invoices_client_idx"');
     expect(sql).toContain(
-      'ON "invoices" USING btree ("practice_id","client_id","deleted_at","created_at")'
+      'ON "invoices" USING btree ("practice_id","client_id","deleted_at","created_at")',
     );
     expect(sql).toContain('CREATE INDEX "invoices_patient_idx"');
     expect(sql).toContain(
-      'ON "invoices" USING btree ("practice_id","patient_id","client_id","deleted_at")'
+      'ON "invoices" USING btree ("practice_id","patient_id","client_id","deleted_at")',
     );
   });
 
   it("commits active communications indexes used by shared inbox workflows", () => {
     const sql = readRepoFile(
-      "packages/db/drizzle/0021_communications_active_indexes.sql"
+      "packages/db/drizzle/0021_communications_active_indexes.sql",
     );
 
     for (const indexName of [
@@ -460,71 +450,132 @@ describe("committed Drizzle migrations", () => {
     }
 
     expect(sql).toContain(
-      'ON "communications" USING btree ("practice_id","deleted_at","created_at")'
+      'ON "communications" USING btree ("practice_id","deleted_at","created_at")',
     );
     expect(sql).toContain(
-      'ON "communications" USING btree ("practice_id","client_id","deleted_at","created_at")'
+      'ON "communications" USING btree ("practice_id","client_id","deleted_at","created_at")',
     );
     expect(sql).toContain(
-      'ON "communications" USING btree ("practice_id","direction","status","deleted_at")'
+      'ON "communications" USING btree ("practice_id","direction","status","deleted_at")',
     );
     expect(sql).toContain(
-      'ON "communications" USING btree ("practice_id","assigned_to","deleted_at")'
+      'ON "communications" USING btree ("practice_id","assigned_to","deleted_at")',
     );
     expect(sql).toContain(
-      'ON "communications" USING btree ("practice_id","provider_message_id","channel","direction")'
+      'ON "communications" USING btree ("practice_id","provider_message_id","channel","direction")',
     );
   });
 
   it("commits email suppressions used by Resend bounce and complaint webhooks", () => {
-    const sql = readRepoFile(
-      "packages/db/drizzle/0022_email_suppressions.sql"
-    );
+    const sql = readRepoFile("packages/db/drizzle/0022_email_suppressions.sql");
 
-    expect(sql).toContain(
-      'CREATE TYPE "public"."email_suppression_reason"'
-    );
+    expect(sql).toContain('CREATE TYPE "public"."email_suppression_reason"');
     expect(sql).toContain('CREATE TABLE "email_suppressions"');
     expect(sql).toContain(
-      'CREATE UNIQUE INDEX "email_suppressions_practice_email_uq"'
+      'CREATE UNIQUE INDEX "email_suppressions_practice_email_uq"',
     );
     expect(sql).toContain(
-      'ON "email_suppressions" USING btree ("practice_id","email")'
+      'ON "email_suppressions" USING btree ("practice_id","email")',
     );
+    expect(sql).toContain('CREATE INDEX "email_suppressions_practice_idx"');
     expect(sql).toContain(
-      'CREATE INDEX "email_suppressions_practice_idx"'
-    );
-    expect(sql).toContain(
-      'ON "email_suppressions" USING btree ("practice_id","deleted_at")'
+      'ON "email_suppressions" USING btree ("practice_id","deleted_at")',
     );
   });
 
   it("commits the tenant-scoped exact-file migration run ledger", () => {
     const journal = JSON.parse(
-      readRepoFile("packages/db/drizzle/meta/_journal.json")
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
     ) as { entries?: Array<{ tag?: string }> };
     expect(journal.entries?.map((entry) => entry.tag)).toContain(
-      "0041_aromatic_rhino"
+      "0041_aromatic_rhino",
     );
 
-    const sql = readRepoFile(
-      "packages/db/drizzle/0041_aromatic_rhino.sql"
-    );
+    const sql = readRepoFile("packages/db/drizzle/0041_aromatic_rhino.sql");
     expect(sql).toContain('CREATE TABLE "migration_runs"');
     expect(sql).toContain(
-      'CREATE TYPE "public"."migration_run_mode" AS ENUM(\'clients\', \'patients\', \'vaccinations\', \'soap_notes\')'
+      "CREATE TYPE \"public\".\"migration_run_mode\" AS ENUM('clients', 'patients', 'vaccinations', 'soap_notes')",
     );
     expect(sql).toContain("'previewed', 'superseded', 'committing'");
     expect(sql).toContain('CONSTRAINT "migration_runs_file_hash_check"');
     expect(sql).toContain('CONSTRAINT "migration_runs_counts_check"');
     expect(sql).toContain(
-      'CREATE UNIQUE INDEX "migration_runs_active_preview_uq"'
+      'CREATE UNIQUE INDEX "migration_runs_active_preview_uq"',
     );
     expect(sql).toContain(
-      'WHERE "migration_runs"."status" = \'previewed\' and "migration_runs"."deleted_at" is null'
+      'WHERE "migration_runs"."status" = \'previewed\' and "migration_runs"."deleted_at" is null',
     );
 
     const rls = readRepoFile("packages/db/rls/enable-rls.sql");
     expect(rls).toContain("'migration_runs'");
+  });
+
+  it("fails clearly before enforcing one active invoice per visit", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries?: Array<{ tag?: string }> };
+    expect(journal.entries?.map((entry) => entry.tag)).toContain(
+      "0042_tough_mattie_franklin",
+    );
+
+    const sql = readRepoFile(
+      "packages/db/drizzle/0042_tough_mattie_franklin.sql",
+    );
+    expect(sql).toContain('CREATE TABLE "visit_closeouts"');
+    expect(sql).toContain('"medication_snapshot" jsonb');
+    expect(sql).toContain('"follow_up_scheduled_at" timestamp with time zone');
+    expect(sql).toContain('GROUP BY "practice_id", "appointment_id"');
+    expect(sql).toContain("HAVING count(*) > 1");
+    expect(sql).toContain(
+      "duplicate active visit invoices require audited reconciliation",
+    );
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX "invoices_active_appointment_uq"',
+    );
+  });
+
+  it("adds retry-safe billing operations and accountable follow-up work", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries?: Array<{ tag?: string }> };
+    expect(journal.entries?.map((entry) => entry.tag)).toContain(
+      "0043_normal_bloodstrike",
+    );
+
+    const sql = readRepoFile("packages/db/drizzle/0043_normal_bloodstrike.sql");
+    expect(sql).toContain('"prescriptions" ADD COLUMN "operation_id" uuid');
+    expect(sql).toContain(
+      '"invoice_adjustments" ADD COLUMN "operation_key" varchar(160)',
+    );
+    expect(sql).toContain(
+      'CONSTRAINT "invoice_items_source_prescription_id_prescriptions_id_fk"',
+    );
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX "invoice_items_source_prescription_invoice_uq"',
+    );
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX "prescriptions_practice_operation_uq"',
+    );
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX "invoice_adjustments_operation_key_uq"',
+    );
+    expect(sql).toContain("invoice_adjustments_operation_result_check");
+    expect(sql).toContain(
+      'ALTER TYPE "public"."visit_follow_up_disposition" RENAME TO "visit_follow_up_disposition_old"',
+    );
+    expect(sql).toContain(
+      'CREATE TYPE "public"."visit_follow_up_disposition" AS ENUM(\'none\', \'needed\', \'scheduled\')',
+    );
+    expect(sql).toContain(
+      'ALTER TABLE "visit_closeouts" ALTER COLUMN "follow_up_disposition" TYPE',
+    );
+    expect(sql).not.toContain("ADD VALUE 'needed'");
+    expect(sql).toContain(
+      '"visit_closeouts" ADD COLUMN "follow_up_due_date" date',
+    );
+    expect(sql).toContain(
+      '"visit_closeouts" ADD COLUMN "amendment_draft" jsonb',
+    );
+    expect(sql).toContain("visit_closeouts_follow_up_resolution_check");
   });
 });

--- a/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
+++ b/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
@@ -3,21 +3,24 @@ import { describe, expect, it } from "vitest";
 
 const workspaceSource = readFileSync(
   "app/(dashboard)/encounters/[appointmentId]/page.tsx",
-  "utf8"
+  "utf8",
 );
 const scheduleSource = readFileSync(
   "app/(dashboard)/schedule/page.tsx",
-  "utf8"
+  "utf8",
 );
 const soapSource = readFileSync(
   "app/(dashboard)/records/new-soap/[patientId]/page.tsx",
-  "utf8"
+  "utf8",
 );
 
 describe("clinic encounter workspace", () => {
   it("opens from an appointment and keeps visit and patient context together", () => {
     expect(scheduleSource).toContain("Open visit");
-    expect(scheduleSource).toContain("href={`/encounters/${appointment.id}`}");
+    expect(scheduleSource).toContain(
+      "`/encounters/${appointment.id}#visit-closeout`",
+    );
+    expect(scheduleSource).toContain("`/encounters/${appointment.id}`");
     expect(workspaceSource).toContain("trpc.appointments.getById.useQuery");
     expect(workspaceSource).toContain("trpc.patients.getById.useQuery");
     expect(workspaceSource).toContain("Clinical work");
@@ -28,20 +31,20 @@ describe("clinic encounter workspace", () => {
   it("links SOAP documentation to the appointment and returns to the visit", () => {
     expect(workspaceSource).toContain("?appointmentId=${appointmentId}");
     expect(soapSource).toContain(
-      'const appointmentId = searchParams.get("appointmentId") ?? undefined'
+      'const appointmentId = searchParams.get("appointmentId") ?? undefined',
     );
     expect(soapSource).toContain("appointmentId,");
     expect(soapSource).toContain(
-      "`/encounters/${encodeURIComponent(appointmentId)}`"
+      "`/encounters/${encodeURIComponent(appointmentId)}`",
     );
     expect(soapSource).toContain(
-      "This note will be linked to the current appointment."
+      "This note will be linked to the current appointment.",
     );
   });
 
   it("creates appointment-linked service and product charges with role guards", () => {
     expect(workspaceSource).toContain(
-      'role === "admin" || role === "front_desk"'
+      'role === "admin" || role === "front_desk"',
     );
     expect(workspaceSource).toContain('itemType: "service" as const');
     expect(workspaceSource).toContain('itemType: "product" as const');
@@ -54,13 +57,13 @@ describe("clinic encounter workspace", () => {
 
   it("edits an existing unpaid draft without creating a duplicate invoice", () => {
     expect(workspaceSource).toContain(
-      "trpc.billing.updateInvoiceItems.useMutation"
+      "trpc.billing.updateInvoiceItems.useMutation",
     );
     expect(workspaceSource).toContain("Loading existing visit charges...");
     expect(workspaceSource).toContain("Only unpaid");
     expect(workspaceSource).toContain("Update visit invoice");
     expect(workspaceSource).toContain(
-      "Product stock is restored and re-deducted atomically"
+      "Visit-prescription stock was already dispensed and is not moved twice.",
     );
     expect(workspaceSource).toContain("isBillingInvoiceLineTotalValid");
   });
@@ -69,16 +72,57 @@ describe("clinic encounter workspace", () => {
     expect(workspaceSource).toContain("invoiceStateReady");
     expect(workspaceSource).toContain("Confirming visit invoice state...");
     expect(workspaceSource).toContain(
-      "Charge capture is locked because invoice state could not be"
+      "Charge capture is locked because invoice state could not be",
     );
     expect(workspaceSource).toContain(
-      "Unable to load invoice state. Do not create duplicate charges"
+      "Unable to load invoice state. Do not create duplicate charges",
     );
     expect(workspaceSource).toContain("No active invoice for this visit");
     expect(workspaceSource).toContain("!invoice.isEstimate");
     expect(workspaceSource).toContain("Charge catalog is empty");
     expect(workspaceSource).toContain(
-      "Charge capture is locked because tax and currency settings could"
+      "Charge capture is locked because tax and currency settings could",
     );
+  });
+
+  it("requires the durable two-stage closeout instead of a direct checkout", () => {
+    expect(workspaceSource).toContain("trpc.encounters.getCloseout.useQuery");
+    expect(workspaceSource).toContain(
+      "trpc.encounters.finalizeClinical.useMutation",
+    );
+    expect(workspaceSource).toContain(
+      "trpc.encounters.completeVisit.useMutation",
+    );
+    expect(workspaceSource).toContain("Finalize clinical handoff");
+    expect(workspaceSource).toContain("Billing and owner handoff");
+    expect(workspaceSource).toContain("Download discharge");
+    expect(workspaceSource).not.toContain(
+      'return { label: "Check out", status: "checked_out" }',
+    );
+  });
+
+  it("makes clinical finalization explanatory and prevents late validation", () => {
+    expect(workspaceSource).toContain("finalizationIssues");
+    expect(workspaceSource).toContain("Before finalizing");
+    expect(workspaceSource).toContain("Documented exception");
+    expect(workspaceSource).toContain("linkedMedicationCount");
+    expect(workspaceSource).toContain("disabled={!canFinalizeNow}");
+  });
+
+  it("keeps the signed owner handoff reviewable and mobile billing reachable", () => {
+    expect(workspaceSource).toContain("Diagnosis or visit summary");
+    expect(workspaceSource).toContain("Warning signs and when to call");
+    expect(workspaceSource).toContain("Prior finalized versions");
+    expect(workspaceSource).toContain("downloadHistoricalDischarge");
+    expect(workspaceSource).toContain('id="charge-capture"');
+    expect(workspaceSource).toContain('href="#charge-capture"');
+    expect(workspaceSource).toContain("tabIndex={-1}");
+  });
+
+  it("links prescriptions to the visit and preserves their inventory ownership", () => {
+    expect(workspaceSource).toContain("tab=prescriptions&new=1");
+    expect(workspaceSource).toContain("sourcePrescriptionId");
+    expect(workspaceSource).toContain("inventory already dispensed");
+    expect(workspaceSource).toContain("expectedUpdatedAt");
   });
 });

--- a/apps/web/lib/__tests__/heavy-client-imports.test.ts
+++ b/apps/web/lib/__tests__/heavy-client-imports.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, it } from "vitest";
 const PDF_ACTION_PAGES = [
   "app/(dashboard)/billing/page.tsx",
   "app/(dashboard)/patients/[id]/page.tsx",
+  "app/(dashboard)/encounters/[appointmentId]/page.tsx",
   "app/(dashboard)/records/page.tsx",
   "app/(dashboard)/reports/page.tsx",
-  "app/(dashboard)/whiteboard/page.tsx",
   "app/portal/[token]/pets/[petId]/page.tsx",
 ];
 

--- a/apps/web/lib/__tests__/schema-indexes.test.ts
+++ b/apps/web/lib/__tests__/schema-indexes.test.ts
@@ -13,6 +13,7 @@ import {
   controlledSubstanceLog,
   emailSuppressions,
   invoices,
+  invoiceAdjustments,
   invoiceItems,
   labResults,
   locationMessaging,
@@ -264,7 +265,20 @@ describe("hot table indexes", () => {
     [
       "invoice_items",
       invoiceItems,
-      ["invoice_items_invoice_idx", "invoice_items_item_idx"],
+      [
+        "invoice_items_invoice_idx",
+        "invoice_items_item_idx",
+        "invoice_items_source_prescription_idx",
+        "invoice_items_source_prescription_invoice_uq",
+      ],
+    ],
+    [
+      "invoice_adjustments",
+      invoiceAdjustments,
+      [
+        "invoice_adjustments_invoice_idx",
+        "invoice_adjustments_operation_key_uq",
+      ],
     ],
     [
       "payments",
@@ -278,6 +292,8 @@ describe("hot table indexes", () => {
         "prescriptions_patient_status_idx",
         "prescriptions_practice_status_idx",
         "prescriptions_product_idx",
+        "prescriptions_appointment_idx",
+        "prescriptions_practice_operation_uq",
       ],
     ],
     [

--- a/apps/web/lib/__tests__/whiteboard-ui.test.ts
+++ b/apps/web/lib/__tests__/whiteboard-ui.test.ts
@@ -5,8 +5,11 @@ describe("whiteboard appointment workflow UI", () => {
   it("does not offer status transitions that the appointment lifecycle rejects", () => {
     const source = readFileSync("app/(dashboard)/whiteboard/page.tsx", "utf8");
 
-    expect(source).toContain('current === "checked_out"');
-    expect(source).toContain("Print Discharge");
+    expect(source).toContain("Review closeout");
+    expect(source).toContain("`/encounters/${appointment.id}#visit-closeout`");
+    expect(source).toContain("`/encounters/${appointment.id}`");
+    expect(source).not.toContain('label: "Check Out"');
+    expect(source).not.toContain("generateDischargeInstructions");
     expect(source).not.toContain("Back to Exam");
     expect(source).not.toContain(
       'statusActions.push({ label: "Back to Exam", status: "in_exam"'
@@ -30,16 +33,14 @@ describe("whiteboard appointment workflow UI", () => {
       "const visibleStatusActions = canUpdateStatus ? statusActions : []"
     );
     expect(source).toContain("visibleStatusActions.map");
-    expect(source).toContain("current === \"checked_out\"");
   });
 
-  it("renders whiteboard times and discharge dates in the practice timezone", () => {
+  it("renders whiteboard times in the practice timezone", () => {
     const source = readFileSync("app/(dashboard)/whiteboard/page.tsx", "utf8");
 
     expect(source).toContain("function formatCurrentTime(date: Date, timeZone?: string | null)");
     expect(source).toContain("function formatCurrentDate(date: Date, timeZone?: string | null)");
     expect(source).toContain("function formatAppointmentTime(date: Date, timeZone?: string | null)");
-    expect(source).toContain("function formatVisitDate(date: Date, timeZone?: string | null)");
     expect(source).toContain("trpc.whiteboard.settings.useQuery");
     expect(source).toContain("const settingsQuery = trpc.whiteboard.settings.useQuery()");
     expect(source).toContain("const practiceSettings = settingsQuery.data");
@@ -71,14 +72,9 @@ describe("whiteboard appointment workflow UI", () => {
     expect(source).toContain("formatCurrentDate(currentTime, verifiedPracticeSettings.timezone)");
     expect(source).toContain("appointment={selectedAppointmentFromList}");
     expect(source).toContain("timeZone={verifiedPracticeSettings.timezone}");
-    expect(source).toContain("practiceName={verifiedPracticeSettings.name}");
-    expect(source).toContain("practicePhone={verifiedPracticeSettings.phone}");
     expect(source).toContain("pageReady &&");
     expect(source).toContain("selectedAppointmentStillActive &&");
     expect(source).toContain("formatAppointmentTime(start, timeZone)");
-    expect(source).toContain("formatVisitDate(new Date(appointment.startTime), timeZone)");
-    expect(source).toContain("practiceName,");
-    expect(source).toContain("practicePhone: practicePhone ?? undefined");
     expect(source).not.toContain("settingsQuery.data?.timezone");
     expect(source).not.toContain("settingsQuery.data?.name");
     expect(source).not.toContain("settingsQuery.data?.phone");

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -46,6 +46,7 @@ import {
   users,
   vaccinationRecords,
   vitalSigns,
+  visitCloseouts,
   webhooks,
   wellnessEnrollments,
   wellnessPlans,
@@ -133,6 +134,7 @@ export const PRACTICE_EXPORT_SECTIONS = [
   "treatmentPlans",
   "treatmentPlanItems",
   "prescriptions",
+  "visitCloseouts",
   "files",
   "controlledSubstanceLog",
   "communications",
@@ -142,6 +144,7 @@ export type PracticeExportSection = (typeof PRACTICE_EXPORT_SECTIONS)[number];
 
 const PRACTICE_EXPORT_OPTIONAL_RESTORE_SECTIONS = [
   "emailSuppressions",
+  "visitCloseouts",
 ] as const satisfies readonly PracticeExportSection[];
 
 export type PracticeExport = {
@@ -254,6 +257,7 @@ const RESTORE_REFERENCE_RULES: RestoreReferenceRule[] = [
   optionalRef("invoices", "patientId", "patients"),
   optionalRef("invoices", "appointmentId", "appointments"),
   requiredRef("invoiceItems", "invoiceId", "invoices"),
+  optionalRef("invoiceItems", "sourcePrescriptionId", "prescriptions"),
   requiredRef("payments", "invoiceId", "invoices"),
   optionalRef("payments", "receivedBy", "users"),
   requiredRef("invoiceAdjustments", "invoiceId", "invoices"),
@@ -293,8 +297,14 @@ const RESTORE_REFERENCE_RULES: RestoreReferenceRule[] = [
   optionalRef("treatmentPlans", "createdBy", "users"),
   requiredRef("treatmentPlanItems", "planId", "treatmentPlans"),
   requiredRef("prescriptions", "patientId", "patients"),
+  optionalRef("prescriptions", "appointmentId", "appointments"),
   optionalRef("prescriptions", "productId", "products"),
   requiredRef("prescriptions", "prescribedBy", "users"),
+  requiredRef("visitCloseouts", "appointmentId", "appointments"),
+  optionalRef("visitCloseouts", "followUpAppointmentId", "appointments"),
+  optionalRef("visitCloseouts", "clinicalFinalizedBy", "users"),
+  optionalRef("visitCloseouts", "invoiceId", "invoices"),
+  optionalRef("visitCloseouts", "completedBy", "users"),
   requiredRef("files", "uploadedBy", "users"),
   optionalRef("controlledSubstanceLog", "patientId", "patients"),
   requiredRef("controlledSubstanceLog", "performedBy", "users"),
@@ -555,6 +565,7 @@ export async function exportPracticeData(
     caseRows,
     treatmentPlanRows,
     prescriptionRows,
+    visitCloseoutRows,
     fileRows,
     controlledSubstanceRows,
     communicationRows,
@@ -595,6 +606,7 @@ export async function exportPracticeData(
     activeRows(db, cases, practiceId),
     activeRows(db, treatmentPlans, practiceId),
     activeRows(db, prescriptions, practiceId),
+    activeRows(db, visitCloseouts, practiceId),
     activeRows(db, files, practiceId),
     activeRows(db, controlledSubstanceLog, practiceId),
     activeRows(db, communications, practiceId),
@@ -735,6 +747,7 @@ export async function exportPracticeData(
     treatmentPlans: treatmentPlanRows,
     treatmentPlanItems: treatmentPlanItemRows,
     prescriptions: prescriptionRows,
+    visitCloseouts: visitCloseoutRows,
     files: fileRows,
     controlledSubstanceLog: controlledSubstanceRows,
     communications: communicationRows,
@@ -820,6 +833,7 @@ async function restorePracticeDataRows(
   await restorePracticeRows("treatmentPlans", treatmentPlans);
   await restoreChildRows("treatmentPlanItems", treatmentPlanItems);
   await restorePracticeRows("prescriptions", prescriptions);
+  await restorePracticeRows("visitCloseouts", visitCloseouts);
   await restorePracticeRows("files", files);
   await restorePracticeRows("controlledSubstanceLog", controlledSubstanceLog);
   await restorePracticeRows("communications", communications);

--- a/apps/web/lib/encounters/closeout-policy.ts
+++ b/apps/web/lib/encounters/closeout-policy.ts
@@ -1,0 +1,13 @@
+export const CLOSEOUT_DIAGNOSIS_MAX_LENGTH = 5_000;
+export const CLOSEOUT_INSTRUCTIONS_MAX_LENGTH = 10_000;
+export const CLOSEOUT_WARNING_SIGNS_MAX_LENGTH = 5_000;
+export const CLOSEOUT_REASON_MAX_LENGTH = 1_000;
+export const CLOSEOUT_FOLLOW_UP_NOTES_MAX_LENGTH = 5_000;
+
+export const CLOSEOUT_BYPASS_MESSAGE =
+  "Review and complete the visit closeout before checking out this appointment.";
+
+export function trimmedOrNull(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}

--- a/apps/web/lib/scheduling/appointment-status.ts
+++ b/apps/web/lib/scheduling/appointment-status.ts
@@ -16,8 +16,8 @@ const allowedAppointmentStatusTransitions: Record<
 > = {
   scheduled: ["confirmed", "checked_in", "no_show", "cancelled"],
   confirmed: ["scheduled", "checked_in", "no_show", "cancelled"],
-  checked_in: ["in_exam", "checked_out", "no_show", "cancelled"],
-  in_exam: ["checked_out", "no_show", "cancelled"],
+  checked_in: ["in_exam", "no_show", "cancelled"],
+  in_exam: ["checked_out", "cancelled"],
   checked_out: [],
   no_show: ["scheduled"],
   cancelled: ["scheduled"],

--- a/apps/web/server/__tests__/appointments-safety.test.ts
+++ b/apps/web/server/__tests__/appointments-safety.test.ts
@@ -63,6 +63,7 @@ function createDb(opts?: {
     const afterWhere = {
       limit: vi.fn(async () => result),
       orderBy: vi.fn(async () => result),
+      for: vi.fn(async () => result),
       then: (
         resolve: (value: unknown[]) => unknown,
         reject?: (error: unknown) => unknown
@@ -451,6 +452,45 @@ describe("appointments target safety", () => {
       })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects direct checkout so closeout gates cannot be bypassed", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [[{ id: APPOINTMENT_ID, status: "in_exam" }]],
+    });
+
+    await expect(
+      callerWithDb(db).updateStatus({
+        id: APPOINTMENT_ID,
+        status: "checked_out",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Review and complete the visit closeout before checking out this appointment.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("does not cancel or reopen a clinically finalized visit", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [{ id: APPOINTMENT_ID, status: "in_exam" }],
+        [{ id: "closeout", status: "clinical_finalized" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).updateStatus({
+        id: APPOINTMENT_ID,
+        status: "cancelled",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Clinical handoff is finalized. Complete the visit through closeout instead of changing its status.",
+    });
     expect(updateSet).not.toHaveBeenCalled();
   });
 

--- a/apps/web/server/__tests__/billing-adjustments.test.ts
+++ b/apps/web/server/__tests__/billing-adjustments.test.ts
@@ -18,6 +18,7 @@ const { billingRouter } = await import("../routers/billing");
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const INVOICE_ID = "00000000-0000-0000-0000-000000000002";
+const OPERATION_ID = "00000000-0000-0000-0000-000000000009";
 
 const baseInvoice = {
   id: INVOICE_ID,
@@ -27,7 +28,10 @@ const baseInvoice = {
   isEstimate: false,
 };
 
-function callerWithDb(db: Record<string, unknown>) {
+function callerWithDb(
+  db: Record<string, unknown>,
+  injectOperationId = true
+) {
   const session = {
     user: {
       id: USER_ID,
@@ -37,7 +41,20 @@ function callerWithDb(db: Record<string, unknown>) {
       practiceId: PRACTICE_ID,
     },
   };
-  return billingRouter.createCaller({ db, session } as never);
+  const caller = billingRouter.createCaller({ db, session } as never);
+  if (!injectOperationId) return caller as any;
+  return new Proxy(caller, {
+    get(target, property, receiver) {
+      if (property === "applyInvoiceAdjustment") {
+        return (input: Record<string, unknown>) =>
+          target.applyInvoiceAdjustment({
+            operationId: OPERATION_ID,
+            ...input,
+          } as never);
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  }) as any;
 }
 
 function thenableRows(result: unknown[]) {
@@ -54,15 +71,23 @@ function thenableRows(result: unknown[]) {
 function createDb(opts: {
   selectResults: unknown[][];
   adjustmentInsert?: Record<string, unknown>;
+  replayAdjustment?: Record<string, unknown>;
+  includeOperationLookup?: boolean;
   updateReturns?: unknown[][];
 }) {
-  const selectResults = [...opts.selectResults];
+  const selectResults = [
+    ...(opts.includeOperationLookup === false
+      ? []
+      : [opts.replayAdjustment ? [opts.replayAdjustment] : []]),
+    ...opts.selectResults,
+  ];
   const select = vi.fn(() => {
     const result = selectResults.shift() ?? [];
     const afterWhere = thenableRows(result);
     const builder = {
       from: vi.fn(() => builder),
       leftJoin: vi.fn(() => builder),
+      innerJoin: vi.fn(() => builder),
       where: vi.fn(() => afterWhere),
       orderBy: vi.fn(async () => result),
       limit: vi.fn(async () => result),
@@ -104,6 +129,21 @@ afterEach(() => {
 });
 
 describe("billing invoice adjustments", () => {
+  it("requires an operation ID before adjustment DB work", async () => {
+    const { db, select, insertValues } = createDb({ selectResults: [] });
+
+    await expect(
+      callerWithDb(db, false).applyInvoiceAdjustment({
+        invoiceId: INVOICE_ID,
+        type: "credit",
+        amount: "10.00",
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid adjustment amounts before DB work", async () => {
     const { db, select, insertValues } = createDb({ selectResults: [] });
 
@@ -118,6 +158,7 @@ describe("billing invoice adjustments", () => {
     await expect(
       callerWithDb(db).applyInvoiceAdjustment({
         invoiceId: INVOICE_ID,
+        operationId: OPERATION_ID,
         type: "write_off",
         amount: "100000000",
       })
@@ -200,6 +241,7 @@ describe("billing invoice adjustments", () => {
     await expect(
       callerWithDb(db).applyInvoiceAdjustment({
         invoiceId: INVOICE_ID,
+        operationId: OPERATION_ID,
         type: "write_off",
         amount: "80.00",
         reason: "Bad debt",
@@ -217,6 +259,8 @@ describe("billing invoice adjustments", () => {
         amount: "80.00",
         reason: "Bad debt",
         createdBy: USER_ID,
+        operationKey: `dashboard-adjustment:${PRACTICE_ID}:${OPERATION_ID}`,
+        balanceAfter: "0.00",
       })
     );
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
@@ -232,6 +276,62 @@ describe("billing invoice adjustments", () => {
         source: "dashboard",
       }
     );
+  });
+
+  it("returns the original adjustment for an exact operation retry", async () => {
+    const replayAdjustment = {
+      id: "00000000-0000-0000-0000-000000000003",
+      invoiceId: INVOICE_ID,
+      type: "write_off",
+      amount: "80.00",
+      reason: "Bad debt",
+      createdBy: USER_ID,
+      balanceAfter: "0.00",
+    };
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [],
+      replayAdjustment,
+    });
+
+    await expect(
+      callerWithDb(db).applyInvoiceAdjustment({
+        invoiceId: INVOICE_ID,
+        operationId: OPERATION_ID,
+        type: "write_off",
+        amount: "80.00",
+        reason: "Bad debt",
+      })
+    ).resolves.toMatchObject({ ...replayAdjustment, balanceDue: "0.00" });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects reuse of an adjustment operation ID with changed details", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [],
+      replayAdjustment: {
+        id: "00000000-0000-0000-0000-000000000003",
+        invoiceId: INVOICE_ID,
+        type: "credit",
+        amount: "25.00",
+        reason: null,
+        balanceAfter: "55.00",
+      },
+    });
+
+    await expect(
+      callerWithDb(db).applyInvoiceAdjustment({
+        invoiceId: INVOICE_ID,
+        operationId: OPERATION_ID,
+        type: "credit",
+        amount: "30.00",
+      })
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("does not insert an adjustment when the invoice balance changed concurrently", async () => {
@@ -293,7 +393,10 @@ describe("billing invoice adjustments", () => {
   });
 
   it("validates invoice ownership before listing adjustments", async () => {
-    const { db, select } = createDb({ selectResults: [[]] });
+    const { db, select } = createDb({
+      selectResults: [[]],
+      includeOperationLookup: false,
+    });
 
     await expect(
       callerWithDb(db).listAdjustments({ invoiceId: INVOICE_ID })
@@ -305,6 +408,7 @@ describe("billing invoice adjustments", () => {
   it("voids only invoices with no payments or adjustments", async () => {
     const { db, updateSet } = createDb({
       selectResults: [[{ ...baseInvoice, paidAmount: "0.00" }], []],
+      includeOperationLookup: false,
       updateReturns: [[{ id: INVOICE_ID, status: "void" }]],
     });
 
@@ -318,6 +422,7 @@ describe("billing invoice adjustments", () => {
   it("does not void when invoice history changed concurrently", async () => {
     const { db, updateSet } = createDb({
       selectResults: [[{ ...baseInvoice, paidAmount: "0.00" }], []],
+      includeOperationLookup: false,
       updateReturns: [[]],
     });
 
@@ -334,6 +439,7 @@ describe("billing invoice adjustments", () => {
   it("rejects voiding invoices with payment history", async () => {
     const { db, updateSet } = createDb({
       selectResults: [[baseInvoice], []],
+      includeOperationLookup: false,
     });
 
     await expect(

--- a/apps/web/server/__tests__/billing-invoice-integrity.test.ts
+++ b/apps/web/server/__tests__/billing-invoice-integrity.test.ts
@@ -18,6 +18,8 @@ const PRODUCT_ID = "00000000-0000-0000-0000-000000000004";
 const INVOICE_ID = "00000000-0000-0000-0000-000000000005";
 const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000006";
 const SERVICE_ID = "00000000-0000-0000-0000-000000000007";
+const PRESCRIPTION_ID = "00000000-0000-0000-0000-000000000008";
+const UPDATED_AT = new Date("2026-08-08T12:00:00.000Z");
 
 function callerWithDb(db: Record<string, unknown>, role = "front_desk") {
   const session = {
@@ -70,6 +72,7 @@ function createDb(opts: {
     const builder = {
       from: vi.fn(() => builder),
       leftJoin: vi.fn(() => builder),
+      innerJoin: vi.fn(() => builder),
       where: vi.fn(() => afterWhere),
       orderBy: vi.fn(async () => result),
       limit: vi.fn(async () => result),
@@ -294,6 +297,7 @@ describe("billing invoice integrity", () => {
         [{ id: PATIENT_ID }],
         [{ id: APPOINTMENT_ID }],
         [{ taxRatePercent: "0.00" }],
+        [{ id: APPOINTMENT_ID, status: "in_exam" }],
         [],
         [{ id: PRODUCT_ID, deletedAt: null }],
       ],
@@ -324,6 +328,7 @@ describe("billing invoice integrity", () => {
         [{ id: PATIENT_ID }],
         [{ id: APPOINTMENT_ID }],
         [{ taxRatePercent: "0.00" }],
+        [{ id: APPOINTMENT_ID, status: "in_exam" }],
         [{ id: INVOICE_ID }],
       ],
     });
@@ -345,6 +350,35 @@ describe("billing invoice integrity", () => {
     expect(duplicate.db.execute).toHaveBeenCalled();
     expect(duplicate.updateSet).not.toHaveBeenCalled();
     expect(duplicate.insertValues).not.toHaveBeenCalled();
+  });
+
+  it("rechecks and locks the visit before creating a real invoice", async () => {
+    const { db, insertValues, lockCalls } = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID }],
+        [{ id: PATIENT_ID }],
+        [{ id: APPOINTMENT_ID }],
+        [{ taxRatePercent: "0.00" }],
+        [{ id: APPOINTMENT_ID, status: "checked_out" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).createInvoice({
+        clientId: CLIENT_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        items: [productLine],
+        isEstimate: false,
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Start the exam before capturing visit charges.",
+    });
+    expect(lockCalls).toEqual([
+      { mode: "update", inTransaction: true, writesBeforeLock: 0 },
+    ]);
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("rejects product line references outside the practice", async () => {
@@ -500,6 +534,9 @@ describe("billing invoice integrity", () => {
             paidAmount: "0.00",
             status: "draft",
             isEstimate: false,
+            updatedAt: UPDATED_AT,
+            appointmentId: null,
+            patientId: PATIENT_ID,
           },
         ],
         [{ itemType: "product", itemId: PRODUCT_ID, quantity: 1 }],
@@ -523,6 +560,7 @@ describe("billing invoice integrity", () => {
     await expect(
       callerWithDb(db).updateInvoiceItems({
         id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
         items: [{ ...productLine, quantity: 3 }],
       })
     ).resolves.toMatchObject({
@@ -577,6 +615,9 @@ describe("billing invoice integrity", () => {
             paidAmount: "0.00",
             status: "draft",
             isEstimate: false,
+            updatedAt: UPDATED_AT,
+            appointmentId: null,
+            patientId: PATIENT_ID,
           },
         ],
         [{ itemType: "service", itemId: SERVICE_ID, quantity: 2 }],
@@ -598,6 +639,7 @@ describe("billing invoice integrity", () => {
     await expect(
       callerWithDb(db).updateInvoiceItems({
         id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
         items: [
           {
             description: "Archived exam",
@@ -637,6 +679,9 @@ describe("billing invoice integrity", () => {
               paidAmount: "0.00",
               status: "draft",
               isEstimate: false,
+              updatedAt: UPDATED_AT,
+              appointmentId: null,
+              patientId: PATIENT_ID,
             },
           ],
           previousQuantity === 0
@@ -655,6 +700,7 @@ describe("billing invoice integrity", () => {
       await expect(
         callerWithDb(db).updateInvoiceItems({
           id: INVOICE_ID,
+          expectedUpdatedAt: UPDATED_AT,
           items: [
             {
               description: "Archived exam",
@@ -705,6 +751,78 @@ describe("billing invoice integrity", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
+  it("charges a visit prescription without deducting already-dispensed stock twice", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID }],
+        [{ id: PATIENT_ID }],
+        [{ id: APPOINTMENT_ID }],
+        [{ taxRatePercent: "0.00" }],
+        [{ id: APPOINTMENT_ID, status: "in_exam" }],
+        [],
+        [{ id: PRODUCT_ID, deletedAt: null }],
+        [{ id: PRESCRIPTION_ID, productId: PRODUCT_ID, quantity: 2 }],
+        [],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).createInvoice({
+        clientId: CLIENT_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        items: [
+          {
+            ...productLine,
+            sourcePrescriptionId: PRESCRIPTION_ID,
+          },
+        ],
+        isEstimate: false,
+      })
+    ).resolves.toMatchObject({ id: INVOICE_ID });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        itemId: PRODUCT_ID,
+        sourcePrescriptionId: PRESCRIPTION_ID,
+        quantity: 2,
+      }),
+    ]);
+  });
+
+  it("rejects an unsourced charge for a product already dispensed by the visit prescription", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID }],
+        [{ id: PATIENT_ID }],
+        [{ id: APPOINTMENT_ID }],
+        [{ taxRatePercent: "0.00" }],
+        [{ id: APPOINTMENT_ID, status: "in_exam" }],
+        [],
+        [{ id: PRODUCT_ID, deletedAt: null }],
+        [{ id: PRESCRIPTION_ID, productId: PRODUCT_ID, quantity: 2 }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).createInvoice({
+        clientId: CLIENT_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        items: [productLine],
+        isEstimate: false,
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Charge a visit-dispensed medication from its prescription entry so stock is not deducted twice.",
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("does not edit a sent invoice or touch its inventory", async () => {
     const { db, insertValues, updateSet } = createDb({
       selectResults: [
@@ -715,6 +833,9 @@ describe("billing invoice integrity", () => {
             paidAmount: "0.00",
             status: "sent",
             isEstimate: false,
+            updatedAt: UPDATED_AT,
+            appointmentId: null,
+            patientId: PATIENT_ID,
           },
         ],
       ],
@@ -723,6 +844,7 @@ describe("billing invoice integrity", () => {
     await expect(
       callerWithDb(db).updateInvoiceItems({
         id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
         items: [productLine],
       })
     ).rejects.toMatchObject({
@@ -744,6 +866,9 @@ describe("billing invoice integrity", () => {
             paidAmount: "0.00",
             status: "draft",
             isEstimate: true,
+            updatedAt: UPDATED_AT,
+            appointmentId: null,
+            patientId: PATIENT_ID,
           },
         ],
       ],
@@ -752,6 +877,7 @@ describe("billing invoice integrity", () => {
     await expect(
       callerWithDb(db).updateInvoiceItems({
         id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
         items: [
           {
             description: "Exam",
@@ -781,6 +907,9 @@ describe("billing invoice integrity", () => {
             paidAmount: "0.00",
             status: "draft",
             isEstimate: false,
+            updatedAt: UPDATED_AT,
+            appointmentId: null,
+            patientId: PATIENT_ID,
           },
         ],
         [],
@@ -791,6 +920,7 @@ describe("billing invoice integrity", () => {
     await expect(
       callerWithDb(db).updateInvoiceItems({
         id: INVOICE_ID,
+        expectedUpdatedAt: UPDATED_AT,
         items: [
           {
             description: "Exam",
@@ -925,6 +1055,7 @@ describe("billing invoice integrity", () => {
           },
         ],
         [],
+        [],
         [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
       ],
       updateReturns: [
@@ -1003,6 +1134,7 @@ describe("billing invoice integrity", () => {
           },
         ],
         [],
+        [],
         [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
       ],
       updateReturns: [
@@ -1019,6 +1151,37 @@ describe("billing invoice integrity", () => {
     expect(updateSet).toHaveBeenNthCalledWith(2, {
       stockQuantity: expect.anything(),
     });
+  });
+
+  it("does not void an invoice referenced by a completed visit closeout", async () => {
+    const { db, updateSet, lockCalls } = createDb({
+      selectResults: [
+        [
+          {
+            id: INVOICE_ID,
+            total: "30.00",
+            paidAmount: "0.00",
+            status: "sent",
+            isEstimate: false,
+            appointmentId: APPOINTMENT_ID,
+          },
+        ],
+        [{ id: APPOINTMENT_ID }],
+        [{ id: "closeout" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).voidInvoice({ id: INVOICE_ID })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "This invoice is part of a completed visit. Reconcile it through an attributed closeout amendment.",
+    });
+    expect(lockCalls).toEqual([
+      { mode: "update", inTransaction: true, writesBeforeLock: 0 },
+    ]);
+    expect(updateSet).not.toHaveBeenCalled();
   });
 
   it("does not restore product stock when dedicated void is repeated", async () => {

--- a/apps/web/server/__tests__/billing-payments.test.ts
+++ b/apps/web/server/__tests__/billing-payments.test.ts
@@ -25,6 +25,7 @@ const { billingRouter } = await import("../routers/billing");
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const INVOICE_ID = "00000000-0000-0000-0000-000000000002";
+const OPERATION_ID = "00000000-0000-0000-0000-000000000009";
 
 const baseInvoice = {
   id: INVOICE_ID,
@@ -34,7 +35,10 @@ const baseInvoice = {
   isEstimate: false,
 };
 
-function callerWithDb(db: Record<string, unknown>) {
+function callerWithDb(
+  db: Record<string, unknown>,
+  injectOperationId = true
+) {
   const session = {
     user: {
       id: USER_ID,
@@ -44,7 +48,20 @@ function callerWithDb(db: Record<string, unknown>) {
       practiceId: PRACTICE_ID,
     },
   };
-  return billingRouter.createCaller({ db, session } as never);
+  const caller = billingRouter.createCaller({ db, session } as never);
+  if (!injectOperationId) return caller as any;
+  return new Proxy(caller, {
+    get(target, property, receiver) {
+      if (property === "recordPayment") {
+        return (input: Record<string, unknown>) =>
+          target.recordPayment({
+            operationId: OPERATION_ID,
+            ...input,
+          } as never);
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  }) as any;
 }
 
 function thenableRows(result: unknown[]) {
@@ -58,15 +75,23 @@ function thenableRows(result: unknown[]) {
 function createDb(opts: {
   selectResults: unknown[][];
   payment?: Record<string, unknown>;
+  replayPayment?: Record<string, unknown>;
+  includeOperationLookup?: boolean;
   updateReturns?: unknown[][];
 }) {
-  const selectResults = [...opts.selectResults];
+  const selectResults = [
+    ...(opts.includeOperationLookup === false
+      ? []
+      : [opts.replayPayment ? [opts.replayPayment] : []]),
+    ...opts.selectResults,
+  ];
   const select = vi.fn(() => {
     const result = selectResults.shift() ?? [];
     const afterWhere = thenableRows(result);
     const builder = {
       from: vi.fn(() => builder),
       leftJoin: vi.fn(() => builder),
+      innerJoin: vi.fn(() => builder),
       where: vi.fn(() => afterWhere),
       orderBy: vi.fn(async () => result),
       limit: vi.fn(async () => result),
@@ -107,6 +132,21 @@ afterEach(() => {
 });
 
 describe("billing payments", () => {
+  it("requires an operation ID before payment DB work", async () => {
+    const { db, select, insertValues } = createDb({ selectResults: [] });
+
+    await expect(
+      callerWithDb(db, false).recordPayment({
+        invoiceId: INVOICE_ID,
+        amount: "30.00",
+        method: "cash",
+      })
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid payment amounts before DB work", async () => {
     const { db, select, insertValues } = createDb({ selectResults: [] });
 
@@ -235,6 +275,7 @@ describe("billing payments", () => {
     await expect(
       callerWithDb(db).recordPayment({
         invoiceId: INVOICE_ID,
+        operationId: OPERATION_ID,
         amount: " 30.00 ",
         method: "cash",
         notes: "  cash drawer  ",
@@ -248,10 +289,67 @@ describe("billing payments", () => {
         method: "cash",
         receivedBy: USER_ID,
         notes: "cash drawer",
+        externalId: `dashboard-payment:${PRACTICE_ID}:${OPERATION_ID}`,
       })
     );
     expect(updateSet).toHaveBeenCalledWith({ paidAmount: "50.00" });
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns the original payment for an exact operation retry", async () => {
+    const replayPayment = {
+      id: "00000000-0000-0000-0000-000000000003",
+      invoiceId: INVOICE_ID,
+      amount: "30.00",
+      method: "cash",
+      notes: "cash drawer",
+      receivedBy: USER_ID,
+      externalId: `dashboard-payment:${PRACTICE_ID}:${OPERATION_ID}`,
+    };
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [],
+      replayPayment,
+    });
+
+    await expect(
+      callerWithDb(db).recordPayment({
+        invoiceId: INVOICE_ID,
+        operationId: OPERATION_ID,
+        amount: "30.00",
+        method: "cash",
+        notes: "cash drawer",
+      })
+    ).resolves.toMatchObject(replayPayment);
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
+    expect(mocks.loadClientReceipt).not.toHaveBeenCalled();
+  });
+
+  it("rejects reuse of a payment operation ID with changed details", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [],
+      replayPayment: {
+        id: "00000000-0000-0000-0000-000000000003",
+        invoiceId: INVOICE_ID,
+        amount: "30.00",
+        method: "cash",
+        notes: null,
+      },
+    });
+
+    await expect(
+      callerWithDb(db).recordPayment({
+        invoiceId: INVOICE_ID,
+        operationId: OPERATION_ID,
+        amount: "35.00",
+        method: "cash",
+      })
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("does not insert a payment when the invoice balance changed concurrently", async () => {
@@ -331,7 +429,10 @@ describe("billing payments", () => {
   });
 
   it("requires a payment or adjustment to settle an invoice", async () => {
-    const { db, updateSet } = createDb({ selectResults: [[baseInvoice]] });
+    const { db, updateSet } = createDb({
+      selectResults: [[baseInvoice]],
+      includeOperationLookup: false,
+    });
 
     await expect(
       callerWithDb(db).updateInvoiceStatus({
@@ -350,6 +451,7 @@ describe("billing payments", () => {
   it("does not void an invoice when history changed concurrently", async () => {
     const { db, updateSet } = createDb({
       selectResults: [[{ ...baseInvoice, paidAmount: "0.00" }], []],
+      includeOperationLookup: false,
       updateReturns: [[]],
     });
 
@@ -369,7 +471,10 @@ describe("billing payments", () => {
   });
 
   it("validates invoice ownership before listing payments", async () => {
-    const { db, select } = createDb({ selectResults: [[]] });
+    const { db, select } = createDb({
+      selectResults: [[]],
+      includeOperationLookup: false,
+    });
 
     await expect(
       callerWithDb(db).listPayments({ invoiceId: INVOICE_ID })

--- a/apps/web/server/__tests__/encounters-closeout.test.ts
+++ b/apps/web/server/__tests__/encounters-closeout.test.ts
@@ -1,0 +1,933 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+
+const mocks = vi.hoisted(() => ({
+  recordAuditLog: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: mocks.recordAuditLog,
+}));
+
+const { encountersRouter } = await import("../routers/encounters");
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000002";
+const PATIENT_ID = "00000000-0000-0000-0000-000000000003";
+const CLIENT_ID = "00000000-0000-0000-0000-000000000004";
+const CLOSEOUT_ID = "00000000-0000-0000-0000-000000000005";
+const INVOICE_ID = "00000000-0000-0000-0000-000000000006";
+const ASSIGNEE_ID = "00000000-0000-0000-0000-000000000007";
+
+function callerWithDb(db: Record<string, unknown>, role = "admin") {
+  return encountersRouter.createCaller({
+    db,
+    session: {
+      user: {
+        id: USER_ID,
+        email: `${role}@example.com`,
+        name: "Clinic User",
+        role,
+        practiceId: PRACTICE_ID,
+      },
+    },
+  } as never);
+}
+
+function createDb(opts: {
+  selectResults?: unknown[][];
+  updateResults?: unknown[][];
+  insertResults?: unknown[][];
+}) {
+  const selectResults = [...(opts.selectResults ?? [])];
+  const select = vi.fn(() => {
+    const result = selectResults.shift() ?? [];
+    const builder: Record<string, any> = {};
+    builder.from = vi.fn(() => builder);
+    builder.leftJoin = vi.fn(() => builder);
+    builder.innerJoin = vi.fn(() => builder);
+    builder.where = vi.fn(() => builder);
+    builder.orderBy = vi.fn(() => builder);
+    builder.limit = vi.fn(() => builder);
+    builder.offset = vi.fn(() => builder);
+    builder.for = vi.fn(async () => result);
+    builder.then = (
+      resolve: (value: unknown[]) => unknown,
+      reject?: (error: unknown) => unknown
+    ) => Promise.resolve(result).then(resolve, reject);
+    return builder;
+  });
+
+  const updateResults = [...(opts.updateResults ?? [])];
+  const updateSet = vi.fn((values: unknown) => {
+    const returning = vi.fn(async () => updateResults.shift() ?? []);
+    return {
+      where: vi.fn(() => ({ returning })),
+      values,
+    };
+  });
+  const update = vi.fn(() => ({ set: updateSet }));
+
+  const insertResults = [...(opts.insertResults ?? [])];
+  const insertValues = vi.fn((values: unknown) => ({
+    returning: vi.fn(async () => insertResults.shift() ?? []),
+    values,
+  }));
+  const insert = vi.fn(() => ({ values: insertValues }));
+
+  const db: Record<string, unknown> = {
+    select,
+    update,
+    insert,
+    execute: vi.fn(async () => undefined),
+  };
+  db.transaction = vi.fn(async (fn: (tx: unknown) => unknown) => fn(db));
+  return { db, select, updateSet, insertValues };
+}
+
+const openAppointment = {
+  id: APPOINTMENT_ID,
+  status: "in_exam",
+  startTime: new Date("2026-08-08T16:00:00.000Z"),
+  patientId: PATIENT_ID,
+  clientId: CLIENT_ID,
+  requiresDoctor: 1,
+};
+
+const clinicalFinalized = {
+  id: CLOSEOUT_ID,
+  practiceId: PRACTICE_ID,
+  appointmentId: APPOINTMENT_ID,
+  status: "clinical_finalized",
+  revision: 2,
+  diagnosisSummary: null,
+  dischargeInstructions: "Give with food.",
+  warningSigns: null,
+  noInstructionsReason: null,
+  prescriptionDisposition: "not_needed",
+  followUpDisposition: "none",
+  followUpNotes: null,
+  followUpAppointmentId: null,
+  followUpScheduledAt: null,
+  followUpDueDate: null,
+  followUpAssignedTo: null,
+  followUpAssigneeName: null,
+  followUpResolution: null,
+  followUpResolutionAppointmentId: null,
+  followUpResolutionScheduledAt: null,
+  followUpResolutionNotes: null,
+  followUpResolvedAt: null,
+  followUpResolvedBy: null,
+  followUpResolverName: null,
+  medicationSnapshot: [],
+  amendmentHistory: [],
+  amendmentDraft: null,
+  documentationExceptionReason: "Brief technician recheck",
+  clinicalFinalizedAt: new Date("2026-08-08T17:00:00.000Z"),
+  clinicalFinalizedBy: USER_ID,
+  clinicalFinalizerName: "Clinic User",
+  chargeDisposition: null,
+  invoiceId: null,
+  noChargeReason: null,
+  handoffMethod: null,
+};
+
+const clinicalInput = {
+  appointmentId: APPOINTMENT_ID,
+  expectedRevision: 0,
+  diagnosisSummary: null,
+  dischargeInstructions: "Continue normal activity.",
+  warningSigns: null,
+  noInstructionsReason: null,
+  prescriptionDisposition: "not_needed" as const,
+  followUpDisposition: "none" as const,
+  followUpNotes: null,
+  followUpAppointmentId: null,
+  documentationExceptionReason: "Brief technician recheck",
+};
+
+const activeAmendmentDraft = {
+  baseRevision: 2,
+  reason: "Correct the dosage wording",
+  reopenedAt: "2026-08-08T18:00:00.000Z",
+  reopenedBy: USER_ID,
+  reopenedByName: "Clinic User",
+  diagnosisSummary: null,
+  dischargeInstructions: "Give with food.",
+  warningSigns: null,
+  noInstructionsReason: null,
+  prescriptionDisposition: "not_needed" as const,
+  followUpDisposition: "none" as const,
+  followUpNotes: null,
+  followUpAppointmentId: null,
+  followUpDueDate: null,
+  followUpAssignedTo: null,
+  documentationExceptionReason: "Brief technician recheck",
+};
+
+afterEach(() => vi.clearAllMocks());
+
+describe("encounter closeout database locking", () => {
+  it("locks only the appointment row when its optional type is left joined", () => {
+    const source = readFileSync(
+      new URL("../routers/encounters.ts", import.meta.url),
+      "utf8"
+    );
+
+    expect(source).toContain('.for("update", { of: appointments })');
+  });
+});
+
+describe("encounter closeout safety", () => {
+  it("atomically completes an explicit no-charge visit", async () => {
+    const completed = {
+      ...clinicalFinalized,
+      status: "completed",
+      revision: 3,
+      chargeDisposition: "no_charge",
+      noChargeReason: "Complimentary postoperative recheck",
+      handoffMethod: "verbal",
+    };
+    const checkedOut = { ...openAppointment, status: "checked_out" };
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [clinicalFinalized],
+        [],
+      ],
+      updateResults: [[completed], [checkedOut]],
+    });
+
+    await expect(
+      callerWithDb(db).completeVisit({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 2,
+        chargeDisposition: "no_charge",
+        noChargeReason: "Complimentary postoperative recheck",
+        handoffMethod: "verbal",
+      })
+    ).resolves.toEqual({ closeout: completed, appointment: checkedOut });
+
+    expect(updateSet).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        status: "completed",
+        chargeDisposition: "no_charge",
+        revision: 3,
+      })
+    );
+    expect(updateSet).toHaveBeenNthCalledWith(2, { status: "checked_out" });
+  });
+
+  it("returns the stored result for an exact completion retry", async () => {
+    const completed = {
+      ...clinicalFinalized,
+      status: "completed",
+      revision: 3,
+      chargeDisposition: "no_charge",
+      noChargeReason: "Complimentary recheck",
+      handoffMethod: "print",
+    };
+    const checkedOut = { ...openAppointment, status: "checked_out" };
+    const { db, updateSet } = createDb({
+      selectResults: [[checkedOut], [{ id: PATIENT_ID }], [completed]],
+    });
+
+    await expect(
+      callerWithDb(db).completeVisit({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 2,
+        chargeDisposition: "no_charge",
+        noChargeReason: "Complimentary recheck",
+        handoffMethod: "print",
+      })
+    ).resolves.toEqual({ closeout: completed, appointment: checkedOut });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("does not complete without a finalized clinical handoff", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [[openAppointment], [{ id: PATIENT_ID }], []],
+    });
+
+    await expect(
+      callerWithDb(db).completeVisit({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 1,
+        chargeDisposition: "no_charge",
+        noChargeReason: "Complimentary recheck",
+        handoffMethod: "verbal",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Finalize the clinical handoff before completing the visit.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("does not complete while an attributed clinical amendment is in progress", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [
+          {
+            ...clinicalFinalized,
+            revision: 3,
+            amendmentDraft: activeAmendmentDraft,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).completeVisit({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 3,
+        chargeDisposition: "no_charge",
+        noChargeReason: "Complimentary recheck",
+        handoffMethod: "verbal",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Finish the attributed clinical amendment before completing the visit.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects paid checkout when the active invoice is still a draft", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [clinicalFinalized],
+        [
+          {
+            id: INVOICE_ID,
+            status: "draft",
+            total: "100.00",
+            paidAmount: "0.00",
+            dueDate: null,
+          },
+        ],
+        [{ itemCount: 1 }],
+        [{ adjustedAmount: "0" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).completeVisit({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 2,
+        chargeDisposition: "paid",
+        noChargeReason: null,
+        handoffMethod: "print",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "The visit invoice is not fully paid.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "paid",
+      chargeDisposition: "paid" as const,
+      invoice: {
+        id: INVOICE_ID,
+        status: "paid",
+        total: "100.00",
+        paidAmount: "100.00",
+        dueDate: null,
+      },
+    },
+    {
+      label: "accounts receivable",
+      chargeDisposition: "accounts_receivable" as const,
+      invoice: {
+        id: INVOICE_ID,
+        status: "sent",
+        total: "100.00",
+        paidAmount: "0.00",
+        dueDate: "2026-09-01",
+      },
+    },
+  ])("completes a verified $label visit", async ({ chargeDisposition, invoice }) => {
+    const completed = {
+      ...clinicalFinalized,
+      status: "completed",
+      revision: 3,
+      chargeDisposition,
+      invoiceId: INVOICE_ID,
+      handoffMethod: "print",
+    };
+    const checkedOut = { ...openAppointment, status: "checked_out" };
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [clinicalFinalized],
+        [invoice],
+        [{ itemCount: 1 }],
+        [{ adjustedAmount: "0" }],
+      ],
+      updateResults: [[completed], [checkedOut]],
+    });
+
+    await expect(
+      callerWithDb(db).completeVisit({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 2,
+        chargeDisposition,
+        noChargeReason: null,
+        handoffMethod: "print",
+      })
+    ).resolves.toEqual({ closeout: completed, appointment: checkedOut });
+    expect(updateSet).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        status: "completed",
+        chargeDisposition,
+        invoiceId: INVOICE_ID,
+      })
+    );
+  });
+
+  it("requires a linked SOAP note or an attributable exception", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [[openAppointment], [{ id: PATIENT_ID }], [], []],
+    });
+
+    await expect(
+      callerWithDb(db, "veterinarian").finalizeClinical({
+        ...clinicalInput,
+        documentationExceptionReason: null,
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Link a SOAP note or document why one is not required.",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("finalizes a validated clinical handoff and increments its revision", async () => {
+    const finalized = {
+      ...clinicalFinalized,
+      dischargeInstructions: "Continue normal activity.",
+      revision: 1,
+    };
+    const { db, insertValues } = createDb({
+      selectResults: [[openAppointment], [{ id: PATIENT_ID }], [], []],
+      insertResults: [[finalized]],
+    });
+
+    await expect(
+      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput)
+    ).resolves.toEqual(finalized);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appointmentId: APPOINTMENT_ID,
+        status: "clinical_finalized",
+        clinicalFinalizedBy: USER_ID,
+        clinicalFinalizerName: "Clinic User",
+        medicationSnapshot: [],
+        revision: 1,
+      })
+    );
+  });
+
+  it("freezes active visit medications into the finalized handoff", async () => {
+    const medication = {
+      prescriptionId: "00000000-0000-0000-0000-000000000077",
+      medicationName: "Carprofen",
+      dosage: "75 mg",
+      frequency: "Every 12 hours",
+      instructions: "Give with food",
+      quantity: 10,
+    };
+    const finalized = {
+      ...clinicalFinalized,
+      prescriptionDisposition: "prescribed",
+      medicationSnapshot: [medication],
+      revision: 1,
+    };
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [],
+        [{ id: "soap" }],
+        [medication],
+      ],
+      insertResults: [[finalized]],
+    });
+
+    await expect(
+      callerWithDb(db, "veterinarian").finalizeClinical({
+        ...clinicalInput,
+        prescriptionDisposition: "prescribed",
+      })
+    ).resolves.toEqual(finalized);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ medicationSnapshot: [medication] })
+    );
+  });
+
+  it("rejects no-prescription disposition when active visit prescriptions exist", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [],
+        [{ id: "soap" }],
+        [
+          {
+            prescriptionId: "00000000-0000-0000-0000-000000000077",
+            medicationName: "Carprofen",
+            dosage: "75 mg",
+            frequency: "Every 12 hours",
+            instructions: null,
+            quantity: 10,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput)
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "This visit has linked prescriptions. Confirm that prescriptions were provided.",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("requires the exam to be started before clinical closeout", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [{ ...openAppointment, status: "checked_in" }],
+        [{ id: PATIENT_ID }],
+      ],
+    });
+    await expect(
+      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput)
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Start the exam before preparing the clinical closeout.",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("keeps front desk users from authoring clinical content", async () => {
+    const { db, select } = createDb({});
+    await expect(
+      callerWithDb(db, "front_desk").finalizeClinical(clinicalInput)
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("opens an amendment without replacing the operative signed handoff", async () => {
+    const reopened = {
+      ...clinicalFinalized,
+      revision: 3,
+      amendmentDraft: expect.any(Object),
+    };
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [clinicalFinalized],
+      ],
+      updateResults: [[reopened]],
+    });
+
+    await expect(
+      callerWithDb(db).reopenClinical({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 2,
+        reason: "Correct the dosage wording",
+      })
+    ).resolves.toEqual(reopened);
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        revision: 3,
+        amendmentDraft: expect.objectContaining({
+            baseRevision: 2,
+            reason: "Correct the dosage wording",
+            reopenedBy: USER_ID,
+            dischargeInstructions: "Give with food.",
+          }),
+      })
+    );
+    const values = updateSet.mock.calls[0]![0] as Record<string, unknown>;
+    expect(values).not.toHaveProperty("status");
+    expect(values).not.toHaveProperty("clinicalFinalizedAt");
+    expect(values).not.toHaveProperty("medicationSnapshot");
+    expect(values).not.toHaveProperty("amendmentHistory");
+  });
+
+  it("saves amendment edits inside the draft without mutating signed fields", async () => {
+    const signedWithDraft = {
+      ...clinicalFinalized,
+      revision: 3,
+      amendmentDraft: activeAmendmentDraft,
+    };
+    const saved = {
+      ...signedWithDraft,
+      revision: 4,
+      amendmentDraft: {
+        ...activeAmendmentDraft,
+        dischargeInstructions: "Give one tablet with food.",
+      },
+    };
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [signedWithDraft],
+      ],
+      updateResults: [[saved]],
+    });
+
+    await expect(
+      callerWithDb(db, "technician").saveDraft({
+        ...clinicalInput,
+        expectedRevision: 3,
+        dischargeInstructions: "Give one tablet with food.",
+      })
+    ).resolves.toEqual(saved);
+
+    expect(updateSet).toHaveBeenCalledWith({
+      amendmentDraft: expect.objectContaining({
+        baseRevision: 2,
+        reason: "Correct the dosage wording",
+        dischargeInstructions: "Give one tablet with food.",
+      }),
+      revision: 4,
+    });
+    const values = updateSet.mock.calls[0]![0] as Record<string, unknown>;
+    expect(values).not.toHaveProperty("dischargeInstructions");
+    expect(values).not.toHaveProperty("clinicalFinalizedBy");
+  });
+
+  it("opens and atomically promotes an amendment after completed checkout", async () => {
+    const checkedOut = { ...openAppointment, status: "checked_out" };
+    const completed = {
+      ...clinicalFinalized,
+      status: "completed",
+      revision: 3,
+      chargeDisposition: "no_charge",
+      noChargeReason: "Complimentary recheck",
+      handoffMethod: "print",
+      completedAt: new Date("2026-08-08T18:30:00.000Z"),
+      completedBy: USER_ID,
+    };
+    const completedWithDraft = {
+      ...completed,
+      revision: 4,
+      amendmentDraft: {
+        ...activeAmendmentDraft,
+        baseRevision: 3,
+      },
+    };
+    const openDb = createDb({
+      selectResults: [[checkedOut], [{ id: PATIENT_ID }], [completed]],
+      updateResults: [[completedWithDraft]],
+    });
+
+    await expect(
+      callerWithDb(openDb.db).reopenClinical({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 3,
+        reason: "Correct the dosage wording",
+      })
+    ).resolves.toEqual(completedWithDraft);
+    const openValues = openDb.updateSet.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(openValues).not.toHaveProperty("status");
+    expect(openValues).not.toHaveProperty("chargeDisposition");
+    expect(openValues).not.toHaveProperty("completedAt");
+
+    const promoted = {
+      ...completedWithDraft,
+      revision: 5,
+      dischargeInstructions: "Give one tablet with food.",
+      amendmentDraft: null,
+      amendmentHistory: [expect.any(Object)],
+    };
+    const promoteDb = createDb({
+      selectResults: [
+        [checkedOut],
+        [{ id: PATIENT_ID }],
+        [completedWithDraft],
+        [],
+        [],
+      ],
+      updateResults: [[promoted]],
+    });
+
+    await expect(
+      callerWithDb(promoteDb.db, "veterinarian").finalizeClinical({
+        ...clinicalInput,
+        expectedRevision: 4,
+        dischargeInstructions: "Give one tablet with food.",
+      })
+    ).resolves.toEqual(promoted);
+
+    expect(promoteDb.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "completed",
+        dischargeInstructions: "Give one tablet with food.",
+        amendmentDraft: null,
+        amendmentHistory: [
+          expect.objectContaining({
+            priorRevision: 3,
+            reason: "Correct the dosage wording",
+            clinicalFinalizerName: "Clinic User",
+            dischargeInstructions: "Give with food.",
+          }),
+        ],
+        revision: 5,
+      })
+    );
+    const promoteValues = promoteDb.updateSet.mock.calls[0]![0] as Record<
+      string,
+      unknown
+    >;
+    expect(promoteValues).not.toHaveProperty("chargeDisposition");
+    expect(promoteValues).not.toHaveProperty("invoiceId");
+    expect(promoteValues).not.toHaveProperty("completedAt");
+  });
+
+  it("preserves operational resolution when an amendment leaves the needed follow-up unchanged", async () => {
+    const checkedOut = { ...openAppointment, status: "checked_out" };
+    const resolutionAppointmentId =
+      "00000000-0000-0000-0000-000000000008";
+    const resolvedAt = new Date("2026-08-09T17:00:00.000Z");
+    const resolutionScheduledAt = new Date("2099-01-02T17:00:00.000Z");
+    const completedWithDraft = {
+      ...clinicalFinalized,
+      status: "completed",
+      revision: 5,
+      followUpDisposition: "needed",
+      followUpDueDate: "2099-01-01",
+      followUpAssignedTo: ASSIGNEE_ID,
+      followUpAssigneeName: "Alex Coordinator",
+      followUpResolution: "scheduled",
+      followUpResolutionAppointmentId: resolutionAppointmentId,
+      followUpResolutionScheduledAt: resolutionScheduledAt,
+      followUpResolvedAt: resolvedAt,
+      followUpResolvedBy: USER_ID,
+      followUpResolverName: "Clinic User",
+      chargeDisposition: "no_charge",
+      noChargeReason: "Complimentary recheck",
+      handoffMethod: "print",
+      completedAt: new Date("2026-08-08T18:30:00.000Z"),
+      completedBy: USER_ID,
+      amendmentDraft: {
+        ...activeAmendmentDraft,
+        baseRevision: 3,
+        followUpDisposition: "needed",
+        followUpDueDate: "2099-01-01",
+        followUpAssignedTo: ASSIGNEE_ID,
+      },
+    };
+    const finalized = {
+      ...completedWithDraft,
+      revision: 6,
+      dischargeInstructions: "Updated activity instructions.",
+      amendmentDraft: null,
+    };
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [checkedOut],
+        [{ id: PATIENT_ID }],
+        [completedWithDraft],
+        [],
+        [],
+        [{ name: "Alex Coordinator", email: "alex@example.com" }],
+      ],
+      updateResults: [[finalized]],
+    });
+
+    await expect(
+      callerWithDb(db, "veterinarian").finalizeClinical({
+        ...clinicalInput,
+        expectedRevision: 5,
+        dischargeInstructions: "Updated activity instructions.",
+        followUpDisposition: "needed",
+        followUpDueDate: "2099-01-01",
+        followUpAssignedTo: ASSIGNEE_ID,
+      })
+    ).resolves.toEqual(finalized);
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        followUpResolution: "scheduled",
+        followUpResolutionAppointmentId: resolutionAppointmentId,
+        followUpResolutionScheduledAt: resolutionScheduledAt,
+        followUpResolvedAt: resolvedAt,
+        followUpResolvedBy: USER_ID,
+        amendmentHistory: [
+          expect.objectContaining({
+            followUpDisposition: "needed",
+            followUpResolution: "scheduled",
+            followUpResolutionAppointmentId: resolutionAppointmentId,
+            followUpResolvedBy: USER_ID,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("finalizes an accountable needed follow-up for the pending queue", async () => {
+    const finalized = {
+      ...clinicalFinalized,
+      revision: 1,
+      followUpDisposition: "needed",
+      followUpDueDate: "2099-01-01",
+      followUpAssignedTo: ASSIGNEE_ID,
+      followUpAssigneeName: "Alex Coordinator",
+    };
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [],
+        [],
+        [],
+        [{ name: "Alex Coordinator", email: "alex@example.com" }],
+      ],
+      insertResults: [[finalized]],
+    });
+
+    await expect(
+      callerWithDb(db, "veterinarian").finalizeClinical({
+        ...clinicalInput,
+        followUpDisposition: "needed",
+        followUpDueDate: "2099-01-01",
+        followUpAssignedTo: ASSIGNEE_ID,
+      })
+    ).resolves.toEqual(finalized);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        followUpDisposition: "needed",
+        followUpDueDate: "2099-01-01",
+        followUpAssignedTo: ASSIGNEE_ID,
+        followUpAssigneeName: "Alex Coordinator",
+        followUpAppointmentId: null,
+        followUpScheduledAt: null,
+      })
+    );
+  });
+
+  it("returns completed visits with unresolved needed follow-ups", async () => {
+    const pending = {
+      closeoutId: CLOSEOUT_ID,
+      appointmentId: APPOINTMENT_ID,
+      closeoutStatus: "completed",
+      dueDate: "2099-01-01",
+      assignedTo: ASSIGNEE_ID,
+      assigneeName: "Alex Coordinator",
+    };
+    const { db } = createDb({ selectResults: [[pending]] });
+
+    await expect(
+      callerWithDb(db, "front_desk").listPendingFollowUps()
+    ).resolves.toEqual([pending]);
+  });
+
+  it("resolves a needed follow-up operationally without rewriting the signed disposition", async () => {
+    const checkedOut = { ...openAppointment, status: "checked_out" };
+    const pending = {
+      ...clinicalFinalized,
+      status: "completed",
+      revision: 4,
+      followUpDisposition: "needed",
+      followUpDueDate: "2099-01-01",
+      followUpAssignedTo: ASSIGNEE_ID,
+      followUpAssigneeName: "Alex Coordinator",
+      chargeDisposition: "no_charge",
+      noChargeReason: "Complimentary recheck",
+      handoffMethod: "print",
+      completedAt: new Date("2026-08-08T18:30:00.000Z"),
+      completedBy: USER_ID,
+    };
+    const scheduledAppointment = {
+      id: "00000000-0000-0000-0000-000000000008",
+      startTime: new Date("2099-01-02T17:00:00.000Z"),
+    };
+    const resolved = {
+      ...pending,
+      revision: 5,
+      followUpResolution: "scheduled",
+      followUpResolutionAppointmentId: scheduledAppointment.id,
+      followUpResolutionScheduledAt: scheduledAppointment.startTime,
+      followUpResolvedAt: expect.any(Date),
+      followUpResolvedBy: USER_ID,
+      followUpResolverName: "Clinic User",
+    };
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [checkedOut],
+        [{ id: PATIENT_ID }],
+        [pending],
+        [scheduledAppointment],
+      ],
+      updateResults: [[resolved]],
+    });
+
+    await expect(
+      callerWithDb(db, "front_desk").resolveNeededFollowUp({
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 4,
+        resolution: "scheduled",
+        resolutionAppointmentId: scheduledAppointment.id,
+        notes: null,
+      })
+    ).resolves.toEqual(resolved);
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        followUpResolution: "scheduled",
+        followUpResolutionAppointmentId: scheduledAppointment.id,
+        followUpResolutionScheduledAt: scheduledAppointment.startTime,
+        followUpResolvedBy: USER_ID,
+        followUpResolverName: "Clinic User",
+        revision: 5,
+      })
+    );
+    const values = updateSet.mock.calls[0]![0] as Record<string, unknown>;
+    expect(values).not.toHaveProperty("followUpDisposition");
+    expect(values).not.toHaveProperty("followUpDueDate");
+    expect(values).not.toHaveProperty("clinicalFinalizedAt");
+  });
+
+  it("keeps technicians from finalizing doctor-required visits", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [[openAppointment], [{ id: PATIENT_ID }]],
+    });
+    await expect(
+      callerWithDb(db, "technician").finalizeClinical(clinicalInput)
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message:
+        "A veterinarian must finalize instructions for a doctor-required visit.",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a missing or cross-tenant appointment", async () => {
+    const { db, updateSet, insertValues } = createDb({ selectResults: [[]] });
+    await expect(
+      callerWithDb(db).saveDraft(clinicalInput)
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/server/__tests__/records-prescription-safety.test.ts
+++ b/apps/web/server/__tests__/records-prescription-safety.test.ts
@@ -27,8 +27,10 @@ const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const PATIENT_ID = "00000000-0000-0000-0000-000000000002";
 const PRODUCT_ID = "00000000-0000-0000-0000-000000000004";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000005";
+const OPERATION_ID = "00000000-0000-0000-0000-000000000009";
 
-function callerWithDb(db: Record<string, unknown>) {
+function callerWithDb(db: Record<string, unknown>, injectOperationId = true) {
   const session = {
     user: {
       id: USER_ID,
@@ -38,14 +40,30 @@ function callerWithDb(db: Record<string, unknown>) {
       practiceId: PRACTICE_ID,
     },
   };
-  return recordsRouter.createCaller({ db, session } as never);
+  const caller = recordsRouter.createCaller({ db, session } as never);
+  if (!injectOperationId) return caller as any;
+  return new Proxy(caller, {
+    get(target, property, receiver) {
+      if (property === "createPrescription") {
+        return (input: Record<string, unknown>) =>
+          target.createPrescription({
+            operationId: OPERATION_ID,
+            ...input,
+          } as never);
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  }) as any;
 }
 
 function createThenableResult(result: unknown[]) {
   const afterWhere = {
     limit: vi.fn(async () => result),
-    then: (resolve: (value: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
-      Promise.resolve(result).then(resolve, reject),
+    for: vi.fn(async () => result),
+    then: (
+      resolve: (value: unknown[]) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => Promise.resolve(result).then(resolve, reject),
   };
   return afterWhere;
 }
@@ -53,9 +71,13 @@ function createThenableResult(result: unknown[]) {
 function createDb(opts: {
   selectResults: unknown[][];
   inserted?: Record<string, unknown>;
+  existingPrescription?: Record<string, unknown>;
   updateReturns?: unknown[][];
 }) {
-  const selectResults = [...opts.selectResults];
+  const selectResults = [
+    opts.existingPrescription ? [opts.existingPrescription] : [],
+    ...opts.selectResults,
+  ];
   const select = vi.fn(() => {
     const result = selectResults.shift() ?? [];
     const afterWhere = createThenableResult(result);
@@ -115,6 +137,23 @@ describe("records.createPrescription safety enforcement", () => {
     },
   ];
 
+  it("requires an operation ID before prescription DB work", async () => {
+    const { db, select, insertValues } = createDb({ selectResults: [] });
+
+    await expect(
+      callerWithDb(db, false).createPrescription({
+        patientId: PATIENT_ID,
+        medicationName: "Carprofen 75 mg",
+        dosage: "75 mg",
+        frequency: "Every 12 hours",
+        startDate: "2026-06-27",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("blocks allergy warnings unless the clinician acknowledges them", async () => {
     const { db, insertValues } = createDb({
       selectResults: [patientRow, carprofenAllergy, [], []],
@@ -123,11 +162,12 @@ describe("records.createPrescription safety enforcement", () => {
     await expect(
       callerWithDb(db).createPrescription({
         patientId: PATIENT_ID,
+        operationId: OPERATION_ID,
         medicationName: "Carprofen 75 mg",
         dosage: "75 mg",
         frequency: "Every 12 hours",
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -141,16 +181,17 @@ describe("records.createPrescription safety enforcement", () => {
     await expect(
       callerWithDb(db).createPrescription({
         patientId: PATIENT_ID,
+        operationId: OPERATION_ID,
         medicationName: "Carprofen 75 mg",
         dosage: "75 mg",
         frequency: "Every 12 hours",
         startDate: "2026-06-27",
         acknowledgeSafetyWarnings: true,
-      })
+      }),
     ).resolves.toMatchObject({ medicationName: "Carprofen 75 mg" });
 
     expect(insertValues).toHaveBeenCalledWith(
-      expect.not.objectContaining({ acknowledgeSafetyWarnings: true })
+      expect.not.objectContaining({ acknowledgeSafetyWarnings: true }),
     );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -158,7 +199,8 @@ describe("records.createPrescription safety enforcement", () => {
         prescribedBy: USER_ID,
         patientId: PATIENT_ID,
         medicationName: "Carprofen 75 mg",
-      })
+        operationId: OPERATION_ID,
+      }),
     );
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
       PRACTICE_ID,
@@ -170,8 +212,179 @@ describe("records.createPrescription safety enforcement", () => {
         prescribedBy: USER_ID,
         productId: null,
         source: "dashboard",
-      }
+      },
     );
+  });
+
+  it("returns the original prescription for an exact operation retry", async () => {
+    const existingPrescription = {
+      id: "00000000-0000-0000-0000-000000000003",
+      practiceId: PRACTICE_ID,
+      patientId: PATIENT_ID,
+      appointmentId: null,
+      medicationName: "Carprofen 75 mg",
+      dosage: "75 mg",
+      frequency: "Every 12 hours",
+      quantity: 10,
+      productId: PRODUCT_ID,
+      refillsRemaining: 0,
+      startDate: "2026-06-27",
+      endDate: null,
+      instructions: null,
+      prescribedBy: USER_ID,
+      operationId: OPERATION_ID,
+    };
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [],
+      existingPrescription,
+    });
+
+    await expect(
+      callerWithDb(db).createPrescription({
+        patientId: PATIENT_ID,
+        operationId: OPERATION_ID,
+        medicationName: "Carprofen 75 mg",
+        dosage: "75 mg",
+        frequency: "Every 12 hours",
+        quantity: 10,
+        productId: PRODUCT_ID,
+        startDate: "2026-06-27",
+      }),
+    ).resolves.toMatchObject(existingPrescription);
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects reuse of a prescription operation ID with changed details", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [],
+      existingPrescription: {
+        id: "00000000-0000-0000-0000-000000000003",
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: null,
+        medicationName: "Carprofen 75 mg",
+        dosage: "75 mg",
+        frequency: "Every 12 hours",
+        quantity: null,
+        productId: null,
+        refillsRemaining: 0,
+        startDate: "2026-06-27",
+        endDate: null,
+        instructions: null,
+        prescribedBy: USER_ID,
+        operationId: OPERATION_ID,
+      },
+    });
+
+    await expect(
+      callerWithDb(db).createPrescription({
+        patientId: PATIENT_ID,
+        operationId: OPERATION_ID,
+        medicationName: "Meloxicam 7.5 mg",
+        dosage: "7.5 mg",
+        frequency: "Daily",
+        startDate: "2026-06-27",
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("links a prescription only to a visit for the same tenant and patient", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        patientRow,
+        [{ id: APPOINTMENT_ID }],
+        [],
+        [],
+        [],
+        [{ id: APPOINTMENT_ID, status: "in_exam" }],
+        [],
+      ],
+      inserted: {
+        id: "00000000-0000-0000-0000-000000000003",
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        medicationName: "Carprofen 75 mg",
+        prescribedBy: USER_ID,
+        productId: null,
+      },
+    });
+
+    await expect(
+      callerWithDb(db).createPrescription({
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        medicationName: "Carprofen 75 mg",
+        dosage: "75 mg",
+        frequency: "Every 12 hours",
+        startDate: "2026-06-27",
+      }),
+    ).resolves.toMatchObject({ appointmentId: APPOINTMENT_ID });
+
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+      }),
+    );
+  });
+
+  it("rejects visit prescriptions after the clinical handoff is finalized", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        patientRow,
+        [{ id: APPOINTMENT_ID }],
+        [],
+        [],
+        [],
+        [{ id: APPOINTMENT_ID, status: "in_exam" }],
+        [{ status: "clinical_finalized" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).createPrescription({
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        medicationName: "Carprofen 75 mg",
+        dosage: "75 mg",
+        frequency: "Every 12 hours",
+        startDate: "2026-06-27",
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Clinical handoff is finalized. Use an attributed amendment before changing visit prescriptions.",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing, cross-tenant, or wrong-patient visit link", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [patientRow, []],
+    });
+
+    await expect(
+      callerWithDb(db).createPrescription({
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        medicationName: "Carprofen 75 mg",
+        dosage: "75 mg",
+        frequency: "Every 12 hours",
+        startDate: "2026-06-27",
+      }),
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Appointment not found",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("rejects a linked inventory product outside the practice", async () => {
@@ -188,7 +401,7 @@ describe("records.createPrescription safety enforcement", () => {
         quantity: 10,
         productId: PRODUCT_ID,
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -213,7 +426,7 @@ describe("records.createPrescription safety enforcement", () => {
         frequency: "Every 12 hours",
         productId: PRODUCT_ID,
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -230,7 +443,7 @@ describe("records.createPrescription safety enforcement", () => {
         frequency: "Every 12 hours",
         quantity: -1,
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -241,7 +454,7 @@ describe("records.createPrescription safety enforcement", () => {
         frequency: "Every 12 hours",
         quantity: PRESCRIPTION_COUNT_MAX + 1,
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -252,7 +465,7 @@ describe("records.createPrescription safety enforcement", () => {
         frequency: "Every 12 hours",
         refillsRemaining: 1.5,
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -263,7 +476,7 @@ describe("records.createPrescription safety enforcement", () => {
         frequency: "Every 12 hours",
         refillsRemaining: PRESCRIPTION_COUNT_MAX + 1,
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -274,7 +487,7 @@ describe("records.createPrescription safety enforcement", () => {
         frequency: "Every 12 hours",
         instructions: "A".repeat(PRESCRIPTION_INSTRUCTIONS_MAX_LENGTH + 1),
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -288,7 +501,7 @@ describe("records.createPrescription safety enforcement", () => {
       callerWithDb(db).checkPrescriptionSafety({
         patientId: PATIENT_ID,
         medicationName: "A".repeat(PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -298,7 +511,7 @@ describe("records.createPrescription safety enforcement", () => {
         dosage: "75 mg",
         frequency: "Every 12 hours",
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -308,7 +521,7 @@ describe("records.createPrescription safety enforcement", () => {
         dosage: "A".repeat(PRESCRIPTION_DOSAGE_MAX_LENGTH + 1),
         frequency: "Every 12 hours",
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -318,7 +531,7 @@ describe("records.createPrescription safety enforcement", () => {
         dosage: "75 mg",
         frequency: "A".repeat(PRESCRIPTION_FREQUENCY_MAX_LENGTH + 1),
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -335,7 +548,7 @@ describe("records.createPrescription safety enforcement", () => {
         dosage: "75 mg",
         frequency: "Every 12 hours",
         startDate: "2026-02-31",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -346,7 +559,7 @@ describe("records.createPrescription safety enforcement", () => {
         frequency: "Every 12 hours",
         startDate: "2026-06-27",
         endDate: "2026-06-26",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -374,7 +587,7 @@ describe("records.createPrescription safety enforcement", () => {
         quantity: 10,
         productId: PRODUCT_ID,
         startDate: "2026-06-27",
-      })
+      }),
     ).resolves.toMatchObject({ medicationName: "Carprofen 75 mg" });
 
     expect(transaction).toHaveBeenCalledTimes(2);
@@ -383,7 +596,7 @@ describe("records.createPrescription safety enforcement", () => {
       expect.objectContaining({
         productId: PRODUCT_ID,
         quantity: 10,
-      })
+      }),
     );
   });
 
@@ -408,7 +621,7 @@ describe("records.createPrescription safety enforcement", () => {
         quantity: 10,
         productId: PRODUCT_ID,
         startDate: "2026-06-27",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(transaction).toHaveBeenCalledTimes(2);
@@ -420,7 +633,7 @@ describe("records.createPrescription safety enforcement", () => {
 describe("records list query scoping", () => {
   const source = readFileSync(
     new URL("../routers/records.ts", import.meta.url),
-    "utf8"
+    "utf8",
   );
 
   it("keeps joined staff rows tenant scoped and active", () => {
@@ -435,32 +648,57 @@ describe("records list query scoping", () => {
         new RegExp(
           `leftJoin\\(\\s*users,\\s*and\\(\\s*eq\\(${foreignKey.replace(
             ".",
-            "\\."
+            "\\.",
           )}, users\\.id\\),\\s*eq\\(users\\.practiceId, ctx\\.practiceId\\),\\s*isNull\\(users\\.deletedAt\\)\\s*\\)\\s*\\)`,
-          "s"
-        )
+          "s",
+        ),
       );
     }
   });
 
   it("keeps prescription inventory joins tenant scoped and active", () => {
     expect(source).toMatch(
-      /leftJoin\(\s*products,\s*and\(\s*eq\(prescriptions\.productId, products\.id\),\s*eq\(products\.practiceId, ctx\.practiceId\),\s*isNull\(products\.deletedAt\)\s*\)\s*\)/s
+      /leftJoin\(\s*products,\s*and\(\s*eq\(prescriptions\.productId, products\.id\),\s*eq\(products\.practiceId, ctx\.practiceId\),\s*isNull\(products\.deletedAt\)\s*\)\s*\)/s,
     );
   });
 
   it("scopes prescription safety allergy reads through the tenant patient", () => {
     const allergySafetyBlock = source.match(
-      /\.from\(patientAllergies\)[\s\S]+?isNull\(patientAllergies\.deletedAt\)/
+      /\.from\(patientAllergies\)[\s\S]+?isNull\(patientAllergies\.deletedAt\)/,
     )?.[0];
-    expect(allergySafetyBlock).toContain("eq(patientAllergies.patientId, patientId)");
+    expect(allergySafetyBlock).toContain(
+      "eq(patientAllergies.patientId, patientId)",
+    );
     expect(allergySafetyBlock).toContain("from ${patients}");
     expect(allergySafetyBlock).toContain(
-      "${patients.id} = ${patientAllergies.patientId}"
+      "${patients.id} = ${patientAllergies.patientId}",
     );
     expect(allergySafetyBlock).toContain(
-      "${patients.practiceId} = ${ctx.practiceId}"
+      "${patients.practiceId} = ${ctx.practiceId}",
     );
     expect(allergySafetyBlock).toContain("${patients.deletedAt} is null");
+  });
+});
+
+describe("records prescription retry UX", () => {
+  const source = readFileSync(
+    new URL("../../app/(dashboard)/records/page.tsx", import.meta.url),
+    "utf8",
+  );
+
+  it("keeps one operation ID until prescription creation succeeds or is cancelled", () => {
+    expect(source).toContain(
+      "prescriptionOperationId.current ??= crypto.randomUUID()",
+    );
+    expect(source).toContain("operationId: prescriptionOperationId.current");
+    expect(source).toContain("prescriptionOperationId.current = null");
+  });
+
+  it("keeps URL-linked prescription creation behind a prerender-safe boundary", () => {
+    expect(source).toContain("function RecordsPageContent()");
+    expect(source).toContain(
+      '<Suspense fallback={<RecordsLoadingPanel label="Loading records..." />}>',
+    );
+    expect(source).toContain("<RecordsPageContent />");
   });
 });

--- a/apps/web/server/__tests__/whiteboard.test.ts
+++ b/apps/web/server/__tests__/whiteboard.test.ts
@@ -65,6 +65,7 @@ function createStatusDb(opts?: {
     const result = selectResults.shift() ?? [];
     const afterWhere = {
       limit: vi.fn(async () => result),
+      for: vi.fn(async () => result),
     };
     const builder = {
       from: vi.fn(() => builder),
@@ -307,6 +308,24 @@ describe("whiteboard workflows", () => {
       message: "Cannot change appointment status from checked_out to scheduled.",
     });
 
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects direct checkout so closeout gates cannot be bypassed", async () => {
+    const { db, updateSet } = createStatusDb({
+      selectResults: [[{ id: APPOINTMENT_ID, status: "in_exam" }]],
+    });
+
+    await expect(
+      callerWithDb(db).updateStatus({
+        id: APPOINTMENT_ID,
+        status: "checked_out",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Review and complete the visit closeout before checking out this appointment.",
+    });
     expect(updateSet).not.toHaveBeenCalled();
   });
 

--- a/apps/web/server/routers/_app.ts
+++ b/apps/web/server/routers/_app.ts
@@ -16,6 +16,7 @@ import { dataRouter } from "./data";
 import { aiRouter } from "./ai";
 import { webhooksRouter } from "./webhooks";
 import { notificationsRouter } from "./notifications";
+import { encountersRouter } from "./encounters";
 import { templatesRouter } from "./templates";
 import { controlledSubstancesRouter } from "./controlled-substances";
 import { insuranceRouter } from "./insurance";
@@ -49,6 +50,7 @@ export const appRouter = createRouter({
   ai: aiRouter,
   webhooks: webhooksRouter,
   notifications: notificationsRouter,
+  encounters: encountersRouter,
   templates: templatesRouter,
   controlledSubstances: controlledSubstancesRouter,
   insurance: insuranceRouter,

--- a/apps/web/server/routers/appointments.ts
+++ b/apps/web/server/routers/appointments.ts
@@ -12,6 +12,7 @@ import {
   users,
   rooms,
   recurringSeries,
+  visitCloseouts,
 } from "@openpims/db";
 import {
   detectConflicts,
@@ -48,6 +49,7 @@ import {
 import { generateCalendarFeedToken } from "@/lib/calendar/tokens";
 import { appBaseUrl } from "@/lib/app-url";
 import { recordActivationIfReached } from "@/lib/funnel-events-server";
+import { CLOSEOUT_BYPASS_MESSAGE } from "@/lib/encounters/closeout-policy";
 
 type AppointmentsContext = {
   db: Database;
@@ -600,6 +602,7 @@ export const appointmentsRouter = createRouter({
           notes: appointments.notes,
           recurringSeriesId: appointments.recurringSeriesId,
           patientName: patients.name,
+          patientSpecies: patients.species,
           patientId: appointments.patientId,
           clientFirstName: clients.firstName,
           clientLastName: clients.lastName,
@@ -608,6 +611,7 @@ export const appointmentsRouter = createRouter({
           doctorId: appointments.doctorId,
           typeName: appointmentTypes.name,
           typeColor: appointmentTypes.color,
+          typeRequiresDoctor: appointmentTypes.requiresDoctor,
           roomName: rooms.name,
         })
         .from(appointments)
@@ -743,55 +747,99 @@ export const appointmentsRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const [current] = await ctx.db
-        .select({
-          id: appointments.id,
-          status: appointments.status,
-        })
-        .from(appointments)
-        .where(
-          and(
-            eq(appointments.id, input.id),
-            eq(appointments.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(appointments.deletedAt)
+      const { current, appt } = await ctx.db.transaction(async (tx) => {
+        const [current] = await tx
+          .select({ id: appointments.id, status: appointments.status })
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.id, input.id),
+              eq(appointments.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(appointments.deletedAt)
+            )
           )
-        )
-        .limit(1);
+          .for("update");
 
-      if (!current) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Appointment not found",
-        });
-      }
+        if (!current) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Appointment not found",
+          });
+        }
+        if (input.status === "checked_out") {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: CLOSEOUT_BYPASS_MESSAGE,
+          });
+        }
+        if (!canTransitionAppointmentStatus(current.status, input.status)) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `Cannot change appointment status from ${current.status} to ${input.status}.`,
+          });
+        }
 
-      if (!canTransitionAppointmentStatus(current.status, input.status)) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: `Cannot change appointment status from ${current.status} to ${input.status}.`,
-        });
-      }
-
-      const [appt] = await ctx.db
-        .update(appointments)
-        .set({ status: input.status })
-        .where(
-          and(
-            eq(appointments.id, input.id),
-            eq(appointments.practiceId, ctx.practiceId),
-            eq(appointments.status, current.status),
-            activePracticePredicate(ctx.practiceId),
-            isNull(appointments.deletedAt)
+        const [closeout] = await tx
+          .select({ id: visitCloseouts.id, status: visitCloseouts.status })
+          .from(visitCloseouts)
+          .where(
+            and(
+              eq(visitCloseouts.appointmentId, input.id),
+              eq(visitCloseouts.practiceId, ctx.practiceId),
+              isNull(visitCloseouts.deletedAt)
+            )
           )
-        )
-        .returning();
-      if (!appt) {
-        throw new TRPCError({
-          code: "CONFLICT",
-          message: "Appointment status changed; try again.",
-        });
-      }
+          .limit(1);
+        if (
+          closeout?.status === "clinical_finalized" ||
+          closeout?.status === "completed"
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Clinical handoff is finalized. Complete the visit through closeout instead of changing its status.",
+          });
+        }
+
+        const [appt] = await tx
+          .update(appointments)
+          .set({ status: input.status })
+          .where(
+            and(
+              eq(appointments.id, input.id),
+              eq(appointments.practiceId, ctx.practiceId),
+              eq(appointments.status, current.status),
+              activePracticePredicate(ctx.practiceId),
+              isNull(appointments.deletedAt)
+            )
+          )
+          .returning();
+        if (!appt) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Appointment status changed; try again.",
+          });
+        }
+        if (
+          closeout?.status === "draft" &&
+          (input.status === "cancelled" || input.status === "no_show")
+        ) {
+          const now = new Date();
+          await tx
+            .update(visitCloseouts)
+            .set({ deletedAt: now, updatedAt: now })
+            .where(
+              and(
+                eq(visitCloseouts.id, closeout.id),
+                eq(visitCloseouts.practiceId, ctx.practiceId),
+                eq(visitCloseouts.status, "draft"),
+                isNull(visitCloseouts.deletedAt)
+              )
+            );
+        }
+        return { current, appt };
+      });
       if (appt.status === "checked_in") {
         await dispatchWebhookEvent(ctx.practiceId, "appointment.checked_in", {
           id: appt.id,

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -74,6 +74,8 @@ import {
   users,
   practices,
   appointments,
+  prescriptions,
+  visitCloseouts,
 } from "@openpims/db";
 import {
   clinicalDateInput,
@@ -82,7 +84,7 @@ import {
 } from "@/lib/records/clinical-inputs";
 import { listOffsetInput } from "./pagination";
 
-type BillingDb = Pick<Database, "select" | "insert" | "update">;
+type BillingDb = Pick<Database, "select" | "insert" | "update" | "execute">;
 type ServiceCatalogDb = Pick<Database, "select" | "execute">;
 
 type BillingContext = {
@@ -96,9 +98,26 @@ type InvoiceForPayment = {
   paidAmount: string | null;
   status: "draft" | "sent" | "paid" | "overdue" | "void";
   isEstimate: boolean;
+  appointmentId?: string | null;
 };
 
 type InvoiceAdjustmentType = "credit" | "write_off";
+type InvoiceStatus = "draft" | "sent" | "paid" | "overdue" | "void";
+
+const allowedInvoiceStatusTransitions: Record<
+  InvoiceStatus,
+  readonly InvoiceStatus[]
+> = {
+  draft: ["sent", "void"],
+  sent: ["overdue", "void"],
+  overdue: ["sent", "void"],
+  paid: [],
+  void: [],
+};
+
+function canTransitionInvoiceStatus(current: InvoiceStatus, next: InvoiceStatus) {
+  return current === next || allowedInvoiceStatusTransitions[current].includes(next);
+}
 
 type PaymentAccountRow = typeof practicePaymentAccounts.$inferSelect;
 
@@ -223,6 +242,7 @@ const invoiceLineInput = z
     unitPrice: nonNegativeMoneySchema,
     itemType: z.enum(["service", "product"]),
     itemId: z.string().uuid().optional(),
+    sourcePrescriptionId: z.string().uuid().optional(),
   })
   .superRefine((item, ctx) => {
     const totalCents = moneyToCents(item.unitPrice) * item.quantity;
@@ -231,6 +251,16 @@ const invoiceLineInput = z
         code: z.ZodIssueCode.custom,
         path: ["unitPrice"],
         message: "Line item total must fit a currency amount.",
+      });
+    }
+    if (
+      item.sourcePrescriptionId &&
+      (item.itemType !== "product" || !item.itemId)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["sourcePrescriptionId"],
+        message: "A prescription charge must reference its dispensed product.",
       });
     }
   });
@@ -266,6 +296,7 @@ const createInvoiceInput = z
 const updateInvoiceItemsInput = z
   .object({
     id: z.string().uuid(),
+    expectedUpdatedAt: z.date(),
     items: z
       .array(invoiceLineInput)
       .min(1, "An invoice must include at least one line item.")
@@ -294,6 +325,7 @@ type InvoiceLineInput = {
   unitPrice: string;
   itemType: "service" | "product";
   itemId?: string | null;
+  sourcePrescriptionId?: string | null;
 };
 
 function activePracticeWhere(practiceId: string) {
@@ -376,6 +408,7 @@ async function getInvoiceForPractice(
       paidAmount: invoices.paidAmount,
       status: invoices.status,
       isEstimate: invoices.isEstimate,
+      appointmentId: invoices.appointmentId,
     })
     .from(invoices)
     .where(
@@ -747,6 +780,101 @@ async function assertAppointmentBelongsToClientPatient(
   return appointment;
 }
 
+async function lockAppointmentForVisitBilling(
+  ctx: BillingContext,
+  appointmentId: string,
+  clientId: string,
+  patientId: string | undefined,
+  isEstimate: boolean
+) {
+  const conditions = [
+    eq(appointments.id, appointmentId),
+    eq(appointments.practiceId, ctx.practiceId),
+    eq(appointments.clientId, clientId),
+    isNull(appointments.deletedAt),
+  ];
+  if (patientId) conditions.push(eq(appointments.patientId, patientId));
+
+  const [appointment] = await ctx.db
+    .select({ id: appointments.id, status: appointments.status })
+    .from(appointments)
+    .where(and(...conditions))
+    .for("update");
+  if (!appointment) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Appointment not found for this client and patient.",
+    });
+  }
+  if (!isEstimate && appointment.status !== "in_exam") {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "Start the exam before capturing visit charges.",
+    });
+  }
+  if (
+    isEstimate &&
+    (appointment.status === "checked_out" ||
+      appointment.status === "cancelled" ||
+      appointment.status === "no_show")
+  ) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "A terminal appointment cannot receive a new estimate.",
+    });
+  }
+  return appointment;
+}
+
+async function assertInvoiceNotCompletedCloseout(
+  ctx: BillingContext,
+  invoiceId: string
+) {
+  const [closeout] = await ctx.db
+    .select({ id: visitCloseouts.id })
+    .from(visitCloseouts)
+    .where(
+      and(
+        eq(visitCloseouts.invoiceId, invoiceId),
+        eq(visitCloseouts.practiceId, ctx.practiceId),
+        eq(visitCloseouts.status, "completed"),
+        isNull(visitCloseouts.deletedAt)
+      )
+    )
+    .limit(1);
+  if (closeout) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "This invoice is part of a completed visit. Reconcile it through an attributed closeout amendment.",
+    });
+  }
+}
+
+async function lockAppointmentForInvoiceMutation(
+  ctx: BillingContext,
+  appointmentId: string | null | undefined
+) {
+  if (!appointmentId) return;
+  const [appointment] = await ctx.db
+    .select({ id: appointments.id })
+    .from(appointments)
+    .where(
+      and(
+        eq(appointments.id, appointmentId),
+        eq(appointments.practiceId, ctx.practiceId),
+        isNull(appointments.deletedAt)
+      )
+    )
+    .for("update");
+  if (!appointment) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "The linked appointment is no longer available.",
+    });
+  }
+}
+
 async function assertLineItemReferences(
   ctx: BillingContext,
   items: readonly InvoiceLineInput[],
@@ -844,6 +972,119 @@ async function assertLineItemReferences(
   }
 }
 
+function stockOwnedItems(
+  items: readonly InvoiceLineInput[]
+): DispensableItem[] {
+  return items
+    .filter((item) => !item.sourcePrescriptionId)
+    .map((item) => ({
+      itemType: item.itemType,
+      itemId: item.itemId,
+      quantity: item.quantity,
+    }));
+}
+
+async function assertPrescriptionChargeSources(
+  ctx: BillingContext,
+  items: readonly InvoiceLineInput[],
+  options: {
+    appointmentId?: string | null;
+    patientId?: string | null;
+    currentInvoiceId?: string;
+  }
+) {
+  const sourcedItems = items.filter((item) => item.sourcePrescriptionId);
+  const sourceIds = sourcedItems.map((item) => item.sourcePrescriptionId!);
+  if (new Set(sourceIds).size !== sourceIds.length) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "A prescription can appear only once on an invoice.",
+    });
+  }
+  if (!options.appointmentId || !options.patientId) {
+    if (sourceIds.length > 0) {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Prescription charges require a visit-linked invoice.",
+      });
+    }
+    return;
+  }
+
+  const linkedPrescriptions = await ctx.db
+    .select({
+      id: prescriptions.id,
+      productId: prescriptions.productId,
+      quantity: prescriptions.quantity,
+    })
+    .from(prescriptions)
+    .where(
+      and(
+        eq(prescriptions.appointmentId, options.appointmentId),
+        eq(prescriptions.patientId, options.patientId),
+        eq(prescriptions.practiceId, ctx.practiceId),
+        isNull(prescriptions.deletedAt),
+        isNotNull(prescriptions.productId)
+      )
+    )
+    .orderBy(prescriptions.id)
+    .for("share");
+  const byId = new Map(linkedPrescriptions.map((rx) => [rx.id, rx]));
+  const visitProductIds = new Set(
+    linkedPrescriptions.map((rx) => rx.productId).filter(Boolean)
+  );
+
+  for (const item of items) {
+    if (item.itemType !== "product" || !item.itemId) continue;
+    if (!item.sourcePrescriptionId) {
+      if (visitProductIds.has(item.itemId)) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            "Charge a visit-dispensed medication from its prescription entry so stock is not deducted twice.",
+        });
+      }
+      continue;
+    }
+    const prescription = byId.get(item.sourcePrescriptionId);
+    if (
+      !prescription ||
+      prescription.productId !== item.itemId ||
+      (prescription.quantity !== null && prescription.quantity !== item.quantity)
+    ) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Prescription charge no longer matches the visit dispensation.",
+      });
+    }
+  }
+
+  if (sourceIds.length > 0) {
+    const conditions = [
+      inArray(invoiceItems.sourcePrescriptionId, sourceIds),
+      isNull(invoiceItems.deletedAt),
+      eq(invoices.practiceId, ctx.practiceId),
+      ne(invoices.status, "void"),
+      isNull(invoices.deletedAt),
+    ];
+    if (options.currentInvoiceId) {
+      conditions.push(ne(invoices.id, options.currentInvoiceId));
+    }
+    const [alreadyCharged] = await ctx.db
+      .select({ id: invoiceItems.id })
+      .from(invoiceItems)
+      .innerJoin(invoices, eq(invoiceItems.invoiceId, invoices.id))
+      .where(and(...conditions))
+      .limit(1);
+    if (alreadyCharged) {
+      throw new TRPCError({
+        code: "CONFLICT",
+        message: "A visit prescription has already been charged on another invoice.",
+      });
+    }
+  }
+}
+
 async function deductProductStock(
   ctx: BillingContext,
   items: readonly DispensableItem[]
@@ -889,6 +1130,7 @@ async function invoiceProductItemsForStock(
       and(
         eq(invoiceItems.invoiceId, invoiceId),
         invoiceItemPracticeScope(ctx),
+        isNull(invoiceItems.sourcePrescriptionId),
         isNull(invoiceItems.deletedAt)
       )
     );
@@ -1148,6 +1390,7 @@ export const billingRouter = createRouter({
             ), 0)`,
             dueDate: invoices.dueDate,
             createdAt: invoices.createdAt,
+            updatedAt: invoices.updatedAt,
             isEstimate: invoices.isEstimate,
             clientFirstName: clients.firstName,
             clientLastName: clients.lastName,
@@ -1202,6 +1445,7 @@ export const billingRouter = createRouter({
           paidAmount: invoices.paidAmount,
           dueDate: invoices.dueDate,
           createdAt: invoices.createdAt,
+          updatedAt: invoices.updatedAt,
           clientFirstName: clients.firstName,
           clientLastName: clients.lastName,
           clientEmail: clients.email,
@@ -1296,6 +1540,12 @@ export const billingRouter = createRouter({
       if (existing.status === "void" && input.status === "void") {
         return existing;
       }
+      if (!canTransitionInvoiceStatus(existing.status, input.status)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Cannot change invoice status from ${existing.status} to ${input.status}.`,
+        });
+      }
       const updates: Record<string, any> = { status: input.status };
       const updateConditions: SQL[] = [
         eq(invoices.id, input.id),
@@ -1306,22 +1556,27 @@ export const billingRouter = createRouter({
         eq(invoices.paidAmount, existing.paidAmount ?? "0"),
       ];
       if (input.status === "void") {
-        const adjustedCents = await getInvoiceAdjustmentTotalCents(ctx, input.id);
-        if (moneyToCents(existing.paidAmount) > 0 || adjustedCents > 0) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message: "Cannot void an invoice with payments or adjustments.",
-          });
-        }
-        updateConditions.push(
-          noActivePaymentsForInvoice(),
-          noActiveAdjustmentsForInvoice()
-        );
-      }
-
-      if (input.status === "void") {
         return ctx.db.transaction(async (tx) => {
           const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+          await lockAppointmentForInvoiceMutation(
+            txCtx,
+            existing.appointmentId
+          );
+          await assertInvoiceNotCompletedCloseout(txCtx, input.id);
+          const adjustedCents = await getInvoiceAdjustmentTotalCents(
+            txCtx,
+            input.id
+          );
+          if (moneyToCents(existing.paidAmount) > 0 || adjustedCents > 0) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "Cannot void an invoice with payments or adjustments.",
+            });
+          }
+          updateConditions.push(
+            noActivePaymentsForInvoice(),
+            noActiveAdjustmentsForInvoice()
+          );
           const [invoice] = await tx
             .update(invoices)
             .set(updates)
@@ -1580,6 +1835,13 @@ export const billingRouter = createRouter({
           await tx.execute(
             sql`select pg_advisory_xact_lock(hashtextextended(${input.appointmentId}, 0))`
           );
+          await lockAppointmentForVisitBilling(
+            txCtx,
+            input.appointmentId,
+            input.clientId,
+            input.patientId,
+            input.isEstimate ?? false
+          );
           const [existingVisitInvoice] = await tx
             .select({ id: invoices.id })
             .from(invoices)
@@ -1604,8 +1866,12 @@ export const billingRouter = createRouter({
         await assertLineItemReferences(txCtx, input.items, {
           lockProductsForStock: !(input.isEstimate ?? false),
         });
+        await assertPrescriptionChargeSources(txCtx, input.items, {
+          appointmentId: input.appointmentId,
+          patientId: input.patientId,
+        });
         if (!(input.isEstimate ?? false)) {
-          await deductProductStock(txCtx, input.items);
+          await deductProductStock(txCtx, stockOwnedItems(input.items));
         }
 
         const [invoice] = await tx
@@ -1635,6 +1901,7 @@ export const billingRouter = createRouter({
               total: (item.quantity * parseFloat(item.unitPrice)).toFixed(2),
               itemType: item.itemType as "service" | "product",
               itemId: item.itemId ?? null,
+              sourcePrescriptionId: item.sourcePrescriptionId ?? null,
             }))
           );
         }
@@ -1676,6 +1943,9 @@ export const billingRouter = createRouter({
             status: invoices.status,
             isEstimate: invoices.isEstimate,
             paidAmount: invoices.paidAmount,
+            appointmentId: invoices.appointmentId,
+            patientId: invoices.patientId,
+            updatedAt: invoices.updatedAt,
           })
           .from(invoices)
           .where(
@@ -1697,6 +1967,12 @@ export const billingRouter = createRouter({
               "Convert or replace the estimate before editing visit invoice charges.",
           });
         }
+        if (existing.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Invoice changed in another session. Refresh before saving charges.",
+          });
+        }
         if (existing.status !== "draft" || moneyToCents(existing.paidAmount) > 0) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
@@ -1704,14 +1980,48 @@ export const billingRouter = createRouter({
               "Only an unpaid draft invoice can have its line items changed.",
           });
         }
-
+        if (existing.appointmentId) {
+          const [appointment] = await tx
+            .select({
+              id: appointments.id,
+              clientId: appointments.clientId,
+              patientId: appointments.patientId,
+            })
+            .from(appointments)
+            .where(
+              and(
+                eq(appointments.id, existing.appointmentId),
+                eq(appointments.practiceId, ctx.practiceId),
+                isNull(appointments.deletedAt)
+              )
+            )
+            .limit(1);
+          if (!appointment?.clientId) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "The linked visit is no longer billable.",
+            });
+          }
+          await lockAppointmentForVisitBilling(
+            txCtx,
+            existing.appointmentId,
+            appointment.clientId,
+            appointment.patientId ?? undefined,
+            false
+          );
+        }
         const previousItems = await invoiceProductItemsForStock(txCtx, input.id);
         await assertLineItemReferences(txCtx, input.items, {
           previousItems,
           lockProductsForStock: true,
         });
+        await assertPrescriptionChargeSources(txCtx, input.items, {
+          appointmentId: existing.appointmentId,
+          patientId: existing.patientId,
+          currentInvoiceId: existing.id,
+        });
         await restoreProductStock(txCtx, previousItems);
-        await deductProductStock(txCtx, input.items);
+        await deductProductStock(txCtx, stockOwnedItems(input.items));
 
         const [invoice] = await tx
           .update(invoices)
@@ -1728,7 +2038,10 @@ export const billingRouter = createRouter({
               isNull(invoices.deletedAt),
               eq(invoices.status, "draft"),
               eq(invoices.isEstimate, existing.isEstimate),
-              eq(invoices.paidAmount, existing.paidAmount ?? "0.00")
+              eq(invoices.paidAmount, existing.paidAmount ?? "0.00"),
+              eq(invoices.updatedAt, input.expectedUpdatedAt),
+              noActivePaymentsForInvoice(),
+              noActiveAdjustmentsForInvoice()
             )
           )
           .returning();
@@ -1762,6 +2075,7 @@ export const billingRouter = createRouter({
             total: centsToMoney(moneyToCents(item.unitPrice) * item.quantity),
             itemType: item.itemType,
             itemId: item.itemId ?? null,
+            sourcePrescriptionId: item.sourcePrescriptionId ?? null,
           }))
         );
 
@@ -1800,40 +2114,81 @@ export const billingRouter = createRouter({
     .input(
       z.object({
         invoiceId: z.string().uuid(),
+        operationId: z.string().uuid(),
         amount: paymentAmountSchema,
         method: z.enum(["cash", "credit_card", "debit_card", "check", "online", "other"]),
         notes: billingNotesInput,
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const invoice = await getInvoiceForPractice(ctx, input.invoiceId);
-      assertCanRecordPayment(invoice);
+      const operationKey = `dashboard-payment:${ctx.practiceId}:${input.operationId}`;
+      const result = await ctx.db.transaction(async (tx) => {
+        const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+        );
 
-      const totalCents = moneyToCents(invoice.total);
-      const paidBeforeCents = moneyToCents(invoice.paidAmount);
-      const adjustedCents = await getInvoiceAdjustmentTotalCents(
-        ctx,
-        input.invoiceId
-      );
-      const amountCents = moneyToCents(input.amount);
-      const balanceCents = invoiceBalanceCents(invoice, adjustedCents);
+        const [existingPayment] = await tx
+          .select({
+            id: payments.id,
+            invoiceId: payments.invoiceId,
+            amount: payments.amount,
+            method: payments.method,
+            notes: payments.notes,
+            receivedBy: payments.receivedBy,
+            receivedAt: payments.receivedAt,
+            externalId: payments.externalId,
+          })
+          .from(payments)
+          .innerJoin(invoices, eq(payments.invoiceId, invoices.id))
+          .where(
+            and(
+              eq(payments.externalId, operationKey),
+              eq(invoices.practiceId, ctx.practiceId)
+            )
+          )
+          .limit(1);
+        if (existingPayment) {
+          if (
+            existingPayment.invoiceId !== input.invoiceId ||
+            moneyToCents(existingPayment.amount) !== moneyToCents(input.amount) ||
+            existingPayment.method !== input.method ||
+            (existingPayment.notes ?? null) !== (input.notes ?? null)
+          ) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "This payment operation ID was already used for different details.",
+            });
+          }
+          return { payment: existingPayment, replayed: true as const };
+        }
 
-      if (amountCents > balanceCents) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Payment exceeds the invoice balance.",
-        });
-      }
+        const invoice = await getInvoiceForPractice(txCtx, input.invoiceId);
+        assertCanRecordPayment(invoice);
+        const totalCents = moneyToCents(invoice.total);
+        const paidBeforeCents = moneyToCents(invoice.paidAmount);
+        const adjustedCents = await getInvoiceAdjustmentTotalCents(
+          txCtx,
+          input.invoiceId
+        );
+        const amountCents = moneyToCents(input.amount);
+        const balanceCents = invoiceBalanceCents(invoice, adjustedCents);
 
-      const paidAfterCents = paidBeforeCents + amountCents;
-      const updates: Record<string, any> = {
-        paidAmount: centsToMoney(paidAfterCents),
-      };
-      if (paidAfterCents + adjustedCents >= totalCents) {
-        updates.status = "paid";
-      }
+        if (amountCents > balanceCents) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Payment exceeds the invoice balance.",
+          });
+        }
 
-      const payment = await ctx.db.transaction(async (tx) => {
+        const paidAfterCents = paidBeforeCents + amountCents;
+        const updates: Record<string, any> = {
+          paidAmount: centsToMoney(paidAfterCents),
+        };
+        if (paidAfterCents + adjustedCents >= totalCents) {
+          updates.status = "paid";
+        }
+
         const [updatedInvoice] = await tx
           .update(invoices)
           .set(updates)
@@ -1866,18 +2221,29 @@ export const billingRouter = createRouter({
             method: input.method,
             receivedBy: ctx.user.id,
             notes: input.notes ?? null,
+            externalId: operationKey,
           })
           .returning();
 
-        return createdPayment!;
+        return {
+          payment: createdPayment!,
+          replayed: false as const,
+          markedPaid: updates.status === "paid",
+          invoiceTotal: invoice.total,
+          paidAfterCents,
+          adjustedCents,
+          amountCents,
+        };
       });
 
-      if (updates.status === "paid") {
+      if (result.replayed) return result.payment;
+
+      if (result.markedPaid) {
         await dispatchWebhookEvent(ctx.practiceId, "invoice.paid", {
           id: input.invoiceId,
-          paymentId: payment.id,
-          paidAmount: centsToMoney(paidAfterCents),
-          total: invoice.total,
+          paymentId: result.payment.id,
+          paidAmount: centsToMoney(result.paidAfterCents),
+          total: result.invoiceTotal,
           source: "dashboard",
         });
       }
@@ -1885,14 +2251,17 @@ export const billingRouter = createRouter({
       // Email the pet owner a receipt (no-op when no email on file; a lost
       // email never fails the payment).
       const receipt = await loadClientReceipt(ctx.db, input.invoiceId, {
-        amountPaidCents: amountCents,
-        balanceRemainingCents: totalCents - paidAfterCents - adjustedCents,
+        amountPaidCents: result.amountCents,
+        balanceRemainingCents:
+          moneyToCents(result.invoiceTotal) -
+          result.paidAfterCents -
+          result.adjustedCents,
       });
       if (receipt) {
         await deliverClientReceipt(receipt);
       }
 
-      return payment;
+      return result.payment;
     }),
 
   listPayments: protectedProcedure
@@ -2338,6 +2707,7 @@ export const billingRouter = createRouter({
     .input(
       z.object({
         invoiceId: z.string().uuid(),
+        operationId: z.string().uuid(),
         type: z.enum(["credit", "write_off"]),
         amount: paymentAmountSchema,
         reason: z
@@ -2348,33 +2718,78 @@ export const billingRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const invoice = await getInvoiceForPractice(ctx, input.invoiceId);
-      assertCanAdjustInvoice(invoice);
+      const operationKey = `dashboard-adjustment:${ctx.practiceId}:${input.operationId}`;
+      const result = await ctx.db.transaction(async (tx) => {
+        const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+        );
 
-      const adjustedBeforeCents = await getInvoiceAdjustmentTotalCents(
-        ctx,
-        input.invoiceId
-      );
-      const amountCents = moneyToCents(input.amount);
-      const balanceCents = invoiceBalanceCents(invoice, adjustedBeforeCents);
-      const adjustedAfterCents = adjustedBeforeCents + amountCents;
-      const closesInvoice =
-        moneyToCents(invoice.paidAmount) + adjustedAfterCents >=
-        moneyToCents(invoice.total);
+        const [existingAdjustment] = await tx
+          .select({
+            id: invoiceAdjustments.id,
+            invoiceId: invoiceAdjustments.invoiceId,
+            type: invoiceAdjustments.type,
+            amount: invoiceAdjustments.amount,
+            reason: invoiceAdjustments.reason,
+            createdBy: invoiceAdjustments.createdBy,
+            createdAt: invoiceAdjustments.createdAt,
+            operationKey: invoiceAdjustments.operationKey,
+            balanceAfter: invoiceAdjustments.balanceAfter,
+          })
+          .from(invoiceAdjustments)
+          .innerJoin(invoices, eq(invoiceAdjustments.invoiceId, invoices.id))
+          .where(
+            and(
+              eq(invoiceAdjustments.operationKey, operationKey),
+              eq(invoices.practiceId, ctx.practiceId)
+            )
+          )
+          .limit(1);
+        if (existingAdjustment) {
+          if (
+            existingAdjustment.invoiceId !== input.invoiceId ||
+            existingAdjustment.type !== input.type ||
+            moneyToCents(existingAdjustment.amount) !== moneyToCents(input.amount) ||
+            (existingAdjustment.reason ?? null) !== (input.reason ?? null)
+          ) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "This adjustment operation ID was already used for different details.",
+            });
+          }
+          return {
+            adjustment: existingAdjustment,
+            replayed: true as const,
+          };
+        }
 
-      if (amountCents > balanceCents) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: `${adjustmentLabel(input.type)} exceeds the invoice balance.`,
-        });
-      }
+        const invoice = await getInvoiceForPractice(txCtx, input.invoiceId);
+        assertCanAdjustInvoice(invoice);
+        const adjustedBeforeCents = await getInvoiceAdjustmentTotalCents(
+          txCtx,
+          input.invoiceId
+        );
+        const amountCents = moneyToCents(input.amount);
+        const balanceCents = invoiceBalanceCents(invoice, adjustedBeforeCents);
+        const adjustedAfterCents = adjustedBeforeCents + amountCents;
+        const closesInvoice =
+          moneyToCents(invoice.paidAmount) + adjustedAfterCents >=
+          moneyToCents(invoice.total);
 
-      const invoiceUpdates: Record<string, any> = { updatedAt: new Date() };
-      if (closesInvoice) {
-        invoiceUpdates.status = "paid";
-      }
+        if (amountCents > balanceCents) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `${adjustmentLabel(input.type)} exceeds the invoice balance.`,
+          });
+        }
 
-      const adjustment = await ctx.db.transaction(async (tx) => {
+        const invoiceUpdates: Record<string, any> = { updatedAt: new Date() };
+        if (closesInvoice) {
+          invoiceUpdates.status = "paid";
+        }
+
         const [updatedInvoice] = await tx
           .update(invoices)
           .set(invoiceUpdates)
@@ -2407,27 +2822,44 @@ export const billingRouter = createRouter({
             amount: input.amount,
             reason: input.reason || null,
             createdBy: ctx.user.id,
+            operationKey,
+            balanceAfter: centsToMoney(balanceCents - amountCents),
           })
           .returning();
 
-        return createdAdjustment!;
+        return {
+          adjustment: createdAdjustment!,
+          replayed: false as const,
+          closesInvoice,
+          invoiceTotal: invoice.total,
+          invoicePaidAmount: invoice.paidAmount ?? "0.00",
+          adjustedAfterCents,
+          balanceDueCents: balanceCents - amountCents,
+        };
       });
 
-      if (closesInvoice) {
+      if (result.replayed) {
+        return {
+          ...result.adjustment,
+          balanceDue: result.adjustment.balanceAfter ?? "0.00",
+        };
+      }
+
+      if (result.closesInvoice) {
         await dispatchWebhookEvent(ctx.practiceId, "invoice.paid", {
           id: input.invoiceId,
-          adjustmentId: adjustment.id,
+          adjustmentId: result.adjustment.id,
           adjustmentType: input.type,
-          paidAmount: invoice.paidAmount ?? "0.00",
-          adjustedAmount: centsToMoney(adjustedAfterCents),
-          total: invoice.total,
+          paidAmount: result.invoicePaidAmount,
+          adjustedAmount: centsToMoney(result.adjustedAfterCents),
+          total: result.invoiceTotal,
           source: "dashboard",
         });
       }
 
       return {
-        ...adjustment,
-        balanceDue: centsToMoney(balanceCents - amountCents),
+        ...result.adjustment,
+        balanceDue: centsToMoney(result.balanceDueCents),
       };
     }),
 
@@ -2446,16 +2878,20 @@ export const billingRouter = createRouter({
         return invoice;
       }
 
-      const adjustedCents = await getInvoiceAdjustmentTotalCents(ctx, input.id);
-      if (moneyToCents(invoice.paidAmount) > 0 || adjustedCents > 0) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Cannot void an invoice with payments or adjustments.",
-        });
-      }
-
       const voided = await ctx.db.transaction(async (tx) => {
         const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+        await lockAppointmentForInvoiceMutation(txCtx, invoice.appointmentId);
+        await assertInvoiceNotCompletedCloseout(txCtx, input.id);
+        const adjustedCents = await getInvoiceAdjustmentTotalCents(
+          txCtx,
+          input.id
+        );
+        if (moneyToCents(invoice.paidAmount) > 0 || adjustedCents > 0) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Cannot void an invoice with payments or adjustments.",
+          });
+        }
         const [updated] = await tx
           .update(invoices)
           .set({ status: "void" })

--- a/apps/web/server/routers/encounters.ts
+++ b/apps/web/server/routers/encounters.ts
@@ -1,0 +1,1468 @@
+import { z } from "zod";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  inArray,
+  isNull,
+  ne,
+  sql,
+} from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import { createRouter, protectedProcedure, requireRole } from "../trpc";
+import type { Database } from "@openpims/db/client";
+import {
+  appointments,
+  appointmentTypes,
+  clients,
+  invoiceAdjustments,
+  invoiceItems,
+  invoices,
+  patients,
+  practices,
+  prescriptions,
+  products,
+  soapNotes,
+  visitCloseouts,
+  users,
+} from "@openpims/db";
+import {
+  CLOSEOUT_DIAGNOSIS_MAX_LENGTH,
+  CLOSEOUT_FOLLOW_UP_NOTES_MAX_LENGTH,
+  CLOSEOUT_INSTRUCTIONS_MAX_LENGTH,
+  CLOSEOUT_REASON_MAX_LENGTH,
+  CLOSEOUT_WARNING_SIGNS_MAX_LENGTH,
+  trimmedOrNull,
+} from "@/lib/encounters/closeout-policy";
+import {
+  invoiceBalanceCents,
+  moneyToCents,
+} from "@/lib/billing/invoice-balance";
+import { canTransitionAppointmentStatus } from "@/lib/scheduling/appointment-status";
+import { formatDateInputForTimeZone } from "@/lib/date-input";
+import { clinicalDateInput } from "@/lib/records/clinical-inputs";
+
+type EncounterDb = Pick<Database, "select" | "insert" | "update">;
+
+type EncounterContext = {
+  db: EncounterDb;
+  practiceId: string;
+};
+
+const optionalText = (label: string, max: number) =>
+  z
+    .string()
+    .trim()
+    .max(max, `${label} must be at most ${max} characters.`)
+    .nullable()
+    .optional()
+    .transform((value) => trimmedOrNull(value));
+
+const clinicalDraftInput = z.object({
+  appointmentId: z.string().uuid(),
+  expectedRevision: z.number().int().min(0),
+  diagnosisSummary: optionalText("Diagnosis summary", CLOSEOUT_DIAGNOSIS_MAX_LENGTH),
+  dischargeInstructions: optionalText(
+    "Discharge instructions",
+    CLOSEOUT_INSTRUCTIONS_MAX_LENGTH
+  ),
+  warningSigns: optionalText("Warning signs", CLOSEOUT_WARNING_SIGNS_MAX_LENGTH),
+  noInstructionsReason: optionalText(
+    "No-instructions reason",
+    CLOSEOUT_REASON_MAX_LENGTH
+  ),
+  prescriptionDisposition: z.enum(["prescribed", "not_needed"]).nullable(),
+  followUpDisposition: z.enum(["none", "needed", "scheduled"]).nullable(),
+  followUpNotes: optionalText(
+    "Follow-up notes",
+    CLOSEOUT_FOLLOW_UP_NOTES_MAX_LENGTH
+  ),
+  followUpAppointmentId: z.string().uuid().nullable(),
+  followUpDueDate: clinicalDateInput("Follow-up due date")
+    .nullable()
+    .optional()
+    .transform((value) => value ?? null),
+  followUpAssignedTo: z
+    .string()
+    .uuid()
+    .nullable()
+    .optional()
+    .transform((value) => value ?? null),
+  documentationExceptionReason: optionalText(
+    "Documentation exception",
+    CLOSEOUT_REASON_MAX_LENGTH
+  ),
+});
+
+const finalizeClinicalInput = clinicalDraftInput.superRefine((input, ctx) => {
+  const hasInstructions = Boolean(input.dischargeInstructions);
+  const hasNoInstructionsReason = Boolean(input.noInstructionsReason);
+  if (hasInstructions === hasNoInstructionsReason) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["dischargeInstructions"],
+      message:
+        "Enter owner instructions or explain why no instructions are needed.",
+    });
+  }
+  if (!input.prescriptionDisposition) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["prescriptionDisposition"],
+      message: "Confirm whether this visit produced a prescription.",
+    });
+  }
+  if (!input.followUpDisposition) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["followUpDisposition"],
+      message: "Choose a follow-up disposition.",
+    });
+    return;
+  }
+  if (
+    input.followUpDisposition === "scheduled" &&
+    !input.followUpAppointmentId
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["followUpAppointmentId"],
+      message: "Choose the scheduled follow-up appointment.",
+    });
+  }
+  if (
+    input.followUpDisposition === "needed" &&
+    (!input.followUpDueDate || !input.followUpAssignedTo)
+  ) {
+    if (!input.followUpDueDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["followUpDueDate"],
+        message: "Choose when the follow-up is due.",
+      });
+    }
+    if (!input.followUpAssignedTo) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["followUpAssignedTo"],
+        message: "Assign a staff member to own the follow-up.",
+      });
+    }
+  }
+  if (
+    input.followUpDisposition !== "needed" &&
+    (input.followUpDueDate || input.followUpAssignedTo)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["followUpDueDate"],
+      message: "Due date and assignee are only used when follow-up is needed.",
+    });
+  }
+});
+
+const completeVisitInput = z
+  .object({
+    appointmentId: z.string().uuid(),
+    expectedRevision: z.number().int().min(1),
+    chargeDisposition: z.enum(["paid", "accounts_receivable", "no_charge"]),
+    noChargeReason: optionalText("No-charge reason", CLOSEOUT_REASON_MAX_LENGTH),
+    handoffMethod: z.enum(["print", "verbal", "declined"]),
+  })
+  .superRefine((input, ctx) => {
+    if (input.chargeDisposition === "no_charge" && !input.noChargeReason) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["noChargeReason"],
+        message: "Explain why this visit has no charge.",
+      });
+    }
+    if (input.chargeDisposition !== "no_charge" && input.noChargeReason) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["noChargeReason"],
+        message: "A no-charge reason is only used for no-charge visits.",
+      });
+    }
+  });
+
+const reopenClinicalInput = z.object({
+  appointmentId: z.string().uuid(),
+  expectedRevision: z.number().int().min(1),
+  reason: z
+    .string()
+    .trim()
+    .min(5, "Explain why the finalized handoff needs correction.")
+    .max(CLOSEOUT_REASON_MAX_LENGTH),
+});
+
+const resolveNeededFollowUpInput = z
+  .object({
+    appointmentId: z.string().uuid(),
+    expectedRevision: z.number().int().min(1),
+    resolution: z.enum(["scheduled", "completed", "not_needed"]),
+    resolutionAppointmentId: z
+      .string()
+      .uuid()
+      .nullable()
+      .optional()
+      .transform((value) => value ?? null),
+    notes: optionalText("Follow-up resolution notes", CLOSEOUT_REASON_MAX_LENGTH),
+  })
+  .superRefine((input, ctx) => {
+    if (input.resolution === "scheduled" && !input.resolutionAppointmentId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["resolutionAppointmentId"],
+        message: "Choose the scheduled follow-up appointment.",
+      });
+    }
+    if (
+      input.resolution !== "scheduled" &&
+      input.resolutionAppointmentId
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["resolutionAppointmentId"],
+        message: "Only scheduled resolutions can link an appointment.",
+      });
+    }
+    if (input.resolution !== "scheduled" && !input.notes) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["notes"],
+        message: "Document how the follow-up obligation was resolved.",
+      });
+    }
+  });
+
+function activePracticePredicate(practiceId: string) {
+  return sql`exists (
+    select 1 from ${practices}
+    where ${practices.id} = ${practiceId}
+      and ${practices.deletedAt} is null
+  )`;
+}
+
+async function lockAppointment(
+  ctx: EncounterContext,
+  appointmentId: string
+) {
+  const [appointment] = await ctx.db
+    .select({
+      id: appointments.id,
+      status: appointments.status,
+      startTime: appointments.startTime,
+      patientId: appointments.patientId,
+      clientId: appointments.clientId,
+      requiresDoctor: appointmentTypes.requiresDoctor,
+      practiceTimezone: practices.timezone,
+    })
+    .from(appointments)
+    .innerJoin(
+      practices,
+      and(
+        eq(appointments.practiceId, practices.id),
+        eq(practices.id, ctx.practiceId),
+        isNull(practices.deletedAt)
+      )
+    )
+    .leftJoin(
+      appointmentTypes,
+      and(
+        eq(appointments.typeId, appointmentTypes.id),
+        eq(appointmentTypes.practiceId, ctx.practiceId),
+        isNull(appointmentTypes.deletedAt)
+      )
+    )
+    .where(
+      and(
+        eq(appointments.id, appointmentId),
+        eq(appointments.practiceId, ctx.practiceId),
+        activePracticePredicate(ctx.practiceId),
+        isNull(appointments.deletedAt)
+      )
+    )
+    .limit(1)
+    .for("update", { of: appointments });
+
+  if (!appointment) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" });
+  }
+  if (!appointment.patientId || !appointment.clientId) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "Attach a patient and client before closing this visit.",
+    });
+  }
+
+  const [patient] = await ctx.db
+    .select({ id: patients.id })
+    .from(patients)
+    .where(
+      and(
+        eq(patients.id, appointment.patientId),
+        eq(patients.clientId, appointment.clientId),
+        eq(patients.practiceId, ctx.practiceId),
+        isNull(patients.deletedAt)
+      )
+    )
+    .limit(1);
+  if (!patient) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "The appointment patient and client no longer match.",
+    });
+  }
+  return { ...appointment, patientId: appointment.patientId, clientId: appointment.clientId };
+}
+
+async function getCloseoutRow(ctx: EncounterContext, appointmentId: string) {
+  const [closeout] = await ctx.db
+    .select()
+    .from(visitCloseouts)
+    .where(
+      and(
+        eq(visitCloseouts.appointmentId, appointmentId),
+        eq(visitCloseouts.practiceId, ctx.practiceId),
+        isNull(visitCloseouts.deletedAt)
+      )
+    )
+    .limit(1);
+  return closeout ?? null;
+}
+
+function assertOpenForClinical(status: string) {
+  if (status !== "in_exam") {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "Start the exam before preparing the clinical closeout.",
+    });
+  }
+}
+
+function sameClinicalPayload(
+  row: typeof visitCloseouts.$inferSelect,
+  input: z.infer<typeof clinicalDraftInput>
+) {
+  return (
+    row.diagnosisSummary === input.diagnosisSummary &&
+    row.dischargeInstructions === input.dischargeInstructions &&
+    row.warningSigns === input.warningSigns &&
+    row.noInstructionsReason === input.noInstructionsReason &&
+    row.prescriptionDisposition === input.prescriptionDisposition &&
+    row.followUpDisposition === input.followUpDisposition &&
+    row.followUpNotes === input.followUpNotes &&
+    row.followUpAppointmentId === input.followUpAppointmentId &&
+    row.followUpDueDate === input.followUpDueDate &&
+    row.followUpAssignedTo === input.followUpAssignedTo &&
+    row.documentationExceptionReason === input.documentationExceptionReason
+  );
+}
+
+function clinicalDraftValues(input: z.infer<typeof clinicalDraftInput>) {
+  return {
+    diagnosisSummary: input.diagnosisSummary,
+    dischargeInstructions: input.dischargeInstructions,
+    warningSigns: input.warningSigns,
+    noInstructionsReason: input.noInstructionsReason,
+    prescriptionDisposition: input.prescriptionDisposition,
+    followUpDisposition: input.followUpDisposition,
+    followUpNotes: input.followUpNotes,
+    followUpAppointmentId: input.followUpAppointmentId,
+    followUpDueDate: input.followUpDueDate,
+    followUpAssignedTo: input.followUpAssignedTo,
+    documentationExceptionReason: input.documentationExceptionReason,
+  };
+}
+
+function assertAmendmentAppointmentState(
+  appointmentStatus: string,
+  closeoutStatus: (typeof visitCloseouts.$inferSelect)["status"]
+) {
+  const isOpenFinalizedVisit =
+    closeoutStatus === "clinical_finalized" && appointmentStatus === "in_exam";
+  const isCompletedVisit =
+    closeoutStatus === "completed" && appointmentStatus === "checked_out";
+  if (!isOpenFinalizedVisit && !isCompletedVisit) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "The signed clinical handoff and appointment state no longer match. Refresh before amending.",
+    });
+  }
+}
+
+async function appointmentInvoiceRows(
+  ctx: EncounterContext,
+  appointmentId: string,
+  patientId: string,
+  clientId: string,
+  lock = false
+) {
+  const query = ctx.db
+    .select({
+      id: invoices.id,
+      status: invoices.status,
+      total: invoices.total,
+      paidAmount: invoices.paidAmount,
+      dueDate: invoices.dueDate,
+    })
+    .from(invoices)
+    .where(
+      and(
+        eq(invoices.appointmentId, appointmentId),
+        eq(invoices.patientId, patientId),
+        eq(invoices.clientId, clientId),
+        eq(invoices.practiceId, ctx.practiceId),
+        eq(invoices.isEstimate, false),
+        ne(invoices.status, "void"),
+        isNull(invoices.deletedAt)
+      )
+    )
+    .orderBy(desc(invoices.createdAt));
+  return lock ? query.for("update") : query;
+}
+
+async function invoiceReadiness(
+  ctx: EncounterContext,
+  row: Awaited<ReturnType<typeof appointmentInvoiceRows>>[number]
+) {
+  const [[itemsSummary], [adjustmentsSummary]] = await Promise.all([
+    ctx.db
+      .select({ itemCount: sql<number>`count(*)::int` })
+      .from(invoiceItems)
+      .where(
+        and(
+          eq(invoiceItems.invoiceId, row.id),
+          isNull(invoiceItems.deletedAt)
+        )
+      ),
+    ctx.db
+      .select({
+        adjustedAmount: sql<string>`coalesce(sum(${invoiceAdjustments.amount}), 0)::text`,
+      })
+      .from(invoiceAdjustments)
+      .where(
+        and(
+          eq(invoiceAdjustments.invoiceId, row.id),
+          isNull(invoiceAdjustments.deletedAt)
+        )
+      ),
+  ]);
+  const adjustedAmount = adjustmentsSummary?.adjustedAmount ?? "0";
+  const adjustedCents = moneyToCents(adjustedAmount);
+  return {
+    ...row,
+    itemCount: itemsSummary?.itemCount ?? 0,
+    adjustedAmount,
+    balanceDueCents: invoiceBalanceCents(row, adjustedCents),
+  };
+}
+
+export const encountersRouter = createRouter({
+  listPendingFollowUps: protectedProcedure.query(async ({ ctx }) =>
+    ctx.db
+      .select({
+        closeoutId: visitCloseouts.id,
+        appointmentId: visitCloseouts.appointmentId,
+        closeoutStatus: visitCloseouts.status,
+        revision: visitCloseouts.revision,
+        dueDate: visitCloseouts.followUpDueDate,
+        assignedTo: visitCloseouts.followUpAssignedTo,
+        assigneeName: visitCloseouts.followUpAssigneeName,
+        followUpNotes: visitCloseouts.followUpNotes,
+        resolution: visitCloseouts.followUpResolution,
+        resolutionAppointmentId:
+          visitCloseouts.followUpResolutionAppointmentId,
+        resolutionScheduledAt: visitCloseouts.followUpResolutionScheduledAt,
+        resolutionNotes: visitCloseouts.followUpResolutionNotes,
+        resolvedAt: visitCloseouts.followUpResolvedAt,
+        resolvedBy: visitCloseouts.followUpResolvedBy,
+        resolverName: visitCloseouts.followUpResolverName,
+        patientId: patients.id,
+        patientName: patients.name,
+        clientId: clients.id,
+        clientFirstName: clients.firstName,
+        clientLastName: clients.lastName,
+        visitStartedAt: appointments.startTime,
+      })
+      .from(visitCloseouts)
+      .innerJoin(
+        appointments,
+        and(
+          eq(visitCloseouts.appointmentId, appointments.id),
+          eq(appointments.practiceId, ctx.practiceId),
+          isNull(appointments.deletedAt)
+        )
+      )
+      .innerJoin(
+        patients,
+        and(
+          eq(appointments.patientId, patients.id),
+          eq(patients.practiceId, ctx.practiceId),
+          isNull(patients.deletedAt)
+        )
+      )
+      .innerJoin(
+        clients,
+        and(
+          eq(appointments.clientId, clients.id),
+          eq(patients.clientId, clients.id),
+          eq(clients.practiceId, ctx.practiceId),
+          isNull(clients.deletedAt)
+        )
+      )
+      .where(
+        and(
+          eq(visitCloseouts.practiceId, ctx.practiceId),
+          eq(visitCloseouts.followUpDisposition, "needed"),
+          inArray(visitCloseouts.status, ["clinical_finalized", "completed"]),
+          isNull(visitCloseouts.followUpResolvedAt),
+          activePracticePredicate(ctx.practiceId),
+          isNull(visitCloseouts.deletedAt)
+        )
+      )
+      .orderBy(asc(visitCloseouts.followUpDueDate), asc(visitCloseouts.createdAt))
+  ),
+
+  getCloseout: protectedProcedure
+    .input(z.object({ appointmentId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const [appointment] = await ctx.db
+        .select({
+          id: appointments.id,
+          patientId: appointments.patientId,
+          clientId: appointments.clientId,
+          practiceName: practices.name,
+          practicePhone: practices.phone,
+          practiceTimezone: practices.timezone,
+        })
+        .from(appointments)
+        .innerJoin(
+          practices,
+          and(
+            eq(appointments.practiceId, practices.id),
+            eq(practices.id, ctx.practiceId),
+            isNull(practices.deletedAt)
+          )
+        )
+        .where(
+          and(
+            eq(appointments.id, input.appointmentId),
+            eq(appointments.practiceId, ctx.practiceId),
+            activePracticePredicate(ctx.practiceId),
+            isNull(appointments.deletedAt)
+          )
+        )
+        .limit(1);
+      if (!appointment) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" });
+      }
+
+      const [
+        closeout,
+        linkedSoapRows,
+        medications,
+        followUpAppointments,
+        followUpAssignees,
+      ] = await Promise.all([
+          getCloseoutRow(ctx, input.appointmentId),
+          ctx.db
+            .select({ id: soapNotes.id })
+            .from(soapNotes)
+            .where(
+              and(
+                eq(soapNotes.appointmentId, input.appointmentId),
+                eq(soapNotes.practiceId, ctx.practiceId),
+                isNull(soapNotes.deletedAt)
+              )
+            ),
+          ctx.db
+            .select({
+              id: prescriptions.id,
+              medicationName: prescriptions.medicationName,
+              dosage: prescriptions.dosage,
+              frequency: prescriptions.frequency,
+              instructions: prescriptions.instructions,
+              quantity: prescriptions.quantity,
+              productId: prescriptions.productId,
+              productName: products.name,
+              productUnitPrice: products.unitPrice,
+            })
+            .from(prescriptions)
+            .leftJoin(
+              products,
+              and(
+                eq(prescriptions.productId, products.id),
+                eq(products.practiceId, ctx.practiceId),
+                isNull(products.deletedAt)
+              )
+            )
+            .where(
+              and(
+                eq(prescriptions.appointmentId, input.appointmentId),
+                eq(prescriptions.practiceId, ctx.practiceId),
+                isNull(prescriptions.deletedAt)
+              )
+            )
+            .orderBy(desc(prescriptions.createdAt)),
+          appointment.patientId && appointment.clientId
+            ? ctx.db
+                .select({
+                  id: appointments.id,
+                  startTime: appointments.startTime,
+                  status: appointments.status,
+                })
+                .from(appointments)
+                .where(
+                  and(
+                    eq(appointments.patientId, appointment.patientId),
+                    eq(appointments.clientId, appointment.clientId),
+                    eq(appointments.practiceId, ctx.practiceId),
+                    gt(appointments.startTime, new Date()),
+                    inArray(appointments.status, ["scheduled", "confirmed"]),
+                    isNull(appointments.deletedAt)
+                  )
+                )
+                .orderBy(appointments.startTime)
+                .limit(25)
+            : Promise.resolve([]),
+          ctx.db
+            .select({
+              id: users.id,
+              name: users.name,
+              email: users.email,
+              role: users.role,
+            })
+            .from(users)
+            .where(
+              and(
+                eq(users.practiceId, ctx.practiceId),
+                inArray(users.role, [
+                  "admin",
+                  "veterinarian",
+                  "technician",
+                  "front_desk",
+                ]),
+                activePracticePredicate(ctx.practiceId),
+                isNull(users.deletedAt)
+              )
+            )
+            .orderBy(asc(users.name), asc(users.email))
+            .limit(100),
+        ]);
+
+      const rawInvoices =
+        appointment.patientId && appointment.clientId
+          ? await appointmentInvoiceRows(
+              ctx,
+              input.appointmentId,
+              appointment.patientId,
+              appointment.clientId
+            )
+          : [];
+      const invoiceSummaries = await Promise.all(
+        rawInvoices.map((invoice) => invoiceReadiness(ctx, invoice))
+      );
+
+      return {
+        closeout,
+        practice: {
+          name: appointment.practiceName,
+          phone: appointment.practicePhone,
+          timezone: appointment.practiceTimezone,
+        },
+        linkedSoapCount: linkedSoapRows.length,
+        medications,
+        followUpAppointments,
+        followUpAssignees,
+        invoices: invoiceSummaries,
+      };
+    }),
+
+  saveDraft: protectedProcedure
+    .use(requireRole("admin", "veterinarian", "technician"))
+    .input(clinicalDraftInput)
+    .mutation(async ({ ctx, input }) =>
+      ctx.db.transaction(async (tx) => {
+        const txCtx: EncounterContext = { db: tx, practiceId: ctx.practiceId };
+        const appointment = await lockAppointment(txCtx, input.appointmentId);
+        const existing = await getCloseoutRow(txCtx, input.appointmentId);
+
+        if (existing?.amendmentDraft) {
+          assertAmendmentAppointmentState(appointment.status, existing.status);
+          if (existing.revision !== input.expectedRevision) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "Closeout changed in another session. Refresh before saving.",
+            });
+          }
+          const [saved] = await tx
+            .update(visitCloseouts)
+            .set({
+              amendmentDraft: {
+                ...existing.amendmentDraft,
+                ...clinicalDraftValues(input),
+              },
+              revision: existing.revision + 1,
+            })
+            .where(
+              and(
+                eq(visitCloseouts.id, existing.id),
+                eq(visitCloseouts.practiceId, ctx.practiceId),
+                eq(visitCloseouts.status, existing.status),
+                eq(visitCloseouts.revision, existing.revision),
+                sql`${visitCloseouts.amendmentDraft} is not null`,
+                isNull(visitCloseouts.deletedAt)
+              )
+            )
+            .returning();
+          if (!saved) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "Closeout changed; refresh and retry.",
+            });
+          }
+          return saved;
+        }
+
+        if (existing && existing.status !== "draft") {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "Clinical closeout is signed. Start an attributed amendment before editing it.",
+          });
+        }
+        assertOpenForClinical(appointment.status);
+        const revision = existing?.revision ?? 0;
+        if (revision !== input.expectedRevision) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Closeout changed in another session. Refresh before saving.",
+          });
+        }
+        const values = {
+          ...clinicalDraftValues(input),
+          revision: revision + 1,
+        };
+        if (existing) {
+          const [saved] = await tx
+            .update(visitCloseouts)
+            .set(values)
+            .where(
+              and(
+                eq(visitCloseouts.id, existing.id),
+                eq(visitCloseouts.practiceId, ctx.practiceId),
+                eq(visitCloseouts.status, "draft"),
+                eq(visitCloseouts.revision, revision),
+                isNull(visitCloseouts.deletedAt)
+              )
+            )
+            .returning();
+          if (!saved) {
+            throw new TRPCError({ code: "CONFLICT", message: "Closeout changed; refresh and retry." });
+          }
+          return saved;
+        }
+        const [saved] = await tx
+          .insert(visitCloseouts)
+          .values({
+            ...values,
+            practiceId: ctx.practiceId,
+            appointmentId: input.appointmentId,
+          })
+          .returning();
+        return saved!;
+      })
+    ),
+
+  finalizeClinical: protectedProcedure
+    .use(requireRole("admin", "veterinarian", "technician"))
+    .input(finalizeClinicalInput)
+    .mutation(async ({ ctx, input }) =>
+      ctx.db.transaction(async (tx) => {
+        const txCtx: EncounterContext = { db: tx, practiceId: ctx.practiceId };
+        const appointment = await lockAppointment(txCtx, input.appointmentId);
+        if (
+          appointment.requiresDoctor !== 0 &&
+          ctx.user.role !== "veterinarian"
+        ) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message:
+              "A veterinarian must finalize instructions for a doctor-required visit.",
+          });
+        }
+        const existing = await getCloseoutRow(txCtx, input.appointmentId);
+        const amendmentDraft = existing?.amendmentDraft ?? null;
+        if (amendmentDraft && existing) {
+          assertAmendmentAppointmentState(appointment.status, existing.status);
+        } else if (existing && existing.status !== "draft") {
+          if (sameClinicalPayload(existing, input)) return existing;
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "Clinical closeout is signed. Start an attributed amendment before replacing it.",
+          });
+        } else {
+          assertOpenForClinical(appointment.status);
+        }
+        const revision = existing?.revision ?? 0;
+        if (revision !== input.expectedRevision) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Closeout changed in another session. Refresh before finalizing.",
+          });
+        }
+
+        const [soap] = await tx
+          .select({ id: soapNotes.id })
+          .from(soapNotes)
+          .where(
+            and(
+              eq(soapNotes.appointmentId, input.appointmentId),
+              eq(soapNotes.practiceId, ctx.practiceId),
+              isNull(soapNotes.deletedAt)
+            )
+          )
+          .limit(1);
+        if (!soap && !input.documentationExceptionReason) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "Link a SOAP note or document why one is not required.",
+          });
+        }
+
+        const medicationSnapshot = await tx
+          .select({
+            prescriptionId: prescriptions.id,
+            medicationName: prescriptions.medicationName,
+            dosage: prescriptions.dosage,
+            frequency: prescriptions.frequency,
+            instructions: prescriptions.instructions,
+            quantity: prescriptions.quantity,
+          })
+          .from(prescriptions)
+          .where(
+            and(
+              eq(prescriptions.appointmentId, input.appointmentId),
+              eq(prescriptions.patientId, appointment.patientId),
+              eq(prescriptions.practiceId, ctx.practiceId),
+              eq(prescriptions.status, "active"),
+              isNull(prescriptions.deletedAt)
+            )
+          )
+          .orderBy(prescriptions.createdAt);
+        if (
+          input.prescriptionDisposition === "prescribed" &&
+          medicationSnapshot.length === 0
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "Create and link the visit prescription before finalizing.",
+          });
+        }
+        if (
+          input.prescriptionDisposition === "not_needed" &&
+          medicationSnapshot.length > 0
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "This visit has linked prescriptions. Confirm that prescriptions were provided.",
+          });
+        }
+
+        let followUpScheduledAt: Date | null = null;
+        let followUpAssigneeName: string | null = null;
+        if (input.followUpDisposition === "scheduled") {
+          const [followUp] = await tx
+            .select({
+              id: appointments.id,
+              startTime: appointments.startTime,
+            })
+            .from(appointments)
+            .where(
+              and(
+                eq(appointments.id, input.followUpAppointmentId!),
+                eq(appointments.patientId, appointment.patientId),
+                eq(appointments.clientId, appointment.clientId),
+                eq(appointments.practiceId, ctx.practiceId),
+                gt(appointments.startTime, new Date()),
+                inArray(appointments.status, ["scheduled", "confirmed"]),
+                isNull(appointments.deletedAt)
+              )
+            )
+            .limit(1);
+          if (!followUp) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "The selected follow-up appointment is no longer available.",
+            });
+          }
+          followUpScheduledAt = followUp.startTime;
+        } else if (input.followUpDisposition === "needed") {
+          const today = formatDateInputForTimeZone(
+            new Date(),
+            appointment.practiceTimezone
+          );
+          if (!input.followUpDueDate || input.followUpDueDate < today) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "Follow-up due date cannot be before today.",
+            });
+          }
+          const [assignee] = await tx
+            .select({ name: users.name, email: users.email })
+            .from(users)
+            .where(
+              and(
+                eq(users.id, input.followUpAssignedTo!),
+                eq(users.practiceId, ctx.practiceId),
+                inArray(users.role, [
+                  "admin",
+                  "veterinarian",
+                  "technician",
+                  "front_desk",
+                ]),
+                activePracticePredicate(ctx.practiceId),
+                isNull(users.deletedAt)
+              )
+            )
+            .limit(1);
+          if (!assignee) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "The assigned follow-up owner is no longer active.",
+            });
+          }
+          followUpAssigneeName = assignee.name?.trim() || assignee.email;
+        }
+
+        const now = new Date();
+        const preserveFollowUpResolution = Boolean(
+          amendmentDraft &&
+            existing &&
+            input.followUpDisposition === "needed" &&
+            existing.followUpDisposition === "needed" &&
+            existing.followUpDueDate === input.followUpDueDate &&
+            existing.followUpAssignedTo === input.followUpAssignedTo
+        );
+        const values = {
+          ...clinicalDraftValues(input),
+          followUpAppointmentId:
+            input.followUpDisposition === "scheduled"
+              ? input.followUpAppointmentId
+              : null,
+          followUpScheduledAt,
+          followUpDueDate:
+            input.followUpDisposition === "needed"
+              ? input.followUpDueDate
+              : null,
+          followUpAssignedTo:
+            input.followUpDisposition === "needed"
+              ? input.followUpAssignedTo
+              : null,
+          followUpAssigneeName,
+          followUpResolution: preserveFollowUpResolution
+            ? existing?.followUpResolution ?? null
+            : null,
+          followUpResolutionAppointmentId: preserveFollowUpResolution
+            ? existing?.followUpResolutionAppointmentId ?? null
+            : null,
+          followUpResolutionScheduledAt: preserveFollowUpResolution
+            ? existing?.followUpResolutionScheduledAt ?? null
+            : null,
+          followUpResolutionNotes: preserveFollowUpResolution
+            ? existing?.followUpResolutionNotes ?? null
+            : null,
+          followUpResolvedAt: preserveFollowUpResolution
+            ? existing?.followUpResolvedAt ?? null
+            : null,
+          followUpResolvedBy: preserveFollowUpResolution
+            ? existing?.followUpResolvedBy ?? null
+            : null,
+          followUpResolverName: preserveFollowUpResolution
+            ? existing?.followUpResolverName ?? null
+            : null,
+          medicationSnapshot,
+          status:
+            amendmentDraft && existing
+              ? existing.status
+              : ("clinical_finalized" as const),
+          clinicalFinalizedAt: now,
+          clinicalFinalizedBy: ctx.user.id,
+          clinicalFinalizerName: ctx.user.name,
+          revision: revision + 1,
+        };
+        if (existing && amendmentDraft) {
+          if (
+            !existing.clinicalFinalizedAt ||
+            !existing.clinicalFinalizedBy ||
+            !existing.clinicalFinalizerName ||
+            !existing.prescriptionDisposition ||
+            !existing.followUpDisposition
+          ) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message:
+                "The signed handoff is incomplete and cannot be superseded safely.",
+            });
+          }
+          const priorVersion = {
+            priorRevision: amendmentDraft.baseRevision,
+            reason: amendmentDraft.reason,
+            reopenedAt: amendmentDraft.reopenedAt,
+            reopenedBy: amendmentDraft.reopenedBy,
+            reopenedByName: amendmentDraft.reopenedByName,
+            clinicalFinalizedAt: existing.clinicalFinalizedAt.toISOString(),
+            clinicalFinalizedBy: existing.clinicalFinalizedBy,
+            clinicalFinalizerName: existing.clinicalFinalizerName,
+            diagnosisSummary: existing.diagnosisSummary,
+            dischargeInstructions: existing.dischargeInstructions,
+            warningSigns: existing.warningSigns,
+            noInstructionsReason: existing.noInstructionsReason,
+            prescriptionDisposition: existing.prescriptionDisposition,
+            medicationSnapshot: existing.medicationSnapshot,
+            followUpDisposition: existing.followUpDisposition,
+            followUpNotes: existing.followUpNotes,
+            followUpAppointmentId: existing.followUpAppointmentId,
+            followUpScheduledAt:
+              existing.followUpScheduledAt?.toISOString() ?? null,
+            followUpDueDate: existing.followUpDueDate,
+            followUpAssignedTo: existing.followUpAssignedTo,
+            followUpAssigneeName: existing.followUpAssigneeName,
+            followUpResolution: existing.followUpResolution,
+            followUpResolutionAppointmentId:
+              existing.followUpResolutionAppointmentId,
+            followUpResolutionScheduledAt:
+              existing.followUpResolutionScheduledAt?.toISOString() ?? null,
+            followUpResolutionNotes: existing.followUpResolutionNotes,
+            followUpResolvedAt:
+              existing.followUpResolvedAt?.toISOString() ?? null,
+            followUpResolvedBy: existing.followUpResolvedBy,
+            followUpResolverName: existing.followUpResolverName,
+            documentationExceptionReason: existing.documentationExceptionReason,
+          };
+          const [finalized] = await tx
+            .update(visitCloseouts)
+            .set({
+              ...values,
+              amendmentHistory: [
+                ...existing.amendmentHistory,
+                priorVersion,
+              ],
+              amendmentDraft: null,
+            })
+            .where(
+              and(
+                eq(visitCloseouts.id, existing.id),
+                eq(visitCloseouts.practiceId, ctx.practiceId),
+                eq(visitCloseouts.status, existing.status),
+                eq(visitCloseouts.revision, revision),
+                sql`${visitCloseouts.amendmentDraft} is not null`,
+                isNull(visitCloseouts.deletedAt)
+              )
+            )
+            .returning();
+          if (!finalized) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "Closeout changed; refresh and retry.",
+            });
+          }
+          return finalized;
+        }
+        if (existing) {
+          const [finalized] = await tx
+            .update(visitCloseouts)
+            .set(values)
+            .where(
+              and(
+                eq(visitCloseouts.id, existing.id),
+                eq(visitCloseouts.practiceId, ctx.practiceId),
+                eq(visitCloseouts.status, "draft"),
+                eq(visitCloseouts.revision, revision),
+                isNull(visitCloseouts.deletedAt)
+              )
+            )
+            .returning();
+          if (!finalized) {
+            throw new TRPCError({ code: "CONFLICT", message: "Closeout changed; refresh and retry." });
+          }
+          return finalized;
+        }
+        const [finalized] = await tx
+          .insert(visitCloseouts)
+          .values({
+            ...values,
+            practiceId: ctx.practiceId,
+            appointmentId: input.appointmentId,
+          })
+          .returning();
+        return finalized!;
+      })
+    ),
+
+  reopenClinical: protectedProcedure
+    .use(requireRole("admin", "veterinarian"))
+    .input(reopenClinicalInput)
+    .mutation(async ({ ctx, input }) =>
+      ctx.db.transaction(async (tx) => {
+        const txCtx: EncounterContext = { db: tx, practiceId: ctx.practiceId };
+        const appointment = await lockAppointment(txCtx, input.appointmentId);
+        const closeout = await getCloseoutRow(txCtx, input.appointmentId);
+        if (
+          closeout?.amendmentDraft?.baseRevision === input.expectedRevision &&
+          closeout.amendmentDraft.reopenedBy === ctx.user.id &&
+          closeout.amendmentDraft.reason === input.reason
+        ) {
+          assertAmendmentAppointmentState(appointment.status, closeout.status);
+          return closeout;
+        }
+        if (
+          !closeout ||
+          (closeout.status !== "clinical_finalized" &&
+            closeout.status !== "completed")
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "Only a signed clinical handoff can be amended.",
+          });
+        }
+        assertAmendmentAppointmentState(appointment.status, closeout.status);
+        if (closeout.amendmentDraft) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "An attributed amendment is already in progress. Refresh to continue it.",
+          });
+        }
+        if (closeout.revision !== input.expectedRevision) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Closeout changed in another session. Refresh before amending.",
+          });
+        }
+        if (
+          !closeout.clinicalFinalizedAt ||
+          !closeout.clinicalFinalizedBy ||
+          !closeout.clinicalFinalizerName ||
+          !closeout.prescriptionDisposition ||
+          !closeout.followUpDisposition
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "The finalized handoff is incomplete and cannot be amended safely.",
+          });
+        }
+
+        const amendmentDraft = {
+          baseRevision: closeout.revision,
+          reason: input.reason,
+          reopenedAt: new Date().toISOString(),
+          reopenedBy: ctx.user.id,
+          reopenedByName: ctx.user.name,
+          diagnosisSummary: closeout.diagnosisSummary,
+          dischargeInstructions: closeout.dischargeInstructions,
+          warningSigns: closeout.warningSigns,
+          noInstructionsReason: closeout.noInstructionsReason,
+          prescriptionDisposition: closeout.prescriptionDisposition,
+          followUpDisposition: closeout.followUpDisposition,
+          followUpNotes: closeout.followUpNotes,
+          followUpAppointmentId: closeout.followUpAppointmentId,
+          followUpDueDate: closeout.followUpDueDate ?? null,
+          followUpAssignedTo: closeout.followUpAssignedTo ?? null,
+          documentationExceptionReason: closeout.documentationExceptionReason,
+        };
+        const [reopened] = await tx
+          .update(visitCloseouts)
+          .set({
+            amendmentDraft,
+            revision: closeout.revision + 1,
+          })
+          .where(
+            and(
+              eq(visitCloseouts.id, closeout.id),
+              eq(visitCloseouts.practiceId, ctx.practiceId),
+              eq(visitCloseouts.status, closeout.status),
+              eq(visitCloseouts.revision, closeout.revision),
+              sql`${visitCloseouts.amendmentDraft} is null`,
+              isNull(visitCloseouts.deletedAt)
+            )
+          )
+          .returning();
+        if (!reopened) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Closeout changed while reopening. Refresh and try again.",
+          });
+        }
+        return reopened;
+      })
+    ),
+
+  resolveNeededFollowUp: protectedProcedure
+    .use(requireRole("admin", "veterinarian", "technician", "front_desk"))
+    .input(resolveNeededFollowUpInput)
+    .mutation(async ({ ctx, input }) =>
+      ctx.db.transaction(async (tx) => {
+        const txCtx: EncounterContext = { db: tx, practiceId: ctx.practiceId };
+        const appointment = await lockAppointment(txCtx, input.appointmentId);
+        const closeout = await getCloseoutRow(txCtx, input.appointmentId);
+        if (
+          !closeout ||
+          (closeout.status !== "clinical_finalized" &&
+            closeout.status !== "completed") ||
+          closeout.followUpDisposition !== "needed"
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "This signed handoff has no pending follow-up obligation.",
+          });
+        }
+        assertAmendmentAppointmentState(appointment.status, closeout.status);
+
+        if (closeout.followUpResolvedAt) {
+          if (
+            closeout.followUpResolution === input.resolution &&
+            closeout.followUpResolutionAppointmentId ===
+              input.resolutionAppointmentId &&
+            closeout.followUpResolutionNotes === input.notes
+          ) {
+            return closeout;
+          }
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "This follow-up obligation is already resolved.",
+          });
+        }
+        if (closeout.revision !== input.expectedRevision) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "Closeout changed in another session. Refresh before resolving follow-up.",
+          });
+        }
+
+        let resolutionScheduledAt: Date | null = null;
+        if (input.resolution === "scheduled") {
+          const [followUp] = await tx
+            .select({ id: appointments.id, startTime: appointments.startTime })
+            .from(appointments)
+            .where(
+              and(
+                eq(appointments.id, input.resolutionAppointmentId!),
+                eq(appointments.patientId, appointment.patientId),
+                eq(appointments.clientId, appointment.clientId),
+                eq(appointments.practiceId, ctx.practiceId),
+                gt(appointments.startTime, new Date()),
+                inArray(appointments.status, ["scheduled", "confirmed"]),
+                isNull(appointments.deletedAt)
+              )
+            )
+            .limit(1);
+          if (!followUp) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "The selected follow-up appointment is no longer available.",
+            });
+          }
+          resolutionScheduledAt = followUp.startTime;
+        }
+
+        const now = new Date();
+        const [resolved] = await tx
+          .update(visitCloseouts)
+          .set({
+            followUpResolution: input.resolution,
+            followUpResolutionAppointmentId:
+              input.resolution === "scheduled"
+                ? input.resolutionAppointmentId
+                : null,
+            followUpResolutionScheduledAt: resolutionScheduledAt,
+            followUpResolutionNotes: input.notes,
+            followUpResolvedAt: now,
+            followUpResolvedBy: ctx.user.id,
+            followUpResolverName: ctx.user.name,
+            revision: closeout.revision + 1,
+          })
+          .where(
+            and(
+              eq(visitCloseouts.id, closeout.id),
+              eq(visitCloseouts.practiceId, ctx.practiceId),
+              eq(visitCloseouts.status, closeout.status),
+              eq(visitCloseouts.followUpDisposition, "needed"),
+              eq(visitCloseouts.revision, closeout.revision),
+              isNull(visitCloseouts.followUpResolvedAt),
+              isNull(visitCloseouts.deletedAt)
+            )
+          )
+          .returning();
+        if (!resolved) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Follow-up changed; refresh and retry.",
+          });
+        }
+        return resolved;
+      })
+    ),
+
+  completeVisit: protectedProcedure
+    .use(requireRole("admin", "veterinarian", "technician", "front_desk"))
+    .input(completeVisitInput)
+    .mutation(async ({ ctx, input }) =>
+      ctx.db.transaction(async (tx) => {
+        const txCtx: EncounterContext = { db: tx, practiceId: ctx.practiceId };
+        const appointment = await lockAppointment(txCtx, input.appointmentId);
+        const closeout = await getCloseoutRow(txCtx, input.appointmentId);
+
+        if (appointment.status === "checked_out") {
+          if (
+            closeout?.status === "completed" &&
+            closeout.chargeDisposition === input.chargeDisposition &&
+            closeout.handoffMethod === input.handoffMethod &&
+            closeout.noChargeReason === input.noChargeReason
+          ) {
+            return { closeout, appointment };
+          }
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "This visit is already checked out. Refresh to view its saved closeout.",
+          });
+        }
+        if (!canTransitionAppointmentStatus(appointment.status, "checked_out")) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "This appointment is not ready for checkout.",
+          });
+        }
+        if (!closeout || closeout.status !== "clinical_finalized") {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "Finalize the clinical handoff before completing the visit.",
+          });
+        }
+        if (closeout.amendmentDraft) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Finish the attributed clinical amendment before completing the visit.",
+          });
+        }
+        if (closeout.revision !== input.expectedRevision) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Closeout changed in another session. Refresh before completing the visit.",
+          });
+        }
+
+        const invoiceRows = await appointmentInvoiceRows(
+          txCtx,
+          input.appointmentId,
+          appointment.patientId,
+          appointment.clientId,
+          true
+        );
+        if (invoiceRows.length > 1) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "This visit has multiple active invoices. Resolve them before checkout.",
+          });
+        }
+        const invoice = invoiceRows[0]
+          ? await invoiceReadiness(txCtx, invoiceRows[0])
+          : null;
+        let invoiceId: string | null = null;
+        if (input.chargeDisposition === "no_charge") {
+          if (invoice) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "Void or resolve the active visit invoice before marking no charge.",
+            });
+          }
+        } else {
+          if (!invoice || invoice.itemCount < 1) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "Save at least one visit charge before checkout.",
+            });
+          }
+          if (
+            input.chargeDisposition === "paid" &&
+            (invoice.status !== "paid" || invoice.balanceDueCents !== 0)
+          ) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "The visit invoice is not fully paid.",
+            });
+          }
+          if (
+            input.chargeDisposition === "accounts_receivable" &&
+            (!["sent", "overdue"].includes(invoice.status) ||
+              !invoice.dueDate ||
+              invoice.balanceDueCents <= 0)
+          ) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "Pay-later visits need a sent invoice, due date, and open balance.",
+            });
+          }
+          invoiceId = invoice.id;
+        }
+
+        const now = new Date();
+        const [completed] = await tx
+          .update(visitCloseouts)
+          .set({
+            status: "completed",
+            chargeDisposition: input.chargeDisposition,
+            invoiceId,
+            noChargeReason:
+              input.chargeDisposition === "no_charge"
+                ? input.noChargeReason
+                : null,
+            handoffMethod: input.handoffMethod,
+            completedAt: now,
+            completedBy: ctx.user.id,
+            revision: closeout.revision + 1,
+          })
+          .where(
+            and(
+              eq(visitCloseouts.id, closeout.id),
+              eq(visitCloseouts.practiceId, ctx.practiceId),
+              eq(visitCloseouts.status, "clinical_finalized"),
+              eq(visitCloseouts.revision, closeout.revision),
+              isNull(visitCloseouts.deletedAt)
+            )
+          )
+          .returning();
+        if (!completed) {
+          throw new TRPCError({ code: "CONFLICT", message: "Closeout changed; refresh and retry." });
+        }
+        const [checkedOut] = await tx
+          .update(appointments)
+          .set({ status: "checked_out" })
+          .where(
+            and(
+              eq(appointments.id, input.appointmentId),
+              eq(appointments.practiceId, ctx.practiceId),
+              eq(appointments.status, appointment.status),
+              isNull(appointments.deletedAt)
+            )
+          )
+          .returning();
+        if (!checkedOut) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Appointment changed; the closeout was not completed.",
+          });
+        }
+        return { closeout: completed, appointment: checkedOut };
+      })
+    ),
+});

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -20,6 +20,7 @@ import {
   consentForms,
   consentRequests,
   files,
+  visitCloseouts,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
@@ -90,7 +91,7 @@ export {
   PROCEDURE_NOTES_MAX_LENGTH,
 } from "@/lib/records/procedure-policy";
 
-type RecordsDb = Pick<Database, "select" | "insert" | "update">;
+type RecordsDb = Pick<Database, "select" | "insert" | "update" | "execute">;
 
 type RecordsContext = {
   db: RecordsDb;
@@ -181,6 +182,8 @@ const createProblemInput = z.object({
 const createPrescriptionInput = z
   .object({
     patientId: z.string().uuid(),
+    appointmentId: z.string().uuid().optional(),
+    operationId: z.string().uuid(),
     medicationName: clinicalTextInput(
       "Medication name",
       PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH
@@ -303,6 +306,58 @@ async function assertAppointmentBelongsToPatient(
   }
 
   return appointment;
+}
+
+async function lockOpenAppointmentForPrescription(
+  ctx: RecordsContext,
+  appointmentId: string,
+  patientId: string
+) {
+  const [appointment] = await ctx.db
+    .select({ id: appointments.id, status: appointments.status })
+    .from(appointments)
+    .where(
+      and(
+        eq(appointments.id, appointmentId),
+        eq(appointments.patientId, patientId),
+        eq(appointments.practiceId, ctx.practiceId),
+        activePracticePredicate(ctx.practiceId),
+        isNull(appointments.deletedAt)
+      )
+    )
+    .for("update");
+
+  if (!appointment) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" });
+  }
+  if (appointment.status !== "in_exam") {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "Start the exam before creating a visit-linked prescription.",
+    });
+  }
+
+  const [lockedCloseout] = await ctx.db
+    .select({ status: visitCloseouts.status })
+    .from(visitCloseouts)
+    .where(
+      and(
+        eq(visitCloseouts.appointmentId, appointmentId),
+        eq(visitCloseouts.practiceId, ctx.practiceId),
+        isNull(visitCloseouts.deletedAt)
+      )
+    )
+    .limit(1);
+  if (
+    lockedCloseout?.status === "clinical_finalized" ||
+    lockedCloseout?.status === "completed"
+  ) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Clinical handoff is finalized. Use an attributed amendment before changing visit prescriptions.",
+    });
+  }
 }
 
 /**
@@ -572,13 +627,6 @@ export const recordsRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       await assertPatientBelongsToPractice(ctx, input.patientId);
-      if (input.appointmentId) {
-        await assertAppointmentBelongsToPatient(
-          ctx,
-          input.appointmentId,
-          input.patientId
-        );
-      }
       const normalizedNote = {
         subjective: normalizeSoapSection(input.subjective),
         objective: normalizeSoapSection(input.objective),
@@ -756,6 +804,7 @@ export const recordsRouter = createRouter({
       return ctx.db
         .select({
           id: prescriptions.id,
+          appointmentId: prescriptions.appointmentId,
           medicationName: prescriptions.medicationName,
           dosage: prescriptions.dosage,
           frequency: prescriptions.frequency,
@@ -823,55 +872,114 @@ export const recordsRouter = createRouter({
     .use(requireRole("admin", "veterinarian"))
     .input(createPrescriptionInput)
     .mutation(async ({ ctx, input }) => {
-      await assertPatientBelongsToPractice(ctx, input.patientId);
-      const safety = await assessPrescriptionSafety(
-        ctx,
-        input.patientId,
-        input.medicationName
-      );
-      if (input.productId) {
-        const product = await assertDispensedProductBelongsToPractice(
-          ctx,
-          input.productId
-        );
-        if (!input.quantity || input.quantity <= 0) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message:
-              "Enter a dispensed quantity before linking inventory stock.",
-          });
-        }
-        if (product.stockQuantity < input.quantity) {
-          throw new TRPCError({
-            code: "BAD_REQUEST",
-            message:
-              "Insufficient stock for the dispensed prescription quantity.",
-          });
-        }
-      }
-
-      if (safety.requiresOverride && !input.acknowledgeSafetyWarnings) {
-        throw new TRPCError({
-          code: "PRECONDITION_FAILED",
-          message:
-            "Prescription has allergy or interaction warnings that require clinician acknowledgement.",
-        });
-      }
-
-      const prescriptionInput = {
-        patientId: input.patientId,
-        medicationName: input.medicationName,
-        dosage: input.dosage,
-        frequency: input.frequency,
-        quantity: input.quantity,
-        productId: input.productId,
-        refillsRemaining: input.refillsRemaining,
-        startDate: input.startDate,
-        endDate: input.endDate,
-        instructions: input.instructions,
-      };
-      const rx = await ctx.db.transaction(async (tx) => {
+      const result = await ctx.db.transaction(async (tx) => {
         const txCtx: RecordsContext = { db: tx, practiceId: ctx.practiceId };
+        const operationKey = `dashboard-prescription:${ctx.practiceId}:${input.operationId}`;
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${operationKey}, 0))`
+        );
+
+        const [existing] = await tx
+          .select({
+            id: prescriptions.id,
+            practiceId: prescriptions.practiceId,
+            patientId: prescriptions.patientId,
+            appointmentId: prescriptions.appointmentId,
+            medicationName: prescriptions.medicationName,
+            dosage: prescriptions.dosage,
+            frequency: prescriptions.frequency,
+            quantity: prescriptions.quantity,
+            productId: prescriptions.productId,
+            refillsRemaining: prescriptions.refillsRemaining,
+            startDate: prescriptions.startDate,
+            endDate: prescriptions.endDate,
+            status: prescriptions.status,
+            instructions: prescriptions.instructions,
+            prescribedBy: prescriptions.prescribedBy,
+            operationId: prescriptions.operationId,
+            createdAt: prescriptions.createdAt,
+          })
+          .from(prescriptions)
+          .where(
+            and(
+              eq(prescriptions.practiceId, ctx.practiceId),
+              eq(prescriptions.operationId, input.operationId)
+            )
+          )
+          .limit(1);
+        if (existing) {
+          if (
+            existing.patientId !== input.patientId ||
+            (existing.appointmentId ?? null) !== (input.appointmentId ?? null) ||
+            existing.medicationName !== input.medicationName ||
+            existing.dosage !== input.dosage ||
+            existing.frequency !== input.frequency ||
+            (existing.quantity ?? null) !== (input.quantity ?? null) ||
+            (existing.productId ?? null) !== (input.productId ?? null) ||
+            existing.refillsRemaining !== input.refillsRemaining ||
+            existing.startDate !== input.startDate ||
+            (existing.endDate ?? null) !== (input.endDate ?? null) ||
+            (existing.instructions ?? null) !== (input.instructions ?? null)
+          ) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "This prescription operation ID was already used for different details.",
+            });
+          }
+          return { rx: existing, replayed: true as const };
+        }
+
+        await assertPatientBelongsToPractice(txCtx, input.patientId);
+        if (input.appointmentId) {
+          await assertAppointmentBelongsToPatient(
+            txCtx,
+            input.appointmentId,
+            input.patientId
+          );
+        }
+        const safety = await assessPrescriptionSafety(
+          txCtx,
+          input.patientId,
+          input.medicationName
+        );
+        if (input.productId) {
+          const product = await assertDispensedProductBelongsToPractice(
+            txCtx,
+            input.productId
+          );
+          if (!input.quantity || input.quantity <= 0) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "Enter a dispensed quantity before linking inventory stock.",
+            });
+          }
+          if (product.stockQuantity < input.quantity) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "Insufficient stock for the dispensed prescription quantity.",
+            });
+          }
+        }
+
+        if (safety.requiresOverride && !input.acknowledgeSafetyWarnings) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Prescription has allergy or interaction warnings that require clinician acknowledgement.",
+          });
+        }
+
+        if (input.appointmentId) {
+          await lockOpenAppointmentForPrescription(
+            txCtx,
+            input.appointmentId,
+            input.patientId
+          );
+        }
+
         if (input.productId && input.quantity && input.quantity > 0) {
           await deductDispensedProductStock(
             txCtx,
@@ -883,22 +991,36 @@ export const recordsRouter = createRouter({
         const [rx] = await tx
           .insert(prescriptions)
           .values({
-            ...prescriptionInput,
+            patientId: input.patientId,
+            appointmentId: input.appointmentId,
+            medicationName: input.medicationName,
+            dosage: input.dosage,
+            frequency: input.frequency,
+            quantity: input.quantity,
+            productId: input.productId,
+            refillsRemaining: input.refillsRemaining,
+            startDate: input.startDate,
+            endDate: input.endDate,
+            instructions: input.instructions,
             prescribedBy: ctx.user.id,
             practiceId: ctx.practiceId,
+            operationId: input.operationId,
           })
           .returning();
-        return rx!;
+        return { rx: rx!, replayed: false as const };
       });
-      await dispatchWebhookEvent(ctx.practiceId, "prescription.created", {
-        id: rx.id,
-        patientId: rx.patientId,
-        medicationName: rx.medicationName,
-        prescribedBy: rx.prescribedBy,
-        productId: rx.productId,
-        source: "dashboard",
-      });
-      return rx;
+      if (!result.replayed) {
+        await dispatchWebhookEvent(ctx.practiceId, "prescription.created", {
+          id: result.rx.id,
+          patientId: result.rx.patientId,
+          appointmentId: result.rx.appointmentId,
+          medicationName: result.rx.medicationName,
+          prescribedBy: result.rx.prescribedBy,
+          productId: result.rx.productId,
+          source: "dashboard",
+        });
+      }
+      return result.rx;
     }),
 
   // Lab Results

--- a/apps/web/server/routers/whiteboard.ts
+++ b/apps/web/server/routers/whiteboard.ts
@@ -10,6 +10,7 @@ import {
   users,
   appointmentTypes,
   rooms,
+  visitCloseouts,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import { dateInputUtcRangeForTimeZone } from "@/lib/date-input";
@@ -18,6 +19,7 @@ import {
   canTransitionAppointmentStatus,
 } from "@/lib/scheduling/appointment-status";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
+import { CLOSEOUT_BYPASS_MESSAGE } from "@/lib/encounters/closeout-policy";
 
 type WhiteboardContext = {
   db: Database;
@@ -169,55 +171,98 @@ export const whiteboardRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const [current] = await ctx.db
-        .select({
-          id: appointments.id,
-          status: appointments.status,
-        })
-        .from(appointments)
-        .where(
-          and(
-            eq(appointments.id, input.id),
-            eq(appointments.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(appointments.deletedAt)
+      const { current, appt } = await ctx.db.transaction(async (tx) => {
+        const [current] = await tx
+          .select({ id: appointments.id, status: appointments.status })
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.id, input.id),
+              eq(appointments.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(appointments.deletedAt)
+            )
           )
-        )
-        .limit(1);
+          .for("update");
+        if (!current) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Appointment not found",
+          });
+        }
+        if (input.status === "checked_out") {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: CLOSEOUT_BYPASS_MESSAGE,
+          });
+        }
+        if (!canTransitionAppointmentStatus(current.status, input.status)) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: `Cannot change appointment status from ${current.status} to ${input.status}.`,
+          });
+        }
 
-      if (!current) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Appointment not found",
-        });
-      }
-
-      if (!canTransitionAppointmentStatus(current.status, input.status)) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: `Cannot change appointment status from ${current.status} to ${input.status}.`,
-        });
-      }
-
-      const [appt] = await ctx.db
-        .update(appointments)
-        .set({ status: input.status })
-        .where(
-          and(
-            eq(appointments.id, input.id),
-            eq(appointments.practiceId, ctx.practiceId),
-            eq(appointments.status, current.status),
-            activePracticePredicate(ctx.practiceId),
-            isNull(appointments.deletedAt)
+        const [closeout] = await tx
+          .select({ id: visitCloseouts.id, status: visitCloseouts.status })
+          .from(visitCloseouts)
+          .where(
+            and(
+              eq(visitCloseouts.appointmentId, input.id),
+              eq(visitCloseouts.practiceId, ctx.practiceId),
+              isNull(visitCloseouts.deletedAt)
+            )
           )
-        )
-        .returning();
-      if (!appt) {
-        throw new TRPCError({
-          code: "CONFLICT",
-          message: "Appointment status changed; try again.",
-        });
-      }
+          .limit(1);
+        if (
+          closeout?.status === "clinical_finalized" ||
+          closeout?.status === "completed"
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Clinical handoff is finalized. Complete the visit through closeout instead of changing its status.",
+          });
+        }
+
+        const [appt] = await tx
+          .update(appointments)
+          .set({ status: input.status })
+          .where(
+            and(
+              eq(appointments.id, input.id),
+              eq(appointments.practiceId, ctx.practiceId),
+              eq(appointments.status, current.status),
+              activePracticePredicate(ctx.practiceId),
+              isNull(appointments.deletedAt)
+            )
+          )
+          .returning();
+        if (!appt) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "Appointment status changed; try again.",
+          });
+        }
+        if (
+          closeout?.status === "draft" &&
+          (input.status === "cancelled" || input.status === "no_show")
+        ) {
+          const now = new Date();
+          await tx
+            .update(visitCloseouts)
+            .set({ deletedAt: now, updatedAt: now })
+            .where(
+              and(
+                eq(visitCloseouts.id, closeout.id),
+                eq(visitCloseouts.practiceId, ctx.practiceId),
+                eq(visitCloseouts.status, "draft"),
+                isNull(visitCloseouts.deletedAt)
+              )
+            );
+        }
+        return { current, appt };
+      });
       if (appt.status === "checked_in") {
         await dispatchWebhookEvent(ctx.practiceId, "appointment.checked_in", {
           id: appt.id,

--- a/packages/db/drizzle/0042_tough_mattie_franklin.sql
+++ b/packages/db/drizzle/0042_tough_mattie_franklin.sql
@@ -1,0 +1,114 @@
+CREATE TYPE "public"."visit_charge_disposition" AS ENUM('paid', 'accounts_receivable', 'no_charge');--> statement-breakpoint
+CREATE TYPE "public"."visit_closeout_status" AS ENUM('draft', 'clinical_finalized', 'completed');--> statement-breakpoint
+CREATE TYPE "public"."visit_follow_up_disposition" AS ENUM('none', 'scheduled');--> statement-breakpoint
+CREATE TYPE "public"."visit_handoff_method" AS ENUM('print', 'verbal', 'declined');--> statement-breakpoint
+CREATE TYPE "public"."visit_prescription_disposition" AS ENUM('prescribed', 'not_needed');--> statement-breakpoint
+CREATE TABLE "visit_closeouts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	"practice_id" uuid NOT NULL,
+	"appointment_id" uuid NOT NULL,
+	"status" "visit_closeout_status" DEFAULT 'draft' NOT NULL,
+	"diagnosis_summary" text,
+	"discharge_instructions" text,
+	"warning_signs" text,
+	"no_instructions_reason" text,
+	"prescription_disposition" "visit_prescription_disposition",
+	"follow_up_disposition" "visit_follow_up_disposition",
+	"follow_up_notes" text,
+	"follow_up_appointment_id" uuid,
+	"follow_up_scheduled_at" timestamp with time zone,
+	"medication_snapshot" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"amendment_history" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"documentation_exception_reason" text,
+	"clinical_finalized_at" timestamp with time zone,
+	"clinical_finalized_by" uuid,
+	"clinical_finalizer_name" text,
+	"charge_disposition" "visit_charge_disposition",
+	"invoice_id" uuid,
+	"no_charge_reason" text,
+	"handoff_method" "visit_handoff_method",
+	"completed_at" timestamp with time zone,
+	"completed_by" uuid,
+	"revision" integer DEFAULT 1 NOT NULL,
+	CONSTRAINT "visit_closeouts_revision_check" CHECK ("visit_closeouts"."revision" >= 1),
+	CONSTRAINT "visit_closeouts_clinical_state_check" CHECK ("visit_closeouts"."status" = 'draft'
+        or (
+          "visit_closeouts"."clinical_finalized_at" is not null
+          and "visit_closeouts"."clinical_finalized_by" is not null
+          and length(btrim(coalesce("visit_closeouts"."clinical_finalizer_name", ''))) > 0
+          and "visit_closeouts"."prescription_disposition" is not null
+          and (
+            "visit_closeouts"."prescription_disposition" = 'prescribed'
+            and jsonb_array_length("visit_closeouts"."medication_snapshot") > 0
+            or "visit_closeouts"."prescription_disposition" = 'not_needed'
+            and jsonb_array_length("visit_closeouts"."medication_snapshot") = 0
+          )
+          and (
+            length(btrim(coalesce("visit_closeouts"."discharge_instructions", ''))) > 0
+            or length(btrim(coalesce("visit_closeouts"."no_instructions_reason", ''))) > 0
+          )
+          and "visit_closeouts"."follow_up_disposition" is not null
+          and (
+            "visit_closeouts"."follow_up_disposition" = 'none'
+            or (
+              "visit_closeouts"."follow_up_disposition" = 'scheduled'
+              and "visit_closeouts"."follow_up_appointment_id" is not null
+              and "visit_closeouts"."follow_up_scheduled_at" is not null
+            )
+          )
+        )),
+	CONSTRAINT "visit_closeouts_completed_state_check" CHECK ("visit_closeouts"."status" <> 'completed'
+        or (
+          "visit_closeouts"."completed_at" is not null
+          and "visit_closeouts"."completed_by" is not null
+          and "visit_closeouts"."charge_disposition" is not null
+          and "visit_closeouts"."handoff_method" is not null
+          and (
+            "visit_closeouts"."charge_disposition" = 'no_charge'
+            and "visit_closeouts"."invoice_id" is null
+            and length(btrim(coalesce("visit_closeouts"."no_charge_reason", ''))) > 0
+            or "visit_closeouts"."charge_disposition" in ('paid', 'accounts_receivable')
+            and "visit_closeouts"."invoice_id" is not null
+          )
+        ))
+);
+--> statement-breakpoint
+ALTER TABLE "prescriptions" ADD COLUMN "appointment_id" uuid;--> statement-breakpoint
+ALTER TABLE "invoice_items" ADD COLUMN "source_prescription_id" uuid;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_appointment_id_appointments_id_fk" FOREIGN KEY ("appointment_id") REFERENCES "public"."appointments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_follow_up_appointment_id_appointments_id_fk" FOREIGN KEY ("follow_up_appointment_id") REFERENCES "public"."appointments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_clinical_finalized_by_users_id_fk" FOREIGN KEY ("clinical_finalized_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_invoice_id_invoices_id_fk" FOREIGN KEY ("invoice_id") REFERENCES "public"."invoices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_completed_by_users_id_fk" FOREIGN KEY ("completed_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "visit_closeouts_appointment_uq" ON "visit_closeouts" USING btree ("appointment_id");--> statement-breakpoint
+CREATE INDEX "visit_closeouts_practice_status_idx" ON "visit_closeouts" USING btree ("practice_id","status","updated_at");--> statement-breakpoint
+ALTER TABLE "prescriptions" ADD CONSTRAINT "prescriptions_appointment_id_appointments_id_fk" FOREIGN KEY ("appointment_id") REFERENCES "public"."appointments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "soap_notes_appointment_idx" ON "soap_notes" USING btree ("practice_id","appointment_id","deleted_at");--> statement-breakpoint
+CREATE INDEX "prescriptions_appointment_idx" ON "prescriptions" USING btree ("practice_id","appointment_id","deleted_at");--> statement-breakpoint
+CREATE INDEX "invoice_items_source_prescription_idx" ON "invoice_items" USING btree ("source_prescription_id","deleted_at");--> statement-breakpoint
+CREATE INDEX "invoices_appointment_idx" ON "invoices" USING btree ("practice_id","appointment_id","deleted_at","is_estimate","status");--> statement-breakpoint
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "invoices"
+    WHERE "appointment_id" IS NOT NULL
+      AND "is_estimate" = false
+      AND "status" <> 'void'
+      AND "deleted_at" IS NULL
+    GROUP BY "practice_id", "appointment_id"
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION USING
+      MESSAGE = 'Cannot create invoices_active_appointment_uq: duplicate active visit invoices require audited reconciliation.',
+      HINT = 'Run the OpenVPM duplicate active visit invoice preflight and reconcile each appointment before retrying this migration.';
+  END IF;
+END $$;--> statement-breakpoint
+CREATE UNIQUE INDEX "invoices_active_appointment_uq" ON "invoices" USING btree ("practice_id","appointment_id") WHERE "invoices"."appointment_id" is not null
+          and "invoices"."is_estimate" = false
+          and "invoices"."status" <> 'void'
+          and "invoices"."deleted_at" is null;

--- a/packages/db/drizzle/0043_normal_bloodstrike.sql
+++ b/packages/db/drizzle/0043_normal_bloodstrike.sql
@@ -1,0 +1,103 @@
+CREATE TYPE "public"."visit_follow_up_resolution" AS ENUM('scheduled', 'completed', 'not_needed');--> statement-breakpoint
+ALTER TABLE "visit_closeouts" DROP CONSTRAINT "visit_closeouts_clinical_state_check";--> statement-breakpoint
+ALTER TYPE "public"."visit_follow_up_disposition" RENAME TO "visit_follow_up_disposition_old";--> statement-breakpoint
+CREATE TYPE "public"."visit_follow_up_disposition" AS ENUM('none', 'needed', 'scheduled');--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ALTER COLUMN "follow_up_disposition" TYPE "public"."visit_follow_up_disposition" USING "follow_up_disposition"::text::"public"."visit_follow_up_disposition";--> statement-breakpoint
+DROP TYPE "public"."visit_follow_up_disposition_old";--> statement-breakpoint
+ALTER TABLE "prescriptions" ADD COLUMN "operation_id" uuid;--> statement-breakpoint
+ALTER TABLE "invoice_adjustments" ADD COLUMN "operation_key" varchar(160);--> statement-breakpoint
+ALTER TABLE "invoice_adjustments" ADD COLUMN "balance_after" numeric(10, 2);--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "follow_up_due_date" date;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "follow_up_assigned_to" uuid;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "follow_up_assignee_name" text;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "follow_up_resolution" "visit_follow_up_resolution";--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "follow_up_resolution_appointment_id" uuid;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "follow_up_resolution_scheduled_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "follow_up_resolution_notes" text;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "follow_up_resolved_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "follow_up_resolved_by" uuid;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "follow_up_resolver_name" text;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD COLUMN "amendment_draft" jsonb;--> statement-breakpoint
+ALTER TABLE "invoice_items" ADD CONSTRAINT "invoice_items_source_prescription_id_prescriptions_id_fk" FOREIGN KEY ("source_prescription_id") REFERENCES "public"."prescriptions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_follow_up_assigned_to_users_id_fk" FOREIGN KEY ("follow_up_assigned_to") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_follow_up_resolved_by_users_id_fk" FOREIGN KEY ("follow_up_resolved_by") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_resolution_appointment_fk" FOREIGN KEY ("follow_up_resolution_appointment_id") REFERENCES "public"."appointments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "prescriptions_practice_operation_uq" ON "prescriptions" USING btree ("practice_id","operation_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "invoice_adjustments_operation_key_uq" ON "invoice_adjustments" USING btree ("operation_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "invoice_items_source_prescription_invoice_uq" ON "invoice_items" USING btree ("invoice_id","source_prescription_id") WHERE "invoice_items"."source_prescription_id" is not null and "invoice_items"."deleted_at" is null;--> statement-breakpoint
+CREATE INDEX "visit_closeouts_pending_follow_up_idx" ON "visit_closeouts" USING btree ("practice_id","follow_up_disposition","follow_up_resolved_at","follow_up_due_date");--> statement-breakpoint
+ALTER TABLE "invoice_adjustments" ADD CONSTRAINT "invoice_adjustments_operation_result_check" CHECK (("invoice_adjustments"."operation_key" is null and "invoice_adjustments"."balance_after" is null)
+        or ("invoice_adjustments"."operation_key" is not null and "invoice_adjustments"."balance_after" is not null and "invoice_adjustments"."balance_after" >= 0));--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_amendment_draft_check" CHECK (("visit_closeouts"."status" = 'draft' and "visit_closeouts"."amendment_draft" is null)
+        or (
+          "visit_closeouts"."status" in ('clinical_finalized', 'completed')
+          and (
+            "visit_closeouts"."amendment_draft" is null
+            or jsonb_typeof("visit_closeouts"."amendment_draft") = 'object'
+          )
+        ));--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_follow_up_resolution_check" CHECK ("visit_closeouts"."follow_up_resolved_at" is null
+        and "visit_closeouts"."follow_up_resolution" is null
+        and "visit_closeouts"."follow_up_resolution_appointment_id" is null
+        and "visit_closeouts"."follow_up_resolution_scheduled_at" is null
+        and "visit_closeouts"."follow_up_resolution_notes" is null
+        and "visit_closeouts"."follow_up_resolved_by" is null
+        and "visit_closeouts"."follow_up_resolver_name" is null
+        or (
+          "visit_closeouts"."follow_up_disposition" = 'needed'
+          and "visit_closeouts"."follow_up_resolved_at" is not null
+          and "visit_closeouts"."follow_up_resolution" is not null
+          and "visit_closeouts"."follow_up_resolved_by" is not null
+          and length(btrim(coalesce("visit_closeouts"."follow_up_resolver_name", ''))) > 0
+          and (
+            "visit_closeouts"."follow_up_resolution" = 'scheduled'
+            and "visit_closeouts"."follow_up_resolution_appointment_id" is not null
+            and "visit_closeouts"."follow_up_resolution_scheduled_at" is not null
+            or "visit_closeouts"."follow_up_resolution" in ('completed', 'not_needed')
+            and "visit_closeouts"."follow_up_resolution_appointment_id" is null
+            and "visit_closeouts"."follow_up_resolution_scheduled_at" is null
+            and length(btrim(coalesce("visit_closeouts"."follow_up_resolution_notes", ''))) > 0
+          )
+        ));--> statement-breakpoint
+ALTER TABLE "visit_closeouts" ADD CONSTRAINT "visit_closeouts_clinical_state_check" CHECK ("visit_closeouts"."status" = 'draft'
+        or (
+          "visit_closeouts"."clinical_finalized_at" is not null
+          and "visit_closeouts"."clinical_finalized_by" is not null
+          and length(btrim(coalesce("visit_closeouts"."clinical_finalizer_name", ''))) > 0
+          and "visit_closeouts"."prescription_disposition" is not null
+          and (
+            "visit_closeouts"."prescription_disposition" = 'prescribed'
+            and jsonb_array_length("visit_closeouts"."medication_snapshot") > 0
+            or "visit_closeouts"."prescription_disposition" = 'not_needed'
+            and jsonb_array_length("visit_closeouts"."medication_snapshot") = 0
+          )
+          and (
+            length(btrim(coalesce("visit_closeouts"."discharge_instructions", ''))) > 0
+            or length(btrim(coalesce("visit_closeouts"."no_instructions_reason", ''))) > 0
+          )
+          and "visit_closeouts"."follow_up_disposition" is not null
+          and (
+            "visit_closeouts"."follow_up_disposition" = 'none'
+            and "visit_closeouts"."follow_up_appointment_id" is null
+            and "visit_closeouts"."follow_up_scheduled_at" is null
+            and "visit_closeouts"."follow_up_due_date" is null
+            and "visit_closeouts"."follow_up_assigned_to" is null
+            and "visit_closeouts"."follow_up_assignee_name" is null
+            or (
+              "visit_closeouts"."follow_up_disposition" = 'scheduled'
+              and "visit_closeouts"."follow_up_appointment_id" is not null
+              and "visit_closeouts"."follow_up_scheduled_at" is not null
+              and "visit_closeouts"."follow_up_due_date" is null
+              and "visit_closeouts"."follow_up_assigned_to" is null
+              and "visit_closeouts"."follow_up_assignee_name" is null
+            )
+            or (
+              "visit_closeouts"."follow_up_disposition" = 'needed'
+              and "visit_closeouts"."follow_up_appointment_id" is null
+              and "visit_closeouts"."follow_up_scheduled_at" is null
+              and "visit_closeouts"."follow_up_due_date" is not null
+              and "visit_closeouts"."follow_up_assigned_to" is not null
+              and length(btrim(coalesce("visit_closeouts"."follow_up_assignee_name", ''))) > 0
+            )
+          )
+        ));

--- a/packages/db/drizzle/meta/0042_snapshot.json
+++ b/packages/db/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,11981 @@
+{
+  "id": "bb8e26c9-206d-4283-aeca-61693754a466",
+  "prevId": "87d8db3f-9f64-48fd-aa64-c6c5d3c5bea1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "scheduled"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0043_snapshot.json
+++ b/packages/db/drizzle/meta/0043_snapshot.json
@@ -1,0 +1,12232 @@
+{
+  "id": "b467e37d-ae0f-4152-8532-fa361ff23392",
+  "prevId": "bb8e26c9-206d-4283-aeca-61693754a466",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -295,6 +295,20 @@
       "when": 1786186474122,
       "tag": "0041_aromatic_rhino",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1786193220069,
+      "tag": "0042_tough_mattie_franklin",
+      "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1786197649043,
+      "tag": "0043_normal_bloodstrike",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -22,6 +22,7 @@ const TABLES = [
   "invoices",
   "lab_results",
   "procedures",
+  "visit_closeouts",
   "prescriptions",
   "vaccination_records",
   "soap_notes",

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -57,7 +57,7 @@ DECLARE
     'locations','patients','practice_payment_accounts','prescriptions','problem_list','procedures','products','purchase_orders',
     'recurring_series','rooms','services','sms_suppressions','soap_notes','staff_schedules','suppliers',
     'treatment_plans','treatment_templates','usage_records','users','vaccination_records',
-    'vital_signs','webhooks','wellness_enrollments','wellness_plans'
+    'visit_closeouts','vital_signs','webhooks','wellness_enrollments','wellness_plans'
   ];
 BEGIN
   FOREACH t IN ARRAY tbls LOOP

--- a/packages/db/schema/billing.ts
+++ b/packages/db/schema/billing.ts
@@ -13,6 +13,7 @@ import {
   index,
   uniqueIndex,
   check,
+  type AnyPgColumn,
 } from "drizzle-orm/pg-core";
 import { relations, sql } from "drizzle-orm";
 import { baseColumns } from "./common";
@@ -22,6 +23,7 @@ import { clients } from "./clients";
 import { patients } from "./patients";
 import { appointments } from "./scheduling";
 import { users } from "./users";
+import { prescriptions } from "./prescriptions";
 
 export const invoiceStatusEnum = pgEnum("invoice_status", [
   "draft",
@@ -162,6 +164,21 @@ export const invoices = pgTable(
       table.clientId,
       table.deletedAt
     ),
+    appointmentIdx: index("invoices_appointment_idx").on(
+      table.practiceId,
+      table.appointmentId,
+      table.deletedAt,
+      table.isEstimate,
+      table.status
+    ),
+    activeAppointmentUq: uniqueIndex("invoices_active_appointment_uq")
+      .on(table.practiceId, table.appointmentId)
+      .where(
+        sql`${table.appointmentId} is not null
+          and ${table.isEstimate} = false
+          and ${table.status} <> 'void'
+          and ${table.deletedAt} is null`
+      ),
   })
 );
 
@@ -178,6 +195,12 @@ export const invoiceItems = pgTable(
     total: numeric("total", { precision: 10, scale: 2 }).notNull(),
     itemType: invoiceItemTypeEnum("item_type").notNull(),
     itemId: uuid("item_id"),
+    // A visit-linked prescription already owns the inventory deduction. This
+    // source identity lets billing charge it without dispensing the stock a
+    // second time.
+    sourcePrescriptionId: uuid("source_prescription_id").references(
+      (): AnyPgColumn => prescriptions.id
+    ),
   },
   (table) => ({
     invoiceIdx: index("invoice_items_invoice_idx").on(
@@ -189,6 +212,17 @@ export const invoiceItems = pgTable(
       table.deletedAt,
       table.itemId
     ),
+    sourcePrescriptionIdx: index("invoice_items_source_prescription_idx").on(
+      table.sourcePrescriptionId,
+      table.deletedAt
+    ),
+    sourcePrescriptionInvoiceUq: uniqueIndex(
+      "invoice_items_source_prescription_invoice_uq"
+    )
+      .on(table.invoiceId, table.sourcePrescriptionId)
+      .where(
+        sql`${table.sourcePrescriptionId} is not null and ${table.deletedAt} is null`
+      ),
   })
 );
 
@@ -203,11 +237,21 @@ export const invoiceAdjustments = pgTable(
     amount: numeric("amount", { precision: 10, scale: 2 }).notNull(),
     reason: text("reason"),
     createdBy: uuid("created_by").references(() => users.id),
+    operationKey: varchar("operation_key", { length: 160 }),
+    balanceAfter: numeric("balance_after", { precision: 10, scale: 2 }),
   },
   (table) => ({
     invoiceIdx: index("invoice_adjustments_invoice_idx").on(
       table.invoiceId,
       table.deletedAt
+    ),
+    operationKeyUq: uniqueIndex("invoice_adjustments_operation_key_uq").on(
+      table.operationKey
+    ),
+    operationResultCheck: check(
+      "invoice_adjustments_operation_result_check",
+      sql`(${table.operationKey} is null and ${table.balanceAfter} is null)
+        or (${table.operationKey} is not null and ${table.balanceAfter} is not null and ${table.balanceAfter} >= 0)`
     ),
   })
 );
@@ -362,6 +406,10 @@ export const invoiceItemsRelations = relations(invoiceItems, ({ one }) => ({
   invoice: one(invoices, {
     fields: [invoiceItems.invoiceId],
     references: [invoices.id],
+  }),
+  sourcePrescription: one(prescriptions, {
+    fields: [invoiceItems.sourcePrescriptionId],
+    references: [prescriptions.id],
   }),
 }));
 

--- a/packages/db/schema/clinical.ts
+++ b/packages/db/schema/clinical.ts
@@ -77,6 +77,11 @@ export const soapNotes = pgTable(
   (table) => ({
     patientIdx: index("soap_notes_patient_idx").on(table.patientId),
     practiceIdx: index("soap_notes_practice_idx").on(table.practiceId, table.deletedAt),
+    appointmentIdx: index("soap_notes_appointment_idx").on(
+      table.practiceId,
+      table.appointmentId,
+      table.deletedAt
+    ),
   })
 );
 

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -21,3 +21,4 @@ export * from "./demo-access";
 export * from "./booking";
 export * from "./funnel-events";
 export * from "./migrations";
+export * from "./visit-closeouts";

--- a/packages/db/schema/prescriptions.ts
+++ b/packages/db/schema/prescriptions.ts
@@ -7,6 +7,8 @@ import {
   integer,
   date,
   index,
+  uniqueIndex,
+  type AnyPgColumn,
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 import { baseColumns } from "./common";
@@ -14,6 +16,7 @@ import { practices } from "./practices";
 import { users } from "./users";
 import { patients } from "./patients";
 import { products } from "./billing";
+import { appointments } from "./scheduling";
 
 export const prescriptionStatusEnum = pgEnum("prescription_status", [
   "active",
@@ -38,11 +41,13 @@ export const prescriptions = pgTable(
     patientId: uuid("patient_id")
       .notNull()
       .references(() => patients.id),
+    appointmentId: uuid("appointment_id").references(() => appointments.id),
     medicationName: varchar("medication_name", { length: 255 }).notNull(),
     dosage: varchar("dosage", { length: 128 }).notNull(),
     frequency: varchar("frequency", { length: 128 }).notNull(),
     quantity: integer("quantity"),
-    productId: uuid("product_id").references(() => products.id),
+    productId: uuid("product_id").references((): AnyPgColumn => products.id),
+    operationId: uuid("operation_id"),
     refillsRemaining: integer("refills_remaining").notNull().default(0),
     prescribedBy: uuid("prescribed_by")
       .notNull()
@@ -63,6 +68,15 @@ export const prescriptions = pgTable(
       table.deletedAt
     ),
     productIdx: index("prescriptions_product_idx").on(table.productId),
+    appointmentIdx: index("prescriptions_appointment_idx").on(
+      table.practiceId,
+      table.appointmentId,
+      table.deletedAt
+    ),
+    operationUq: uniqueIndex("prescriptions_practice_operation_uq").on(
+      table.practiceId,
+      table.operationId
+    ),
   })
 );
 
@@ -82,6 +96,10 @@ export const prescriptionsRelations = relations(prescriptions, ({ one }) => ({
   patient: one(patients, {
     fields: [prescriptions.patientId],
     references: [patients.id],
+  }),
+  appointment: one(appointments, {
+    fields: [prescriptions.appointmentId],
+    references: [appointments.id],
   }),
   prescriber: one(users, {
     fields: [prescriptions.prescribedBy],

--- a/packages/db/schema/visit-closeouts.ts
+++ b/packages/db/schema/visit-closeouts.ts
@@ -1,0 +1,369 @@
+import {
+  check,
+  date,
+  foreignKey,
+  index,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { relations, sql } from "drizzle-orm";
+import { baseColumns } from "./common";
+import { practices } from "./practices";
+import { appointments } from "./scheduling";
+import { users } from "./users";
+import { invoices } from "./billing";
+
+export const visitCloseoutStatusEnum = pgEnum("visit_closeout_status", [
+  "draft",
+  "clinical_finalized",
+  "completed",
+]);
+
+export const visitChargeDispositionEnum = pgEnum("visit_charge_disposition", [
+  "paid",
+  "accounts_receivable",
+  "no_charge",
+]);
+
+export const visitPrescriptionDispositionEnum = pgEnum(
+  "visit_prescription_disposition",
+  ["prescribed", "not_needed"],
+);
+
+export const visitFollowUpDispositionEnum = pgEnum(
+  "visit_follow_up_disposition",
+  ["none", "needed", "scheduled"],
+);
+
+export const visitHandoffMethodEnum = pgEnum("visit_handoff_method", [
+  "print",
+  "verbal",
+  "declined",
+]);
+
+export const visitFollowUpResolutionEnum = pgEnum(
+  "visit_follow_up_resolution",
+  ["scheduled", "completed", "not_needed"],
+);
+
+export type VisitMedicationSnapshot = {
+  prescriptionId: string;
+  medicationName: string;
+  dosage: string;
+  frequency: string;
+  instructions: string | null;
+  quantity: number | null;
+};
+
+export type VisitCloseoutAmendment = {
+  priorRevision: number;
+  reason: string;
+  reopenedAt: string;
+  reopenedBy: string;
+  reopenedByName: string;
+  clinicalFinalizedAt: string;
+  clinicalFinalizedBy: string;
+  clinicalFinalizerName: string;
+  diagnosisSummary: string | null;
+  dischargeInstructions: string | null;
+  warningSigns: string | null;
+  noInstructionsReason: string | null;
+  prescriptionDisposition: "prescribed" | "not_needed";
+  medicationSnapshot: VisitMedicationSnapshot[];
+  followUpDisposition: "none" | "needed" | "scheduled";
+  followUpNotes: string | null;
+  followUpAppointmentId: string | null;
+  followUpScheduledAt: string | null;
+  followUpDueDate: string | null;
+  followUpAssignedTo: string | null;
+  followUpAssigneeName: string | null;
+  followUpResolution: "scheduled" | "completed" | "not_needed" | null;
+  followUpResolutionAppointmentId: string | null;
+  followUpResolutionScheduledAt: string | null;
+  followUpResolutionNotes: string | null;
+  followUpResolvedAt: string | null;
+  followUpResolvedBy: string | null;
+  followUpResolverName: string | null;
+  documentationExceptionReason: string | null;
+};
+
+/**
+ * Editable replacement content for an attributed amendment. The currently
+ * finalized clinical fields and their medication/follow-up snapshots remain on
+ * the closeout row until this draft is validated and promoted atomically.
+ */
+export type VisitCloseoutAmendmentDraft = {
+  baseRevision: number;
+  reason: string;
+  reopenedAt: string;
+  reopenedBy: string;
+  reopenedByName: string;
+  diagnosisSummary: string | null;
+  dischargeInstructions: string | null;
+  warningSigns: string | null;
+  noInstructionsReason: string | null;
+  prescriptionDisposition: "prescribed" | "not_needed" | null;
+  followUpDisposition: "none" | "needed" | "scheduled" | null;
+  followUpNotes: string | null;
+  followUpAppointmentId: string | null;
+  followUpDueDate: string | null;
+  followUpAssignedTo: string | null;
+  documentationExceptionReason: string | null;
+};
+
+/**
+ * Durable, attributable closeout state for a clinic visit. Clinical content is
+ * finalized first; operational checkout then verifies billing and owner
+ * handoff before changing the appointment to the terminal checked_out state.
+ */
+export const visitCloseouts = pgTable(
+  "visit_closeouts",
+  {
+    ...baseColumns(),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    appointmentId: uuid("appointment_id")
+      .notNull()
+      .references(() => appointments.id),
+    status: visitCloseoutStatusEnum("status").notNull().default("draft"),
+    diagnosisSummary: text("diagnosis_summary"),
+    dischargeInstructions: text("discharge_instructions"),
+    warningSigns: text("warning_signs"),
+    noInstructionsReason: text("no_instructions_reason"),
+    prescriptionDisposition: visitPrescriptionDispositionEnum(
+      "prescription_disposition",
+    ),
+    followUpDisposition: visitFollowUpDispositionEnum("follow_up_disposition"),
+    followUpNotes: text("follow_up_notes"),
+    followUpAppointmentId: uuid("follow_up_appointment_id").references(
+      () => appointments.id,
+    ),
+    followUpScheduledAt: timestamp("follow_up_scheduled_at", {
+      withTimezone: true,
+    }),
+    followUpDueDate: date("follow_up_due_date"),
+    followUpAssignedTo: uuid("follow_up_assigned_to").references(
+      () => users.id,
+    ),
+    followUpAssigneeName: text("follow_up_assignee_name"),
+    followUpResolution: visitFollowUpResolutionEnum("follow_up_resolution"),
+    followUpResolutionAppointmentId: uuid(
+      "follow_up_resolution_appointment_id",
+    ),
+    followUpResolutionScheduledAt: timestamp(
+      "follow_up_resolution_scheduled_at",
+      { withTimezone: true },
+    ),
+    followUpResolutionNotes: text("follow_up_resolution_notes"),
+    followUpResolvedAt: timestamp("follow_up_resolved_at", {
+      withTimezone: true,
+    }),
+    followUpResolvedBy: uuid("follow_up_resolved_by").references(
+      () => users.id,
+    ),
+    followUpResolverName: text("follow_up_resolver_name"),
+    medicationSnapshot: jsonb("medication_snapshot")
+      .$type<VisitMedicationSnapshot[]>()
+      .notNull()
+      .default([]),
+    amendmentHistory: jsonb("amendment_history")
+      .$type<VisitCloseoutAmendment[]>()
+      .notNull()
+      .default([]),
+    amendmentDraft: jsonb(
+      "amendment_draft",
+    ).$type<VisitCloseoutAmendmentDraft | null>(),
+    documentationExceptionReason: text("documentation_exception_reason"),
+    clinicalFinalizedAt: timestamp("clinical_finalized_at", {
+      withTimezone: true,
+    }),
+    clinicalFinalizedBy: uuid("clinical_finalized_by").references(
+      () => users.id,
+    ),
+    clinicalFinalizerName: text("clinical_finalizer_name"),
+    chargeDisposition: visitChargeDispositionEnum("charge_disposition"),
+    invoiceId: uuid("invoice_id").references(() => invoices.id),
+    noChargeReason: text("no_charge_reason"),
+    handoffMethod: visitHandoffMethodEnum("handoff_method"),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    completedBy: uuid("completed_by").references(() => users.id),
+    revision: integer("revision").notNull().default(1),
+  },
+  (table) => ({
+    appointmentUq: uniqueIndex("visit_closeouts_appointment_uq").on(
+      table.appointmentId,
+    ),
+    practiceStatusIdx: index("visit_closeouts_practice_status_idx").on(
+      table.practiceId,
+      table.status,
+      table.updatedAt,
+    ),
+    pendingFollowUpIdx: index("visit_closeouts_pending_follow_up_idx").on(
+      table.practiceId,
+      table.followUpDisposition,
+      table.followUpResolvedAt,
+      table.followUpDueDate,
+    ),
+    resolutionAppointmentFk: foreignKey({
+      columns: [table.followUpResolutionAppointmentId],
+      foreignColumns: [appointments.id],
+      name: "visit_closeouts_resolution_appointment_fk",
+    }),
+    revisionCheck: check(
+      "visit_closeouts_revision_check",
+      sql`${table.revision} >= 1`,
+    ),
+    amendmentDraftCheck: check(
+      "visit_closeouts_amendment_draft_check",
+      sql`(${table.status} = 'draft' and ${table.amendmentDraft} is null)
+        or (
+          ${table.status} in ('clinical_finalized', 'completed')
+          and (
+            ${table.amendmentDraft} is null
+            or jsonb_typeof(${table.amendmentDraft}) = 'object'
+          )
+        )`,
+    ),
+    clinicalStateCheck: check(
+      "visit_closeouts_clinical_state_check",
+      sql`${table.status} = 'draft'
+        or (
+          ${table.clinicalFinalizedAt} is not null
+          and ${table.clinicalFinalizedBy} is not null
+          and length(btrim(coalesce(${table.clinicalFinalizerName}, ''))) > 0
+          and ${table.prescriptionDisposition} is not null
+          and (
+            ${table.prescriptionDisposition} = 'prescribed'
+            and jsonb_array_length(${table.medicationSnapshot}) > 0
+            or ${table.prescriptionDisposition} = 'not_needed'
+            and jsonb_array_length(${table.medicationSnapshot}) = 0
+          )
+          and (
+            length(btrim(coalesce(${table.dischargeInstructions}, ''))) > 0
+            or length(btrim(coalesce(${table.noInstructionsReason}, ''))) > 0
+          )
+          and ${table.followUpDisposition} is not null
+          and (
+            ${table.followUpDisposition} = 'none'
+            and ${table.followUpAppointmentId} is null
+            and ${table.followUpScheduledAt} is null
+            and ${table.followUpDueDate} is null
+            and ${table.followUpAssignedTo} is null
+            and ${table.followUpAssigneeName} is null
+            or (
+              ${table.followUpDisposition} = 'scheduled'
+              and ${table.followUpAppointmentId} is not null
+              and ${table.followUpScheduledAt} is not null
+              and ${table.followUpDueDate} is null
+              and ${table.followUpAssignedTo} is null
+              and ${table.followUpAssigneeName} is null
+            )
+            or (
+              ${table.followUpDisposition} = 'needed'
+              and ${table.followUpAppointmentId} is null
+              and ${table.followUpScheduledAt} is null
+              and ${table.followUpDueDate} is not null
+              and ${table.followUpAssignedTo} is not null
+              and length(btrim(coalesce(${table.followUpAssigneeName}, ''))) > 0
+            )
+          )
+        )`,
+    ),
+    completedStateCheck: check(
+      "visit_closeouts_completed_state_check",
+      sql`${table.status} <> 'completed'
+        or (
+          ${table.completedAt} is not null
+          and ${table.completedBy} is not null
+          and ${table.chargeDisposition} is not null
+          and ${table.handoffMethod} is not null
+          and (
+            ${table.chargeDisposition} = 'no_charge'
+            and ${table.invoiceId} is null
+            and length(btrim(coalesce(${table.noChargeReason}, ''))) > 0
+            or ${table.chargeDisposition} in ('paid', 'accounts_receivable')
+            and ${table.invoiceId} is not null
+          )
+        )`,
+    ),
+    followUpResolutionCheck: check(
+      "visit_closeouts_follow_up_resolution_check",
+      sql`${table.followUpResolvedAt} is null
+        and ${table.followUpResolution} is null
+        and ${table.followUpResolutionAppointmentId} is null
+        and ${table.followUpResolutionScheduledAt} is null
+        and ${table.followUpResolutionNotes} is null
+        and ${table.followUpResolvedBy} is null
+        and ${table.followUpResolverName} is null
+        or (
+          ${table.followUpDisposition} = 'needed'
+          and ${table.followUpResolvedAt} is not null
+          and ${table.followUpResolution} is not null
+          and ${table.followUpResolvedBy} is not null
+          and length(btrim(coalesce(${table.followUpResolverName}, ''))) > 0
+          and (
+            ${table.followUpResolution} = 'scheduled'
+            and ${table.followUpResolutionAppointmentId} is not null
+            and ${table.followUpResolutionScheduledAt} is not null
+            or ${table.followUpResolution} in ('completed', 'not_needed')
+            and ${table.followUpResolutionAppointmentId} is null
+            and ${table.followUpResolutionScheduledAt} is null
+            and length(btrim(coalesce(${table.followUpResolutionNotes}, ''))) > 0
+          )
+        )`,
+    ),
+  }),
+);
+
+export const visitCloseoutsRelations = relations(visitCloseouts, ({ one }) => ({
+  practice: one(practices, {
+    fields: [visitCloseouts.practiceId],
+    references: [practices.id],
+  }),
+  appointment: one(appointments, {
+    relationName: "closedAppointment",
+    fields: [visitCloseouts.appointmentId],
+    references: [appointments.id],
+  }),
+  followUpAppointment: one(appointments, {
+    relationName: "followUpAppointment",
+    fields: [visitCloseouts.followUpAppointmentId],
+    references: [appointments.id],
+  }),
+  followUpResolutionAppointment: one(appointments, {
+    relationName: "followUpResolutionAppointment",
+    fields: [visitCloseouts.followUpResolutionAppointmentId],
+    references: [appointments.id],
+  }),
+  invoice: one(invoices, {
+    fields: [visitCloseouts.invoiceId],
+    references: [invoices.id],
+  }),
+  clinicalFinalizer: one(users, {
+    relationName: "clinicalFinalizer",
+    fields: [visitCloseouts.clinicalFinalizedBy],
+    references: [users.id],
+  }),
+  followUpAssignee: one(users, {
+    relationName: "followUpAssignee",
+    fields: [visitCloseouts.followUpAssignedTo],
+    references: [users.id],
+  }),
+  followUpResolver: one(users, {
+    relationName: "followUpResolver",
+    fields: [visitCloseouts.followUpResolvedBy],
+    references: [users.id],
+  }),
+  completer: one(users, {
+    relationName: "visitCompleter",
+    fields: [visitCloseouts.completedBy],
+    references: [users.id],
+  }),
+}));

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -41,6 +41,10 @@ const aUser = randomUUID();
 const bUser = randomUUID();
 const aMigrationRun = randomUUID();
 const bMigrationRun = randomUUID();
+const aAppointment = randomUUID();
+const bAppointment = randomUUID();
+const aCloseout = randomUUID();
+const bCloseout = randomUUID();
 const funnelEventId = randomUUID();
 let failures = 0;
 
@@ -70,6 +74,14 @@ try {
     (${bMigrationRun}, ${bId}, ${bUser}, 'clients', 'other', ${"b".repeat(64)}, 10, now() + interval '1 day')`;
   await owner`insert into funnel_events (id, event_name, practice_id)
     values (${funnelEventId}, 'registration', ${aId})`;
+  await owner`insert into appointments (id, practice_id, client_id, start_time, end_time)
+    select ${aAppointment}::uuid, ${aId}::uuid, id, now(), now() + interval '30 minutes'
+    from clients where practice_id = ${aId}
+    union all
+    select ${bAppointment}::uuid, ${bId}::uuid, id, now(), now() + interval '30 minutes'
+    from clients where practice_id = ${bId}`;
+  await owner`insert into visit_closeouts (id, practice_id, appointment_id)
+    values (${aCloseout}, ${aId}, ${aAppointment}), (${bCloseout}, ${bId}, ${bAppointment})`;
 
   // Tenant A context sees only A's rows.
   const aRows = await appTransaction(async (tx) => {
@@ -100,6 +112,16 @@ try {
     aMigrationRows.length === 1 &&
       aMigrationRows[0]!.id === aMigrationRun &&
       aMigrationRows[0]!.practice_id === aId,
+  );
+  const aCloseoutRows = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id, practice_id from visit_closeouts where id in (${aCloseout}, ${bCloseout})`;
+  });
+  check(
+    "tenant A sees only A's visit closeout",
+    aCloseoutRows.length === 1 &&
+      aCloseoutRows[0]!.id === aCloseout &&
+      aCloseoutRows[0]!.practice_id === aId,
   );
 
   const hiddenMigrationUpdate = await appTransaction(async (tx) => {
@@ -201,9 +223,11 @@ try {
 } finally {
   // Cleanup (as owner).
   await owner`delete from invoice_adjustments where invoice_id in (${aInvoice}, ${bInvoice})`;
+  await owner`delete from visit_closeouts where id in (${aCloseout}, ${bCloseout})`;
   await owner`delete from funnel_events where id = ${funnelEventId}`;
   await owner`delete from invoices where id in (${aInvoice}, ${bInvoice})`;
   await owner`delete from migration_runs where id in (${aMigrationRun}, ${bMigrationRun})`;
+  await owner`delete from appointments where id in (${aAppointment}, ${bAppointment})`;
   await owner`delete from clients where practice_id in (${aId}, ${bId})`;
   await owner`delete from users where id in (${aUser}, ${bUser})`;
   await owner`delete from practices where id in (${aId}, ${bId})`;


### PR DESCRIPTION
## Why

OpenVPM needs a safe, auditable path from an active appointment through clinical handoff, charge capture, payment/AR disposition, and checkout before a design-partner clinic can rely on it for a full day.

## What changed

- adds a durable appointment-scoped visit closeout with draft, veterinarian finalization, immutable signed snapshots, attributed amendments, and completed-visit audit history
- links SOAP notes, prescriptions, invoice items, invoices, and checkout to the appointment
- makes prescription dispensing, payments, invoice adjustments, and visit invoice creation retry-safe with operation IDs and uniqueness guards
- adds an explicit needed-follow-up workflow with due date, assignee, dashboard queue, and audited resolution
- blocks unsafe checkout until clinical, billing, and owner-handoff requirements are satisfied
- makes schedule and whiteboard appointment overlays accessible and routes active visits into the encounter workspace
- includes backup/reset/RLS coverage and two reviewable Drizzle migrations
- handles existing-database enum upgrades transactionally and locks only the appointment row when optional appointment type data is left joined

## Verification

- rendered clinic journey: checked in → SOAP → visit prescription → veterinarian sign-off → $70.20 visit invoice → payment → checkout → attributed signed amendment
- mobile encounter and schedule dialog walkthrough
- 2,497 tests passing across 271 files
- 281 focused closeout/billing/accessibility/migration tests passing
- monorepo type-check passing
- optimized production build passing for all 40 routes
- fresh PostgreSQL 17: all 44 migrations, zero schema drift, 14/14 RLS isolation checks, migration concurrency/idempotency/rollback proof
- existing PostgreSQL database: upgrade from 33 to 44 migrations passing
- production and staging preflight: zero duplicate active appointment invoices
- staged secret scan: no leaks found

## Deployment note

Apply the committed migrations before or with the application release. The active-invoice uniqueness migration fails closed if pre-existing duplicate active appointment invoices are introduced after the preflight.