### PR TITLE
Measure and guide clinics to a completed first visit

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -560,7 +560,7 @@ export default function AdminPage() {
         </div>
         {funnel ? (
           <>
-            <div className="mt-3 grid gap-4 sm:grid-cols-3 xl:grid-cols-6">
+            <div className="mt-3 grid gap-4 sm:grid-cols-3 xl:grid-cols-7">
               <div>
                 <p className="text-sm text-muted-foreground">Signups</p>
                 <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
@@ -595,6 +595,15 @@ export default function AdminPage() {
                 </p>
               </div>
               <div>
+                <p className="text-sm text-muted-foreground">First visit done</p>
+                <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
+                  {funnel.totals.firstVisitCompleted}
+                  <span className="ml-2 text-sm font-normal text-muted-foreground">
+                    {formatPct(funnel.totals.firstVisitCompletionRate)}
+                  </span>
+                </p>
+              </div>
+              <div>
                 <p className="text-sm text-muted-foreground">Billing started</p>
                 <p className="mt-1 font-heading text-2xl font-bold tabular-nums">
                   {funnel.totals.billingStarted}
@@ -615,9 +624,11 @@ export default function AdminPage() {
             </div>
             <p className="mt-3 text-xs text-muted-foreground">
               Setup progress comes from the guided clinic setup. Activated = added a
-              real client and booked a real visit. Billing started = Stripe
-              subscription created; paid active = billing status active. All rates
-              are signup-cohort rates for this window.
+              real client and booked a real visit. First visit done requires a
+              completed clinical and billing closeout; its rate is measured from
+              activated clinics. Billing started = Stripe subscription created;
+              paid active = billing status active. Other rates are signup-cohort
+              rates for this window.
             </p>
           </>
         ) : (

--- a/apps/web/app/api/cron/activation-digest/route.test.ts
+++ b/apps/web/app/api/cron/activation-digest/route.test.ts
@@ -51,11 +51,13 @@ function funnel(days: number, totals: Partial<ActivationFunnel["totals"]> = {}):
       setupStarted: 3,
       setupCompleted: 2,
       activated: 2,
+      firstVisitCompleted: 1,
       billingStarted: 2,
       subscribed: 1,
       setupStartRate: 0.6,
       setupCompletionRate: 0.4,
       activationRate: 0.4,
+      firstVisitCompletionRate: 0.5,
       billingStartRate: 0.4,
       conversionRate: 0.2,
       ...totals,
@@ -172,6 +174,18 @@ describe("activation digest cron", () => {
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         html: expect.stringContaining("Billing started"),
+      })
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: expect.stringContaining("First visit done"),
+      })
+    );
+    expect(mocks.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        html: expect.stringContaining(
+          "its rate is measured from activated clinics"
+        ),
       })
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(

--- a/apps/web/app/api/cron/activation-digest/route.ts
+++ b/apps/web/app/api/cron/activation-digest/route.ts
@@ -96,11 +96,13 @@ function funnelSection(title: string, funnel: ActivationFunnel): string {
     setupStarted,
     setupCompleted,
     activated,
+    firstVisitCompleted,
     billingStarted,
     subscribed,
     setupStartRate,
     setupCompletionRate,
     activationRate,
+    firstVisitCompletionRate,
     billingStartRate,
     conversionRate,
   } = funnel.totals;
@@ -111,6 +113,7 @@ function funnelSection(title: string, funnel: ActivationFunnel): string {
     <th style="padding:4px 12px 4px 0;font-weight:500;">Setup started</th>
     <th style="padding:4px 12px 4px 0;font-weight:500;">Setup complete</th>
     <th style="padding:4px 12px 4px 0;font-weight:500;">Activated</th>
+    <th style="padding:4px 12px 4px 0;font-weight:500;">First visit done</th>
     <th style="padding:4px 12px 4px 0;font-weight:500;">Billing started</th>
     <th style="padding:4px 0;font-weight:500;">Paid active</th>
   </tr>
@@ -119,6 +122,7 @@ function funnelSection(title: string, funnel: ActivationFunnel): string {
     <td style="padding:2px 12px 2px 0;">${setupStarted} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(setupStartRate)}</span></td>
     <td style="padding:2px 12px 2px 0;">${setupCompleted} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(setupCompletionRate)}</span></td>
     <td style="padding:2px 12px 2px 0;">${activated} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(activationRate)}</span></td>
+    <td style="padding:2px 12px 2px 0;">${firstVisitCompleted} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(firstVisitCompletionRate)}</span></td>
     <td style="padding:2px 12px 2px 0;">${billingStarted} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(billingStartRate)}</span></td>
     <td style="padding:2px 0;">${subscribed} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(conversionRate)}</span></td>
   </tr>
