### PR TITLE
fix(analytics): record activation across every booking path

### DIFF
--- a/apps/web/app/api/v1/appointments/route.test.ts
+++ b/apps/web/app/api/v1/appointments/route.test.ts
@@ -69,6 +69,7 @@ const mocks = vi.hoisted(() => {
       ) => fn(db)
     ),
     dispatchWebhookEvent: vi.fn(async () => undefined),
+    recordActivationAfterAppointmentCreated: vi.fn(async () => true),
     db,
     insertRow,
     insertReturning,
@@ -92,6 +93,11 @@ vi.mock("@/lib/tenant-db", () => ({
 
 vi.mock("@/lib/webhook-dispatcher", () => ({
   dispatchWebhookEvent: mocks.dispatchWebhookEvent,
+}));
+
+vi.mock("@/lib/funnel-events-server", () => ({
+  recordActivationAfterAppointmentCreated:
+    mocks.recordActivationAfterAppointmentCreated,
 }));
 
 const { GET, POST } = await import("./route");
@@ -574,6 +580,11 @@ describe("/api/v1/appointments", () => {
         roomId: ROOM_ID,
         source: "api",
       })
+    );
+    expect(mocks.recordActivationAfterAppointmentCreated).toHaveBeenCalledWith(
+      mocks.db,
+      PRACTICE_ID,
+      "api.v1.appointments.POST"
     );
     const webhookCall = mocks.dispatchWebhookEvent.mock.calls[0] as
       | unknown[]

--- a/apps/web/app/api/v1/appointments/route.ts
+++ b/apps/web/app/api/v1/appointments/route.ts
@@ -26,6 +26,7 @@ import { authenticateApiKey } from "@/lib/api-auth";
 import { withTenant } from "@/lib/tenant-db";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
 import { appointmentCreatedWebhookPayload } from "@/lib/appointment-webhooks";
+import { recordActivationAfterAppointmentCreated } from "@/lib/funnel-events-server";
 import {
   withErrorHandling,
   apiError,
@@ -402,6 +403,12 @@ export async function POST(req: Request) {
       return { ok: true as const, row: row! };
     });
     if (!result.ok) return result.response;
+
+    await recordActivationAfterAppointmentCreated(
+      db,
+      auth.ctx.practiceId,
+      "api.v1.appointments.POST"
+    );
 
     const apiAppointment = toApiAppointment(result.row);
 

--- a/apps/web/lib/__tests__/funnel-events-server.test.ts
+++ b/apps/web/lib/__tests__/funnel-events-server.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
 
 const mocks = vi.hoisted(() => {
   const selectResults: unknown[][] = [];
@@ -32,6 +33,7 @@ const mocks = vi.hoisted(() => {
 
 const {
   ensureRegistrationFirstTouch,
+  recordActivationAfterAppointmentCreated,
   recordPracticeFunnelStage,
 } = await import("../funnel-events-server");
 
@@ -147,5 +149,44 @@ describe("registration funnel attribution", () => {
         practiceId: PRACTICE_ID,
       })
     );
+  });
+});
+
+describe("appointment activation telemetry", () => {
+  it("keeps demo clients and appointments out of the durable stage", () => {
+    const source = readFileSync(
+      new URL("../funnel-events-server.ts", import.meta.url),
+      "utf8"
+    );
+
+    expect(source).toContain("p.settings -> 'demoData' -> 'clientIds'");
+    expect(source).toContain("p.settings -> 'demoData' -> 'appointmentIds'");
+    expect(source).toContain(".onConflictDoNothing()");
+  });
+
+  it("does not fail a durable appointment when activation persistence fails", async () => {
+    const error = new Error("analytics unavailable");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const db = {
+      transaction: vi.fn(async () => {
+        throw error;
+      }),
+    };
+
+    await expect(
+      recordActivationAfterAppointmentCreated(
+        db as never,
+        PRACTICE_ID,
+        "booking.book"
+      )
+    ).resolves.toBe(false);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[booking.book] activation funnel event failed:",
+      error
+    );
+    consoleError.mockRestore();
   });
 });

