### PR TITLE
feat(admin): add clinic activation recovery queue

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -54,6 +54,17 @@ const statusStyles: Record<string, string> = {
   none: "bg-gray-100 text-gray-500",
 };
 
+const recoveryTrialStyles: Record<string, string> = {
+  active: "bg-green-100 text-green-700",
+  ending_soon: "bg-amber-100 text-amber-800",
+  expired: "bg-red-100 text-red-700",
+  no_trial: "bg-gray-100 text-gray-600",
+};
+
+function recoveryLabel(value: string) {
+  return value.replaceAll("_", " ");
+}
+
 export default function AdminPage() {
   const utils = trpc.useUtils();
   const { data, isLoading, error, refetch } =
@@ -62,6 +73,8 @@ export default function AdminPage() {
     });
   const { data: funnel, error: funnelError } =
     trpc.admin.activationFunnel.useQuery({ days: 30 }, { retry: false });
+  const { data: recoveryQueue, error: recoveryError } =
+    trpc.admin.activationRecovery.useQuery(undefined, { retry: false });
   const { data: journey, error: journeyError } =
     trpc.admin.journeyFunnel.useQuery({ days: 30 }, { retry: false });
   const { data: messagingQueue, error: messagingQueueError } =
@@ -81,6 +94,7 @@ export default function AdminPage() {
       setAnalyticsError(null);
       utils.admin.overview.invalidate();
       utils.admin.activationFunnel.invalidate();
+      utils.admin.activationRecovery.invalidate();
     },
     onError: (err) => setAnalyticsError(err.message),
   });
@@ -174,7 +188,7 @@ export default function AdminPage() {
   const kpis = [
     { label: "Practices", value: String(data.totals.practices), icon: Building2 },
     { label: "Est. MRR", value: formatUsd(data.totals.estimatedMrr), icon: DollarSign },
-    { label: "On trial", value: String(data.totals.trialing), icon: Clock },
+    { label: "Active trials", value: String(data.totals.activeTrials), icon: Clock },
     { label: "Active", value: String(data.totals.active), icon: CheckCircle },
     { label: "Past due", value: String(data.totals.pastDue), icon: AlertTriangle },
   ];
@@ -202,6 +216,122 @@ export default function AdminPage() {
             </div>
           );
         })}
