### PR TITLE
Harden texting pilot operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,9 @@ TELNYX_PUBLIC_KEY=
 MESSAGING_REGISTRATION_ENCRYPTION_KEY=
 # Explicit spend/mutation kill-switch for number and A2P provisioning.
 MESSAGING_PROVISIONING_ENABLED=false
+# Hosted production also requires the pilot clinic's practice UUID here before
+# that clinic can create a fee-bearing number order. Comma-separate UUIDs.
+MESSAGING_PROVISIONING_PRACTICE_IDS=
 
 # Twilio (fallback SMS provider)
 TWILIO_ACCOUNT_SID=

--- a/apps/web/app/api/cron/reminders/route.ts
+++ b/apps/web/app/api/cron/reminders/route.ts
@@ -451,6 +451,9 @@ export async function GET(request: Request) {
           smsConsent: appt.smsConsent ?? false,
           hasEmail: Boolean(normalizeEmailSuppressionAddress(appt.clientEmail)),
           quietHours: isQuietHours(now, appt.practiceTimezone),
+          // This sweep runs hourly, so preserve an SMS preference and retry
+          // after quiet hours instead of silently changing the channel.
+          deferQuietHoursSms: true,
         });
 
         if (channel === "skip") {

--- a/apps/web/lib/__tests__/audit.test.ts
+++ b/apps/web/lib/__tests__/audit.test.ts
@@ -43,6 +43,25 @@ describe("redactSecrets", () => {
     expect(out.secret).toBe("[redacted]");
     expect(out.authToken).toBe("[redacted]");
   });
+  it("redacts government tax identifiers used for carrier registration", () => {
+    const out = redactSecrets({
+      taxId: "12-3456789",
+      federalTaxId: "12-3456789",
+      ein: "123456789",
+      ssn: "123-45-6789",
+      taxIdLast4: "6789",
+      legalName: "Healthy Pets LLC",
+    });
+
+    expect(out).toEqual({
+      taxId: "[redacted]",
+      federalTaxId: "[redacted]",
+      ein: "[redacted]",
+      ssn: "[redacted]",
+      taxIdLast4: "[redacted]",
+      legalName: "Healthy Pets LLC",
+    });
+  });
   it("redacts nested secret-ish keys without dropping non-secret context", () => {
     const out = redactSecrets({
       patientId: "patient-1",

--- a/apps/web/lib/__tests__/cron-schedule.test.ts
+++ b/apps/web/lib/__tests__/cron-schedule.test.ts
@@ -20,5 +20,10 @@ describe("Vercel cron schedule", () => {
         "/api/cron/activation-digest",
       ])
     );
+
+    expect(
+      config.crons?.find((cron) => cron.path === "/api/cron/reminders")
+        ?.schedule
+    ).toBe("0 * * * *");
   });
 });

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -9,7 +9,8 @@ import { auditLog } from "@openpims/db";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const SECRET_KEY_RE = /pass(word)?|secret|token|keyhash|^key$|apikey/i;
+const SECRET_KEY_RE =
+  /pass(word)?|secret|token|keyhash|^key$|apikey|tax.?id|\bein\b|ssn/i;
 // Bulk import/restore payloads (raw CSV, full backup JSON) can be megabytes of
 // medical records + client PII. The audit trail records who ran the import and
 // when, not a second copy of the data, so these are replaced with a marker.