--- a/apps/web/lib/agent/__tests__/tools.test.ts
+++ b/apps/web/lib/agent/__tests__/tools.test.ts
@@ -3,10 +3,16 @@ import { readFileSync } from "node:fs";
 
 const webhookMocks = vi.hoisted(() => ({
   dispatchWebhookEvent: vi.fn(async () => undefined),
+  recordActivationAfterAppointmentCreated: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/webhook-dispatcher", () => ({
   dispatchWebhookEvent: webhookMocks.dispatchWebhookEvent,
+}));
+
+vi.mock("@/lib/funnel-events-server", () => ({
+  recordActivationAfterAppointmentCreated:
+    webhookMocks.recordActivationAfterAppointmentCreated,
 }));
 
 import {
@@ -363,6 +369,9 @@ describe("book_appointment validation", () => {
       "appointment.created",
       expect.objectContaining({ source: "agent" })
     );
+    expect(
+      webhookMocks.recordActivationAfterAppointmentCreated
+    ).toHaveBeenCalledWith(ctx.db, PRACTICE_ID, "agent.book_appointment");
   });
 });
 

--- a/apps/web/lib/agent/tools.ts
+++ b/apps/web/lib/agent/tools.ts
@@ -31,6 +31,7 @@ import {
 } from "@openpims/db";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
 import { appointmentCreatedWebhookPayload } from "@/lib/appointment-webhooks";
+import { recordActivationAfterAppointmentCreated } from "@/lib/funnel-events-server";
 import {
   dateInputTimeUtcInstant,
   formatDateInputForTimeZone,
@@ -571,6 +572,11 @@ const bookAppointment: AgentTool = {
         notes: input.notes ?? null,
       })
       .returning();
+    await recordActivationAfterAppointmentCreated(
+      ctx.db,
+      ctx.practiceId,
+      "agent.book_appointment"
+    );
     await dispatchWebhookEvent(
       ctx.practiceId,
       "appointment.created",

--- a/apps/web/lib/funnel-events-server.ts
+++ b/apps/web/lib/funnel-events-server.ts
@@ -182,6 +182,25 @@ export async function recordActivationIfReached(
   });
 }
 
+/**
+ * Appointment creation is a primary product action, so activation telemetry
+ * must never turn a durable booking into a failed request. Each creation path
+ * calls this only after its appointment insert/transaction succeeds. The
+ * practice-stage unique index keeps retries idempotent.
+ */
+export async function recordActivationAfterAppointmentCreated(
+  db: Database,
+  practiceId: string,
+  source: string
+): Promise<boolean> {
+  try {
+    return await recordActivationIfReached(db, practiceId);
+  } catch (err) {
+    console.error(`[${source}] activation funnel event failed:`, err);
+    return false;
+  }
+}
+
 export async function recordRegistration(
   db: Database,
   practiceId: string

--- a/apps/web/server/__tests__/appointments-safety.test.ts
+++ b/apps/web/server/__tests__/appointments-safety.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 const mocks = vi.hoisted(() => ({
   recordAuditLog: vi.fn(async () => undefined),
   dispatchWebhookEvent: vi.fn(async () => undefined),
+  recordActivationAfterAppointmentCreated: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/audit", () => ({
@@ -12,6 +13,11 @@ vi.mock("@/lib/audit", () => ({
 
 vi.mock("@/lib/webhook-dispatcher", () => ({
   dispatchWebhookEvent: mocks.dispatchWebhookEvent,
+}));
+
+vi.mock("@/lib/funnel-events-server", () => ({
+  recordActivationAfterAppointmentCreated:
+    mocks.recordActivationAfterAppointmentCreated,
 }));
 
 const { appointmentsRouter } = await import("../routers/appointments");
@@ -376,6 +382,11 @@ describe("appointments target safety", () => {
         clientId: CLIENT_ID,
         source: "dashboard",
       })
+    );
+    expect(mocks.recordActivationAfterAppointmentCreated).toHaveBeenCalledWith(
+      db,
+      PRACTICE_ID,
+      "appointments.create"
     );
   });
 
@@ -1023,6 +1034,11 @@ describe("appointments target safety", () => {
         notes: "Follow-up recheck",
         recurringSeriesId: SERIES_ID,
       })
+    );
+    expect(mocks.recordActivationAfterAppointmentCreated).toHaveBeenCalledWith(
+      db,
+      PRACTICE_ID,
+      "appointments.createRecurring"
     );
   });
 

--- a/apps/web/server/__tests__/booking-router.test.ts
+++ b/apps/web/server/__tests__/booking-router.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   billingEnforced: vi.fn(() => false),
   hasHostedFullAccess: vi.fn(() => true),
   dispatchWebhookEvent: vi.fn(async () => undefined),
+  recordActivationAfterAppointmentCreated: vi.fn(async () => true),
   recordAuditLog: vi.fn(async () => undefined),
 }));
 