+      </div>
+
+      {/* Activation recovery queue */}
+      <div className="mt-6 rounded-lg border border-border bg-card p-5">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <TrendingUp className="h-4 w-4" />
+          <span className="text-sm">Clinic activation recovery</span>
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Ranked by the next operator action, then by days since a real clinic
+          milestone. Internal/test workspaces and sample data are excluded.
+        </p>
+        {recoveryQueue ? (
+          <div className="mt-4 overflow-x-auto rounded-md border border-border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border bg-muted/30 text-left text-muted-foreground">
+                  <th className="px-3 py-2 font-medium">Rank</th>
+                  <th className="px-3 py-2 font-medium">Clinic contact</th>
+                  <th className="px-3 py-2 font-medium">Trial</th>
+                  <th className="px-3 py-2 font-medium">Setup</th>
+                  <th className="px-3 py-2 font-medium">Real activity</th>
+                  <th className="px-3 py-2 font-medium">Stage</th>
+                  <th className="px-3 py-2 font-medium">Next action</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {recoveryQueue.map((clinic) => (
+                  <tr key={clinic.practiceId} className="align-top hover:bg-muted/20">
+                    <td className="px-3 py-2 font-medium tabular-nums">
+                      {clinic.queueRank}
+                    </td>
+                    <td className="px-3 py-2">
+                      <p className="font-medium">{clinic.practiceName}</p>
+                      {clinic.verifiedAdminEmail && clinic.verifiedAdminEmailAt ? (
+                        <a
+                          href={`mailto:${clinic.verifiedAdminEmail}`}
+                          className="mt-0.5 block text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                        >
+                          {clinic.verifiedAdminName
+                            ? `${clinic.verifiedAdminName} · `
+                            : ""}
+                          {clinic.verifiedAdminEmail}
+                        </a>
+                      ) : (
+                        <p className="mt-0.5 text-xs font-medium text-amber-700">
+                          No verified admin contact
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-medium capitalize ${
+                          recoveryTrialStyles[clinic.trialState] ??
+                          recoveryTrialStyles.no_trial
+                        }`}
+                      >
+                        {recoveryLabel(clinic.trialState)}
+                      </span>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {clinic.trialEndsAt
+                          ? `Ends ${formatDate(clinic.trialEndsAt, clinic.timezone)}`
+                          : "No trial end"}
+                      </p>
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      <p>{clinic.setupStage}</p>
+                      {clinic.setupHelpRequestedAt ? (
+                        <p className="mt-0.5 text-xs font-medium text-emerald-700">
+                          Help requested {formatDate(
+                            clinic.setupHelpRequestedAt,
+                            clinic.timezone
+                          )}
+                        </p>
+                      ) : null}
+                    </td>
+                    <td className="px-3 py-2">
+                      <p className="tabular-nums">
+                        {clinic.realClientCount} clients ·{" "}
+                        {clinic.realAppointmentCount} visits
+                      </p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        Last {formatDate(
+                          clinic.lastMeaningfulActivityAt,
+                          clinic.timezone
+                        )} · stalled {clinic.stallAgeDays}d
+                      </p>
+                    </td>
+                    <td className="px-3 py-2 capitalize text-muted-foreground">
+                      {recoveryLabel(clinic.authoritativeStage)}
+                    </td>
+                    <td className="px-3 py-2">
+                      <p className="font-medium">{clinic.nextAction}</p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        Priority {clinic.nextActionPriority}
+                      </p>
+                    </td>
+                  </tr>
+                ))}
+                {recoveryQueue.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-3 py-6 text-center text-muted-foreground">
+                      No clinic workspaces need activation recovery.
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="mt-3 text-sm text-muted-foreground">
+            {recoveryError
+              ? "Could not load activation recovery."
+              : "Loading activation recovery…"}
+          </p>
+        )}
       </div>
 
       {/* Messaging carrier operations */}
@@ -495,11 +625,11 @@ export default function AdminPage() {
             </div>
 
             <div className="mt-5 grid gap-2 text-sm text-muted-foreground sm:grid-cols-2 xl:grid-cols-6">
-              <p>Left before trying: {journey.totals.leftBeforeTrying}</p>
-              <p>Demo without signup: {journey.totals.demoAbandoned}</p>
-              <p>Signup without activation: {journey.totals.registrationAbandoned}</p>
-              <p>Activated without card: {journey.totals.activationAbandoned}</p>
-              <p>Card without payment: {journey.totals.cardAbandoned}</p>
+              <p>Left before trying (7d+): {journey.totals.leftBeforeTrying}</p>
+              <p>Demo without signup (7d+): {journey.totals.demoAbandoned}</p>
+              <p>Signup stalled (7d+): {journey.totals.registrationAbandoned}</p>
+              <p>Activation stalled (7d+): {journey.totals.activationAbandoned}</p>
+              <p>Card stalled after trial (7d+): {journey.totals.cardAbandoned}</p>
               <p>Client errors: {journey.totals.clientErrors}</p>
             </div>
 
@@ -540,7 +670,8 @@ export default function AdminPage() {
             </div>
             <p className="mt-3 text-xs text-muted-foreground">
               Anonymous first touch is carried across openvpm.com, demo, and signup.
-              Rates are visit-to-step for demo and registration, then step-to-step.
+              Rates are visit-to-step for demo and registration, then step-to-step.{" "}
+              Stalls require seven full days; active card-on-file trials are not stalled.
               {journey.totals.unattributedRegistrations > 0
                 ? ` ${journey.totals.unattributedRegistrations} registration(s) could not be matched to a first touch.`
                 : ""}

--- a/apps/web/lib/__tests__/activation-recovery.test.ts
+++ b/apps/web/lib/__tests__/activation-recovery.test.ts
@@ -1,0 +1,222 @@
+import { readFileSync } from "node:fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const executeResults: unknown[][] = [];
+  const execute = vi.fn(async () => executeResults.shift() ?? []);
+  const db = { execute };
+  return {
+    db,
+    execute,
+    executeResults,
+    withSystem: vi.fn(
+      async (database: unknown, fn: (tx: unknown) => Promise<unknown>) =>
+        fn(database)
+    ),
+  };
+});
+
+vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
+
+const {
+  classifyRecoveryTrial,
+  computeActivationRecovery,
+  deriveRecoveryNextAction,
+  deriveRecoveryStage,
+} = await import("@/lib/admin/activation-recovery");
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mocks.executeResults.length = 0;
+});
+
+describe("activation recovery", () => {
+  it("classifies trial boundaries at one injected, timezone-safe clock", () => {
+    const now = new Date("2026-08-08T12:00:00.000Z");
+
+    expect(
+      classifyRecoveryTrial("trialing", "2026-08-12T12:00:00.000Z", now)
+    ).toBe("active");
+    expect(
+      classifyRecoveryTrial("trialing", "2026-08-11T12:00:00.000Z", now)
+    ).toBe("ending_soon");
+    expect(
+      classifyRecoveryTrial("trialing", "2026-08-08T12:00:00.000Z", now)
+    ).toBe("expired");
+    expect(classifyRecoveryTrial("none", null, now)).toBe("no_trial");
+
+    // The same instant with an offset must classify identically.
+    expect(
+      classifyRecoveryTrial("trialing", "2026-08-11T08:00:00-04:00", now)
+    ).toBe("ending_soon");
+  });
+
+  it("derives every authoritative progress stage from durable product data", () => {
+    const base = {
+      billingStatus: "trialing",
+      stripeSubscriptionId: null,
+      setupStarted: false,
+      setupCompleted: false,
+      realClientCount: 0,
+      realAppointmentCount: 0,
+    };
+
+    expect(deriveRecoveryStage(base)).toBe("registered");
+    expect(deriveRecoveryStage({ ...base, setupStarted: true })).toBe(
+      "setup_started"
+    );
+    expect(
+      deriveRecoveryStage({ ...base, setupStarted: true, setupCompleted: true })
+    ).toBe("setup_complete");
+    expect(deriveRecoveryStage({ ...base, realClientCount: 1 })).toBe(
+      "client_added"
+    );
+    expect(deriveRecoveryStage({ ...base, realAppointmentCount: 1 })).toBe(
+      "appointment_booked"
+    );
+    expect(
+      deriveRecoveryStage({
+        ...base,
+        realClientCount: 1,
+        realAppointmentCount: 1,
+      })
+    ).toBe("activated");
+    expect(
+      deriveRecoveryStage({ ...base, stripeSubscriptionId: "sub_123" })
+    ).toBe("card_on_file");
+    expect(deriveRecoveryStage({ ...base, billingStatus: "active" })).toBe(
+      "paid"
+    );
+  });
+
+  it("covers help, contact, access, setup, activation, card, and paid actions", () => {
+    const base = {
+      trialState: "active" as const,
+      stage: "registered" as const,
+      setupStage: "Not started",
+      setupHelpRequested: false,
+      hasVerifiedAdmin: true,
+      hasAnyAdmin: true,
+    };
+
+    const cases = [
+      [{ ...base, setupHelpRequested: true }, "Respond to setup help request"],
+      [{ ...base, hasVerifiedAdmin: false }, "Verify the primary admin email"],
+      [
+        { ...base, hasVerifiedAdmin: false, hasAnyAdmin: false },
+        "Restore an admin contact",
+      ],
+      [{ ...base, trialState: "expired" as const }, "Review a qualified trial extension"],
+      [{ ...base, trialState: "no_trial" as const }, "Restore trial or billing access"],
+      [
+        { ...base, trialState: "ending_soon" as const },
+        "Help add a card before trial end",
+      ],
+      [{ ...base, stage: "setup_started" as const, setupStage: "Data import" }, "Unblock Data import"],
+      [{ ...base, stage: "setup_complete" as const }, "Help import the first real client"],
+      [{ ...base, stage: "client_added" as const }, "Help book the first real appointment"],
+      [{ ...base, stage: "appointment_booked" as const }, "Help add the appointment's client"],
+      [{ ...base, stage: "activated" as const }, "Invite clinic to add a card"],
+      [
+        { ...base, stage: "card_on_file" as const },
+        "Support the first successful clinic week",
+      ],
+      [
+        { ...base, trialState: "no_trial" as const, stage: "paid" as const },
+        "Support retention and expansion",
+      ],
+    ] as const;
+
+    for (const [input, label] of cases) {
+      expect(deriveRecoveryNextAction(input).label).toBe(label);
+    }
+  });
+
+  it("runs one system aggregate and ranks help requests ahead of older stalls", async () => {
+    const now = new Date("2026-08-08T12:00:00.000Z");
+    mocks.executeResults.push([
+      {
+        practiceId: "00000000-0000-0000-0000-000000000001",
+        practiceName: "Older Clinic",
+        billingStatus: "trialing",
+        trialEndsAt: "2026-08-20T12:00:00.000Z",
+        stripeSubscriptionId: null,
+        timezone: "America/Los_Angeles",
+        createdAt: "2026-07-01T12:00:00.000Z",
+        settings: {},
+        verifiedAdminName: "Owner",
+        verifiedAdminEmail: "owner@example.com",
+        verifiedAdminEmailAt: "2026-07-01T13:00:00.000Z",
+        activeAdminCount: "1",
+        realClientCount: "0",
+        realAppointmentCount: "0",
+        lastMeaningfulActivityAt: "2026-07-01T12:00:00.000Z",
+      },
+      {
+        practiceId: "00000000-0000-0000-0000-000000000002",
+        practiceName: "Help Clinic",
+        billingStatus: "trialing",
+        trialEndsAt: "2026-08-20T12:00:00.000Z",
+        stripeSubscriptionId: null,
+        timezone: "Pacific/Auckland",
+        createdAt: "2026-08-01T12:00:00.000Z",
+        settings: {
+          onboardingState: {
+            journeyStepId: "data",
+            setupHelpRequestedAt: "2026-08-07T12:00:00.000Z",
+          },
+        },
+        verifiedAdminName: "Admin",
+        verifiedAdminEmail: "admin@example.com",
+        verifiedAdminEmailAt: "2026-08-01T13:00:00.000Z",
+        activeAdminCount: 1,
+        realClientCount: 2,
+        realAppointmentCount: 0,
+        lastMeaningfulActivityAt: "2026-08-07T12:00:00.000Z",
+      },
+    ]);
+
+    const result = await computeActivationRecovery(mocks.db as never, now);
+
+    expect(mocks.withSystem).toHaveBeenCalledWith(mocks.db, expect.any(Function));
+    expect(mocks.execute).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      queueRank: 1,
+      practiceName: "Help Clinic",
+      setupStage: "Data import",
+      realClientCount: 2,
+      stallAgeDays: 1,
+      authoritativeStage: "client_added",
+      nextAction: "Respond to setup help request",
+    });
+    expect(result[1]).toMatchObject({
+      queueRank: 2,
+      practiceName: "Older Clinic",
+      stallAgeDays: 38,
+      authoritativeStage: "registered",
+    });
+  });
+
+  it("excludes analytics, soft-deleted, and demo data in the aggregate SQL", () => {
+    const source = readFileSync("lib/admin/activation-recovery.ts", "utf8");
+
+    expect(source).toContain("p.settings ->> 'analyticsExcluded' is distinct from 'true'");
+    expect(source).toContain("p.deleted_at is null");
+    expect(source).toContain("u.deleted_at is null");
+    expect(source).toContain("c.deleted_at is null");
+    expect(source).toContain("a.deleted_at is null");
+    expect(source).toContain("p.settings -> 'demoData' -> 'clientIds'");
+    expect(source).toContain("p.settings -> 'demoData' -> 'appointmentIds'");
+    expect(source).toContain("not (pb.demo_client_ids @> to_jsonb(c.id::text))");
+    expect(source).toContain("not (pb.demo_appointment_ids @> to_jsonb(a.id::text))");
+    expect(source).toContain("u.email_verified_at is not null");
+    expect(source).toContain("order by u.practice_id, u.created_at, u.id");
+    expect(source).not.toContain("join lateral");
+    expect(source).toContain("max(greatest(c.created_at, c.updated_at))");
+    expect(source).toContain("max(greatest(a.created_at, a.updated_at))");
+    expect(source).toContain("max(fe.created_at) as last_funnel_activity_at");
+    expect(source).toContain("fe.deleted_at is null");
+    expect(source).toContain("'registration', 'activation', 'card_added', 'paid'");
+  });
+});

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -49,6 +49,30 @@ describe("admin UI", () => {
     expect(source).toContain("Could not load the funnel.");
   });
 
+  it("shows a ranked activation recovery queue with verified contacts", () => {
+    expect(source).toContain("trpc.admin.activationRecovery.useQuery");
+    expect(source).toContain("Clinic activation recovery");
+    expect(source).toContain("clinic.queueRank");
+    expect(source).toContain("clinic.verifiedAdminEmail && clinic.verifiedAdminEmailAt");
+    expect(source).toContain('href={`mailto:${clinic.verifiedAdminEmail}`}');
+    expect(source).toContain("No verified admin contact");
+    expect(source).toContain("clinic.setupStage");
+    expect(source).toContain("clinic.setupHelpRequestedAt");
+    expect(source).toContain("clinic.realClientCount");
+    expect(source).toContain("clinic.realAppointmentCount");
+    expect(source).toContain("clinic.lastMeaningfulActivityAt");
+    expect(source).toContain("clinic.stallAgeDays");
+    expect(source).toContain("clinic.authoritativeStage");
+    expect(source).toContain("clinic.nextAction");
+    expect(source).toContain("clinic.nextActionPriority");
+  });
+
+  it("labels the overview KPI as active trials", () => {
+    expect(source).toContain('label: "Active trials"');
+    expect(source).toContain("data.totals.activeTrials");
+    expect(source).not.toContain('label: "On trial"');
+  });
+
   it("shows production journey cohorts and abandonment counts", () => {
     expect(source).toContain(
       "trpc.admin.journeyFunnel.useQuery({ days: 30 }, { retry: false })"
@@ -61,6 +85,8 @@ describe("admin UI", () => {
     expect(source).toContain("journey.totals.cardAbandoned");
     expect(source).toContain("journey.totals.clientErrors");
     expect(source).toContain("journey.weeks.map");
+    expect(source).toContain("Stalls require seven full days");
+    expect(source).toContain("active card-on-file trials are not stalled");
   });
 
   it("shows trial source and setup stage for diagnosing individual drop-off", () => {

--- a/apps/web/lib/__tests__/journey-funnel.test.ts
+++ b/apps/web/lib/__tests__/journey-funnel.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -100,5 +101,18 @@ describe("computeJourneyFunnel", () => {
       cardRate: 0,
       paidRate: 0,
     });
+  });
+
+  it("only calls mature stalls abandoned and exempts active card trials", () => {
+    const source = readFileSync("lib/admin/journey-funnel.ts", "utf8");
+
+    expect(source).toContain("export const ABANDONMENT_GRACE_DAYS = 7");
+    expect(source).toContain("s.cohort_at < ${abandonedBefore}::timestamptz");
+    expect(source).toContain("s.registered_at < ${abandonedBefore}::timestamptz");
+    expect(source).toContain("s.activation_at < ${abandonedBefore}::timestamptz");
+    expect(source).toContain("s.card_added_at < ${abandonedBefore}::timestamptz");
+    expect(source).toContain("s.stripe_subscription_id is not null");
+    expect(source).toContain("s.billing_status = 'trialing'");
+    expect(source).toContain("s.trial_ends_at > ${now.toISOString()}::timestamptz");
   });
 });

--- a/apps/web/lib/admin/activation-recovery.ts
+++ b/apps/web/lib/admin/activation-recovery.ts
@@ -1,0 +1,420 @@
+import { sql } from "drizzle-orm";
+import type { Database } from "@openpims/db/client";
+import { withSystem } from "@/lib/tenant-db";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+export const TRIAL_ENDING_SOON_DAYS = 3;
+
+export type RecoveryTrialState =
+  | "active"
+  | "ending_soon"
+  | "expired"
+  | "no_trial";
+
+export type RecoveryStage =
+  | "registered"
+  | "setup_started"
+  | "setup_complete"
+  | "client_added"
+  | "appointment_booked"
+  | "activated"
+  | "card_on_file"
+  | "paid";
+
+export interface RecoveryNextAction {
+  priority: number;
+  label: string;
+}
+
+export interface ActivationRecoveryPractice {
+  queueRank: number;
+  practiceId: string;
+  practiceName: string;
+  billingStatus: string;
+  trialEndsAt: Date | null;
+  trialState: RecoveryTrialState;
+  timezone: string;
+  createdAt: Date;
+  verifiedAdminName: string | null;
+  verifiedAdminEmail: string | null;
+  verifiedAdminEmailAt: Date | null;
+  setupStage: string;
+  setupHelpRequestedAt: Date | null;
+  realClientCount: number;
+  realAppointmentCount: number;
+  lastMeaningfulActivityAt: Date;
+  stallAgeDays: number;
+  authoritativeStage: RecoveryStage;
+  nextAction: string;
+  nextActionPriority: number;
+}
+
+interface RecoveryRow {
+  practiceId: string;
+  practiceName: string;
+  billingStatus: string;
+  trialEndsAt: Date | string | null;
+  stripeSubscriptionId: string | null;
+  timezone: string;
+  createdAt: Date | string;
+  settings: unknown;
+  verifiedAdminName: string | null;
+  verifiedAdminEmail: string | null;
+  verifiedAdminEmailAt: Date | string | null;
+  activeAdminCount: number | string;
+  realClientCount: number | string;
+  realAppointmentCount: number | string;
+  lastMeaningfulActivityAt: Date | string;
+}
+
+type RecoverySettings = {
+  onboardingCompletedAt?: string | null;
+  onboardingState?: {
+    journeyStepId?: string | null;
+    journeyDismissed?: boolean;
+    setupHelpRequestedAt?: string | null;
+  };
+};
+
+const setupStepLabels: Record<string, string> = {
+  intent: "Starting path",
+  basics: "Clinic basics",
+  branding: "Branding",
+  team: "Team",
+  data: "Data import",
+  agent: "AI helper",
+  phone: "Texting",
+  billing: "Billing",
+  allSet: "Finish",
+};
+
+function rowsFromExecute<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  const rows = (result as { rows?: unknown[] } | null)?.rows;
+  return Array.isArray(rows) ? (rows as T[]) : [];
+}
+
+function validDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function classifyRecoveryTrial(
+  billingStatus: string,
+  trialEndsAt: Date | string | null | undefined,
+  now: Date
+): RecoveryTrialState {
+  const end = validDate(trialEndsAt);
+  if (billingStatus !== "trialing" || !end) return "no_trial";
+  if (end.getTime() <= now.getTime()) return "expired";
+  if (
+    end.getTime() <=
+    now.getTime() + TRIAL_ENDING_SOON_DAYS * DAY_MS
+  ) {
+    return "ending_soon";
+  }
+  return "active";
+}
+
+export function recoverySetupState(settingsValue: unknown): {
+  completed: boolean;
+  completedAt: Date | null;
+  started: boolean;
+  stage: string;
+  helpRequestedAt: Date | null;
+} {
+  const settings = (settingsValue ?? {}) as RecoverySettings;
+  const state = settings.onboardingState;
+  const helpRequestedAt = validDate(state?.setupHelpRequestedAt);
+  const completedAt = validDate(settings.onboardingCompletedAt);
+  if (completedAt) {
+    return {
+      completed: true,
+      completedAt,
+      started: true,
+      stage: "Complete",
+      helpRequestedAt,
+    };
+  }
+  const step = state?.journeyStepId?.trim();
+  if (step) {
+    const label = setupStepLabels[step] ?? step;
+    return {
+      completed: false,
+      completedAt: null,
+      started: true,
+      stage: state?.journeyDismissed ? `Paused at ${label}` : label,
+      helpRequestedAt,
+    };
+  }
+  return {
+    completed: false,
+    completedAt: null,
+    started: false,
+    stage: "Not started",
+    helpRequestedAt,
+  };
+}
+
+export function deriveRecoveryStage(input: {
+  billingStatus: string;
+  stripeSubscriptionId: string | null;
+  setupStarted: boolean;
+  setupCompleted: boolean;
+  realClientCount: number;
+  realAppointmentCount: number;
+}): RecoveryStage {
+  if (input.billingStatus === "active") return "paid";
+  if (input.billingStatus === "trialing" && input.stripeSubscriptionId) {
+    return "card_on_file";
+  }
+  if (input.realClientCount > 0 && input.realAppointmentCount > 0) {
+    return "activated";
+  }
+  if (input.realAppointmentCount > 0) return "appointment_booked";
+  if (input.realClientCount > 0) return "client_added";
+  if (input.setupCompleted) return "setup_complete";
+  if (input.setupStarted) return "setup_started";
+  return "registered";
+}
+
+export function deriveRecoveryNextAction(input: {
+  trialState: RecoveryTrialState;
+  stage: RecoveryStage;
+  setupStage: string;
+  setupHelpRequested: boolean;
+  hasVerifiedAdmin: boolean;
+  hasAnyAdmin: boolean;
+}): RecoveryNextAction {
+  if (input.setupHelpRequested) {
+    return { priority: 100, label: "Respond to setup help request" };
+  }
+  if (!input.hasVerifiedAdmin) {
+    return {
+      priority: 95,
+      label: input.hasAnyAdmin
+        ? "Verify the primary admin email"
+        : "Restore an admin contact",
+    };
+  }
+  if (input.stage === "paid") {
+    return { priority: 20, label: "Support retention and expansion" };
+  }
+  if (input.trialState === "expired") {
+    return { priority: 90, label: "Review a qualified trial extension" };
+  }
+  if (input.trialState === "no_trial") {
+    return { priority: 85, label: "Restore trial or billing access" };
+  }
+  if (input.trialState === "ending_soon" && input.stage !== "card_on_file") {
+    return { priority: 80, label: "Help add a card before trial end" };
+  }
+  switch (input.stage) {
+    case "registered":
+      return { priority: 75, label: "Invite clinic into guided setup" };
+    case "setup_started":
+      return { priority: 70, label: `Unblock ${input.setupStage}` };
+    case "setup_complete":
+      return { priority: 65, label: "Help import the first real client" };
+    case "client_added":
+      return { priority: 60, label: "Help book the first real appointment" };
+    case "appointment_booked":
+      return { priority: 60, label: "Help add the appointment's client" };
+    case "activated":
+      return { priority: 55, label: "Invite clinic to add a card" };
+    case "card_on_file":
+      return { priority: 45, label: "Support the first successful clinic week" };
+  }
+}
+
+/**
+ * One system-scoped aggregate statement for the operator recovery queue. Demo,
+ * analytics-excluded, and soft-deleted rows never become clinic progress.
+ */
+export async function computeActivationRecovery(
+  db: Database,
+  now: Date = new Date()
+): Promise<ActivationRecoveryPractice[]> {
+  const result = await withSystem(db, (tx) =>
+    tx.execute(sql`
+      with practice_base as (
+        select
+          p.id,
+          p.name,
+          p.billing_status,
+          p.trial_ends_at,
+          p.stripe_subscription_id,
+          p.timezone,
+          p.created_at,
+          p.settings,
+          coalesce(p.settings -> 'demoData' -> 'clientIds', '[]'::jsonb)
+            as demo_client_ids,
+          coalesce(p.settings -> 'demoData' -> 'appointmentIds', '[]'::jsonb)
+            as demo_appointment_ids
+        from practices p
+        where p.deleted_at is null
+          and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+      ), verified_admin as (
+        select distinct on (u.practice_id)
+          u.practice_id,
+          u.name,
+          u.email,
+          u.email_verified_at
+        from users u
+        join practice_base pb on pb.id = u.practice_id
+        where u.role = 'admin'
+          and u.deleted_at is null
+          and u.email_verified_at is not null
+        order by u.practice_id, u.created_at, u.id
+      ), admin_stats as (
+        select u.practice_id, count(*)::int as active_admin_count
+        from users u
+        join practice_base pb on pb.id = u.practice_id
+        where u.role = 'admin'
+          and u.deleted_at is null
+        group by u.practice_id
+      ), client_stats as (
+        select
+          pb.id as practice_id,
+          count(c.id)::int as real_client_count,
+          max(greatest(c.created_at, c.updated_at)) as last_real_client_at
+        from practice_base pb
+        left join clients c
+          on c.practice_id = pb.id
+          and c.deleted_at is null
+          and not (pb.demo_client_ids @> to_jsonb(c.id::text))
+        group by pb.id
+      ), appointment_stats as (
+        select
+          pb.id as practice_id,
+          count(a.id)::int as real_appointment_count,
+          max(greatest(a.created_at, a.updated_at)) as last_real_appointment_at
+        from practice_base pb
+        left join appointments a
+          on a.practice_id = pb.id
+          and a.deleted_at is null
+          and not (pb.demo_appointment_ids @> to_jsonb(a.id::text))
+        group by pb.id
+      ), funnel_stats as (
+        select
+          fe.practice_id,
+          max(fe.created_at) as last_funnel_activity_at
+        from funnel_events fe
+        join practice_base pb on pb.id = fe.practice_id
+        where fe.deleted_at is null
+          and fe.event_name in ('registration', 'activation', 'card_added', 'paid')
+        group by fe.practice_id
+      )
+      select
+        pb.id as "practiceId",
+        pb.name as "practiceName",
+        pb.billing_status as "billingStatus",
+        pb.trial_ends_at as "trialEndsAt",
+        pb.stripe_subscription_id as "stripeSubscriptionId",
+        pb.timezone,
+        pb.created_at as "createdAt",
+        pb.settings,
+        verified_admin.name as "verifiedAdminName",
+        verified_admin.email as "verifiedAdminEmail",
+        verified_admin.email_verified_at as "verifiedAdminEmailAt",
+        coalesce(admins.active_admin_count, 0)::int as "activeAdminCount",
+        coalesce(client_stats.real_client_count, 0)::int as "realClientCount",
+        coalesce(appointment_stats.real_appointment_count, 0)::int
+          as "realAppointmentCount",
+        greatest(
+          pb.created_at,
+          client_stats.last_real_client_at,
+          appointment_stats.last_real_appointment_at,
+          funnel_stats.last_funnel_activity_at
+        ) as "lastMeaningfulActivityAt"
+      from practice_base pb
+      left join verified_admin on verified_admin.practice_id = pb.id
+      left join admin_stats admins on admins.practice_id = pb.id
+      left join client_stats on client_stats.practice_id = pb.id
+      left join appointment_stats on appointment_stats.practice_id = pb.id
+      left join funnel_stats on funnel_stats.practice_id = pb.id
+      order by pb.created_at, pb.id
+    `)
+  );
+
+  const practices = rowsFromExecute<RecoveryRow>(result).map((row) => {
+    const createdAt = validDate(row.createdAt) ?? now;
+    const trialEndsAt = validDate(row.trialEndsAt);
+    const verifiedAdminEmailAt = validDate(row.verifiedAdminEmailAt);
+    const realClientCount = Number(row.realClientCount) || 0;
+    const realAppointmentCount = Number(row.realAppointmentCount) || 0;
+    const setup = recoverySetupState(row.settings);
+    const lastMeaningfulActivityAt = [
+      createdAt,
+      validDate(row.lastMeaningfulActivityAt),
+      setup.completedAt,
+      setup.helpRequestedAt,
+    ].reduce<Date>(
+      (latest, candidate) =>
+        candidate && candidate.getTime() > latest.getTime() ? candidate : latest,
+      createdAt
+    );
+    const trialState = classifyRecoveryTrial(
+      row.billingStatus,
+      trialEndsAt,
+      now
+    );
+    const authoritativeStage = deriveRecoveryStage({
+      billingStatus: row.billingStatus,
+      stripeSubscriptionId: row.stripeSubscriptionId,
+      setupStarted: setup.started,
+      setupCompleted: setup.completed,
+      realClientCount,
+      realAppointmentCount,
+    });
+    const nextAction = deriveRecoveryNextAction({
+      trialState,
+      stage: authoritativeStage,
+      setupStage: setup.stage,
+      setupHelpRequested: setup.helpRequestedAt != null,
+      hasVerifiedAdmin: Boolean(row.verifiedAdminEmail && verifiedAdminEmailAt),
+      hasAnyAdmin: Number(row.activeAdminCount) > 0,
+    });
+
+    return {
+      queueRank: 0,
+      practiceId: row.practiceId,
+      practiceName: row.practiceName,
+      billingStatus: row.billingStatus,
+      trialEndsAt,
+      trialState,
+      timezone: row.timezone,
+      createdAt,
+      verifiedAdminName: row.verifiedAdminName,
+      verifiedAdminEmail: row.verifiedAdminEmail,
+      verifiedAdminEmailAt,
+      setupStage: setup.stage,
+      setupHelpRequestedAt: setup.helpRequestedAt,
+      realClientCount,
+      realAppointmentCount,
+      lastMeaningfulActivityAt,
+      stallAgeDays: Math.max(
+        0,
+        Math.floor(
+          (now.getTime() - lastMeaningfulActivityAt.getTime()) / DAY_MS
+        )
+      ),
+      authoritativeStage,
+      nextAction: nextAction.label,
+      nextActionPriority: nextAction.priority,
+    };
+  });
+
+  practices.sort(
+    (a, b) =>
+      b.nextActionPriority - a.nextActionPriority ||
+      b.stallAgeDays - a.stallAgeDays ||
+      a.createdAt.getTime() - b.createdAt.getTime() ||
+      a.practiceId.localeCompare(b.practiceId)
+  );
+  return practices.map((practice, index) => ({
+    ...practice,
+    queueRank: index + 1,
+  }));
+}

--- a/apps/web/lib/admin/journey-funnel.ts
+++ b/apps/web/lib/admin/journey-funnel.ts
@@ -4,6 +4,7 @@ import { withSystem } from "@/lib/tenant-db";
 import { funnelRate } from "@/lib/admin/activation-funnel";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+export const ABANDONMENT_GRACE_DAYS = 7;
 
 export interface JourneyFunnelWeek {
   weekStart: string;
@@ -65,9 +66,13 @@ function rowsFromExecute<T>(result: unknown): T[] {
 
 export async function computeJourneyFunnel(
   db: Database,
-  days: number
+  days: number,
+  now: Date = new Date()
 ): Promise<JourneyFunnel> {
-  const windowStart = new Date(Date.now() - days * DAY_MS).toISOString();
+  const windowStart = new Date(now.getTime() - days * DAY_MS).toISOString();
+  const abandonedBefore = new Date(
+    now.getTime() - ABANDONMENT_GRACE_DAYS * DAY_MS
+  ).toISOString();
 
   const { weeklyResult, unattributedResult, errorsResult } = await withSystem(db, async (tx) => {
     const weeklyResult = await tx.execute(sql`
@@ -86,6 +91,7 @@ export async function computeJourneyFunnel(
       ), journeys as (
         select
           ft.anonymous_id,
+          ft.cohort_at,
           date_trunc('week', ft.cohort_at) as week_start,
           exists (
             select 1 from funnel_events demo
@@ -93,8 +99,13 @@ export async function computeJourneyFunnel(
               and demo.event_name = 'demo_gate_submitted'
               and demo.deleted_at is null
           ) as tried_demo,
-          (
-            select registration.practice_id
+          registration.practice_id,
+          registration.registered_at
+        from first_touch ft
+        left join lateral (
+            select
+              registration.practice_id,
+              registration.created_at as registered_at
             from funnel_events registration
             join practices p on p.id = registration.practice_id
             where registration.anonymous_id = ft.anonymous_id
@@ -102,55 +113,73 @@ export async function computeJourneyFunnel(
               and registration.deleted_at is null
               and p.deleted_at is null
               and p.settings ->> 'analyticsExcluded' is distinct from 'true'
-            order by registration.created_at
+            order by registration.created_at, registration.id
             limit 1
-          ) as practice_id
-        from first_touch ft
+        ) registration on true
       ), stages as (
         select
           j.*,
-          exists (
-            select 1 from funnel_events activation
+          (
+            select min(activation.created_at) from funnel_events activation
             where activation.practice_id = j.practice_id
               and activation.event_name = 'activation'
               and activation.deleted_at is null
-          ) as activated,
-          exists (
-            select 1 from funnel_events card
+          ) as activation_at,
+          (
+            select min(card.created_at) from funnel_events card
             where card.practice_id = j.practice_id
               and card.event_name = 'card_added'
               and card.deleted_at is null
-          ) as card_added,
-          exists (
-            select 1 from funnel_events paid
+          ) as card_added_at,
+          (
+            select min(paid.created_at) from funnel_events paid
             where paid.practice_id = j.practice_id
               and paid.event_name = 'paid'
               and paid.deleted_at is null
-          ) as paid
+          ) as paid_at,
+          p.billing_status,
+          p.trial_ends_at,
+          p.stripe_subscription_id
         from journeys j
+        left join practices p on p.id = j.practice_id
       )
       select
         to_char(s.week_start, 'YYYY-MM-DD') as "weekStart",
         count(*)::int as "visitors",
         count(*) filter (where s.tried_demo)::int as "demos",
         count(*) filter (where s.practice_id is not null)::int as "registrations",
-        count(*) filter (where s.activated)::int as "activated",
-        count(*) filter (where s.card_added)::int as "cardAdded",
-        count(*) filter (where s.paid)::int as "paid",
+        count(*) filter (where s.activation_at is not null)::int as "activated",
+        count(*) filter (where s.card_added_at is not null)::int as "cardAdded",
+        count(*) filter (where s.paid_at is not null)::int as "paid",
         count(*) filter (
-          where not s.tried_demo and s.practice_id is null
+          where not s.tried_demo
+            and s.practice_id is null
+            and s.cohort_at < ${abandonedBefore}::timestamptz
         )::int as "leftBeforeTrying",
         count(*) filter (
-          where s.tried_demo and s.practice_id is null
+          where s.tried_demo
+            and s.practice_id is null
+            and s.cohort_at < ${abandonedBefore}::timestamptz
         )::int as "demoAbandoned",
         count(*) filter (
-          where s.practice_id is not null and not s.activated
+          where s.practice_id is not null
+            and s.activation_at is null
+            and s.registered_at < ${abandonedBefore}::timestamptz
         )::int as "registrationAbandoned",
         count(*) filter (
-          where s.activated and not s.card_added
+          where s.activation_at is not null
+            and s.card_added_at is null
+            and s.activation_at < ${abandonedBefore}::timestamptz
         )::int as "activationAbandoned",
         count(*) filter (
-          where s.card_added and not s.paid
+          where s.card_added_at is not null
+            and s.paid_at is null
+            and s.card_added_at < ${abandonedBefore}::timestamptz
+            and not (
+              s.stripe_subscription_id is not null
+              and s.billing_status = 'trialing'
+              and s.trial_ends_at > ${now.toISOString()}::timestamptz
+            )
         )::int as "cardAbandoned"
       from stages s
       group by s.week_start

--- a/apps/web/server/__tests__/admin-activation-funnel.test.ts
+++ b/apps/web/server/__tests__/admin-activation-funnel.test.ts
@@ -69,6 +69,15 @@ describe("admin activation funnel", () => {
     expect(mocks.execute).not.toHaveBeenCalled();
   });
 
+  it("rejects non-platform-admin activation recovery callers", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+
+    await expect(
+      caller("clinic-admin@example.com").activationRecovery()
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(mocks.execute).not.toHaveBeenCalled();
+  });
+
   it("sums weekly rows and computes activation and conversion rates", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
     mocks.executeResults.push([

--- a/apps/web/server/__tests__/admin-overview.test.ts
+++ b/apps/web/server/__tests__/admin-overview.test.ts
@@ -68,6 +68,57 @@ afterEach(() => {
 });
 
 describe("admin overview", () => {
+  it("counts only unexpired trial windows as active trials", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    mocks.selectResults.push(
+      [
+        {
+          id: "00000000-0000-0000-0000-000000000011",
+          name: "Active Trial",
+          tier: "free",
+          billingStatus: "trialing",
+          trialEndsAt: new Date("2099-01-01T00:00:00.000Z"),
+          timezone: "UTC",
+          country: "US",
+          createdAt: new Date("2026-08-01T00:00:00.000Z"),
+          settings: {},
+        },
+        {
+          id: "00000000-0000-0000-0000-000000000012",
+          name: "Expired Trial",
+          tier: "free",
+          billingStatus: "trialing",
+          trialEndsAt: new Date("2020-01-01T00:00:00.000Z"),
+          timezone: "UTC",
+          country: "US",
+          createdAt: new Date("2026-07-01T00:00:00.000Z"),
+          settings: {},
+        },
+        {
+          id: "00000000-0000-0000-0000-000000000013",
+          name: "Malformed Trial",
+          tier: "free",
+          billingStatus: "trialing",
+          trialEndsAt: null,
+          timezone: "UTC",
+          country: "US",
+          createdAt: new Date("2026-06-01T00:00:00.000Z"),
+          settings: {},
+        },
+      ],
+      [],
+      [],
+      [],
+      [],
+      []
+    );
+
+    const result = await caller().overview();
+
+    expect(result.totals.activeTrials).toBe(1);
+    expect(result.totals.practices).toBe(3);
+  });
+
   it("returns practice timezones for cross-tenant date rendering", async () => {
     vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
     mocks.selectResults.push(

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -16,6 +16,7 @@ import {
 import { isPlatformAdmin } from "@/lib/platform-admin";
 import { computeActivationFunnel } from "@/lib/admin/activation-funnel";
 import { computeJourneyFunnel } from "@/lib/admin/journey-funnel";
+import { computeActivationRecovery } from "@/lib/admin/activation-recovery";
 import {
   CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD,
   CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD,
@@ -444,13 +445,20 @@ export const adminRouter = createRouter({
       byTier[t] += 1;
     }
 
+    const overviewNow = new Date();
+
     return {
       practices: practiceRows,
       totals: {
         practices: practiceRows.length,
         estimatedMrr,
         byTier,
-        trialing: practiceRows.filter((p) => p.billingStatus === "trialing").length,
+        activeTrials: practiceRows.filter(
+          (p) =>
+            p.billingStatus === "trialing" &&
+            p.trialEndsAt != null &&
+            p.trialEndsAt.getTime() > overviewNow.getTime()
+        ).length,
         active: practiceRows.filter((p) => p.billingStatus === "active").length,
         pastDue: practiceRows.filter((p) => p.billingStatus === "past_due").length,
       },
@@ -1199,6 +1207,11 @@ export const adminRouter = createRouter({
         .optional()
     )
     .query(({ input }) => computeActivationFunnel(db, input?.days ?? 30)),
+
+  /** Ranked, cross-tenant operator queue for recovering clinic activation. */
+  activationRecovery: platformAdminProcedure.query(() =>
+    computeActivationRecovery(db, new Date())
+  ),
 
   /** Privacy-safe first-touch cohorts spanning visit through paid. */
   journeyFunnel: platformAdminProcedure


### PR DESCRIPTION
## Outcome
Adds a production-operator recovery queue that shows which clinics need help, why they stalled, and the next evidence-backed action.

## Changes
- Separates active, ending-soon, expired, and no-trial states
- Shows only verified admin contact information
- Excludes analytics-tagged internal workspaces and seeded demo rows
- Ranks help requests, access problems, setup stalls, activation, card, and retention actions
- Corrects the overview KPI from stored trialing status to live active trials
- Requires seven full days before labeling a journey abandoned
- Exempts active card-on-file trials from card abandonment

## Verification
- Exact aggregate SQL executed successfully against production-shaped Postgres data
- 25 focused tests passed
- TypeScript type-check passed
- git diff --check passed

## Production data hygiene
Twelve founder/Claude/smoke workspaces were separately tagged with the existing reversible analyticsExcluded flag after exact ID/email review. No accounts or clinic data were deleted.