### PR TITLE
Persist patient date of birth from native form state

### DIFF
--- a/apps/web/app/(dashboard)/patients/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/patients/[id]/edit/page.tsx
@@ -104,6 +104,7 @@ function canManagePatientFormRole(role?: string | null): boolean {
 function EditPatientForm() {
   const params = useParams<{ id: string }>();
   const router = useRouter();
+  const utils = trpc.useUtils();
   const [form, setForm] = useState({
     name: "",
     species: "canine" as string,
@@ -141,7 +142,12 @@ function EditPatientForm() {
   }, [patient]);
 
   const updatePatient = trpc.patients.update.useMutation({
-    onSuccess: () => {
+    onSuccess: (updatedPatient) => {
+      utils.patients.getById.setData({ id: params.id }, (currentPatient) =>
+        currentPatient
+          ? { ...currentPatient, ...updatedPatient }
+          : currentPatient
+      );
       toast.success("Patient updated");
       router.push(`/patients/${params.id}`);
     },
@@ -160,9 +166,13 @@ function EditPatientForm() {
       PATIENT_MICROCHIP_NUMBER_MAX_LENGTH
     );
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
+
+    const submittedDob = (
+      e.currentTarget.elements.namedItem("dob") as HTMLInputElement | null
+    )?.value ?? form.dob;
 
     if (!patient) {
       setError("Load the patient before saving changes.");
@@ -183,7 +193,7 @@ function EditPatientForm() {
       species: form.species as any,
       breed: form.breed.trim() || undefined,
       sex: form.sex ? (form.sex as any) : undefined,
-      dob: form.dob || undefined,
+      dob: submittedDob || null,
       color: form.color.trim() || undefined,
       microchipNumber: form.microchipNumber.trim() || undefined,
       status: form.status as any,
@@ -313,6 +323,7 @@ function EditPatientForm() {
             </label>
             <Input
               id="dob"
+              name="dob"
               type="date"
               value={form.dob}
               onChange={(e) => updateField("dob", e.target.value)}

--- a/apps/web/app/(dashboard)/patients/new/page.tsx
+++ b/apps/web/app/(dashboard)/patients/new/page.tsx
@@ -165,9 +165,13 @@ function NewPatientForm() {
       PATIENT_MICROCHIP_NUMBER_MAX_LENGTH
     );
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
+
+    const submittedDob = (
+      e.currentTarget.elements.namedItem("dob") as HTMLInputElement | null
+    )?.value ?? form.dob;
 
     if (!form.clientId) {
       setError("Please select an owner (client).");
@@ -188,7 +192,7 @@ function NewPatientForm() {
       species: form.species as any,
       breed: form.breed.trim() || undefined,
       sex: form.sex ? (form.sex as any) : undefined,
-      dob: form.dob || undefined,
+      dob: submittedDob || undefined,
       color: form.color.trim() || undefined,
       microchipNumber: form.microchipNumber.trim() || undefined,
     });
@@ -383,6 +387,7 @@ function NewPatientForm() {
             </label>
             <Input
               id="dob"
+              name="dob"
               type="date"
               value={form.dob}
               onChange={(e) => updateField("dob", e.target.value)}

--- a/apps/web/lib/__tests__/client-patient-form-ui.test.ts
+++ b/apps/web/lib/__tests__/client-patient-form-ui.test.ts
@@ -371,7 +371,15 @@ describe("client and patient form UI states", () => {
       expect(source).toContain("isOptionalPatientTextValid(");
       expect(source).toContain("form.microchipNumber");
       expect(source).toContain("Check required fields and field lengths.");
+      expect(source).toContain('name="dob"');
+      expect(source).toContain(
+        'e.currentTarget.elements.namedItem("dob")'
+      );
     }
+
+    expect(newPatient).toContain("dob: submittedDob || undefined");
+    expect(editPatient).toContain("dob: submittedDob || null");
+    expect(editPatient).toContain("utils.patients.getById.setData");
 
     expect(newPatient).toContain(
       "disabled={!canSubmit || createPatient.isPending}"

--- a/apps/web/server/__tests__/patients-safety.test.ts
+++ b/apps/web/server/__tests__/patients-safety.test.ts
@@ -534,6 +534,25 @@ describe("patients mutation safety", () => {
     expect(updateSet).toHaveBeenCalledWith({ name: "Biscuit" });
   });
 
+  it("persists a valid DOB and explicitly clears it with null", async () => {
+    const { db, updateSet } = createDb({
+      updatedRows: [{ id: PATIENT_ID, name: "Biscuit" }],
+    });
+    const caller = callerWithDb(db);
+
+    await caller.update({
+      id: PATIENT_ID,
+      dob: "2021-08-08",
+    });
+    expect(updateSet).toHaveBeenLastCalledWith({ dob: "2021-08-08" });
+
+    await caller.update({
+      id: PATIENT_ID,
+      dob: null,
+    });
+    expect(updateSet).toHaveBeenLastCalledWith({ dob: null });
+  });
+
   it("rejects stale or cross-tenant patient deletes", async () => {
     const { db, updateSet } = createDb({ selectResults: [[]] });
 

--- a/apps/web/server/routers/patients.ts
+++ b/apps/web/server/routers/patients.ts
@@ -72,6 +72,9 @@ const patientManagerProcedure = protectedProcedure.use(
   requireRole("admin", "veterinarian", "technician", "front_desk")
 );
 const patientDobInput = clinicalDateInput("Date of birth").optional();
+const patientDobUpdateInput = clinicalDateInput("Date of birth")
+  .nullable()
+  .optional();
 const patientSearchInput = z
   .string()
   .trim()
@@ -420,7 +423,7 @@ export const patientsRouter = createRouter({
         species: patientMutableInput.species.optional(),
         breed: patientMutableInput.breed,
         sex: patientMutableInput.sex,
-        dob: patientMutableInput.dob,
+        dob: patientDobUpdateInput,
         color: patientMutableInput.color,
         microchipNumber: patientMutableInput.microchipNumber,
         status: patientStatusInput.optional(),


### PR DESCRIPTION
## Summary
- read the native DOB input synchronously at create/edit submission so browser-filled dates cannot diverge from React state
- support explicit DOB clearing with a validated `null` update
- seed the patient detail cache with the canonical update response before navigation
- add form-wiring and server persistence regression coverage

## Production evidence
The live update returned 200 and advanced `updated_at`, but PostgreSQL statement statistics showed the generated UPDATE omitted `dob`; the current-schema INSERT also used DEFAULT for `dob`. The column is a normal nullable DATE with no rewriting trigger or rule, isolating the defect to submit payload construction.

## Verification
- 28 focused form/router tests passed
- web TypeScript check passed
- production Next.js build passed in implementation review
- git diff check passed

No migration, data backfill, messaging change, fee, or external communication is included.