@@ -18,6 +19,11 @@ vi.mock("@/lib/rate-limit", () => ({
 
 vi.mock("@/lib/webhook-dispatcher", () => ({
   dispatchWebhookEvent: mocks.dispatchWebhookEvent,
+}));
+
+vi.mock("@/lib/funnel-events-server", () => ({
+  recordActivationAfterAppointmentCreated:
+    mocks.recordActivationAfterAppointmentCreated,
 }));
 
 vi.mock("@/lib/billing/plans", () => ({
@@ -335,6 +341,11 @@ describe("public booking", () => {
       PRACTICE_ID,
       "appointment.created",
       expect.objectContaining({ source: "booking_page" })
+    );
+    expect(mocks.recordActivationAfterAppointmentCreated).toHaveBeenCalledWith(
+      db,
+      PRACTICE_ID,
+      "booking.book"
     );
   });
 

--- a/apps/web/server/__tests__/data-export.test.ts
+++ b/apps/web/server/__tests__/data-export.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   })),
   isPracticeBackupJsonSizeValid: vi.fn(() => true),
   recordAuditLog: vi.fn(async () => undefined),
+  recordActivationAfterAppointmentCreated: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/backup/export", () => ({
@@ -42,6 +43,11 @@ vi.mock("@/lib/backup/policy", () => ({
 
 vi.mock("@/lib/audit", () => ({
   recordAuditLog: mocks.recordAuditLog,
+}));
+
+vi.mock("@/lib/funnel-events-server", () => ({
+  recordActivationAfterAppointmentCreated:
+    mocks.recordActivationAfterAppointmentCreated,
 }));
 
 const { dataRouter } = await import("../routers/data");
@@ -290,6 +296,11 @@ describe("data full backup restore", () => {
       tx,
       PRACTICE_ID,
       { clients: [] }
+    );
+    expect(mocks.recordActivationAfterAppointmentCreated).toHaveBeenCalledWith(
+      tx,
+      PRACTICE_ID,
+      "data.restoreBackup"
     );
   });
 });

--- a/apps/web/server/__tests__/portal-booking-inputs.test.ts
+++ b/apps/web/server/__tests__/portal-booking-inputs.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   })),
   billingEnforced: vi.fn(() => false),
   dispatchWebhookEvent: vi.fn(async () => undefined),
+  recordActivationAfterAppointmentCreated: vi.fn(async () => true),
   hasHostedFullAccess: vi.fn(() => true),
 }));
 
