### PR TITLE
Restore durable demo conversion telemetry

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -17,7 +17,7 @@ import {
   FUNNEL_EVENTS,
 } from "@/lib/funnel-analytics";
 import { trackFunnelEvent } from "@/lib/track-funnel-event";
-import { useFunnelVisitorId } from "@/lib/funnel-visitor";
+import { getFunnelVisitorId, useFunnelVisitorId } from "@/lib/funnel-visitor";
 
 const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE?.trim() === "true";
 
@@ -58,10 +58,8 @@ function LoginPageInner() {
   const [loading, setLoading] = useState(false);
   const passwordMeetsPolicy =
     password.length > 0 && password.length <= AUTH_PASSWORD_MAX_LENGTH;
-  const emailIsValid =
-    isAuthEmailLengthValid(email) && isValidEmail(email);
-  const canSubmit =
-    emailIsValid && (DEMO_MODE || passwordMeetsPolicy);
+  const emailIsValid = isAuthEmailLengthValid(email) && isValidEmail(email);
+  const canSubmit = emailIsValid && (DEMO_MODE || passwordMeetsPolicy);
 
   useEffect(() => {
     if (!DEMO_MODE) return;
@@ -103,17 +101,20 @@ function LoginPageInner() {
         const gateResponse = await fetch("/api/demo-access", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: email.trim().toLowerCase() }),
+          body: JSON.stringify({
+            email: email.trim().toLowerCase(),
+            anonymousId: visitorId ?? getFunnelVisitorId() ?? undefined,
+          }),
         });
-        const gateResult = (await gateResponse.json().catch(() => null)) as
-          | { ok?: boolean; error?: string }
-          | null;
+        const gateResult = (await gateResponse.json().catch(() => null)) as {
+          ok?: boolean;
+          error?: string;
+        } | null;
         if (!gateResponse.ok || !gateResult?.ok) {
           setError(gateResult?.error ?? "The demo is temporarily unavailable.");
           return;
         }
 
-        trackFunnelEvent(FUNNEL_EVENTS.demoGateSubmitted);
         const result = await signIn("demo", {
           role: "admin",
           redirect: false,
@@ -147,7 +148,9 @@ function LoginPageInner() {
             OpenVPM
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            {DEMO_MODE ? "Explore the live product" : "Sign in to your practice"}
+            {DEMO_MODE
+              ? "Explore the live product"
+              : "Sign in to your practice"}
           </p>
         </div>
 

--- a/apps/web/app/api/demo-access/route.test.ts
+++ b/apps/web/app/api/demo-access/route.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   const onConflictDoUpdate = vi.fn(async () => undefined);
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => {
     values,
     onConflictDoUpdate,
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn({ insert })
+      fn({ insert }),
     ),
     demoModeEnabled: vi.fn(() => true),
     createDemoAccessToken: vi.fn(() => "signed-demo-token"),
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => {
       remaining: 4,
       resetAt: new Date("2026-08-06T19:00:00Z"),
     })),
+    fetchFunnel: vi.fn(),
   };
 });
 