@@ -190,7 +194,7 @@ function digestHtml(
               ${journeySection("Production journey · past 30 days", journeyMonth)}
               ${funnelSection("Past 7 days", week)}
               ${funnelSection("Past 30 days", month)}
-              <p style="margin:24px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Activated = added a real client and booked a real visit. Billing started = a Stripe subscription exists. Paid active = billing status is active. These are signup-cohort rates; demo data never counts.</p>
+              <p style="margin:24px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Activated = added a real client and booked a real visit. First visit done = completed the clinical and billing closeout; its rate is measured from activated clinics. Billing started = a Stripe subscription exists. Paid active = billing status is active. All other rates use the signup cohort; demo data never counts.</p>
             </td>
           </tr>
           <tr>

--- a/apps/web/components/dashboard/activation-checklist.tsx
+++ b/apps/web/components/dashboard/activation-checklist.tsx
@@ -206,6 +206,15 @@ export function ActivationChecklist() {
       href: "/schedule",
     },
     {
+      key: "firstVisit",
+      label: "Complete your first visit",
+      hint: "Check in, start the exam, finalize the owner handoff, save the charge or no-charge reason, and complete checkout.",
+      done: onboardingData.hasCompletedRealVisit,
+      href: onboardingData.nextRealAppointmentId
+        ? `/encounters/${onboardingData.nextRealAppointmentId}`
+        : "/schedule",
+    },
+    {
       key: "team",
       label: "Invite a teammate",
       hint: "Test the handoff between a doctor and the front desk.",
@@ -269,6 +278,9 @@ export function ActivationChecklist() {
             goLiveMilestones.find((milestone) => milestone.key === "team")!,
             goLiveMilestones.find(
               (milestone) => milestone.key === "firstAppointment"
+            )!,
+            goLiveMilestones.find(
+              (milestone) => milestone.key === "firstVisit"
             )!,
           ]
         : goLiveMilestones;

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -30,16 +30,21 @@ describe("admin UI", () => {
     expect(source).toContain("{funnel.totals.setupStarted}");
     expect(source).toContain("{funnel.totals.setupCompleted}");
     expect(source).toContain("{funnel.totals.activated}");
+    expect(source).toContain("First visit done");
+    expect(source).toContain("{funnel.totals.firstVisitCompleted}");
     expect(source).toContain("{funnel.totals.billingStarted}");
     expect(source).toContain("{funnel.totals.subscribed}");
     expect(source).toContain("formatPct(funnel.totals.activationRate)");
+    expect(source).toContain(
+      "formatPct(funnel.totals.firstVisitCompletionRate)"
+    );
     expect(source).toContain("formatPct(funnel.totals.billingStartRate)");
     expect(source).toContain("formatPct(funnel.totals.setupStartRate)");
     expect(source).toContain("formatPct(funnel.totals.setupCompletionRate)");
     expect(source).toContain("formatPct(funnel.totals.conversionRate)");
-    expect(source).toContain(
-      "Activated = added a"
-    );
+    expect(source).toContain("Activated = added a");
+    expect(source).toContain("completed clinical and billing closeout");
+    expect(source).toContain("rate is measured from");
     expect(source).toContain("Billing started = Stripe");
     expect(source).toContain("Could not load the funnel.");
   });

--- a/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
@@ -68,6 +68,17 @@ describe("dashboard onboarding UI states", () => {
     expect(activationSource).toContain(
       "done: onboardingData.hasRealAppointment"
     );
+    expect(activationSource).toContain('label: "Complete your first visit"');
+    expect(activationSource).toContain(
+      "done: onboardingData.hasCompletedRealVisit"
+    );
+    expect(activationSource).toContain(
+      "`/encounters/${onboardingData.nextRealAppointmentId}`"
+    );
+    expect(activationSource).toContain(': "/schedule"');
+    expect(activationSource.indexOf('key: "firstAppointment"')).toBeLessThan(
+      activationSource.indexOf('key: "firstVisit"')
+    );
     expect(activationSource).toContain('label: "Set up client card payments"');
     expect(activationSource).toContain("done: clientPaymentData.enabled");
     expect(activationSource).toContain('pathway.value === "explore"');
@@ -163,6 +174,20 @@ describe("dashboard onboarding UI states", () => {
       "onboardingStatus.data.establishedPractice === true"
     );
     expect(settingsRouter).toContain("ESTABLISHED_PRACTICE_PATIENT_THRESHOLD");
+    expect(settingsRouter).toContain(
+      "eq(visitCloseouts.practiceId, ctx.practiceId)"
+    );
+    expect(settingsRouter).toContain(
+      'eq(visitCloseouts.status, "completed")'
+    );
+    expect(settingsRouter).toContain("isNull(visitCloseouts.deletedAt)");
+    expect(settingsRouter).toContain(
+      "eq(appointments.practiceId, ctx.practiceId)"
+    );
+    expect(settingsRouter).toContain("realAppointmentFilter");
+    expect(settingsRouter).toContain("when 'in_exam' then 0");
+    expect(settingsRouter).toContain("asc(appointments.startTime)");
+    expect(settingsRouter).toContain("asc(appointments.id)");
     // Resume from the durable cursor rather than always step 0.
     expect(journeyProviderSource).toContain(
       "steps.findIndex((s) => s.id === journeyStepId)"

--- a/apps/web/lib/admin/activation-funnel.ts
+++ b/apps/web/lib/admin/activation-funnel.ts
@@ -11,6 +11,9 @@ import { withSystem } from "@/lib/tenant-db";
  *   least one real (non-demo) appointment created after signup. Demo rows are
  *   the ids recorded in practices.settings -> 'demoData' when sample data is
  *   seeded, so they never count toward activation.
+ * - first visit completed: a real appointment has a completed visit_closeout.
+ *   This is the durable clinic-use signal because closeout constraints require
+ *   finalized clinical handoff plus an attributable charge disposition.
  * - billing started: a Stripe subscription exists and local status is trialing
  *   or active. This captures card-on-file commitment before the first charge.
  * - paid active: billingStatus = 'active'. A trialing subscription is not paid.
@@ -28,6 +31,7 @@ export interface ActivationFunnelWeek {
   setupStarted: number;
   setupCompleted: number;
   activated: number;
+  firstVisitCompleted: number;
   billingStarted: number;
   subscribed: number;
 }
@@ -37,6 +41,7 @@ export interface ActivationFunnelTotals {
   setupStarted: number;
   setupCompleted: number;
   activated: number;
+  firstVisitCompleted: number;
   billingStarted: number;
   subscribed: number;
   /** setupStarted / signups; 0 when there are no signups. */
@@ -45,6 +50,8 @@ export interface ActivationFunnelTotals {
   setupCompletionRate: number;
   /** activated / signups; 0 when there are no signups. */
   activationRate: number;
+  /** firstVisitCompleted / activated; 0 when there are no activated clinics. */
+  firstVisitCompletionRate: number;
   /** billingStarted / signups; 0 when there are no signups. */
   billingStartRate: number;
   /** subscribed / signups; 0 when there are no signups. */
@@ -68,6 +75,7 @@ interface FunnelRow {
   setupStarted: number | string;
   setupCompleted: number | string;
   activated: number | string;
+  firstVisitCompleted: number | string;
   billingStarted: number | string;
   subscribed: number | string;
 }
@@ -135,6 +143,21 @@ export async function computeActivationFunnel(
           )
         )::int as "activated",
         count(*) filter (
+          where exists (
+            select 1
+            from visit_closeouts vc
+            join appointments a
+              on a.id = vc.appointment_id
+             and a.practice_id = s.id
+             and a.deleted_at is null
+            where vc.practice_id = s.id
+              and vc.status = 'completed'
+              and vc.deleted_at is null
+              and a.created_at >= s.created_at
+              and not (s.demo_appointment_ids @> to_jsonb(a.id::text))
+          )
+        )::int as "firstVisitCompleted",
+        count(*) filter (
           where s.stripe_subscription_id is not null
             and s.billing_status in ('trialing', 'active')
         )::int as "billingStarted",
@@ -152,6 +175,7 @@ export async function computeActivationFunnel(
       setupStarted: Number(row.setupStarted) || 0,
       setupCompleted: Number(row.setupCompleted) || 0,
       activated: Number(row.activated) || 0,
+      firstVisitCompleted: Number(row.firstVisitCompleted) || 0,
       billingStarted: Number(row.billingStarted) || 0,
       subscribed: Number(row.subscribed) || 0,
     })
@@ -164,6 +188,10 @@ export async function computeActivationFunnel(
     0
   );
   const activated = weeks.reduce((sum, week) => sum + week.activated, 0);
+  const firstVisitCompleted = weeks.reduce(
+    (sum, week) => sum + week.firstVisitCompleted,
+    0
+  );
   const billingStarted = weeks.reduce(
     (sum, week) => sum + week.billingStarted,
     0
@@ -178,11 +206,13 @@ export async function computeActivationFunnel(
       setupStarted,
       setupCompleted,
       activated,
+      firstVisitCompleted,
       billingStarted,
       subscribed,
       setupStartRate: funnelRate(setupStarted, signups),
       setupCompletionRate: funnelRate(setupCompleted, signups),
       activationRate: funnelRate(activated, signups),
+      firstVisitCompletionRate: funnelRate(firstVisitCompleted, activated),
       billingStartRate: funnelRate(billingStarted, signups),
       conversionRate: funnelRate(subscribed, signups),
     },

--- a/apps/web/server/__tests__/admin-activation-funnel.test.ts
+++ b/apps/web/server/__tests__/admin-activation-funnel.test.ts
@@ -72,27 +72,29 @@ describe("admin activation funnel", () => {
   it("sums weekly rows and computes activation and conversion rates", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
     mocks.executeResults.push([
-      { weekStart: "2026-06-15", signups: 4, setupStarted: 3, setupCompleted: 1, activated: 2, billingStarted: 2, subscribed: 1 },
-      { weekStart: "2026-06-22", signups: 6, setupStarted: 4, setupCompleted: 2, activated: 3, billingStarted: 4, subscribed: 2 },
+      { weekStart: "2026-06-15", signups: 4, setupStarted: 3, setupCompleted: 1, activated: 2, firstVisitCompleted: 1, billingStarted: 2, subscribed: 1 },
+      { weekStart: "2026-06-22", signups: 6, setupStarted: 4, setupCompleted: 2, activated: 3, firstVisitCompleted: 2, billingStarted: 4, subscribed: 2 },
     ]);
 
     const result = await caller().activationFunnel({ days: 30 });
 
     expect(result.days).toBe(30);
     expect(result.weeks).toEqual([
-      { weekStart: "2026-06-15", signups: 4, setupStarted: 3, setupCompleted: 1, activated: 2, billingStarted: 2, subscribed: 1 },
-      { weekStart: "2026-06-22", signups: 6, setupStarted: 4, setupCompleted: 2, activated: 3, billingStarted: 4, subscribed: 2 },
+      { weekStart: "2026-06-15", signups: 4, setupStarted: 3, setupCompleted: 1, activated: 2, firstVisitCompleted: 1, billingStarted: 2, subscribed: 1 },
+      { weekStart: "2026-06-22", signups: 6, setupStarted: 4, setupCompleted: 2, activated: 3, firstVisitCompleted: 2, billingStarted: 4, subscribed: 2 },
     ]);
     expect(result.totals).toEqual({
       signups: 10,
       setupStarted: 7,
       setupCompleted: 3,
       activated: 5,
+      firstVisitCompleted: 3,
       billingStarted: 6,
       subscribed: 3,
       setupStartRate: 0.7,
       setupCompletionRate: 0.3,
       activationRate: 0.5,
+      firstVisitCompletionRate: 0.6,
       billingStartRate: 0.6,
       conversionRate: 0.3,
     });
@@ -122,11 +124,13 @@ describe("admin activation funnel", () => {
       setupStarted: 0,
       setupCompleted: 0,
       activated: 0,
+      firstVisitCompleted: 0,
       billingStarted: 0,
       subscribed: 0,
       setupStartRate: 0,
       setupCompletionRate: 0,
       activationRate: 0,
+      firstVisitCompletionRate: 0,
       billingStartRate: 0,
       conversionRate: 0,
     });
@@ -135,13 +139,15 @@ describe("admin activation funnel", () => {
   it("coerces string counts from the driver into numbers", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
     mocks.executeResults.push([
-      { weekStart: "2026-06-29", signups: "2", setupStarted: "1", setupCompleted: "0", activated: "1", billingStarted: "1", subscribed: "0" },
+      { weekStart: "2026-06-29", signups: "2", setupStarted: "1", setupCompleted: "0", activated: "1", firstVisitCompleted: "1", billingStarted: "1", subscribed: "0" },
     ]);
 
     const result = await caller().activationFunnel({ days: 30 });
 
     expect(result.totals.signups).toBe(2);
     expect(result.totals.activated).toBe(1);
+    expect(result.totals.firstVisitCompleted).toBe(1);
+    expect(result.totals.firstVisitCompletionRate).toBe(1);
     expect(result.totals.billingStarted).toBe(1);
     expect(result.totals.activationRate).toBe(0.5);
   });
@@ -168,6 +174,14 @@ describe("admin activation funnel", () => {
     // Activation only counts rows created after the practice signed up.
     expect(source).toContain("c.created_at >= s.created_at");
     expect(source).toContain("a.created_at >= s.created_at");
+
+    // First-visit completion requires a completed, tenant-owned closeout for a
+    // real appointment and uses the same post-signup/demo exclusions.
+    expect(source).toContain("from visit_closeouts vc");
+    expect(source).toContain("a.practice_id = s.id");
+    expect(source).toContain("vc.practice_id = s.id");
+    expect(source).toContain("vc.status = 'completed'");
+    expect(source).toContain("vc.deleted_at is null");
 
     // Subscribed means an active subscription, not a running trial.
     expect(source).toContain("where s.billing_status = 'active'");

--- a/apps/web/server/__tests__/settings-welcome-context.test.ts
+++ b/apps/web/server/__tests__/settings-welcome-context.test.ts
@@ -33,13 +33,14 @@ function callerWithRole(db: Record<string, unknown>, role: string) {
 /** Sequenced select mock: each select() call consumes the next result set. */
 function createDb(selectResults: unknown[][]) {
   const remaining = [...selectResults];
-  const select = vi.fn(() => ({
-    from: vi.fn(() => ({
-      where: vi.fn(() => ({
-        limit: vi.fn(async () => remaining.shift() ?? []),
-      })),
-    })),
-  }));
+  const select = vi.fn(() => {
+    const query: Record<string, ReturnType<typeof vi.fn>> = {};
+    query.innerJoin = vi.fn(() => query);
+    query.where = vi.fn(() => query);
+    query.orderBy = vi.fn(() => query);
+    query.limit = vi.fn(async () => remaining.shift() ?? []);
+    return { from: vi.fn(() => query) };
+  });
   const db: Record<string, unknown> = {
     transaction: async (fn: (tx: unknown) => unknown) => fn(db),
     execute: vi.fn(async () => undefined),
@@ -143,6 +144,8 @@ describe("settings.onboardingStatus", () => {
       [{ id: DEMO_PATIENT_ID }],
       [],
       [],
+      [],
+      [],
     ]);
 
     await expect(
@@ -154,6 +157,8 @@ describe("settings.onboardingStatus", () => {
     const { db } = createDb([
       [{ settings: demoSettings }],
       [{ id: DEMO_PATIENT_ID }, { id: "real-patient-1" }],
+      [],
+      [],
       [],
       [],
     ]);
@@ -180,6 +185,8 @@ describe("settings.onboardingStatus", () => {
       [{ id: DEMO_PATIENT_ID }],
       [],
       [],
+      [],
+      [],
     ]);
 
     await expect(
@@ -196,6 +203,8 @@ describe("settings.onboardingStatus", () => {
       [{ id: DEMO_PATIENT_ID }],
       [{ id: "real-appointment-1" }],
       [{ id: "real-appointment-1" }],
+      [],
+      [],
     ]);
 
     await expect(
@@ -203,6 +212,47 @@ describe("settings.onboardingStatus", () => {
     ).resolves.toMatchObject({
       hasRealAppointment: true,
       hasCompletedRealAppointment: true,
+      hasCompletedRealVisit: false,
+      nextRealAppointmentId: null,
+    });
+  });
+
+  it("requires a completed closeout instead of treating legacy checkout as a completed visit", async () => {
+    const { db } = createDb([
+      [{ settings: demoSettings }],
+      [{ id: DEMO_PATIENT_ID }],
+      [{ id: "real-appointment-1" }],
+      [{ id: "real-appointment-1" }],
+      [],
+      [{ id: "real-appointment-2" }],
+    ]);
+
+    await expect(
+      callerWithRole(db, "admin").onboardingStatus()
+    ).resolves.toMatchObject({
+      hasCompletedRealAppointment: true,
+      hasCompletedRealVisit: false,
+      nextRealAppointmentId: "real-appointment-2",
+    });
+  });
+
+  it("recognizes a completed closeout as the durable first-visit milestone", async () => {
+    const { db } = createDb([
+      [{ settings: demoSettings }],
+      [{ id: DEMO_PATIENT_ID }, { id: "real-patient-1" }],
+      [{ id: "real-appointment-1" }],
+      [{ id: "real-appointment-1" }],
+      [{ id: "closeout-1" }],
+      [],
+    ]);
+
+    await expect(
+      callerWithRole(db, "admin").onboardingStatus()
+    ).resolves.toMatchObject({
+      hasRealAppointment: true,
+      hasCompletedRealAppointment: true,
+      hasCompletedRealVisit: true,
+      nextRealAppointmentId: null,
     });
   });
 });

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { randomUUID } from "crypto";
-import { eq, and, isNull, inArray, ne, notInArray, sql } from "drizzle-orm";
+import { asc, eq, and, isNull, inArray, ne, notInArray, sql } from "drizzle-orm";
 import { hash } from "bcryptjs";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
@@ -23,6 +23,7 @@ import {
   products,
   locations,
   locationMessaging,
+  visitCloseouts,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import { regionDefaults } from "@/lib/locale/format";
@@ -808,8 +809,13 @@ export const settingsRouter = createRouter({
       demoAppointmentIds.length > 0
         ? notInArray(appointments.id, demoAppointmentIds)
         : undefined;
-    const [existingPatients, firstRealAppointment, completedRealAppointment] =
-      await Promise.all([
+    const [
+      existingPatients,
+      firstRealAppointment,
+      completedRealAppointment,
+      completedRealVisit,
+      nextRealAppointment,
+    ] = await Promise.all([
         ctx.db
           .select({ id: patients.id })
           .from(patients)
@@ -843,6 +849,49 @@ export const settingsRouter = createRouter({
             )
           )
           .limit(1),
+        ctx.db
+          .select({ id: visitCloseouts.id })
+          .from(visitCloseouts)
+          .innerJoin(
+            appointments,
+            and(
+              eq(appointments.id, visitCloseouts.appointmentId),
+              eq(appointments.practiceId, ctx.practiceId),
+              isNull(appointments.deletedAt),
+              realAppointmentFilter
+            )
+          )
+          .where(
+            and(
+              eq(visitCloseouts.practiceId, ctx.practiceId),
+              eq(visitCloseouts.status, "completed"),
+              isNull(visitCloseouts.deletedAt)
+            )
+          )
+          .limit(1),
+        ctx.db
+          .select({ id: appointments.id })
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.practiceId, ctx.practiceId),
+              inArray(appointments.status, activeSchedulingStatuses),
+              isNull(appointments.deletedAt),
+              realAppointmentFilter
+            )
+          )
+          .orderBy(
+            sql`case ${appointments.status}
+              when 'in_exam' then 0
+              when 'checked_in' then 1
+              when 'confirmed' then 2
+              when 'scheduled' then 3
+              else 4
+            end`,
+            asc(appointments.startTime),
+            asc(appointments.id)
+          )
+          .limit(1),
       ]);
     const demoPatientIds = new Set(settings.demoData?.patientIds ?? []);
     return {
@@ -858,8 +907,15 @@ export const settingsRouter = createRouter({
       // the clinic-ready path. Demo appointments must never complete it.
       hasRealAppointment: firstRealAppointment.length > 0,
       // Checked out is the first durable signal that the practice has run the
-      // workflow, rather than merely exploring the calendar.
+      // legacy workflow, rather than merely exploring the calendar.
       hasCompletedRealAppointment: completedRealAppointment.length > 0,
+      // The clinic-ready activation gate is stronger: the closeout constraint
+      // proves clinical finalization, owner handoff, and an attributable
+      // paid/AR/no-charge disposition for a real tenant-owned appointment.
+      hasCompletedRealVisit: completedRealVisit.length > 0,
+      // Resume the most advanced nonterminal visit without adding another
+      // client request. Stable status/time/id ordering keeps the CTA durable.
+      nextRealAppointmentId: nextRealAppointment[0]?.id ?? null,
       onboardingDraft: settings.onboardingDraft ?? null,
       establishedPractice:
         existingPatients.length >= ESTABLISHED_PRACTICE_PATIENT_THRESHOLD,


### PR DESCRIPTION
## What changed

- adds a durable `Complete your first visit` activation milestone immediately after the first real appointment
- links the clinic directly into its most advanced active encounter, with deterministic status/time/id ordering and a schedule fallback
- requires a completed, tenant-owned, non-demo visit closeout instead of treating legacy `checked_out` state as clinic-ready completion
- adds `firstVisitCompleted` and completion-from-activation rate to the platform admin funnel and Monday digest
- keeps the data in the existing onboarding query, avoiding another client-side request waterfall

## Why

Booking an appointment proves intent; completing the clinical handoff and charge/no-charge closeout proves the clinic received operational value. This makes onboarding and operator reporting optimize for real clinic use rather than setup activity.

## Safety

- no schema migration
- every query is tenant scoped and excludes soft-deleted/demo appointments
- closeout and appointment ownership are both checked
- legacy checked-out appointments remain visible as the legacy signal but do not complete the new milestone
- deterministic resume ordering is `in_exam`, `checked_in`, `confirmed`, `scheduled`, then start time and ID

## Validation

- focused milestone/admin/digest tests: 34 passed
- full web suite: 2,508 passed
- web type-check: passed
- production Next.js build: passed
- diff check: clean