### PR TITLE
Make clinic SMS registration launch-ready

### DIFF
--- a/apps/web/app/sms/[practiceId]/layout.tsx
+++ b/apps/web/app/sms/[practiceId]/layout.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { PawMark } from "@/components/brand/paw-mark";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Clinic text messaging information - OpenVPM",
+  description:
+    "Program information, consent disclosure, privacy policy, and terms for clinic text messages powered by OpenVPM.",
+  robots: { index: false, follow: false },
+};
+
+export default async function SmsProgramLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ practiceId: string }>;
+}) {
+  const { practiceId } = await params;
+  const root = "/sms/" + encodeURIComponent(practiceId);
+
+  return (
+    <div className="min-h-screen bg-surface">
+      <header className="border-b border-border bg-card">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center justify-between gap-4 px-4 py-4">
+          <Link href={root} className="flex items-center gap-2">
+            <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
+              <PawMark className="h-4 w-4 text-primary-foreground" />
+            </span>
+            <span className="font-heading text-lg font-semibold">OpenVPM</span>
+          </Link>
+          <nav
+            aria-label="Text messaging policies"
+            className="flex flex-wrap gap-x-4 gap-y-2 text-sm text-muted-foreground"
+          >
+            <Link href={root + "/opt-in"} className="hover:text-foreground">
+              Consent
+            </Link>
+            <Link href={root + "/privacy"} className="hover:text-foreground">
+              Privacy
+            </Link>
+            <Link href={root + "/terms"} className="hover:text-foreground">
+              Terms
+            </Link>
+          </nav>
+        </div>
+      </header>
+      <main id="main-content" className="mx-auto max-w-3xl px-4 py-10">
+        <article className="space-y-6 text-sm leading-6 text-foreground [&_a]:text-primary [&_a]:underline-offset-2 hover:[&_a]:underline [&_h1]:font-heading [&_h1]:text-3xl [&_h1]:font-semibold [&_h2]:mt-8 [&_h2]:font-heading [&_h2]:text-xl [&_h2]:font-semibold [&_li]:text-muted-foreground [&_p]:text-muted-foreground [&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-6">
+          {children}
+        </article>
+      </main>
+      <footer className="border-t border-border bg-card">
+        <div className="mx-auto max-w-3xl px-4 py-6 text-center text-xs text-muted-foreground">
+          Text messaging powered by OpenVPM
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/app/sms/[practiceId]/opt-in/page.tsx
+++ b/apps/web/app/sms/[practiceId]/opt-in/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from "next/navigation";
+import { getPublicMessagingProgram } from "@/lib/messaging/public-program";
+import { SMS_CONSENT_DISCLOSURE } from "@/lib/messaging/consent";
+
+export default async function SmsOptInPage({
+  params,
+}: {
+  params: Promise<{ practiceId: string }>;
+}) {
+  const { practiceId } = await params;
+  const program = await getPublicMessagingProgram(practiceId);
+  if (!program) notFound();
+
+  return (
+    <>
+      <p className="font-medium text-primary">{program.displayName}</p>
+      <h1>How SMS consent is collected</h1>
+      <p>Last updated: August 8, 2026</p>
+
+      <p>
+        Clients may opt in during phone or in-person intake. Clinic staff read
+        or show the disclosure below, ask for an explicit choice, and record the
+        client&apos;s answer in OpenVPM. The consent control is optional and is
+        not selected by default. No text is sent until consent is recorded.
+      </p>
+
+      <h2>Disclosure shown or read to clients</h2>
+      <blockquote className="rounded-lg border border-border bg-card p-5 text-base leading-7 text-foreground shadow-sm">
+        {SMS_CONSENT_DISCLOSURE.snapshot}
+      </blockquote>
+
+      <h2>Evidence retained</h2>
+      <p>
+        OpenVPM records the consent choice, date and time, mobile number,
+        disclosure text, and consent source. Replying STOP creates a suppression
+        that blocks further sends. Replying START, YES, or UNSTOP may
+        re-establish consent from the client&apos;s own phone.
+      </p>
+    </>
+  );
+}

--- a/apps/web/app/sms/[practiceId]/page.tsx
+++ b/apps/web/app/sms/[practiceId]/page.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getPublicMessagingProgram } from "@/lib/messaging/public-program";
+
+export default async function SmsProgramPage({
+  params,
+}: {
+  params: Promise<{ practiceId: string }>;
+}) {
+  const { practiceId } = await params;
+  const program = await getPublicMessagingProgram(practiceId);
+  if (!program) notFound();
+  const root = "/sms/" + encodeURIComponent(program.practiceId);
+
+  return (
+    <>
+      <p className="font-medium text-primary">Clinic text messaging</p>
+      <h1>{program.displayName}</h1>
+      <p>
+        {program.displayName} may use OpenVPM to send requested veterinary
+        service messages. These may include appointment reminders, vaccination
+        and care updates, and replies to client questions.
+      </p>
+
+      <h2>Your choice</h2>
+      <p>
+        Text messaging is optional. The clinic records consent before sending
+        messages. Message frequency varies, and message and data rates may
+        apply. Consent is not a condition of purchasing veterinary services.
+      </p>
+
+      <h2>Manage messages</h2>
+      <ul>
+        <li>Reply STOP at any time to stop text messages.</li>
+        <li>Reply HELP for help with the messaging program.</li>
+        <li>
+          You may opt back in later by replying START or giving the clinic new
+          permission.
+        </li>
+      </ul>
+
+      <h2>Program details</h2>
+      <ul>
+        <li>
+          <Link href={root + "/opt-in"}>How consent is collected</Link>
+        </li>
+        <li>
+          <Link href={root + "/privacy"}>SMS privacy policy</Link>
+        </li>
+        <li>
+          <Link href={root + "/terms"}>SMS terms and conditions</Link>
+        </li>
+      </ul>
+
+      <h2>Contact the clinic</h2>
+      <p>
+        {program.businessPhone ? (
+          <>Call {program.businessPhone} for help.</>
+        ) : program.website ? (
+          <>
+            Visit the clinic&apos;s <a href={program.website}>website</a> for
+            contact information.
+          </>
+        ) : (
+          <>Contact the clinic directly for help.</>
+        )}
+      </p>
+
+      <p>Last updated: August 8, 2026</p>
+    </>
+  );
+}

--- a/apps/web/app/sms/[practiceId]/privacy/page.tsx
+++ b/apps/web/app/sms/[practiceId]/privacy/page.tsx
@@ -1,0 +1,85 @@
+import { notFound } from "next/navigation";
+import { getPublicMessagingProgram } from "@/lib/messaging/public-program";
+
+export default async function SmsPrivacyPage({
+  params,
+}: {
+  params: Promise<{ practiceId: string }>;
+}) {
+  const { practiceId } = await params;
+  const program = await getPublicMessagingProgram(practiceId);
+  if (!program) notFound();
+
+  return (
+    <>
+      <p className="font-medium text-primary">{program.displayName}</p>
+      <h1>SMS privacy policy</h1>
+      <p>Last updated: August 8, 2026</p>
+
+      <p>
+        This policy applies to text messages sent by {program.displayName}{" "}
+        through OpenVPM. The clinic controls its client information; OpenVPM
+        processes that information to provide the messaging service.
+      </p>
+
+      <h2>Information used for texting</h2>
+      <p>
+        The clinic may use your name, mobile number, pet and appointment
+        details, message content, consent record, and opt-out status to send
+        requested veterinary service messages and respond to you.
+      </p>
+
+      <h2>How information is used</h2>
+      <ul>
+        <li>Send appointment reminders and schedule updates.</li>
+        <li>Send vaccination, care, prescription, and follow-up notices.</li>
+        <li>Answer client questions and record messaging preferences.</li>
+        <li>Secure, troubleshoot, and document the messaging service.</li>
+      </ul>
+
+      <h2>No sale or promotional sharing</h2>
+      <p>
+        The clinic and OpenVPM do not sell your personal information. SMS opt-in
+        data and consent are not shared with third parties for their own
+        marketing or promotional purposes.
+      </p>
+      <p>
+        Information may be processed by OpenVPM&apos;s infrastructure providers,
+        telecommunications carriers, and other service providers only as needed
+        to deliver, secure, and support the clinic&apos;s messages or meet legal
+        obligations.
+      </p>
+
+      <h2>Retention and security</h2>
+      <p>
+        Consent, message, and opt-out records are retained as part of the
+        clinic&apos;s business and medical-record systems for as long as needed
+        to provide the service and meet legal or operational requirements.
+        OpenVPM uses encryption in transit, role-based access, and tenant
+        isolation to protect hosted records.
+      </p>
+
+      <h2>Your choices</h2>
+      <p>
+        Reply STOP to stop text messages or HELP for help. You may also contact
+        the clinic to ask about its records or update your communication
+        preferences. An opt-out applies to text messages; the clinic may still
+        contact you through other channels when appropriate.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        {program.businessPhone ? (
+          <>Call {program.businessPhone} with privacy or messaging questions.</>
+        ) : program.website ? (
+          <>
+            Visit the clinic&apos;s <a href={program.website}>website</a> for
+            contact information.
+          </>
+        ) : (
+          <>Contact {program.displayName} directly with questions.</>
+        )}
+      </p>
+    </>
+  );
+}

--- a/apps/web/app/sms/[practiceId]/terms/page.tsx
+++ b/apps/web/app/sms/[practiceId]/terms/page.tsx
@@ -1,0 +1,68 @@
+import { notFound } from "next/navigation";
+import { getPublicMessagingProgram } from "@/lib/messaging/public-program";
+
+export default async function SmsTermsPage({
+  params,
+}: {
+  params: Promise<{ practiceId: string }>;
+}) {
+  const { practiceId } = await params;
+  const program = await getPublicMessagingProgram(practiceId);
+  if (!program) notFound();
+
+  return (
+    <>
+      <p className="font-medium text-primary">{program.displayName}</p>
+      <h1>SMS terms and conditions</h1>
+      <p>Last updated: August 8, 2026</p>
+
+      <h2>Program</h2>
+      <p>
+        By opting in, you authorize {program.displayName} to send veterinary
+        service text messages to the mobile number you provide. Messages may
+        include appointment reminders, vaccination and care updates,
+        prescription or follow-up notices, and two-way client support. OpenVPM
+        supplies the clinic&apos;s messaging technology.
+      </p>
+
+      <h2>Consent and frequency</h2>
+      <p>
+        Your consent is optional and is not a condition of purchasing goods or
+        services. Message frequency varies based on your pets&apos; care and
+        your interactions with the clinic. Message and data rates may apply.
+      </p>
+
+      <h2>Opt out and help</h2>
+      <ul>
+        <li>Reply STOP to cancel text messages.</li>
+        <li>Reply HELP for help.</li>
+        <li>
+          After opting out, you may receive one confirmation message. You can
+          later reply START or give the clinic new consent to resume messages.
+        </li>
+      </ul>
+
+      <h2>Delivery</h2>
+      <p>
+        Carriers are not liable for delayed or undelivered messages. Texting is
+        not appropriate for emergencies. Contact an emergency veterinary
+        provider directly when urgent care is needed.
+      </p>
+
+      <h2>Privacy and contact</h2>
+      <p>
+        The clinic&apos;s SMS privacy policy explains how messaging information
+        is handled. For program help,{" "}
+        {program.businessPhone ? (
+          <>call {program.businessPhone}.</>
+        ) : program.website ? (
+          <>
+            visit the clinic&apos;s <a href={program.website}>website</a>.
+          </>
+        ) : (
+          <>contact {program.displayName} directly.</>
+        )}
+      </p>
+    </>
+  );
+}

--- a/apps/web/components/settings/messaging-registration-form.tsx
+++ b/apps/web/components/settings/messaging-registration-form.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
+  ExternalLink,
   Loader2,
   ShieldCheck,
 } from "lucide-react";
