### PR TITLE
Expose public SMS compliance pages

### DIFF
--- a/apps/web/middleware.test.ts
+++ b/apps/web/middleware.test.ts
@@ -80,6 +80,23 @@ describe("middleware security headers", () => {
     expectSecurityHeaders(lookalikeResponse);
   });
 
+  it("allows public SMS program pages without exposing lookalike routes", async () => {
+    mocks.getToken.mockResolvedValue(null);
+
+    const programResponse = await middleware(
+      request("/sms/00000000-0000-4000-8000-000000000000/privacy")
+    );
+    const lookalikeResponse = await middleware(request("/sms-settings"));
+
+    expect(mocks.getToken).toHaveBeenCalledTimes(1);
+    expect(programResponse.headers.get("location")).toBeNull();
+    expect(lookalikeResponse.headers.get("location")).toBe(
+      "https://openvpm.test/login?next=%2Fsms-settings"
+    );
+    expectSecurityHeaders(programResponse);
+    expectSecurityHeaders(lookalikeResponse);
+  });
+
   it("allows Vercel observability proxy paths without session lookup", async () => {
     const insights = await middleware(request("/_vercel/insights/view"));
     const proxied = await middleware(request("/5691167a7e0cfa40/view"));

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -17,6 +17,7 @@ const PUBLIC_PATH_PREFIXES = [
   "/register",
   "/reset-password",
   "/sign",
+  "/sms",
   "/verify-email",
 ];
 


### PR DESCRIPTION
## Why
Production smoke testing after #112 found that `/sms/:practiceId` and its privacy, terms, and opt-in pages were redirected to login by the global auth middleware. These pages must be publicly reachable for clinic clients and carrier campaign review.

## Change
- Add the exact `/sms` path prefix to the middleware public allowlist.
- Add a regression test proving nested SMS pages stay public while a lookalike `/sms-settings` route remains protected.

## Validation
- `pnpm --filter @openpims/web test -- middleware.test.ts` (16 tests passed)
- `pnpm --filter @openpims/web type-check` (passed)
- `git diff --check` (passed)

This is a narrow production hotfix discovered by post-deploy smoke testing. Provider provisioning remains disabled.