### PR TITLE
Fix visit-work reconciliation SQL in live encounters

### DIFF
--- a/apps/web/server/__tests__/visit-work-reconciliation.test.ts
+++ b/apps/web/server/__tests__/visit-work-reconciliation.test.ts
@@ -321,6 +321,10 @@ describe("visit work reconciliation", () => {
       new URL("../routers/encounters.ts", import.meta.url),
       "utf8",
     );
+    const recordsRouter = readFileSync(
+      new URL("../routers/records.ts", import.meta.url),
+      "utf8",
+    );
     const migration = readFileSync(
       new URL(
         "../../../../packages/db/drizzle/0045_visit_work_ledger.sql",
@@ -335,6 +339,14 @@ describe("visit work reconciliation", () => {
     );
     expect(router).toContain("eq(invoices.practiceId, ctx.practiceId)");
     expect(router).toContain("eq(invoices.appointmentId, input.appointmentId)");
+    expect(router).toContain(
+      "(practice_id, appointment_id, vaccination_record_id)",
+    );
+    expect(recordsRouter).toContain(
+      "(practice_id, appointment_id, vaccination_record_id)",
+    );
+    expect(router).not.toContain("(${visitWorkItems.practiceId}");
+    expect(recordsRouter).not.toContain("(${visitWorkItems.practiceId}");
     expect(migration).toContain("visit_work_items_vaccination_source_fk");
     expect(migration).toContain("visit_work_items_lab_result_source_fk");
     expect(migration).toContain("visit_work_items_procedure_source_fk");

--- a/apps/web/server/routers/encounters.ts
+++ b/apps/web/server/routers/encounters.ts
@@ -517,7 +517,7 @@ async function syncVisitWorkItems(
 ) {
   await ctx.db.execute(sql`
     insert into ${visitWorkItems}
-      (${visitWorkItems.practiceId}, ${visitWorkItems.appointmentId}, ${visitWorkItems.vaccinationRecordId})
+      (practice_id, appointment_id, vaccination_record_id)
     select ${vaccinationRecords.practiceId}, ${vaccinationRecords.appointmentId}, ${vaccinationRecords.id}
     from ${vaccinationRecords}
     where ${vaccinationRecords.practiceId} = ${ctx.practiceId}
@@ -527,7 +527,7 @@ async function syncVisitWorkItems(
   `);
   await ctx.db.execute(sql`
     insert into ${visitWorkItems}
-      (${visitWorkItems.practiceId}, ${visitWorkItems.appointmentId}, ${visitWorkItems.labResultId})
+      (practice_id, appointment_id, lab_result_id)
     select ${labResults.practiceId}, ${labResults.appointmentId}, ${labResults.id}
     from ${labResults}
     where ${labResults.practiceId} = ${ctx.practiceId}
@@ -537,7 +537,7 @@ async function syncVisitWorkItems(
   `);
   await ctx.db.execute(sql`
     insert into ${visitWorkItems}
-      (${visitWorkItems.practiceId}, ${visitWorkItems.appointmentId}, ${visitWorkItems.procedureId})
+      (practice_id, appointment_id, procedure_id)
     select ${procedures.practiceId}, ${procedures.appointmentId}, ${procedures.id}
     from ${procedures}
     where ${procedures.practiceId} = ${ctx.practiceId}
@@ -547,7 +547,7 @@ async function syncVisitWorkItems(
   `);
   await ctx.db.execute(sql`
     insert into ${visitWorkItems}
-      (${visitWorkItems.practiceId}, ${visitWorkItems.appointmentId}, ${visitWorkItems.prescriptionId})
+      (practice_id, appointment_id, prescription_id)
     select ${prescriptions.practiceId}, ${prescriptions.appointmentId}, ${prescriptions.id}
     from ${prescriptions}
     where ${prescriptions.practiceId} = ${ctx.practiceId}

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -379,28 +379,28 @@ async function registerVisitWorkItem(
   if ("vaccinationRecordId" in source) {
     await ctx.db.execute(sql`
       insert into ${visitWorkItems}
-        (${visitWorkItems.practiceId}, ${visitWorkItems.appointmentId}, ${visitWorkItems.vaccinationRecordId})
+        (practice_id, appointment_id, vaccination_record_id)
       values (${ctx.practiceId}, ${appointmentId}, ${source.vaccinationRecordId})
       on conflict do nothing
     `);
   } else if ("labResultId" in source) {
     await ctx.db.execute(sql`
       insert into ${visitWorkItems}
-        (${visitWorkItems.practiceId}, ${visitWorkItems.appointmentId}, ${visitWorkItems.labResultId})
+        (practice_id, appointment_id, lab_result_id)
       values (${ctx.practiceId}, ${appointmentId}, ${source.labResultId})
       on conflict do nothing
     `);
   } else if ("procedureId" in source) {
     await ctx.db.execute(sql`
       insert into ${visitWorkItems}
-        (${visitWorkItems.practiceId}, ${visitWorkItems.appointmentId}, ${visitWorkItems.procedureId})
+        (practice_id, appointment_id, procedure_id)
       values (${ctx.practiceId}, ${appointmentId}, ${source.procedureId})
       on conflict do nothing
     `);
   } else {
     await ctx.db.execute(sql`
       insert into ${visitWorkItems}
-        (${visitWorkItems.practiceId}, ${visitWorkItems.appointmentId}, ${visitWorkItems.prescriptionId})
+        (practice_id, appointment_id, prescription_id)
       values (${ctx.practiceId}, ${appointmentId}, ${source.prescriptionId})
       on conflict do nothing
     `);


### PR DESCRIPTION
## Incident
A live demo clinic-day smoke test opened a new `in_exam` visit and the reconciliation query failed closed. Vercel runtime logs showed PostgreSQL rejecting the raw ledger upserts: `column "visit_work_items" of relation "visit_work_items" does not exist`.

## Root cause
Raw `INSERT` column lists interpolated Drizzle-qualified column objects. PostgreSQL does not permit those relation-qualified forms in an insert target column list.

## Fix
- use static, schema-owned column identifiers in all four encounter sync upserts
- apply the same correction to all four atomic record-registration upserts
- add regression assertions that reject the qualified target-column pattern

## Verification
- 81 focused visit/record/workspace tests passed
- `pnpm --filter @openpims/web type-check`
- `git diff --check`

No schema change or production mutation is included.