@@ -52,30 +53,52 @@ const EMPTY_FORM: FormState = {
 
 export function MessagingRegistrationForm() {
   const utils = trpc.useUtils();
-  const { data, isLoading, error } = trpc.messaging.getRegistration.useQuery();
+  const registrationQuery = trpc.messaging.getRegistration.useQuery();
+  const defaultsQuery = trpc.messaging.getRegistrationDefaults.useQuery();
+  const data = registrationQuery.data;
+  const defaults = defaultsQuery.data;
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [attested, setAttested] = useState(false);
+  const appliedInitialValues = useRef(false);
 
   useEffect(() => {
-    if (!data) return;
-    setForm({
-      entityType: data.entityType,
-      displayName: data.displayName,
-      legalName: data.legalName,
-      taxId: "",
-      contactFirstName: data.contactFirstName,
-      contactLastName: data.contactLastName,
-      contactEmail: data.contactEmail,
-      businessPhone: data.businessPhone,
-      street: data.street,
-      city: data.city,
-      state: data.state,
-      postalCode: data.postalCode,
-      website: data.website,
-      privacyPolicyUrl: data.privacyPolicyUrl,
-      termsUrl: data.termsUrl,
-    });
-  }, [data]);
+    if (appliedInitialValues.current) return;
+    if (data) {
+      setForm({
+        entityType: data.entityType,
+        displayName: data.displayName,
+        legalName: data.legalName,
+        taxId: "",
+        contactFirstName: data.contactFirstName,
+        contactLastName: data.contactLastName,
+        contactEmail: data.contactEmail,
+        businessPhone: data.businessPhone,
+        street: data.street,
+        city: data.city,
+        state: data.state,
+        postalCode: data.postalCode,
+        website: data.website,
+        privacyPolicyUrl: data.privacyPolicyUrl,
+        termsUrl: data.termsUrl,
+      });
+      appliedInitialValues.current = true;
+      return;
+    }
+    if (data === null && defaults) {
+      setForm((current) => ({
+        ...current,
+        displayName: defaults.displayName,
+        contactFirstName: defaults.contactFirstName,
+        contactLastName: defaults.contactLastName,
+        contactEmail: defaults.contactEmail,
+        businessPhone: defaults.businessPhone,
+        website: defaults.website,
+        privacyPolicyUrl: defaults.privacyPolicyUrl,
+        termsUrl: defaults.termsUrl,
+      }));
+      appliedInitialValues.current = true;
+    }
+  }, [data, defaults]);
 
   const submitted = Boolean(
     data?.providerBrandStatus || data?.providerCampaignStatus
@@ -94,7 +117,7 @@ export function MessagingRegistrationForm() {
     setForm((current) => ({ ...current, [key]: value }));
   }
 
-  if (isLoading) {
+  if (registrationQuery.isLoading || defaultsQuery.isLoading) {
     return (
       <div className="flex items-center gap-2 rounded-lg border border-border p-5 text-sm text-muted-foreground">
         <Loader2 className="h-4 w-4 animate-spin" /> Loading carrier
@@ -102,10 +125,11 @@ export function MessagingRegistrationForm() {
       </div>
     );
   }
-  if (error) {
+  const queryError = registrationQuery.error || defaultsQuery.error;
+  if (queryError) {
     return (
       <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
-        <AlertTriangle className="mr-2 inline h-4 w-4" /> {error.message}
+        <AlertTriangle className="mr-2 inline h-4 w-4" /> {queryError.message}
       </div>
     );
   }
@@ -149,6 +173,45 @@ export function MessagingRegistrationForm() {
           {data.lastSyncedAt
             ? ` Last checked ${new Date(data.lastSyncedAt).toLocaleString()}.`
             : ""}
+        </div>
+      ) : null}
+
+      {defaults ? (
+        <div className="rounded-lg border border-primary/20 bg-primary/5 p-4">
+          <p className="text-sm font-medium text-foreground">
+            Your clinic&apos;s SMS policies are ready
+          </p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            OpenVPM hosts the privacy policy, messaging terms, and exact consent
+            disclosure carriers need to review. You can use these links now or
+            replace them with your own public HTTPS pages.
+          </p>
+          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-2 text-xs">
+            <a
+              href={defaults.privacyPolicyUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
+              Privacy policy <ExternalLink className="h-3 w-3" />
+            </a>
+            <a
+              href={defaults.termsUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
+              Messaging terms <ExternalLink className="h-3 w-3" />
+            </a>
+            <a
+              href={defaults.optInUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
+              Consent disclosure <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
         </div>
       ) : null}
 
@@ -248,25 +311,28 @@ export function MessagingRegistrationForm() {
           disabled={submitted}
         />
         <TextField
-          label="Clinic website (HTTPS)"
+          label="Clinic website or professional profile (HTTPS)"
           type="url"
           value={form.website}
           onChange={(v) => update("website", v)}
           disabled={submitted}
+          description="A public clinic website, Google Business short link, or professional profile (100 characters max)."
         />
         <TextField
-          label="SMS privacy policy URL"
+          label="SMS privacy policy URL (optional)"
           type="url"
           value={form.privacyPolicyUrl}
           onChange={(v) => update("privacyPolicyUrl", v)}
           disabled={submitted}
+          description="Leave blank to use the OpenVPM-hosted clinic policy."
         />
         <TextField
-          label="SMS terms URL"
+          label="SMS terms URL (optional)"
           type="url"
           value={form.termsUrl}
           onChange={(v) => update("termsUrl", v)}
           disabled={submitted}
+          description="Leave blank to use the OpenVPM-hosted clinic terms."
         />
       </div>
 
@@ -281,7 +347,8 @@ export function MessagingRegistrationForm() {
             />
             <span>
               I certify these details are accurate, clients consent before any
-              SMS is sent, and the linked policies explain message frequency,
+              SMS is sent, SMS opt-in data is not sold or shared for third-party
+              marketing, and the linked policies explain message frequency,
               message/data rates, HELP, and STOP opt-out.
             </span>
           </label>
@@ -331,12 +398,14 @@ function TextField({
   onChange,
   type = "text",
   disabled,
+  description,
 }: {
   label: string;
   value: string;
   onChange: (value: string) => void;
   type?: "text" | "email" | "tel" | "url";
   disabled?: boolean;
+  description?: string;
 }) {
   return (
     <Field label={label}>
@@ -346,6 +415,11 @@ function TextField({
         onChange={(event) => onChange(event.target.value)}
         disabled={disabled}
       />
+      {description ? (
+        <span className="block text-xs font-normal leading-4 text-muted-foreground">
+          {description}
+        </span>
+      ) : null}
     </Field>
   );
 }

--- a/apps/web/lib/messaging/__tests__/public-program.test.ts
+++ b/apps/web/lib/messaging/__tests__/public-program.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { messagingProgramUrls } from "../public-program";
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+
+describe("public clinic messaging program", () => {
+  it("builds stable hosted policy and consent URLs", () => {
+    expect(
+      messagingProgramUrls(PRACTICE_ID, "https://app.openvpm.com/settings"),
+    ).toEqual({
+      programUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}`,
+      privacyPolicyUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/privacy`,
+      termsUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/terms`,
+      optInUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/opt-in`,
+    });
+  });
+
+  it("rejects malformed practice identifiers", () => {
+    expect(() =>
+      messagingProgramUrls("../other", "https://app.openvpm.com"),
+    ).toThrow();
+  });
+
+  it("renders the server-owned consent disclosure on the public opt-in page", () => {
+    const source = readFileSync(
+      new URL("../../../app/sms/[practiceId]/opt-in/page.tsx", import.meta.url),
+      "utf8",
+    );
+    expect(source).toContain("SMS_CONSENT_DISCLOSURE.snapshot");
+    expect(source).toContain("not selected by default");
+    expect(source).toContain("No text is sent until consent is recorded");
+  });
+});

--- a/apps/web/lib/messaging/public-program.ts
+++ b/apps/web/lib/messaging/public-program.ts
@@ -1,0 +1,95 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@openpims/db/client";
+import { messagingRegistrations, practices } from "@openpims/db";
+import { appBaseUrl } from "@/lib/app-url";
+import { withSystem } from "@/lib/tenant-db";
+
+const practiceIdSchema = z.string().uuid();
+
+export type PublicMessagingProgram = {
+  practiceId: string;
+  displayName: string;
+  businessPhone: string | null;
+  website: string | null;
+};
+
+function publicHttpsUrlOrNull(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+export function messagingProgramUrls(
+  practiceId: string,
+  baseUrl = appBaseUrl(),
+) {
+  const safePracticeId = practiceIdSchema.parse(practiceId);
+  const base = new URL(baseUrl);
+  const programUrl = new URL(
+    `/sms/${encodeURIComponent(safePracticeId)}`,
+    base,
+  ).toString();
+
+  return {
+    programUrl,
+    privacyPolicyUrl: new URL("privacy", `${programUrl}/`).toString(),
+    termsUrl: new URL("terms", `${programUrl}/`).toString(),
+    optInUrl: new URL("opt-in", `${programUrl}/`).toString(),
+  };
+}
+
+/**
+ * Load only the clinic details that are appropriate for a public carrier and
+ * client-facing SMS disclosure. Legal names, addresses, EINs, and registration
+ * contacts intentionally never cross this boundary.
+ */
+export async function getPublicMessagingProgram(
+  practiceId: string,
+): Promise<PublicMessagingProgram | null> {
+  const parsed = practiceIdSchema.safeParse(practiceId);
+  if (!parsed.success) return null;
+
+  return withSystem(db, async (tx) => {
+    const [row] = await tx
+      .select({
+        practiceId: practices.id,
+        practiceName: practices.name,
+        practicePhone: practices.phone,
+        practiceWebsite: practices.website,
+        registrationDisplayName: messagingRegistrations.displayName,
+        registrationBusinessPhone: messagingRegistrations.businessPhone,
+        registrationWebsite: messagingRegistrations.website,
+      })
+      .from(practices)
+      .leftJoin(
+        messagingRegistrations,
+        and(
+          eq(messagingRegistrations.practiceId, practices.id),
+          isNull(messagingRegistrations.deletedAt),
+        ),
+      )
+      .where(
+        and(
+          eq(practices.id, parsed.data),
+          eq(practices.country, "US"),
+          isNull(practices.deletedAt),
+        ),
+      )
+      .limit(1);
+
+    if (!row) return null;
+    return {
+      practiceId: row.practiceId,
+      displayName: row.registrationDisplayName || row.practiceName,
+      businessPhone: row.registrationBusinessPhone || row.practicePhone || null,
+      website: publicHttpsUrlOrNull(
+        row.registrationWebsite || row.practiceWebsite
+      ),
+    };
+  });
+}

--- a/apps/web/server/__tests__/admin-messaging-operations.test.ts
+++ b/apps/web/server/__tests__/admin-messaging-operations.test.ts
@@ -63,7 +63,7 @@ vi.mock("@/lib/messaging/telnyx-provisioning", () => ({
   TelnyxError: mocks.MockTelnyxError,
 }));
 
-const { adminRouter } = await import("../routers/admin");
+const { adminRouter, messagingCampaignCopy } = await import("../routers/admin");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
@@ -90,6 +90,99 @@ afterEach(() => {
 });
 
 describe("platform messaging operations", () => {
+  it("describes the actual clinic-recorded opt-in flow and required disclosures", () => {
+    const copy = messagingCampaignCopy({
+      displayName: "Healthy Pets",
+      businessPhone: "+15555550100",
+      website: "https://healthypets.example",
+      programUrl:
+        "https://app.openvpm.com/sms/00000000-0000-0000-0000-0000000000aa",
+      privacyPolicyUrl:
+        "https://app.openvpm.com/sms/00000000-0000-0000-0000-0000000000aa/privacy",
+      termsUrl:
+        "https://app.openvpm.com/sms/00000000-0000-0000-0000-0000000000aa/terms",
+      optInUrl:
+        "https://app.openvpm.com/sms/00000000-0000-0000-0000-0000000000aa/opt-in",
+    });
+
+    expect(copy.messageFlow).toContain("phone or in-person intake");
+    expect(copy.messageFlow).toContain("optional and unchecked by default");
+    expect(copy.messageFlow).toContain("Consent is not a condition of purchase");
+    expect(copy.messageFlow).toContain("/opt-in");
+    expect(copy.messageFlow).toContain("/privacy");
+    expect(copy.messageFlow).toContain("/terms");
+    expect(copy.messageFlow).not.toContain("online booking");
+    expect(copy.sample1).toContain("+15555550100");
+    expect(copy.sample3).toContain("https://app.openvpm.com/sms/");
+    expect(copy.helpMessage).toContain("https://healthypets.example");
+    expect(JSON.stringify(copy)).not.toContain("Reply C");
+    expect(JSON.stringify(copy)).not.toContain("invoice");
+    expect(copy.messageFlow).not.toContain("staff member");
+  });
+
+  it("wires stored policies and hosted consent pages into the provider campaign", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    mocks.selectResults.push([
+      {
+        id: "00000000-0000-0000-0000-000000000008",
+        practiceId: PRACTICE_ID,
+        providerBrandId: "brand-123",
+        providerCampaignId: null,
+        displayName: "Healthy Pets",
+        businessPhone: "+15555550100",
+        website: "https://healthypets.example",
+        privacyPolicyUrl: "https://healthypets.example/sms-privacy",
+        termsUrl: "https://healthypets.example/sms-terms",
+      },
+    ]);
+    mocks.getA2pBrand.mockResolvedValue({
+      brandId: "brand-123",
+      identityStatus: "VERIFIED",
+    });
+    mocks.findA2pCampaignByReference.mockResolvedValue(null);
+    mocks.createA2pCampaign.mockResolvedValue({
+      campaignId: "campaign-123",
+      campaignStatus: "PENDING",
+    });
+
+    await expect(
+      caller().submitMessagingCampaign({
+        practiceId: PRACTICE_ID,
+        confirmProviderCharges: true,
+        retryAfterProviderReview: false,
+      })
+    ).resolves.toMatchObject({
+      ok: true,
+      providerCampaignId: "campaign-123",
+      reused: false,
+    });
+
+    expect(mocks.createA2pCampaign).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId: "brand-123",
+        referenceId: `openvpm-clinic-${PRACTICE_ID}`,
+        privacyPolicyUrl: "https://healthypets.example/sms-privacy",
+        termsUrl: "https://healthypets.example/sms-terms",
+        sample3: expect.stringContaining(
+          `https://app.openvpm.com/sms/${PRACTICE_ID}`
+        ),
+        messageFlow: expect.stringContaining(
+          `https://app.openvpm.com/sms/${PRACTICE_ID}/opt-in`
+        ),
+        webhookUrl: "https://app.openvpm.com/api/webhooks/telnyx",
+      })
+    );
+    const payload = mocks.createA2pCampaign.mock.calls[0]?.[0];
+    expect(payload.messageFlow).toContain(
+      "https://healthypets.example/sms-privacy"
+    );
+    expect(payload.messageFlow).toContain(
+      "https://healthypets.example/sms-terms"
+    );
+  });
+
   it("blocks fee-bearing provider work before DB reads while the kill-switch is off", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
     vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "false");

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -172,6 +172,63 @@ describe("messaging provisioning kill-switch", () => {
 });
 
 describe("messaging location target safety", () => {
+  it("prefills carrier registration from the active clinic without exposing legal fields", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    const { db } = createDb({
+      selectResults: [
+        [
+          {
+            name: "Healthy Pets",
+            email: null,
+            phone: null,
+            website: "https://example.com",
+            primaryLocationPhone: "+15555550100",
+          },
+        ],
+      ],
+    });
+
+    await expect(callerWithDb(db).getRegistrationDefaults()).resolves.toEqual({
+      displayName: "Healthy Pets",
+      contactFirstName: "Admin",
+      contactLastName: "",
+      contactEmail: "admin@example.com",
+      businessPhone: "+15555550100",
+      website: "https://example.com",
+      programUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}`,
+      privacyPolicyUrl:
+        `https://app.openvpm.com/sms/${PRACTICE_ID}/privacy`,
+      termsUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/terms`,
+      optInUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/opt-in`,
+    });
+  });
+
+  it("leaves invalid or overlong clinic defaults blank instead of creating save errors", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    const { db } = createDb({
+      selectResults: [
+        [
+          {
+            name: "x".repeat(101),
+            email: "x".repeat(101) + "@example.com",
+            phone: "not-a-phone",
+            website: "https://example.com/" + "x".repeat(101),
+            primaryLocationPhone: null,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).getRegistrationDefaults()
+    ).resolves.toMatchObject({
+      displayName: "",
+      contactEmail: "admin@example.com",
+      businessPhone: "",
+      website: "",
+    });
+  });
+
   it("encrypts clinic tax IDs and upserts registration details tenant-scoped", async () => {
     vi.stubEnv(
       "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
@@ -211,6 +268,38 @@ describe("messaging location target safety", () => {
     });
     expect(values.taxIdEncrypted).toMatch(/^v1:/);
     expect(JSON.stringify(values)).not.toContain("123456789");
+  });
+
+  it("uses the hosted clinic SMS policies when custom links are omitted", async () => {
+    vi.stubEnv(
+      "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
+      Buffer.alloc(32, 9).toString("base64")
+    );
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    const { db, insertValues } = createDb({ selectResults: [[]] });
+
+    await callerWithDb(db).saveRegistration({
+      entityType: "PRIVATE_PROFIT",
+      displayName: "Healthy Pets",
+      legalName: "Healthy Pets LLC",
+      taxId: "12-3456789",
+      contactFirstName: "Alex",
+      contactLastName: "Vet",
+      contactEmail: "alex@example.com",
+      businessPhone: "+15555550100",
+      street: "1 Main St",
+      city: "Denver",
+      state: "CO",
+      postalCode: "80202",
+      website: "https://example.com",
+      certifyAccuracyAndConsent: true,
+    });
+
+    expect(insertValues.mock.calls[0]?.[0]).toMatchObject({
+      privacyPolicyUrl:
+        `https://app.openvpm.com/sms/${PRACTICE_ID}/privacy`,
+      termsUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/terms`,
+    });
   });
 
   it("rejects invalid messaging phone inputs before DB or provider calls", async () => {

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -47,6 +47,7 @@ import {
   mergeRegistrationStatus,
   observedRegistrationStatus,
 } from "@/lib/messaging/a2p-lifecycle";
+import { messagingProgramUrls } from "@/lib/messaging/public-program";
 
 /**
  * Platform-operator only. Crosses tenant boundaries deliberately, so it is
@@ -114,18 +115,26 @@ function campaignReferenceId(practiceId: string) {
   return `openvpm-clinic-${practiceId}`;
 }
 
-function campaignCopy(displayName: string) {
+export function messagingCampaignCopy(input: {
+  displayName: string;
+  businessPhone: string;
+  website: string;
+  programUrl: string;
+  privacyPolicyUrl: string;
+  termsUrl: string;
+  optInUrl: string;
+}) {
   return {
     description:
-      "Veterinary clinic communications including appointment reminders, care follow-ups, invoice notifications, and two-way client support. Messages are sent only to clients whose SMS consent is recorded by the clinic.",
-    sample1: `${displayName}: Reminder—your pet's appointment is tomorrow at 10:00 AM. Reply C to confirm or call the clinic to reschedule. Reply STOP to opt out.`,
-    sample2: `${displayName}: Your pet's care instructions are ready. Reply here with questions or call the clinic. Reply STOP to opt out.`,
-    sample3: `${displayName}: Your invoice is ready to review and pay securely. Reply HELP for help or STOP to opt out.`,
+      "Veterinary clinic communications including appointment reminders, vaccination and care follow-ups, and two-way client support. Messages are sent only to clients whose SMS consent is recorded by the clinic.",
+    sample1: `${input.displayName}: Reminder—your pet's appointment is tomorrow at 10:00 AM. Call ${input.businessPhone} if you need to reschedule. Reply STOP to opt out.`,
+    sample2: `${input.displayName}: Your pet's care instructions are ready. Reply here with questions or call ${input.businessPhone}. Reply STOP to opt out.`,
+    sample3: `${input.displayName}: Clinic text messaging information: ${input.programUrl} Reply HELP for help or STOP to opt out.`,
     messageFlow:
-      "Clients provide their mobile number and consent directly to the veterinary clinic during intake, online booking, by phone, or in person. Clinic staff record that consent in OpenVPM before any SMS is sent. Message frequency varies. Message and data rates may apply. Consent is not a condition of purchase. Clients can reply STOP to opt out or HELP for help.",
-    helpMessage: `Reply to reach ${displayName}, or call the clinic for help. Reply STOP to opt out.`,
-    optinMessage: `${displayName}: You are subscribed to clinic messages. Message frequency varies. Msg & data rates may apply. Reply HELP for help or STOP to opt out.`,
-    optoutMessage: `${displayName}: You have been unsubscribed and will receive no further SMS messages. Reply START to opt back in.`,
+      `Clients opt in during phone or in-person intake. Clinic staff read or show the exact disclosure at ${input.optInUrl}, ask for an explicit choice, and record the consent decision, timestamp, disclosure, consent source, and mobile number in OpenVPM. The consent control is optional and unchecked by default. No SMS is sent before consent is recorded. Message frequency varies. Message and data rates may apply. Consent is not a condition of purchase. Reply STOP to opt out or HELP for help. Privacy: ${input.privacyPolicyUrl} Terms: ${input.termsUrl}`,
+    helpMessage: `Contact ${input.displayName} at ${input.businessPhone} or ${input.website}. Reply STOP to opt out.`,
+    optinMessage: `${input.displayName}: You agreed to receive clinic service texts. Frequency varies. Msg & data rates may apply. Consent is not a condition of purchase. Reply HELP for help or STOP to opt out.`,
+    optoutMessage: `${input.displayName}: You have been unsubscribed and will receive no further SMS messages. Reply START to opt back in.`,
   };
 }
 
@@ -753,7 +762,16 @@ export const adminRouter = createRouter({
         allowReviewedRetry: input.retryAfterProviderReview,
       });
       try {
-        const copy = campaignCopy(registration.displayName);
+        const programUrls = messagingProgramUrls(registration.practiceId);
+        const copy = messagingCampaignCopy({
+          displayName: registration.displayName,
+          businessPhone: registration.businessPhone,
+          website: registration.website,
+          programUrl: programUrls.programUrl,
+          privacyPolicyUrl: registration.privacyPolicyUrl,
+          termsUrl: registration.termsUrl,
+          optInUrl: programUrls.optInUrl,
+        });
         const campaign = await createA2pCampaign({
           brandId: registration.providerBrandId,
           referenceId,

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -31,11 +31,12 @@ import {
   createHostedOrder,
   TelnyxNotConfiguredError,
 } from "@/lib/messaging/telnyx-provisioning";
-import { normalizeAppBaseUrl } from "@/lib/app-url";
+import { appBaseUrl, normalizeAppBaseUrl } from "@/lib/app-url";
 import {
   encryptRegistrationTaxId,
   MessagingRegistrationEncryptionError,
 } from "@/lib/messaging/registration-crypto";
+import { messagingProgramUrls } from "@/lib/messaging/public-program";
 
 const adminOnly = protectedProcedure.use(requireRole("admin"));
 const MESSAGING_REGISTRATION_PENDING_DETAIL =
@@ -73,9 +74,23 @@ const httpsUrlInput = z
     message: "Use a public HTTPS URL.",
   });
 
+const optionalHttpsUrlInput = z
+  .union([httpsUrlInput, z.literal("")])
+  .optional();
+
+const registrationDisplayNameInput = z.string().trim().min(2).max(100);
+const registrationContactNameInput = z.string().trim().min(1).max(100);
+const registrationContactEmailInput = z.string().trim().email().max(100);
+const registrationWebsiteInput = httpsUrlInput.refine(
+  (value) => value.length <= 100,
+  {
+    message: "Website URL must be 100 characters or fewer.",
+  }
+);
+
 const a2pRegistrationInput = z.object({
   entityType: z.enum(["PRIVATE_PROFIT", "NON_PROFIT"]),
-  displayName: z.string().trim().min(2).max(100),
+  displayName: registrationDisplayNameInput,
   legalName: z.string().trim().min(2).max(100),
   taxId: z
     .string()
@@ -83,9 +98,9 @@ const a2pRegistrationInput = z.object({
     .regex(/^(?:\d[ -]?){8}\d$/, "Enter a valid 9-digit US tax ID.")
     .transform((value) => value.replace(/\D/g, ""))
     .optional(),
-  contactFirstName: z.string().trim().min(1).max(100),
-  contactLastName: z.string().trim().min(1).max(100),
-  contactEmail: z.string().trim().email().max(100),
+  contactFirstName: registrationContactNameInput,
+  contactLastName: registrationContactNameInput,
+  contactEmail: registrationContactEmailInput,
   businessPhone: messagingPhoneInput,
   street: z.string().trim().min(3).max(100),
   city: z.string().trim().min(2).max(100),
@@ -98,11 +113,9 @@ const a2pRegistrationInput = z.object({
     .string()
     .trim()
     .regex(/^\d{5}(?:-\d{4})?$/, "Enter a valid US ZIP code."),
-  website: httpsUrlInput.refine((value) => value.length <= 100, {
-    message: "Website URL must be 100 characters or fewer.",
-  }),
-  privacyPolicyUrl: httpsUrlInput,
-  termsUrl: httpsUrlInput,
+  website: registrationWebsiteInput,
+  privacyPolicyUrl: optionalHttpsUrlInput,
+  termsUrl: optionalHttpsUrlInput,
   certifyAccuracyAndConsent: z.literal(true),
 });
 
@@ -217,6 +230,22 @@ function configuredWebhookBaseUrl(): string {
   return "";
 }
 
+function splitContactName(name: string) {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  return {
+    contactFirstName: parts.shift() ?? "",
+    contactLastName: parts.join(" "),
+  };
+}
+
+function stringDefault(
+  schema: z.ZodType<string>,
+  value: string | null | undefined
+): string {
+  const parsed = schema.safeParse(value ?? "");
+  return parsed.success ? parsed.data : "";
+}
+
 export const messagingRouter = createRouter({
   /** Redacted clinic-entered A2P details. Raw/encrypted tax IDs never leave DB. */
   getRegistration: adminOnly.query(async ({ ctx }) => {
@@ -255,6 +284,55 @@ export const messagingRouter = createRouter({
       )
       .limit(1);
     return registration ?? null;
+  }),
+
+  /** Prefill non-legal fields and provide hosted SMS policy URLs. */
+  getRegistrationDefaults: adminOnly.query(async ({ ctx }) => {
+    await assertActivePractice(ctx);
+    const [practice] = await ctx.db
+      .select({
+        name: practices.name,
+        email: practices.email,
+        phone: practices.phone,
+        website: practices.website,
+        primaryLocationPhone: locations.phone,
+      })
+      .from(practices)
+      .leftJoin(
+        locations,
+        and(
+          eq(locations.practiceId, practices.id),
+          eq(locations.isPrimary, true),
+          isNull(locations.deletedAt)
+        )
+      )
+      .where(activePracticeWhere(ctx.practiceId))
+      .limit(1);
+
+    if (!practice) throw practiceNotFound();
+    const policyUrls = messagingProgramUrls(ctx.practiceId, appBaseUrl());
+    const contactName = splitContactName(ctx.user.name);
+
+    return {
+      displayName: stringDefault(registrationDisplayNameInput, practice.name),
+      contactFirstName: stringDefault(
+        registrationContactNameInput,
+        contactName.contactFirstName
+      ),
+      contactLastName: stringDefault(
+        registrationContactNameInput,
+        contactName.contactLastName
+      ),
+      contactEmail:
+        stringDefault(registrationContactEmailInput, practice.email) ||
+        stringDefault(registrationContactEmailInput, ctx.user.email),
+      businessPhone: stringDefault(
+        messagingPhoneInput,
+        practice.phone || practice.primaryLocationPhone
+      ),
+      website: stringDefault(registrationWebsiteInput, practice.website),
+      ...policyUrls,
+    };
   }),
 
   /**
@@ -321,14 +399,24 @@ export const messagingRouter = createRouter({
         });
       }
 
+      const hostedPolicyUrls =
+        !input.privacyPolicyUrl || !input.termsUrl
+          ? messagingProgramUrls(ctx.practiceId, appBaseUrl())
+          : null;
       const { taxId: _taxId, ...fields } = input;
       const { certifyAccuracyAndConsent: _attestation, ...registrationFields } =
         fields;
+      const completedRegistrationFields = {
+        ...registrationFields,
+        privacyPolicyUrl:
+          input.privacyPolicyUrl || hostedPolicyUrls!.privacyPolicyUrl,
+        termsUrl: input.termsUrl || hostedPolicyUrls!.termsUrl,
+      };
       await ctx.db
         .insert(messagingRegistrations)
         .values({
           practiceId: ctx.practiceId,
-          ...registrationFields,
+          ...completedRegistrationFields,
           taxIdEncrypted,
           taxIdLast4,
           complianceAttestedAt: new Date(),
@@ -341,7 +429,7 @@ export const messagingRouter = createRouter({
         .onConflictDoUpdate({
           target: messagingRegistrations.practiceId,
           set: {
-            ...registrationFields,
+            ...completedRegistrationFields,
             taxIdEncrypted,
             taxIdLast4,
             complianceAttestedAt: new Date(),


### PR DESCRIPTION
## Why

Clinic texting cannot launch until each US clinic completes carrier registration. The existing setup added unnecessary friction by requiring clinics to host their own SMS policy pages, and its carrier submission copy described opt-in and reply behavior that OpenVPM does not implement.

## What changed

- adds public, clinic-specific SMS program, privacy, terms, and consent-disclosure pages
- prefills registration from existing practice/admin data while failing safely on invalid or overlong defaults
- makes custom SMS privacy and terms links optional by falling back to the hosted clinic pages
- adds a clear clinic attestation covering consent and no third-party marketing use of opt-in data
- aligns campaign description, samples, HELP/opt-in/opt-out copy, and message flow with the consent evidence OpenVPM actually stores
- includes the stored custom policies plus hosted program/opt-in URLs in the fee-bearing Telnyx campaign payload
- keeps legal names, EINs, addresses, and registration contacts out of the public route

No database migration is required. The provisioning kill switch remains off.

## User impact

A clinic starts with its known name, contact, phone, website, and reviewable OpenVPM-hosted policy links already filled in. The remaining fields are the legal identity and address details carriers genuinely require.

## Validation

- web tests: 270 files, 2,445 tests passed
- focused messaging tests: 36 passed
- TypeScript: passed
- production build: passed
- local admin smoke test: registration defaults and all four public routes passed; malformed practice ID returned 404
- independent security/compliance review: no merge blockers
- secret scan and `git diff --check`: clean

## Rollout guardrails

1. Deploy with `MESSAGING_PROVISIONING_ENABLED=false`.
2. Smoke-test the hosted pages and registration form on production.
3. Have the first supported design partner save and attest its registration.
4. Review the redacted operator queue and Telnyx account/budget controls.
5. Enable provider mutations only for the controlled brand/campaign/number workflow; never enable a sender before campaign approval and a real inbound/outbound test.