@@ -41,6 +42,8 @@ vi.mock("@/lib/rate-limit", async (importOriginal) => {
 
 const { POST } = await import("./route");
 
+const ANONYMOUS_ID = "00000000-0000-4000-8000-000000000001";
+
 function request(body: unknown, headers: HeadersInit = {}) {
   return new Request("https://demo.openvpm.com/api/demo-access", {
     method: "POST",
@@ -53,8 +56,16 @@ function request(body: unknown, headers: HeadersInit = {}) {
   });
 }
 
+beforeEach(() => {
+  vi.stubGlobal("fetch", mocks.fetchFunnel);
+  mocks.fetchFunnel.mockResolvedValue(
+    new Response(JSON.stringify({ ok: true }), { status: 202 }),
+  );
+});
+
 afterEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
   mocks.demoModeEnabled.mockReturnValue(true);
   mocks.createDemoAccessToken.mockReturnValue("signed-demo-token");
   mocks.rateLimit.mockResolvedValue({
@@ -66,7 +77,9 @@ afterEach(() => {
 
 describe("POST /api/demo-access", () => {
   it("captures a normalized lead and returns a signed HttpOnly cookie", async () => {
-    const response = await POST(request({ email: " Vet@Clinic.COM " }));
+    const response = await POST(
+      request({ email: " Vet@Clinic.COM ", anonymousId: ANONYMOUS_ID }),
+    );
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
@@ -84,14 +97,61 @@ describe("POST /api/demo-access", () => {
       expect.objectContaining({
         email: "vet@clinic.com",
         emailHash: expect.stringMatching(/^[a-f0-9]{64}$/),
-      })
+      }),
     );
     expect(response.headers.get("set-cookie")).toContain(
-      "openvpm_demo_access=signed-demo-token"
+      "openvpm_demo_access=signed-demo-token",
     );
     expect(response.headers.get("set-cookie")).toContain("HttpOnly");
     expect(response.headers.get("set-cookie")).toContain("Secure");
     expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(mocks.fetchFunnel).toHaveBeenCalledWith(
+      new URL("https://app.openvpm.com/api/funnel-event"),
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Origin: "https://demo.openvpm.com",
+        },
+      }),
+    );
+    const funnelBody = JSON.parse(
+      String(mocks.fetchFunnel.mock.calls[0]?.[1]?.body),
+    );
+    expect(funnelBody).toMatchObject({
+      eventId: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      ),
+      anonymousId: ANONYMOUS_ID,
+      name: "demo_gate_submitted",
+      source: "demo",
+      path: "/login",
+    });
+    expect(JSON.stringify(funnelBody)).not.toContain("vet@clinic.com");
+  });
+
+  it("keeps access immediate when production funnel recording is unavailable", async () => {
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mocks.fetchFunnel.mockRejectedValueOnce(new Error("funnel unavailable"));
+
+    try {
+      const response = await POST(
+        request({ email: "vet@clinic.com", anonymousId: ANONYMOUS_ID }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("set-cookie")).toContain(
+        "openvpm_demo_access=signed-demo-token",
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        "[demo-access] funnel capture failed:",
+        expect.any(Error),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("does not exist outside the isolated demo deployment", async () => {
@@ -102,11 +162,13 @@ describe("POST /api/demo-access", () => {
     expect(response.status).toBe(404);
     expect(mocks.rateLimit).not.toHaveBeenCalled();
     expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.fetchFunnel).not.toHaveBeenCalled();
   });
 
   it.each([
     { email: "not-an-email" },
     { email: "x".repeat(256) + "@example.com" },
+    { email: "vet@clinic.com", anonymousId: "not-a-uuid" },
     { unexpected: "field" },
   ])("rejects invalid input before rate limiting", async (body) => {
     const response = await POST(request(body));
@@ -114,6 +176,7 @@ describe("POST /api/demo-access", () => {
     expect(response.status).toBe(400);
     expect(mocks.rateLimit).not.toHaveBeenCalled();
     expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.fetchFunnel).not.toHaveBeenCalled();
   });
 
   it("uses the lower email limit in 429 response headers", async () => {
@@ -134,10 +197,13 @@ describe("POST /api/demo-access", () => {
     expect(response.status).toBe(429);
     expect(response.headers.get("x-ratelimit-limit")).toBe("5");
     expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.fetchFunnel).not.toHaveBeenCalled();
   });
 
   it("fails closed when durable rate limiting is unavailable", async () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     mocks.rateLimit.mockRejectedValueOnce(new Error("database unavailable"));
 
     try {
@@ -145,8 +211,21 @@ describe("POST /api/demo-access", () => {
 
       expect(response.status).toBe(503);
       expect(mocks.withSystem).not.toHaveBeenCalled();
+      expect(mocks.fetchFunnel).not.toHaveBeenCalled();
     } finally {
       errorSpy.mockRestore();
     }
+  });
+
+  it("does not record gate acceptance when a demo token cannot be created", async () => {
+    mocks.createDemoAccessToken.mockReturnValueOnce(null as never);
+
+    const response = await POST(
+      request({ email: "vet@clinic.com", anonymousId: ANONYMOUS_ID }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(mocks.onConflictDoUpdate).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchFunnel).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/demo-access/route.ts
+++ b/apps/web/app/api/demo-access/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
 import { sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "@openpims/db/client";
@@ -29,8 +30,54 @@ const DEMO_ACCESS_EMAIL_LIMIT = 5;
 const demoAccessInput = z
   .object({
     email: z.string().trim().email().max(AUTH_EMAIL_MAX_LENGTH),
+    // Optional by design: telemetry must never block immediate demo access.
+    // The demo UI always supplies this first-party anonymous journey UUID.
+    anonymousId: z.string().uuid().optional(),
   })
   .strict();
+
+function funnelEventEndpoint(request: Request): URL {
+  const configured = process.env.NEXT_PUBLIC_FUNNEL_ENDPOINT?.trim();
+  if (configured) {
+    try {
+      return new URL("/api/funnel-event", configured);
+    } catch {
+      // Fall through to the hosted/local default.
+    }
+  }
+
+  const requestUrl = new URL(request.url);
+  const origin =
+    requestUrl.hostname === "demo.openvpm.com"
+      ? "https://app.openvpm.com"
+      : requestUrl.origin;
+  return new URL("/api/funnel-event", origin);
+}
+
+async function recordAcceptedDemoGate(
+  request: Request,
+  anonymousId: string,
+): Promise<void> {
+  const origin = new URL(request.url).origin;
+  const response = await fetch(funnelEventEndpoint(request), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: origin,
+    },
+    body: JSON.stringify({
+      eventId: randomUUID(),
+      anonymousId,
+      name: "demo_gate_submitted",
+      source: "demo",
+      path: "/login",
+    }),
+    signal: AbortSignal.timeout(750),
+  });
+  if (!response.ok) {
+    throw new Error(`funnel endpoint returned ${response.status}`);
+  }
+}
 
 function tooManyRequests(result: RateLimitResult, limit: number) {
   return NextResponse.json(
@@ -38,7 +85,7 @@ function tooManyRequests(result: RateLimitResult, limit: number) {
     {
       status: 429,
       headers: rateLimitResponseHeaders(limit, result),
-    }
+    },
   );
 }
 
@@ -51,7 +98,7 @@ export async function POST(request: Request) {
   if (!body.ok) {
     return NextResponse.json(
       { ok: false, error: "Add a valid work email." },
-      { status: body.reason === "too_large" ? 413 : 400 }
+      { status: body.reason === "too_large" ? 413 : 400 },
     );
   }
 
@@ -59,7 +106,7 @@ export async function POST(request: Request) {
   if (!parsed.success) {
     return NextResponse.json(
       { ok: false, error: "Add a valid work email." },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
@@ -86,7 +133,7 @@ export async function POST(request: Request) {
     console.error("[demo-access] rate limit failed:", error);
     return NextResponse.json(
       { ok: false, error: "The demo is temporarily unavailable." },
-      { status: 503 }
+      { status: 503 },
     );
   }
 
@@ -114,13 +161,13 @@ export async function POST(request: Request) {
             updatedAt: now,
             accessCount: sql`${demoAccesses.accessCount} + 1`,
           },
-        })
+        }),
     );
   } catch (error) {
     console.error("[demo-access] capture failed:", error);
     return NextResponse.json(
       { ok: false, error: "The demo is temporarily unavailable." },
-      { status: 503 }
+      { status: 503 },
     );
   }
 
@@ -128,13 +175,25 @@ export async function POST(request: Request) {
   if (!token) {
     return NextResponse.json(
       { ok: false, error: "The demo is temporarily unavailable." },
-      { status: 503 }
+      { status: 503 },
     );
+  }
+
+  // Gate acceptance is a business event, so record it from the server after
+  // the lead is durably captured. The demo uses a separate database, hence
+  // the server-to-server write to app.openvpm.com. It remains non-blocking for
+  // the visitor if telemetry is unavailable.
+  if (parsed.data.anonymousId) {
+    try {
+      await recordAcceptedDemoGate(request, parsed.data.anonymousId);
+    } catch (error) {
+      console.error("[demo-access] funnel capture failed:", error);
+    }
   }
 
   const response = NextResponse.json(
     { ok: true },
-    { headers: { "Cache-Control": "no-store" } }
+    { headers: { "Cache-Control": "no-store" } },
   );
   response.cookies.set(DEMO_ACCESS_COOKIE_NAME, token, {
     httpOnly: true,

--- a/apps/web/app/api/funnel-event/route.test.ts
+++ b/apps/web/app/api/funnel-event/route.test.ts
@@ -115,4 +115,31 @@ describe("/api/funnel-event", () => {
       "https://openvpm.com"
     );
   });
+
+  it("accepts events from the hosted demo origin", async () => {
+    const response = await POST(
+      request(
+        {
+          ...validEvent,
+          name: "demo_gate_viewed",
+          path: "/login",
+          source: undefined,
+        },
+        "https://demo.openvpm.com"
+      )
+    );
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "https://demo.openvpm.com"
+    );
+    expect(mocks.insertFunnelEvent).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        eventName: "demo_gate_viewed",
+        origin: "https://demo.openvpm.com",
+        path: "/login",
+      })
+    );
+  });
 });

--- a/apps/web/lib/__tests__/demo-conversion-ui.test.ts
+++ b/apps/web/lib/__tests__/demo-conversion-ui.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 describe("demo conversion bridge UI", () => {
   const login = readFileSync("app/(auth)/login/page.tsx", "utf8");
+  const demoAccessRoute = readFileSync("app/api/demo-access/route.ts", "utf8");
   const register = readFileSync("app/(auth)/register/page.tsx", "utf8");
   const layout = readFileSync("app/(dashboard)/layout.tsx", "utf8");
   const bar = readFileSync("components/demo/demo-conversion-bar.tsx", "utf8");
@@ -14,7 +15,12 @@ describe("demo conversion bridge UI", () => {
   it("instruments the email gate and start-clinic CTA", () => {
     expect(login).toContain("FUNNEL_EVENTS.demoLand");
     expect(login).toContain("FUNNEL_EVENTS.demoGateViewed");
-    expect(login).toContain("FUNNEL_EVENTS.demoGateSubmitted");
+    expect(login).toContain("anonymousId: visitorId ?? getFunnelVisitorId()");
+    expect(login).not.toContain(
+      "trackFunnelEvent(FUNNEL_EVENTS.demoGateSubmitted)"
+    );
+    expect(demoAccessRoute).toContain('name: "demo_gate_submitted"');
+    expect(demoAccessRoute).toContain("await recordAcceptedDemoGate");
     expect(login).toContain("FUNNEL_EVENTS.demoCtaStartClinic");
     expect(login).toContain("buildCloudSignupUrl");
     expect(login).toContain("Open the live demo");

--- a/apps/web/lib/security-headers.js
+++ b/apps/web/lib/security-headers.js
@@ -14,7 +14,7 @@ const contentSecurityPolicy = [
   ]
     .filter(Boolean)
     .join(" "),
-  "connect-src 'self' https://vitals.vercel-insights.com https://va.vercel-scripts.com",
+  "connect-src 'self' https://app.openvpm.com https://vitals.vercel-insights.com https://va.vercel-scripts.com",
   "worker-src 'self' blob:",
   process.env.NODE_ENV === "production" ? "upgrade-insecure-requests" : null,
 ]

--- a/apps/web/middleware.test.ts
+++ b/apps/web/middleware.test.ts
@@ -189,6 +189,9 @@ describe("middleware security headers", () => {
 
   it("keeps the CSP compatible with accepted patient photo URLs", () => {
     expect(contentSecurityPolicy).toContain("img-src 'self' data: blob: https:");
+    expect(contentSecurityPolicy).toContain(
+      "connect-src 'self' https://app.openvpm.com"
+    );
     expect(contentSecurityPolicy).toContain("default-src 'self'");
     expect(contentSecurityPolicy).toContain("object-src 'none'");
   });


### PR DESCRIPTION
## What changed

- allows the exact production app origin in the demo deployment’s `connect-src` policy so first-party funnel requests are not blocked by CSP
- keeps the production funnel collector’s exact-origin CORS contract covered by tests
- sends the anonymous journey UUID with the email-gate request
- records `demo_gate_submitted` server-to-server only after the lead is captured and a demo token is available
- removes the duplicate client-owned submission event

## Why

The demo browser posts funnel events to `https://app.openvpm.com`, but the demo CSP previously allowed only same-origin connections. Production therefore recorded visits but no demo progression. The accepted email gate was also vulnerable to navigation timing and browser telemetry blocking.

## Privacy and reliability

The authoritative gate event contains only a generated event UUID, anonymous journey UUID, fixed event name, source, and coarse `/login` path. It never includes the submitted email. Invalid and rate-limited requests do not record the event, and telemetry failure does not block immediate demo access.

## Validation

- focused demo/CORS/CSP tests: 18 passed
- web type-check: passed
- prior full CI and both Vercel previews passed before the server-owned telemetry strengthening; fresh checks run on the new head