--- a/apps/web/lib/messaging/__tests__/reminders.test.ts
+++ b/apps/web/lib/messaging/__tests__/reminders.test.ts
@@ -54,6 +54,15 @@ describe("pickReminderChannel", () => {
   it("falls back to email during quiet hours when email exists", () => {
     expect(pickReminderChannel({ ...base, quietHours: true })).toBe("email");
   });
+  it("defers automated SMS during quiet hours instead of changing channel", () => {
+    expect(
+      pickReminderChannel({
+        ...base,
+        quietHours: true,
+        deferQuietHoursSms: true,
+      })
+    ).toBe("skip");
+  });
   it("returns none when there is no usable channel", () => {
     expect(
       pickReminderChannel({

--- a/apps/web/lib/messaging/__tests__/telnyx-provisioning.test.ts
+++ b/apps/web/lib/messaging/__tests__/telnyx-provisioning.test.ts
@@ -136,6 +136,9 @@ describe("Telnyx provisioning requests", () => {
       webhook_url: "https://app.openvpm.com/api/webhooks/telnyx",
       webhook_api_version: "2",
       whitelisted_destinations: ["US"],
+      daily_spend_limit_enabled: true,
+      daily_spend_limit: "10.00",
+      smart_encoding: true,
     });
   });
 
@@ -159,6 +162,33 @@ describe("Telnyx provisioning requests", () => {
     );
     await vi.advanceTimersByTimeAsync(TELNYX_API_TIMEOUT_MS);
     await result;
+  });
+
+  it("uses the current hosted-number eligibility endpoint and response shape", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          phone_numbers: [
+            {
+              phone_number: "+15555550100",
+              eligible: false,
+              detail: "number_can_not_be_wireless",
+            },
+          ],
+        })
+      )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(checkHostedEligibility("+15555550100")).resolves.toEqual({
+      eligible: false,
+      detail: "number_can_not_be_wireless",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telnyx.com/v2/messaging_hosted_number_orders/eligibility_numbers_check",
+      expect.objectContaining({ method: "POST" })
+    );
   });
 
   it("submits provider-compatible brand and campaign payloads", async () => {

--- a/apps/web/lib/messaging/reminders.ts
+++ b/apps/web/lib/messaging/reminders.ts
@@ -41,7 +41,8 @@ export type ReminderChannel = "sms" | "email" | "skip" | "none";
  * Choose the channel for one reminder:
  * - "sms"   — client prefers SMS, has a phone + consent, and it's not quiet hours
  * - "email" — fall back to email whenever SMS isn't chosen and an email exists
- * - "skip"  — SMS-preferred but quiet hours and no email → defer to a later run
+ * - "skip"  — SMS-preferred during quiet hours and the caller requested deferral,
+ *             or no email exists → defer to a later run
  * - "none"  — no usable channel
  * (The suppression list is enforced separately as a hard gate inside sendSms.)
  */
@@ -51,12 +52,15 @@ export function pickReminderChannel(opts: {
   smsConsent: boolean;
   hasEmail: boolean;
   quietHours: boolean;
+  /** Automated sweeps can retry after quiet hours instead of changing channel. */
+  deferQuietHoursSms?: boolean;
 }): ReminderChannel {
   const smsEligible =
     opts.preferredContactMethod === "sms" &&
     normalizeE164(opts.phone) !== null &&
     opts.smsConsent;
   if (smsEligible && !opts.quietHours) return "sms";
+  if (smsEligible && opts.quietHours && opts.deferQuietHoursSms) return "skip";
   if (opts.hasEmail) return "email";
   if (smsEligible && opts.quietHours) return "skip";
   return "none";

--- a/apps/web/lib/messaging/telnyx-provisioning.ts
+++ b/apps/web/lib/messaging/telnyx-provisioning.ts
@@ -136,14 +136,20 @@ export async function checkHostedEligibility(
   phoneNumber: string
 ): Promise<HostedEligibility> {
   const json = await telnyxRequest<{
-    data?: Array<{ eligible?: boolean; phone_number?: string; reason?: string }>;
-  }>("POST", "/messaging_hosted_number_orders/eligibility_numbers", {
-    phone_numbers: [phoneNumber],
-  });
-  const row = (json.data ?? [])[0];
+    phone_numbers?: Array<{
+      eligible?: boolean;
+      phone_number?: string;
+      detail?: string;
+    }>;
+  }>(
+    "POST",
+    "/messaging_hosted_number_orders/eligibility_numbers_check",
+    { phone_numbers: [phoneNumber] }
+  );
+  const row = (json.phone_numbers ?? [])[0];
   return {
     eligible: Boolean(row?.eligible),
-    detail: row?.reason,
+    detail: row?.detail,
   };
 }
 
@@ -164,6 +170,11 @@ export async function createMessagingProfile(opts: {
       // Telnyx rejects new profiles without an explicit destination allowlist.
       // OpenVPM's supported hosted launch market is the United States.
       whitelisted_destinations: ["US"],
+      // Bound pilot blast radius at the provider as well as in OpenVPM. Smart
+      // encoding keeps common punctuation from unexpectedly multiplying parts.
+      daily_spend_limit_enabled: true,
+      daily_spend_limit: "10.00",
+      smart_encoding: true,
     }
   );
   const id = json.data?.id;

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -145,6 +145,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   delete process.env.NEXT_PUBLIC_APP_URL;
   delete process.env.NEXTAUTH_URL;
+  delete process.env.HOSTED_BILLING_ENABLED;
+  delete process.env.MESSAGING_PROVISIONING_PRACTICE_IDS;
   // The platform kill-switch is on for behavior tests; the gate itself is
   // covered in "messaging provisioning kill-switch".
   vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
@@ -168,6 +170,32 @@ describe("messaging provisioning kill-switch", () => {
     // No DB reads and no Telnyx calls happen while the switch is off.
     expect(select).not.toHaveBeenCalled();
     expect(mocks.searchAvailableNumbers).not.toHaveBeenCalled();
+  });
+
+  it("requires an explicit practice allowlist for hosted number orders", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    const { db, select } = createDb({
+      practiceRows: [
+        {
+          tier: "cloud",
+          billingStatus: "trialing",
+          trialEndsAt: new Date("2099-01-01T00:00:00Z"),
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).provisionNumber({ locationId: LOCATION_ID, mode: "host" })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("approved pilot clinics"),
+    });
+
+    // Only the hosted subscription guard may read; the messaging mutation
+    // stops before its practice/location queries or any provider call.
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
+    expect(mocks.createHostedOrder).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -12,7 +12,7 @@ import {
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import { usageForPractice, currentPeriodMonth } from "@/lib/billing/usage";
-import { getPlan } from "@/lib/billing/plans";
+import { billingEnforced, getPlan } from "@/lib/billing/plans";
 import { normalizeE164 } from "@/lib/messaging";
 import { summarizeInboxSmsStatus } from "@/lib/messaging/inbox-status";
 import { hasNonBlankMessagingSender } from "@/lib/messaging/sender-query";
@@ -175,6 +175,28 @@ function assertProvisioningEnabled(): void {
       code: "PRECONDITION_FAILED",
       message:
         "Texting setup is almost ready. We are finishing carrier registration; check back soon.",
+    });
+  }
+}
+
+/**
+ * Hosted number orders can incur immediate and recurring provider charges.
+ * During controlled rollout, require an explicit tenant allowlist in addition
+ * to the global kill-switch. Self-hosters retain the existing switch-only path.
+ */
+function assertHostedProvisioningPracticeAllowed(practiceId: string): void {
+  if (!billingEnforced()) return;
+  const allowed = new Set(
+    (process.env.MESSAGING_PROVISIONING_PRACTICE_IDS ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+  );
+  if (!allowed.has(practiceId)) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Texting number setup is available only to approved pilot clinics. Contact OpenVPM support.",
     });
   }
 }
@@ -702,6 +724,7 @@ export const messagingRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       assertProvisioningEnabled();
+      assertHostedProvisioningPracticeAllowed(ctx.practiceId);
       await assertActivePractice(ctx);
       const [loc] = await ctx.db
         .select({ id: locations.id, name: locations.name, phone: locations.phone })

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -8,7 +8,7 @@
   "crons": [
     {
       "path": "/api/cron/reminders",
-      "schedule": "0 8 * * *"
+      "schedule": "0 * * * *"
     },
     {
       "path": "/api/cron/backup",

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -87,6 +87,7 @@ TELNYX_API_KEY=...
 TELNYX_PUBLIC_KEY=...
 MESSAGING_REGISTRATION_ENCRYPTION_KEY=... # openssl rand -base64 32
 MESSAGING_PROVISIONING_ENABLED=false
+MESSAGING_PROVISIONING_PRACTICE_IDS= # comma-separated approved pilot practice UUIDs
 AI_MODEL=claude-sonnet-4-6
 ANTHROPIC_API_KEY=...
 OPS_ALERT_WEBHOOK_URL=...
@@ -108,7 +109,12 @@ development calls that do not specify a location; do not point them at an
 individual clinic merely to satisfy readiness checks.
 Keep `MESSAGING_PROVISIONING_ENABLED=false` until the Telnyx account, webhook,
 operator queue, and budget controls have been verified; changing it to `true`
-opens the explicitly confirmed fee-bearing provisioning actions. For a
+opens the explicitly confirmed fee-bearing provisioning actions. Hosted
+number orders additionally require the clinic's practice UUID in
+`MESSAGING_PROVISIONING_PRACTICE_IDS`, so a controlled pilot does not expose
+purchases to every clinic admin. New OpenVPM-created messaging profiles enforce
+a `$10.00` daily Telnyx spend limit and smart encoding; review that cap before
+expanding beyond a design-partner pilot. For a
 Twilio fallback deployment, set `MESSAGING_PROVIDER=twilio` and provide
 `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER` instead of
 the Telnyx send envs.


### PR DESCRIPTION
## Summary
- run reminder delivery hourly so SMS-preferred clients can be reached during clinic-local daytime without changing their channel during quiet hours
- correct hosted-number eligibility calls and add provider-level spend/encoding controls
- require an explicit hosted pilot-clinic allowlist for fee-bearing number provisioning
- redact carrier tax identifiers from audit metadata and document the controlled rollout

## Release decision
This prepares one supervised, single-location US pilot using a newly purchased number. It does not enable provisioning, create carrier resources, or approve a broad texting launch. Existing-number hosting remains an operations-led path because ownership verification and documents are not implemented in-app.

## Verification
- 65 focused tests
- web TypeScript check
- git diff check
- Telnyx API shapes verified against current official documentation