### PR TITLE
Enforce clinical visit integrity for live SOAP writes

### DIFF
--- a/apps/web/app/(dashboard)/agent/page.tsx
+++ b/apps/web/app/(dashboard)/agent/page.tsx
@@ -369,7 +369,7 @@ function AgentRunner() {
                 disabled={!canRun || run.isPending}
                 className="h-3.5 w-3.5 rounded border-border"
               />
-              Allow writes: appointments, vitals, and SOAP notes
+              Allow writes: appointments and patient vitals
             </label>
             <Button
               type="button"
@@ -391,8 +391,8 @@ function AgentRunner() {
           <div className="mt-2 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
             <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
             <p>
-              Write mode can create appointments, record vitals, or save SOAP
-              notes. It turns off automatically after this run.
+              Write mode can create appointments or record patient vitals. It
+              turns off automatically after this run.
             </p>
           </div>
         ) : null}

--- a/apps/web/app/(dashboard)/records/new-soap/[patientId]/page.tsx
+++ b/apps/web/app/(dashboard)/records/new-soap/[patientId]/page.tsx
@@ -91,7 +91,7 @@ export default function NewSoapNotePage() {
   } =
     trpc.patients.getById.useQuery(
       { id: params.patientId },
-      { enabled: !!params.patientId && canCreateSoapNote }
+      { enabled: !!params.patientId && canCreateSoapNote && !!appointmentId }
     );
 
   const createNote = trpc.records.createSoapNote.useMutation({
@@ -106,7 +106,7 @@ export default function NewSoapNotePage() {
 
   // AI draft availability mirrors the OpenVPM Agent (same key + model config).
   const agentStatus = trpc.agent.status.useQuery(undefined, {
-    enabled: canCreateSoapNote,
+    enabled: canCreateSoapNote && !!appointmentId,
   });
   const aiConfigured = agentStatus.data?.configured ?? false;
   const draftWithAi = trpc.ai.draftSoapNote.useMutation({
@@ -132,6 +132,10 @@ export default function NewSoapNotePage() {
   }
 
   function handleSave() {
+    if (!appointmentId) {
+      toast.error("Open an active visit before creating a SOAP note");
+      return;
+    }
     if (!params.patientId || !patient) {
       toast.error("Load the patient before saving a SOAP note");
       return;
@@ -196,6 +200,21 @@ export default function NewSoapNotePage() {
     );
   }
 
+  if (!appointmentId) {
+    return (
+      <EmptyState
+        icon={ClipboardList}
+        title="Open an active visit first"
+        description="SOAP notes must be attached to a visit that is currently in exam. Open the appointment from the schedule, start the exam, and write the note from the encounter workspace."
+        action={{
+          label: "Back to Records",
+          onClick: () => router.push("/records"),
+          icon: ArrowLeft,
+        }}
+      />
+    );
+  }
+
   if (patientLoading) {
     return (
       <div className="flex items-center justify-center gap-2 rounded-lg border border-border bg-card p-8 text-sm text-muted-foreground">
@@ -232,7 +251,7 @@ export default function NewSoapNotePage() {
         className="mb-4"
       >
         <ArrowLeft className="mr-2 h-4 w-4" />
-        {appointmentId ? "Back to visit" : "Back to Records"}
+        Back to visit
       </Button>
 
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -247,11 +266,9 @@ export default function NewSoapNotePage() {
               {patient.breed ? ` (${patient.breed})` : ""}
             </p>
           )}
-          {appointmentId ? (
-            <p className="text-xs text-muted-foreground">
-              This note will be linked to the current appointment.
-            </p>
-          ) : null}
+          <p className="text-xs text-muted-foreground">
+            This note will be linked to the current appointment.
+          </p>
         </div>
         <div className="flex flex-col items-end gap-1">
           <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/app/(dashboard)/records/page.tsx
+++ b/apps/web/app/(dashboard)/records/page.tsx
@@ -673,8 +673,6 @@ function RecordsPageContent() {
     !isLoadingProcedures &&
     !proceduresError &&
     !proceduresList;
-  const canCreateSoapNotes =
-    userRole === "admin" || userRole === "veterinarian";
   const canPrescribe = userRole === "admin" || userRole === "veterinarian";
   const canCreateVaccinations =
     userRole === "admin" ||
@@ -938,16 +936,6 @@ function RecordsPageContent() {
             Clinical documentation and patient history
           </p>
         </div>
-        {selectedPatient && canCreateSoapNotes && (
-          <Button
-            onClick={() =>
-              router.push(`/records/new-soap/${selectedPatient.id}`)
-            }
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            New SOAP Note
-          </Button>
-        )}
       </div>
 
       {/* Patient Search */}
@@ -1226,18 +1214,7 @@ function RecordsPageContent() {
                   <EmptyState
                     icon={FileText}
                     title="No SOAP notes yet"
-                    action={
-                      canCreateSoapNotes
-                        ? {
-                            label: "Create first note",
-                            onClick: () =>
-                              router.push(
-                                `/records/new-soap/${selectedPatient.id}`
-                              ),
-                            icon: Plus,
-                          }
-                        : undefined
-                    }
+                    description="SOAP notes are created from an active visit so documentation stays attached to the correct encounter."
                   />
                 )}
               </div>

--- a/apps/web/app/api-docs/ai/page.tsx
+++ b/apps/web/app/api-docs/ai/page.tsx
@@ -90,7 +90,7 @@ Content-Type: application/json`}
           <CodeBlock>
             {`{
   "patient_id": "uuid",          // Required - the patient record
-  "appointment_id": "uuid",      // Optional - link to appointment
+  "appointment_id": "uuid",      // Required - active in-exam appointment
   "author_id": "uuid",           // Optional if appointment has a doctor
   "subjective": "string",        // Patient history, owner complaints
   "objective": "string",         // Physical exam findings, vitals

--- a/apps/web/app/api-docs/page.tsx
+++ b/apps/web/app/api-docs/page.tsx
@@ -342,9 +342,10 @@ const sections: Section[] = [
       {
         name: "records.createSoapNote",
         method: "POST",
-        description: "Create a SOAP note.",
+        description: "Create a SOAP note for an active in-exam appointment.",
         input: `{
   patientId: string,
+  appointmentId: string,
   subjective: string,
   objective: string,
   assessment: string,
@@ -891,10 +892,10 @@ const sections: Section[] = [
         name: "POST /api/v1/soap-notes",
         method: "POST",
         description:
-          "Create a SOAP note for an external AI scribe and emit the soap_note.created webhook.",
+          "Create a SOAP note for an external AI scribe during an active in-exam appointment and emit the soap_note.created webhook.",
         input: `{
   patient_id: string,
-  appointment_id?: string,
+  appointment_id: string,
   author_id?: string,
   subjective?: string,
   objective?: string,

--- a/apps/web/app/api/v1/soap-notes/route.test.ts
+++ b/apps/web/app/api/v1/soap-notes/route.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => {
   const selectBuilders: Array<{
     from: ReturnType<typeof vi.fn>;
     where: ReturnType<typeof vi.fn>;
+    for: ReturnType<typeof vi.fn>;
     limit: ReturnType<typeof vi.fn>;
   }> = [];
   const insertRow = {
@@ -29,6 +30,7 @@ const mocks = vi.hoisted(() => {
       const builder = {
         from: vi.fn(() => builder),
         where: vi.fn(() => builder),
+        for: vi.fn(async () => result),
         limit: vi.fn(async () => result),
       };
       selectBuilders.push(builder);
@@ -171,7 +173,6 @@ describe("POST /api/v1/soap-notes", () => {
     const response = await POST(
       request(
         soapBody({
-          appointment_id: undefined,
           subjective: "<p><br></p>",
           plan: "&nbsp;",
           author_id: AUTHOR_ID,
@@ -205,19 +206,35 @@ describe("POST /api/v1/soap-notes", () => {
     expect(mocks.db.insert).not.toHaveBeenCalled();
   });
 
-  it("requires an explicit author when no appointment doctor can be inferred", async () => {
+  it("requires an appointment before tenant work", async () => {
     const response = await POST(
       request(soapBody({ appointment_id: undefined, author_id: undefined }))
     );
 
     expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error.message).toBe("Validation failed");
+    expect(json.error.fields.appointment_id).toEqual([expect.any(String)]);
+    expect(mocks.withTenant).not.toHaveBeenCalled();
+  });
+
+  it("requires an explicit clinician when the appointment has no assigned doctor", async () => {
+    mocks.selectResults.push(
+      ACTIVE_PRACTICE,
+      [{ id: PATIENT_ID }],
+      [{ id: APPOINTMENT_ID, doctorId: null, status: "in_exam" }],
+      []
+    );
+
+    const response = await POST(request(soapBody({ author_id: undefined })));
+
+    expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
       error: {
-        message:
-          "author_id is required unless appointment_id has an assigned doctor.",
+        message: "author_id is required when the appointment has no assigned doctor.",
       },
     });
-    expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect(mocks.db.insert).not.toHaveBeenCalled();
   });
 
   it("rejects unowned or deleted patients before inserting", async () => {
@@ -283,7 +300,8 @@ describe("POST /api/v1/soap-notes", () => {
     mocks.selectResults.push(
       ACTIVE_PRACTICE,
       [{ id: PATIENT_ID }],
-      [{ id: APPOINTMENT_ID, doctorId: AUTHOR_ID }],
+      [{ id: APPOINTMENT_ID, doctorId: AUTHOR_ID, status: "in_exam" }],
+      [],
       []
     );
 
@@ -296,7 +314,7 @@ describe("POST /api/v1/soap-notes", () => {
     expect(mocks.db.insert).not.toHaveBeenCalled();
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
 
-    const authorCondition = mocks.selectBuilders[3]?.where.mock.calls[0]?.[0];
+    const authorCondition = mocks.selectBuilders[4]?.where.mock.calls[0]?.[0];
     expect(sqlIncludesColumn(authorCondition, users.practiceId)).toBe(true);
     expect(sqlIncludesColumn(authorCondition, users.deletedAt)).toBe(true);
   });
@@ -305,7 +323,8 @@ describe("POST /api/v1/soap-notes", () => {
     mocks.selectResults.push(
       ACTIVE_PRACTICE,
       [{ id: PATIENT_ID }],
-      [{ id: APPOINTMENT_ID, doctorId: AUTHOR_ID }],
+      [{ id: APPOINTMENT_ID, doctorId: AUTHOR_ID, status: "in_exam" }],
+      [],
       [{ id: AUTHOR_ID }]
     );
 

--- a/apps/web/app/api/v1/soap-notes/route.ts
+++ b/apps/web/app/api/v1/soap-notes/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import type { Database } from "@openpims/db/client";
-import { appointments, patients, soapNotes, users } from "@openpims/db";
+import { patients, soapNotes, users } from "@openpims/db";
 import { authenticateApiKey } from "@/lib/api-auth";
 import { withTenant } from "@/lib/tenant-db";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
@@ -22,11 +22,12 @@ import {
   normalizeSoapSection,
 } from "@/lib/records/soap-content";
 import { assertActivePractice } from "@/lib/compat/shared/active-practice";
+import { lockOpenVisitForClinicalAppend } from "@/lib/records/visit-integrity";
 
 export const dynamic = "force-dynamic";
 
 const AUTHOR_REQUIRED_MESSAGE =
-  "author_id is required unless appointment_id has an assigned doctor.";
+  "author_id is required when the appointment has no assigned doctor.";
 
 type TargetValidationResult =
   | { ok: true; authorId: string }
@@ -53,28 +54,25 @@ async function validateSoapTargets(
     return { ok: false, response: apiError("Patient not found", 404) };
   }
 
-  let appointmentDoctorId: string | null = null;
-  if (input.appointment_id) {
-    const [appointment] = await tx
-      .select({ id: appointments.id, doctorId: appointments.doctorId })
-      .from(appointments)
-      .where(
-        and(
-          eq(appointments.id, input.appointment_id),
-          eq(appointments.patientId, input.patient_id),
-          eq(appointments.practiceId, practiceId),
-          isNull(appointments.deletedAt)
-        )
-      )
-      .limit(1);
-
-    if (!appointment) {
-      return { ok: false, response: apiError("Appointment not found", 404) };
-    }
-    appointmentDoctorId = appointment.doctorId;
+  const visit = await lockOpenVisitForClinicalAppend(tx, {
+    practiceId,
+    patientId: input.patient_id,
+    appointmentId: input.appointment_id,
+  });
+  if (!visit.ok && visit.reason === "appointment_not_found") {
+    return { ok: false, response: apiError("Appointment not found", 404) };
+  }
+  if (!visit.ok) {
+    return {
+      ok: false,
+      response: apiError(
+        "SOAP notes can only be added while the visit is in exam.",
+        409
+      ),
+    };
   }
 
-  const authorId = input.author_id ?? appointmentDoctorId;
+  const authorId = input.author_id ?? visit.appointment.doctorId;
   if (!authorId) {
     return { ok: false, response: apiError(AUTHOR_REQUIRED_MESSAGE, 400) };
   }
@@ -125,10 +123,6 @@ export async function POST(req: Request) {
     if (!hasSoapContent(normalizedNote)) {
       return apiError("SOAP note must include at least one section.", 400);
     }
-    if (!parsed.data.author_id && !parsed.data.appointment_id) {
-      return apiError(AUTHOR_REQUIRED_MESSAGE, 400);
-    }
-
     const result = await withTenant(db, auth.ctx.practiceId, async (tx) => {
       const activePractice = await assertActivePractice(tx, auth.ctx.practiceId);
       if (!activePractice.ok) {
@@ -148,7 +142,7 @@ export async function POST(req: Request) {
         .insert(soapNotes)
         .values({
           patientId: parsed.data.patient_id,
-          appointmentId: parsed.data.appointment_id ?? null,
+          appointmentId: parsed.data.appointment_id,
           authorId: targets.authorId,
           ...normalizedNote,
           practiceId: auth.ctx.practiceId,

--- a/apps/web/lib/__tests__/agent-ui-states.test.ts
+++ b/apps/web/lib/__tests__/agent-ui-states.test.ts
@@ -38,11 +38,11 @@ describe("agent UI states", () => {
 
   it("makes clinical write mode explicit and one-run only", () => {
     expect(source).toContain(
-      "Allow writes: appointments, vitals, and SOAP notes"
+      "Allow writes: appointments and patient vitals"
     );
     expect(source).toContain("Write mode can create appointments");
-    expect(source).toContain("record vitals");
-    expect(source).toContain("save SOAP");
+    expect(source).toContain("record patient vitals");
+    expect(source).not.toContain("save SOAP");
     expect(source).toContain("turns off automatically after this run");
     expect(source).not.toContain("Allow writes (e.g. booking appointments)");
   });

--- a/apps/web/lib/__tests__/api-docs.test.ts
+++ b/apps/web/lib/__tests__/api-docs.test.ts
@@ -98,6 +98,7 @@ describe("API reference docs", () => {
     expect(source).toContain("### `POST /api/v1/soap-notes`");
     expect(source).toContain("Scope `records:write`");
     expect(source).toContain("`soap_note.created` webhook");
+    expect(source).toContain("active in-exam appointment");
     expect(source).toContain(
       "`instruction` must contain non-whitespace text and is trimmed"
     );

--- a/apps/web/lib/__tests__/soap-editor-ui.test.ts
+++ b/apps/web/lib/__tests__/soap-editor-ui.test.ts
@@ -124,8 +124,10 @@ describe("SOAP note editor UX", () => {
       'const accessDenied = status !== "loading" && !canCreateSoapNote'
     );
     expect(source).toContain(
-      "{ enabled: !!params.patientId && canCreateSoapNote }"
+      "{ enabled: !!params.patientId && canCreateSoapNote && !!appointmentId }"
     );
+    expect(source).toContain('title="Open an active visit first"');
+    expect(source).toContain("if (!appointmentId)");
     expect(source).toContain('if (status === "loading")');
     expect(source).toContain("Checking SOAP note access");
     expect(source.indexOf("const [subjective")).toBeLessThan(
@@ -491,9 +493,11 @@ describe("records page state handling", () => {
   it("keeps Records write controls aligned to clinical role gates", () => {
     const source = readFileSync("app/(dashboard)/records/page.tsx", "utf8");
 
-    expect(source).toContain("const canCreateSoapNotes =");
-    expect(source).toContain("selectedPatient && canCreateSoapNotes");
-    expect(source).toContain("canCreateSoapNotes\n                        ? {");
+    expect(source).not.toContain("const canCreateSoapNotes =");
+    expect(source).not.toContain("/records/new-soap/");
+    expect(source).toContain(
+      "SOAP notes are created from an active visit so documentation stays attached to the correct encounter."
+    );
     expect(source).toContain("const canPrescribe =");
     expect(source).toContain("const canCreateVaccinations =");
     expect(source).toContain("const canManageProblems =");

--- a/apps/web/lib/agent/__tests__/tools.test.ts
+++ b/apps/web/lib/agent/__tests__/tools.test.ts
@@ -27,7 +27,6 @@ import {
   DOSING_WEIGHT_MAX_KG,
   FORMULARY_DRUG_ID_MAX_LENGTH,
 } from "@/lib/dosing";
-import { SOAP_SECTION_MAX_LENGTH } from "@/lib/records/soap-content";
 
 // The DB is never touched by these tests — only pure tools (calculate_drug_dose)
 // are executed; DB-backed tools are exercised at the validation layer.
@@ -84,7 +83,6 @@ describe("agent tool registry", () => {
     const writeTools = AGENT_TOOLS.filter((t) => !t.readOnly).map((t) => t.name).sort();
     expect(writeTools).toEqual([
       "book_appointment",
-      "record_soap_note",
       "record_vital_signs",
     ]);
   });
@@ -99,7 +97,6 @@ describe("agent tool registry", () => {
 
     expect(writeToolScopes).toEqual({
       book_appointment: ["appointments:write"],
-      record_soap_note: ["records:write"],
       record_vital_signs: ["records:write"],
     });
   });
@@ -114,6 +111,7 @@ describe("agent tool registry", () => {
 
   it("getTool resolves by name and returns undefined otherwise", () => {
     expect(getTool("find_client")?.name).toBe("find_client");
+    expect(getTool("record_soap_note")).toBeUndefined();
     expect(getTool("nope")).toBeUndefined();
   });
 });
@@ -194,7 +192,6 @@ describe("agent tool input bounds", () => {
     const findClient = getTool("find_client")!;
     const bookAppointment = getTool("book_appointment")!;
     const recordVitals = getTool("record_vital_signs")!;
-    const recordSoapNote = getTool("record_soap_note")!;
 
     const query = findClient.zod.safeParse({ query: "  Ada  " });
     expect(query.success).toBe(true);
@@ -222,12 +219,6 @@ describe("agent tool input bounds", () => {
       }).success
     ).toBe(false);
 
-    expect(
-      recordSoapNote.zod.safeParse({
-        patientId: PATIENT_ID,
-        subjective: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
-      }).success
-    ).toBe(false);
   });
 });
 
@@ -447,109 +438,6 @@ describe("record_vital_signs validation", () => {
         weightKg: "12.3",
         notes: "Bright and alert",
       })
-    );
-  });
-});
-
-describe("record_soap_note validation", () => {
-  const tool = getTool("record_soap_note")!;
-  const SOAP_ID = "00000000-0000-0000-0000-0000000000d1";
-  const APPOINTMENT_ID = "00000000-0000-0000-0000-0000000000d2";
-
-  it("rejects notes with only empty rich-text markup before inserting", async () => {
-    const { ctx, insert } = toolDb([[{ id: PATIENT_ID, clientId: CLIENT_ID }]], {});
-
-    const result = await tool.execute(
-      {
-        patientId: PATIENT_ID,
-        subjective: "<p><br></p>",
-        objective: "<ul><li>&nbsp;</li></ul>",
-      },
-      ctx
-    );
-
-    expect(result).toEqual({
-      error: "SOAP note must include at least one section.",
-    });
-    expect(insert).not.toHaveBeenCalled();
-    expect(webhookMocks.dispatchWebhookEvent).not.toHaveBeenCalled();
-  });
-
-  it("rejects missing or inactive patients before inserting a SOAP note", async () => {
-    const { ctx, insert } = toolDb([[]], {});
-
-    const result = await tool.execute(
-      { patientId: PATIENT_ID, subjective: "Eating well" },
-      ctx
-    );
-
-    expect(result).toEqual({ error: "Patient not found" });
-    expect(insert).not.toHaveBeenCalled();
-    expect(webhookMocks.dispatchWebhookEvent).not.toHaveBeenCalled();
-  });
-
-  it("rejects stale or non-patient appointments before inserting a SOAP note", async () => {
-    const { ctx, insert } = toolDb(
-      [[{ id: PATIENT_ID, clientId: CLIENT_ID }], []],
-      {}
-    );
-
-    const result = await tool.execute(
-      {
-        patientId: PATIENT_ID,
-        appointmentId: APPOINTMENT_ID,
-        subjective: "Eating well",
-      },
-      ctx
-    );
-
-    expect(result).toEqual({ error: "Appointment not found" });
-    expect(insert).not.toHaveBeenCalled();
-    expect(webhookMocks.dispatchWebhookEvent).not.toHaveBeenCalled();
-  });
-
-  it("creates a SOAP note with the current user as author after target validation", async () => {
-    const { ctx, insertValues } = toolDb(
-      [[{ id: PATIENT_ID, clientId: CLIENT_ID }], [{ id: APPOINTMENT_ID }]],
-      {
-        id: SOAP_ID,
-        patientId: PATIENT_ID,
-        appointmentId: APPOINTMENT_ID,
-        authorId: "agent-user",
-      }
-    );
-
-    const result = await tool.execute(
-      {
-        patientId: PATIENT_ID,
-        appointmentId: APPOINTMENT_ID,
-        subjective: " Eating well ",
-        assessment: "<p>Stable.</p>",
-      },
-      ctx
-    );
-
-    expect(result).toEqual({ id: SOAP_ID, patientId: PATIENT_ID });
-    expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({
-        practiceId: PRACTICE_ID,
-        patientId: PATIENT_ID,
-        appointmentId: APPOINTMENT_ID,
-        authorId: "agent-user",
-        subjective: "Eating well",
-        assessment: "<p>Stable.</p>",
-      })
-    );
-    expect(webhookMocks.dispatchWebhookEvent).toHaveBeenCalledWith(
-      PRACTICE_ID,
-      "soap_note.created",
-      {
-        id: SOAP_ID,
-        patientId: PATIENT_ID,
-        appointmentId: APPOINTMENT_ID,
-        authorId: "agent-user",
-        source: "agent",
-      }
     );
   });
 });

--- a/apps/web/lib/agent/runner.ts
+++ b/apps/web/lib/agent/runner.ts
@@ -37,7 +37,6 @@ You help practice staff by using the provided tools to read and act on practice 
 - You operate on a single practice's data; you cannot see other practices.
 - For any drug dose, use calculate_drug_dose and present it as a reference range that the prescribing clinician must verify. Never present a dose as a final prescribing decision.
 - Before booking an appointment, confirm you have the right client and patient (use find_client / get_patient_summary first when ids are not given).
-- Only create SOAP notes when staff explicitly asks you to draft or record one; keep notes factual, concise, and ready for clinician review.
 - Be concise and clinical. Surface warnings the tools return.`;
 
 export interface AgentToolCall {

--- a/apps/web/lib/agent/tools.ts
+++ b/apps/web/lib/agent/tools.ts
@@ -27,7 +27,6 @@ import {
   users,
   rooms,
   practices,
-  soapNotes,
 } from "@openpims/db";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
 import { appointmentCreatedWebhookPayload } from "@/lib/appointment-webhooks";
@@ -57,11 +56,6 @@ import {
   clinicalDecimalInput,
   optionalClinicalTextInput,
 } from "@/lib/records/clinical-inputs";
-import {
-  hasSoapContent,
-  normalizeSoapSection,
-  SOAP_SECTION_MAX_LENGTH,
-} from "@/lib/records/soap-content";
 
 /**
  * The agent's "hands": typed tools that operate the practice's data, always
@@ -188,26 +182,6 @@ async function activePatient(
     )
     .limit(1);
   return patient ?? null;
-}
-
-async function activeAppointmentForPatient(
-  ctx: AgentToolContext,
-  appointmentId: string,
-  patientId: string
-): Promise<boolean> {
-  const [appointment] = await ctx.db
-    .select({ id: appointments.id })
-    .from(appointments)
-    .where(
-      and(
-        eq(appointments.id, appointmentId),
-        eq(appointments.patientId, patientId),
-        eq(appointments.practiceId, ctx.practiceId),
-        isNull(appointments.deletedAt)
-      )
-    )
-    .limit(1);
-  return Boolean(appointment);
 }
 
 async function activeDoctorExists(
@@ -803,104 +777,6 @@ const recordVitalSigns: AgentTool = {
   },
 };
 
-const recordSoapNote: AgentTool = {
-  name: "record_soap_note",
-  description:
-    "Create a SOAP note for a patient. Use only after grounding the note in the chart or staff-provided transcript.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      patientId: { type: "string", description: "Patient UUID" },
-      appointmentId: {
-        type: "string",
-        description: "Optional appointment UUID",
-      },
-      subjective: { type: "string", maxLength: SOAP_SECTION_MAX_LENGTH },
-      objective: { type: "string", maxLength: SOAP_SECTION_MAX_LENGTH },
-      assessment: { type: "string", maxLength: SOAP_SECTION_MAX_LENGTH },
-      plan: { type: "string", maxLength: SOAP_SECTION_MAX_LENGTH },
-    },
-    required: ["patientId"],
-  },
-  zod: z.object({
-    patientId: z.string().uuid(),
-    appointmentId: z.string().uuid().optional(),
-    subjective: optionalClinicalTextInput(
-      "SOAP subjective",
-      SOAP_SECTION_MAX_LENGTH
-    ),
-    objective: optionalClinicalTextInput(
-      "SOAP objective",
-      SOAP_SECTION_MAX_LENGTH
-    ),
-    assessment: optionalClinicalTextInput(
-      "SOAP assessment",
-      SOAP_SECTION_MAX_LENGTH
-    ),
-    plan: optionalClinicalTextInput("SOAP plan", SOAP_SECTION_MAX_LENGTH),
-  }),
-  readOnly: false,
-  requiredApiScopes: ["records:write"],
-  async execute(args, ctx) {
-    const input = this.zod.parse(args) as {
-      patientId: string;
-      appointmentId?: string;
-      subjective?: string;
-      objective?: string;
-      assessment?: string;
-      plan?: string;
-    };
-    if (!(await activePatient(ctx, input.patientId))) {
-      return { error: "Patient not found" };
-    }
-    if (
-      input.appointmentId &&
-      !(await activeAppointmentForPatient(
-        ctx,
-        input.appointmentId,
-        input.patientId
-      ))
-    ) {
-      return { error: "Appointment not found" };
-    }
-
-    const normalizedNote = {
-      subjective: normalizeSoapSection(input.subjective),
-      objective: normalizeSoapSection(input.objective),
-      assessment: normalizeSoapSection(input.assessment),
-      plan: normalizeSoapSection(input.plan),
-    };
-    if (!hasSoapContent(normalizedNote)) {
-      return { error: "SOAP note must include at least one section." };
-    }
-
-    const [note] = await ctx.db
-      .insert(soapNotes)
-      .values({
-        practiceId: ctx.practiceId,
-        patientId: input.patientId,
-        appointmentId: input.appointmentId ?? null,
-        authorId: ctx.userId,
-        ...normalizedNote,
-      })
-      .returning({
-        id: soapNotes.id,
-        patientId: soapNotes.patientId,
-        appointmentId: soapNotes.appointmentId,
-        authorId: soapNotes.authorId,
-      });
-
-    await dispatchWebhookEvent(ctx.practiceId, "soap_note.created", {
-      id: note!.id,
-      patientId: note!.patientId,
-      appointmentId: note!.appointmentId,
-      authorId: note!.authorId,
-      source: "agent",
-    });
-    return { id: note!.id, patientId: note!.patientId };
-  },
-};
-
 const findOpenSlotsTool: AgentTool = {
   name: "find_open_slots",
   description:
@@ -987,7 +863,6 @@ export const AGENT_TOOLS: AgentTool[] = [
   calculateDrugDose,
   listTreatmentPlans,
   recordVitalSigns,
-  recordSoapNote,
 ];
 
 export function getTool(name: string): AgentTool | undefined {

--- a/apps/web/lib/compat/openvpm/__tests__/schema.test.ts
+++ b/apps/web/lib/compat/openvpm/__tests__/schema.test.ts
@@ -155,4 +155,13 @@ describe("SoapNoteCreateSchema validation", () => {
     });
     expect(r.success).toBe(false);
   });
+
+  it("rejects patient-only live SOAP notes without an appointment", () => {
+    const r = SoapNoteCreateSchema.safeParse({
+      patient_id: "22222222-2222-2222-2222-222222222222",
+      subjective: "Eating well",
+      source: "scribenote",
+    });
+    expect(r.success).toBe(false);
+  });
 });

--- a/apps/web/lib/compat/openvpm/schema.ts
+++ b/apps/web/lib/compat/openvpm/schema.ts
@@ -127,7 +127,7 @@ export const AppointmentCreateSchema = z
 /** Inbound body for POST /api/v1/soap-notes. */
 export const SoapNoteCreateSchema = z.object({
   patient_id: z.string().uuid(),
-  appointment_id: z.string().uuid().optional(),
+  appointment_id: z.string().uuid(),
   author_id: z.string().uuid().optional(),
   subjective: ApiSoapSectionInputSchema,
   objective: ApiSoapSectionInputSchema,

--- a/apps/web/lib/records/__tests__/visit-integrity.test.ts
+++ b/apps/web/lib/records/__tests__/visit-integrity.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+import { appointments, practices } from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+import { lockOpenVisitForClinicalAppend } from "../visit-integrity";
+
+const PRACTICE_ID = "00000000-0000-0000-0000-000000000001";
+const PATIENT_ID = "00000000-0000-0000-0000-000000000002";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000003";
+const DOCTOR_ID = "00000000-0000-0000-0000-000000000004";
+
+function sqlIncludesColumn(
+  value: unknown,
+  column: unknown,
+  seen = new WeakSet<object>(),
+): boolean {
+  if (Object.is(value, column)) return true;
+  if (!value || typeof value !== "object" || seen.has(value)) return false;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.some((item) => sqlIncludesColumn(item, column, seen));
+  }
+  return Object.values(value as Record<string, unknown>).some((item) =>
+    sqlIncludesColumn(item, column, seen),
+  );
+}
+
+function visitDb(selectResults: unknown[][]) {
+  const results = [...selectResults];
+  const builders: Array<{
+    where: ReturnType<typeof vi.fn>;
+    for: ReturnType<typeof vi.fn>;
+  }> = [];
+  const select = vi.fn(() => {
+    const result = results.shift() ?? [];
+    const builder = {
+      from: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      for: vi.fn(async () => result),
+      limit: vi.fn(async () => result),
+    };
+    builders.push(builder);
+    return builder;
+  });
+  return { db: { select } as unknown as Database, builders };
+}
+
+function guard(db: Database) {
+  return lockOpenVisitForClinicalAppend(db, {
+    practiceId: PRACTICE_ID,
+    patientId: PATIENT_ID,
+    appointmentId: APPOINTMENT_ID,
+  });
+}
+
+describe("lockOpenVisitForClinicalAppend", () => {
+  it("fails closed for cross-tenant, wrong-patient, deleted, or missing appointments", async () => {
+    const { db, builders } = visitDb([[]]);
+
+    await expect(guard(db)).resolves.toEqual({
+      ok: false,
+      reason: "appointment_not_found",
+    });
+
+    const condition = builders[0]!.where.mock.calls[0]![0];
+    expect(sqlIncludesColumn(condition, appointments.id)).toBe(true);
+    expect(sqlIncludesColumn(condition, appointments.patientId)).toBe(true);
+    expect(sqlIncludesColumn(condition, appointments.practiceId)).toBe(true);
+    expect(sqlIncludesColumn(condition, appointments.deletedAt)).toBe(true);
+    expect(sqlIncludesColumn(condition, practices.id)).toBe(true);
+    expect(sqlIncludesColumn(condition, practices.deletedAt)).toBe(true);
+    expect(builders[0]!.for).toHaveBeenCalledWith("update");
+  });
+
+  it("rejects completed and otherwise non-open appointment states", async () => {
+    const { db } = visitDb([
+      [
+        {
+          id: APPOINTMENT_ID,
+          doctorId: DOCTOR_ID,
+          status: "checked_out",
+        },
+      ],
+    ]);
+
+    await expect(guard(db)).resolves.toEqual({
+      ok: false,
+      reason: "visit_not_open",
+    });
+  });
+
+  it.each(["clinical_finalized", "completed"] as const)(
+    "rejects an in-exam visit whose clinical closeout is %s",
+    async (status) => {
+      const { db } = visitDb([
+        [
+          {
+            id: APPOINTMENT_ID,
+            doctorId: DOCTOR_ID,
+            status: "in_exam",
+          },
+        ],
+        [{ status }],
+      ]);
+
+      await expect(guard(db)).resolves.toEqual({
+        ok: false,
+        reason: "visit_finalized",
+      });
+    },
+  );
+
+  it("returns the assigned clinician for a valid open visit", async () => {
+    const { db } = visitDb([
+      [
+        {
+          id: APPOINTMENT_ID,
+          doctorId: DOCTOR_ID,
+          status: "in_exam",
+        },
+      ],
+      [{ status: "draft" }],
+    ]);
+
+    await expect(guard(db)).resolves.toEqual({
+      ok: true,
+      appointment: {
+        id: APPOINTMENT_ID,
+        doctorId: DOCTOR_ID,
+        status: "in_exam",
+      },
+    });
+  });
+});

--- a/apps/web/lib/records/visit-integrity.ts
+++ b/apps/web/lib/records/visit-integrity.ts
@@ -1,0 +1,87 @@
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { appointments, practices, visitCloseouts } from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+
+export type ClinicalAppendFailure =
+  | "appointment_not_found"
+  | "visit_not_open"
+  | "visit_finalized";
+
+export type ClinicalAppendGuard =
+  | {
+      ok: true;
+      appointment: {
+        id: string;
+        doctorId: string | null;
+        status: "in_exam";
+      };
+    }
+  | { ok: false; reason: ClinicalAppendFailure };
+
+/**
+ * Lock and validate a visit before appending appointment-linked clinical data.
+ * The caller must keep this transaction open through the subsequent write so
+ * closeout/finalization cannot race the append after validation.
+ */
+export async function lockOpenVisitForClinicalAppend(
+  db: Database,
+  input: { practiceId: string; patientId: string; appointmentId: string },
+): Promise<ClinicalAppendGuard> {
+  const [appointment] = await db
+    .select({
+      id: appointments.id,
+      doctorId: appointments.doctorId,
+      status: appointments.status,
+    })
+    .from(appointments)
+    .where(
+      and(
+        eq(appointments.id, input.appointmentId),
+        eq(appointments.patientId, input.patientId),
+        eq(appointments.practiceId, input.practiceId),
+        isNull(appointments.deletedAt),
+        sql`exists (
+          select 1
+          from ${practices}
+          where ${practices.id} = ${input.practiceId}
+            and ${practices.deletedAt} is null
+        )`,
+      ),
+    )
+    .for("update");
+
+  if (!appointment) {
+    return { ok: false, reason: "appointment_not_found" };
+  }
+  if (appointment.status !== "in_exam") {
+    return { ok: false, reason: "visit_not_open" };
+  }
+
+  const [closeout] = await db
+    .select({ status: visitCloseouts.status })
+    .from(visitCloseouts)
+    .where(
+      and(
+        eq(visitCloseouts.appointmentId, appointment.id),
+        eq(visitCloseouts.practiceId, input.practiceId),
+        isNull(visitCloseouts.deletedAt),
+      ),
+    )
+    .limit(1);
+
+  if (
+    closeout?.status === "clinical_finalized" ||
+    closeout?.status === "completed"
+  ) {
+    return { ok: false, reason: "visit_finalized" };
+  }
+
+  return {
+    ok: true,
+    appointment: {
+      id: appointment.id,
+      doctorId: appointment.doctorId,
+      status: "in_exam",
+    },
+  };
+}

--- a/apps/web/server/__tests__/ai-safety.test.ts
+++ b/apps/web/server/__tests__/ai-safety.test.ts
@@ -40,6 +40,7 @@ function createDb(opts?: {
     const result = selectResults.shift() ?? [];
     const afterWhere = {
       limit: vi.fn(async () => result),
+      for: vi.fn(async () => result),
       groupBy: vi.fn(async () => result),
       orderBy: vi.fn(async () => result),
       then: (
@@ -79,6 +80,21 @@ afterEach(() => {
 });
 
 describe("AI SOAP note safety", () => {
+  it("rejects a patient-only live AI SOAP note before querying", async () => {
+    const { db, select, insertValues } = createDb();
+
+    await expect(
+      callerWithDb(db).createSoapFromAI({
+        patientId: PATIENT_ID,
+        subjective: "Eating well",
+        source: "scribe",
+      } as never)
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("requires a tenant-owned patient before creating an AI SOAP note", async () => {
     const { db, insertValues } = createDb({
       selectResults: [[{ id: PRACTICE_ID }], []],
@@ -87,6 +103,7 @@ describe("AI SOAP note safety", () => {
     await expect(
       callerWithDb(db).createSoapFromAI({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         subjective: "Eating well",
         source: "scribe",
       })
@@ -95,7 +112,7 @@ describe("AI SOAP note safety", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("requires optional appointments to belong to the selected patient", async () => {
+  it("requires the appointment to belong to the selected patient", async () => {
     const { db, insertValues } = createDb({
       selectResults: [[{ id: PRACTICE_ID }], [{ id: PATIENT_ID }], []],
     });
@@ -117,7 +134,8 @@ describe("AI SOAP note safety", () => {
       selectResults: [
         [{ id: PRACTICE_ID }],
         [{ id: PATIENT_ID }],
-        [{ id: APPOINTMENT_ID }],
+        [{ id: APPOINTMENT_ID, doctorId: USER_ID, status: "in_exam" }],
+        [],
       ],
       insertedRows: [{ id: NOTE_ID, patientId: PATIENT_ID }],
     });
@@ -153,6 +171,7 @@ describe("AI SOAP note safety", () => {
     await expect(
       callerWithDb(db).createSoapFromAI({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         subjective: "<p><br></p>",
         plan: "&nbsp;",
         source: "scribe",
@@ -168,6 +187,7 @@ describe("AI SOAP note safety", () => {
     await expect(
       callerWithDb(db).createSoapFromAI({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         subjective: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
         source: "scribe",
       })
@@ -176,6 +196,7 @@ describe("AI SOAP note safety", () => {
     await expect(
       callerWithDb(db).createSoapFromAI({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         objective: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
         source: "scribe",
       })
@@ -184,6 +205,7 @@ describe("AI SOAP note safety", () => {
     await expect(
       callerWithDb(db).createSoapFromAI({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         assessment: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
         source: "scribe",
       })
@@ -192,6 +214,7 @@ describe("AI SOAP note safety", () => {
     await expect(
       callerWithDb(db).createSoapFromAI({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         plan: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
         source: "scribe",
       })
@@ -207,6 +230,7 @@ describe("AI SOAP note safety", () => {
     await expect(
       callerWithDb(db).createSoapFromAI({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         subjective: "Eating well",
         source: "A".repeat(AI_SOURCE_MAX_LENGTH + 1),
       })
@@ -222,6 +246,7 @@ describe("AI SOAP note safety", () => {
     await expect(
       callerWithDb(db).createSoapFromAI({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         subjective: "Eating well",
         source: "scribe",
       })

--- a/apps/web/server/__tests__/records-target-safety.test.ts
+++ b/apps/web/server/__tests__/records-target-safety.test.ts
@@ -113,7 +113,23 @@ afterEach(() => {
 
 describe("records target safety", () => {
   const patientRow = [{ id: PATIENT_ID }];
-  const appointmentRow = [{ id: APPOINTMENT_ID }];
+  const appointmentRow = [
+    { id: APPOINTMENT_ID, doctorId: USER_ID, status: "in_exam" },
+  ];
+
+  it("rejects a patient-only live SOAP note before querying", async () => {
+    const { db, select, insertValues } = createDb();
+
+    await expect(
+      callerWithDb(db).createSoapNote({
+        patientId: PATIENT_ID,
+        subjective: "Eating well",
+      } as never)
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
 
   it("returns active practice identity for Records date rendering and PDFs", async () => {
     const { db, select } = createDb({
@@ -181,6 +197,7 @@ describe("records target safety", () => {
     await expect(
       callerWithDb(db).createSoapNote({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         subjective: "Eating well",
       })
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
@@ -375,7 +392,7 @@ describe("records target safety", () => {
 
   it("creates a SOAP note after validating patient and appointment ownership", async () => {
     const { db, insertValues } = createDb({
-      selectResults: [patientRow, appointmentRow],
+      selectResults: [patientRow, appointmentRow, []],
       insertedRows: [
         {
           id: RECORD_ID,
@@ -423,6 +440,7 @@ describe("records target safety", () => {
     await expect(
       callerWithDb(db).createSoapNote({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         subjective: "<p><br></p>",
         objective: "<ul><li>&nbsp;</li></ul>",
       })
@@ -438,6 +456,7 @@ describe("records target safety", () => {
     await expect(
       callerWithDb(db).createSoapNote({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         subjective: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
       })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
@@ -445,6 +464,7 @@ describe("records target safety", () => {
     await expect(
       callerWithDb(db).createSoapNote({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         objective: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
       })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
@@ -452,6 +472,7 @@ describe("records target safety", () => {
     await expect(
       callerWithDb(db).createSoapNote({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         assessment: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
       })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
@@ -459,6 +480,7 @@ describe("records target safety", () => {
     await expect(
       callerWithDb(db).createSoapNote({
         patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
         plan: "A".repeat(SOAP_SECTION_MAX_LENGTH + 1),
       })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });

--- a/apps/web/server/__tests__/vitals-record.test.ts
+++ b/apps/web/server/__tests__/vitals-record.test.ts
@@ -36,6 +36,7 @@ function callerWithDb(db: Record<string, unknown>, role = "technician") {
 function thenableRows(result: unknown[]) {
   return {
     limit: vi.fn(async () => result),
+    for: vi.fn(async () => result),
     then: (resolve: (value: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
       Promise.resolve(result).then(resolve, reject),
   };
@@ -188,20 +189,24 @@ describe("vitals.record tenant safety", () => {
       new URL("../routers/vitals.ts", import.meta.url),
       "utf8"
     );
+    const visitIntegritySource = readFileSync(
+      new URL("../../lib/records/visit-integrity.ts", import.meta.url),
+      "utf8"
+    );
 
     expect(source).toContain("function activePracticePredicate");
     expect(source).toContain("from ${practices}");
     expect(source).toContain("${practices.deletedAt} is null");
     expect(
       source.match(/activePracticePredicate\(practiceId\)/g)?.length ?? 0
-    ).toBeGreaterThanOrEqual(2);
+    ).toBeGreaterThanOrEqual(1);
     expect(source).toContain("activePracticePredicate(ctx.practiceId)");
     expect(source).toMatch(
       /eq\(patients\.practiceId, practiceId\),\s+activePracticePredicate\(practiceId\),\s+isNull\(patients\.deletedAt\)/
     );
-    expect(source).toMatch(
-      /eq\(appointments\.practiceId, practiceId\),\s+activePracticePredicate\(practiceId\),\s+isNull\(appointments\.deletedAt\)/
-    );
+    expect(source).toContain("lockOpenVisitForClinicalAppend");
+    expect(visitIntegritySource).toContain("from ${practices}");
+    expect(visitIntegritySource).toContain("${practices.deletedAt} is null");
     expect(source).toMatch(
       /eq\(vitalSigns\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(vitalSigns\.deletedAt\)/
     );
@@ -251,7 +256,11 @@ describe("vitals.record tenant safety", () => {
 
   it("records appointment-linked vitals after validating patient and appointment", async () => {
     const { db, insertValues } = createDb({
-      selectResults: [[{ id: PATIENT_ID }], [{ id: APPOINTMENT_ID }]],
+      selectResults: [
+        [{ id: PATIENT_ID }],
+        [{ id: APPOINTMENT_ID, doctorId: USER_ID, status: "in_exam" }],
+        [],
+      ],
     });
 
     await expect(

--- a/apps/web/server/routers/ai.ts
+++ b/apps/web/server/routers/ai.ts
@@ -38,6 +38,7 @@ import {
   SOAP_SECTION_MAX_LENGTH,
 } from "@/lib/records/soap-content";
 import { optionalClinicalTextInput } from "@/lib/records/clinical-inputs";
+import { lockOpenVisitForClinicalAppend } from "@/lib/records/visit-integrity";
 import { AI_SOURCE_MAX_LENGTH } from "@/lib/ai/soap";
 
 export { AI_SOURCE_MAX_LENGTH };
@@ -129,28 +130,25 @@ async function assertAppointmentBelongsToPatient(
   appointmentId: string,
   patientId: string
 ) {
-  const [appointment] = await ctx.db
-    .select({ id: appointments.id })
-    .from(appointments)
-    .where(
-      and(
-        eq(appointments.id, appointmentId),
-        eq(appointments.patientId, patientId),
-        eq(appointments.practiceId, ctx.practiceId),
-        activePracticePredicate(ctx.practiceId),
-        isNull(appointments.deletedAt)
-      )
-    )
-    .limit(1);
-
-  if (!appointment) {
+  const visit = await lockOpenVisitForClinicalAppend(ctx.db, {
+    practiceId: ctx.practiceId,
+    appointmentId,
+    patientId,
+  });
+  if (!visit.ok && visit.reason === "appointment_not_found") {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Appointment not found",
     });
   }
+  if (!visit.ok) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "SOAP notes can only be added while the visit is in exam.",
+    });
+  }
 
-  return appointment;
+  return visit.appointment;
 }
 
 export const aiRouter = createRouter({
@@ -160,10 +158,11 @@ export const aiRouter = createRouter({
    * to auto-populate SOAP notes for a patient visit.
    */
   createSoapFromAI: protectedProcedure
+    .use(requireRole("admin", "veterinarian"))
     .input(
       z.object({
         patientId: z.string().uuid(),
-        appointmentId: z.string().uuid().optional(),
+        appointmentId: z.string().uuid(),
         subjective: optionalClinicalTextInput(
           "SOAP subjective",
           SOAP_SECTION_MAX_LENGTH
@@ -186,15 +185,6 @@ export const aiRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) => {
       const { source, ...noteData } = input;
-      await assertActivePractice(ctx);
-      await assertPatientBelongsToPractice(ctx, input.patientId);
-      if (input.appointmentId) {
-        await assertAppointmentBelongsToPatient(
-          ctx,
-          input.appointmentId,
-          input.patientId
-        );
-      }
       const normalizedNote = {
         subjective: normalizeSoapSection(input.subjective),
         objective: normalizeSoapSection(input.objective),
@@ -207,6 +197,13 @@ export const aiRouter = createRouter({
           message: "SOAP note must include at least one section.",
         });
       }
+      await assertActivePractice(ctx);
+      await assertPatientBelongsToPractice(ctx, input.patientId);
+      await assertAppointmentBelongsToPatient(
+        ctx,
+        input.appointmentId,
+        input.patientId
+      );
       const [note] = await ctx.db
         .insert(soapNotes)
         .values({

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -20,7 +20,6 @@ import {
   consentForms,
   consentRequests,
   files,
-  visitCloseouts,
   visitWorkItems,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
@@ -82,6 +81,7 @@ import { CONSENT_FORM_LIBRARY } from "@/lib/consult/consent-form-library";
 import { PATIENT_PHOTO_CATEGORY } from "@/lib/records/file-kinds";
 import { appBaseUrl } from "@/lib/app-url";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
+import { lockOpenVisitForClinicalAppend } from "@/lib/records/visit-integrity";
 import { positiveIntegerColumnInput } from "./storage-bounds";
 
 export { PRESCRIPTION_INSTRUCTIONS_MAX_LENGTH } from "@/lib/records/prescription-policy";
@@ -317,45 +317,21 @@ async function lockOpenAppointmentForClinicalWork(
   patientId: string,
   workLabel: string
 ) {
-  const [appointment] = await ctx.db
-    .select({ id: appointments.id, status: appointments.status })
-    .from(appointments)
-    .where(
-      and(
-        eq(appointments.id, appointmentId),
-        eq(appointments.patientId, patientId),
-        eq(appointments.practiceId, ctx.practiceId),
-        activePracticePredicate(ctx.practiceId),
-        isNull(appointments.deletedAt)
-      )
-    )
-    .for("update");
-
-  if (!appointment) {
+  const visit = await lockOpenVisitForClinicalAppend(ctx.db as Database, {
+    practiceId: ctx.practiceId,
+    appointmentId,
+    patientId,
+  });
+  if (!visit.ok && visit.reason === "appointment_not_found") {
     throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" });
   }
-  if (appointment.status !== "in_exam") {
+  if (!visit.ok && visit.reason === "visit_not_open") {
     throw new TRPCError({
       code: "PRECONDITION_FAILED",
       message: `Start the exam before recording visit-linked ${workLabel}.`,
     });
   }
-
-  const [lockedCloseout] = await ctx.db
-    .select({ status: visitCloseouts.status })
-    .from(visitCloseouts)
-    .where(
-      and(
-        eq(visitCloseouts.appointmentId, appointmentId),
-        eq(visitCloseouts.practiceId, ctx.practiceId),
-        isNull(visitCloseouts.deletedAt)
-      )
-    )
-    .limit(1);
-  if (
-    lockedCloseout?.status === "clinical_finalized" ||
-    lockedCloseout?.status === "completed"
-  ) {
+  if (!visit.ok) {
     throw new TRPCError({
       code: "PRECONDITION_FAILED",
       message: `Clinical handoff is finalized. Use an attributed amendment before changing visit ${workLabel}.`,
@@ -656,7 +632,7 @@ export const recordsRouter = createRouter({
     .input(
       z.object({
         patientId: z.string().uuid(),
-        appointmentId: z.string().uuid().optional(),
+        appointmentId: z.string().uuid(),
         subjective: optionalClinicalTextInput(
           "SOAP subjective",
           SOAP_SECTION_MAX_LENGTH
@@ -673,7 +649,6 @@ export const recordsRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      await assertPatientBelongsToPractice(ctx, input.patientId);
       const normalizedNote = {
         subjective: normalizeSoapSection(input.subjective),
         objective: normalizeSoapSection(input.objective),
@@ -686,6 +661,13 @@ export const recordsRouter = createRouter({
           message: "SOAP note must include at least one section.",
         });
       }
+      await assertPatientBelongsToPractice(ctx, input.patientId);
+      await lockOpenAppointmentForClinicalWork(
+        ctx,
+        input.appointmentId,
+        input.patientId,
+        "SOAP documentation"
+      );
       const [note] = await ctx.db
         .insert(soapNotes)
         .values({

--- a/apps/web/server/routers/vitals.ts
+++ b/apps/web/server/routers/vitals.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { eq, and, isNull, desc, sql } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
-import { appointments, patients, practices, vitalSigns } from "@openpims/db";
+import { patients, practices, vitalSigns } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import {
   clinicalDecimalInput,
@@ -28,6 +28,7 @@ import {
   VITALS_WEIGHT_MAX_KG,
   VITALS_WEIGHT_SCALE,
 } from "@/lib/records/vitals-policy";
+import { lockOpenVisitForClinicalAppend } from "@/lib/records/visit-integrity";
 
 const recordRole = requireRole("admin", "veterinarian", "technician");
 const temperatureInput = clinicalDecimalInput("Temperature", {
@@ -88,24 +89,21 @@ async function assertAppointmentBelongsToPatient(
   appointmentId: string,
   patientId: string
 ) {
-  const [appointment] = await db
-    .select({ id: appointments.id })
-    .from(appointments)
-    .where(
-      and(
-        eq(appointments.id, appointmentId),
-        eq(appointments.patientId, patientId),
-        eq(appointments.practiceId, practiceId),
-        activePracticePredicate(practiceId),
-        isNull(appointments.deletedAt)
-      )
-    )
-    .limit(1);
-
-  if (!appointment) {
+  const visit = await lockOpenVisitForClinicalAppend(db, {
+    practiceId,
+    appointmentId,
+    patientId,
+  });
+  if (!visit.ok && visit.reason === "appointment_not_found") {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Appointment not found",
+    });
+  }
+  if (!visit.ok) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "Vitals can only be added while the visit is in exam.",
     });
   }
 }

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -187,8 +187,9 @@ Scope `records:write`. Create a SOAP note from an external AI scribe. Body:
 }
 ```
 
-`patient_id` and `source` are required. `appointment_id` is optional and must
-belong to the same patient/practice. `author_id` is optional when the linked
+`patient_id`, `appointment_id`, and `source` are required. The appointment must
+belong to the same patient/practice and be an active in-exam appointment whose
+clinical closeout has not been finalized. `author_id` is optional when the
 appointment has an assigned doctor; otherwise it must identify an active admin
 or veterinarian in the authenticated practice. At least one SOAP section must
 contain clinical text. Returns `201` with `{ data: <soap_note> }` and fires the
@@ -204,10 +205,10 @@ practice. Body:
 
 `instruction` must contain non-whitespace text and is trimmed before the agent
 runs. `allow_writes` (default `false`) gates write tools such as booking
-appointments, recording vitals, and drafting SOAP notes. Requests with
+appointments and recording vitals. Requests with
 `allow_writes: true` also require `agent:write`; when the agent invokes a write
 tool, the key must also carry that tool's resource scope, such as
-`appointments:write` for booking or `records:write` for vitals/SOAP notes. Returns
+`appointments:write` for booking or `records:write` for vitals. Returns
 `{ data: { text, toolCalls, iterations, stopReason } }`, where `toolCalls`
 traces every tool the agent invoked. Returns `503` if the configured model
 provider is missing its key (`GOOGLE_API_KEY` or legacy


### PR DESCRIPTION
## Summary
- require every live SOAP write to target the exact tenant-owned appointment currently in exam
- hold an appointment row lock through the tenant transaction and reject finalized closeouts
- remove the unsafe agent SOAP writer and the standalone patient-only SOAP entry point
- restrict dashboard and AI SOAP creation to admin/veterinarian roles and validate REST authorship
- guard appointment-linked vitals with the same open-visit boundary
- update API schemas, docs, UI states, and regression coverage

## Verification
- 2,582 full web tests passed in the implementation review
- 113 focused integrity/API/agent tests passed independently
- web TypeScript check passed
- production Next.js build passed in the implementation review
- git diff check passed

No database migration, messaging change, external communication, or fee-bearing resource is included.