@@ -17,6 +18,11 @@ vi.mock("@/lib/rate-limit", () => ({
 
 vi.mock("@/lib/webhook-dispatcher", () => ({
   dispatchWebhookEvent: mocks.dispatchWebhookEvent,
+}));
+
+vi.mock("@/lib/funnel-events-server", () => ({
+  recordActivationAfterAppointmentCreated:
+    mocks.recordActivationAfterAppointmentCreated,
 }));
 
 vi.mock("@/lib/billing/plans", () => ({
@@ -742,6 +748,11 @@ describe("portal booking input validation", () => {
           "Requested: 2026-07-01 09:00 (America/Los_Angeles)"
         ),
       })
+    );
+    expect(mocks.recordActivationAfterAppointmentCreated).toHaveBeenCalledWith(
+      db,
+      PRACTICE_ID,
+      "portal.requestAppointment"
     );
     const communicationInsert = insertValues.mock.calls[1] as unknown as [
       { content: string; assignedTo?: unknown },

--- a/apps/web/server/routers/appointments.ts
+++ b/apps/web/server/routers/appointments.ts
@@ -48,7 +48,7 @@ import {
 } from "@/lib/scheduling/appointment-status";
 import { generateCalendarFeedToken } from "@/lib/calendar/tokens";
 import { appBaseUrl } from "@/lib/app-url";
-import { recordActivationIfReached } from "@/lib/funnel-events-server";
+import { recordActivationAfterAppointmentCreated } from "@/lib/funnel-events-server";
 import { CLOSEOUT_BYPASS_MESSAGE } from "@/lib/encounters/closeout-policy";
 
 type AppointmentsContext = {
@@ -725,16 +725,16 @@ export const appointmentsRouter = createRouter({
           practiceId: ctx.practiceId,
         })
         .returning();
+      await recordActivationAfterAppointmentCreated(
+        ctx.db,
+        ctx.practiceId,
+        "appointments.create"
+      );
       await dispatchWebhookEvent(
         ctx.practiceId,
         "appointment.created",
         appointmentCreatedWebhookPayload(appt!, "dashboard")
       );
-      try {
-        await recordActivationIfReached(ctx.db, ctx.practiceId);
-      } catch (err) {
-        console.error("[appointments.create] funnel event failed:", err);
-      }
       return appt!;
     }),
 
@@ -1169,7 +1169,7 @@ export const appointmentsRouter = createRouter({
         });
       }
 
-      return ctx.db.transaction(async (tx) => {
+      const result = await ctx.db.transaction(async (tx) => {
         const txCtx = { ...ctx, db: tx as unknown as Database };
         const targets = await assertAppointmentTargets(txCtx, input);
         const timezone = await practiceTimeZone(txCtx);
@@ -1251,6 +1251,14 @@ export const appointmentsRouter = createRouter({
 
         return { seriesId: series!.id, created, skipped };
       });
+      if (result.created > 0) {
+        await recordActivationAfterAppointmentCreated(
+          ctx.db,
+          ctx.practiceId,
+          "appointments.createRecurring"
+        );
+      }
+      return result;
     }),
 
   // ── ICS calendar feed ─────────────────────────────────────

--- a/apps/web/server/routers/booking.ts
+++ b/apps/web/server/routers/booking.ts
@@ -15,6 +15,7 @@ import { rateLimit } from "@/lib/rate-limit";
 import { dateInputTimeUtcInstant } from "@/lib/date-input";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
 import { appointmentCreatedWebhookPayload } from "@/lib/appointment-webhooks";
+import { recordActivationAfterAppointmentCreated } from "@/lib/funnel-events-server";
 import { findOpenSlots } from "@/lib/scheduling/availability";
 import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
 import { generatePortalAccessToken } from "@/lib/portal/tokens";
@@ -538,6 +539,11 @@ export const bookingRouter = createRouter({
           notes: `[Online booking] ${input.reason}`,
         })
         .returning();
+      await recordActivationAfterAppointmentCreated(
+        ctx.db,
+        practice.id,
+        "booking.book"
+      );
 
       // Surface the booking in the communications inbox so the front desk
       // sees new online bookings alongside portal requests and messages.

--- a/apps/web/server/routers/data.ts
+++ b/apps/web/server/routers/data.ts
@@ -55,6 +55,7 @@ import {
   type MigrationPreviewSummary,
   type MigrationRunMode,
 } from "@/lib/import/run-ledger";
+import { recordActivationAfterAppointmentCreated } from "@/lib/funnel-events-server";
 
 const adminProcedure = protectedProcedure.use(requireRole("admin"));
 export { IMPORT_CSV_MAX_BYTES, IMPORT_MAX_ROWS } from "@/lib/import/policy";
@@ -1744,6 +1745,11 @@ export const dataRouter = createRouter({
         ctx.db,
         ctx.practiceId,
         input.backup,
+      );
+      await recordActivationAfterAppointmentCreated(
+        ctx.db,
+        ctx.practiceId,
+        "data.restoreBackup",
       );
       return { dryRun: false as const, ...result };
     }),

--- a/apps/web/server/routers/portal.ts
+++ b/apps/web/server/routers/portal.ts
@@ -20,6 +20,7 @@ import { users } from "@openpims/db";
 import { rateLimit } from "@/lib/rate-limit";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
 import { appointmentCreatedWebhookPayload } from "@/lib/appointment-webhooks";
+import { recordActivationAfterAppointmentCreated } from "@/lib/funnel-events-server";
 import {
   assertSlotWithinPortalBookingHours,
   buildRequestedSlot,
@@ -1012,6 +1013,11 @@ export const portalRouter = createRouter({
           notes: `[Portal request] ${input.reason}`,
         })
         .returning();
+      await recordActivationAfterAppointmentCreated(
+        ctx.db,
+        client.practiceId,
+        "portal.requestAppointment"
+      );
 
       // Mirror into the communications inbox so front desk sees it there too.
       await ctx.db.insert(communications).values({


### PR DESCRIPTION
## Outcome
Activation is now recorded after every successful non-demo appointment creation path: dashboard, recurring series, public booking, client portal, v1 API, AI scheduling, and full-backup restore.

## Safety
- Centralized best-effort helper cannot turn a durable booking into a failed request
- Existing practice/stage uniqueness keeps retries idempotent
- Demo clients and appointments remain excluded
- No schema migration

## Verification
- 151 focused tests passed
- Full web suite: 2,514 tests passed across 272 files
- TypeScript type-check passed
- git diff --check passed