### PR TITLE
Replace unsafe SOAP template claims with verified prompts

### DIFF
--- a/apps/web/app/(dashboard)/records/new-soap/[patientId]/page.tsx
+++ b/apps/web/app/(dashboard)/records/new-soap/[patientId]/page.tsx
@@ -27,6 +27,7 @@ import {
   SOAP_NOTE_TEMPLATES,
   applySoapTemplateToSections,
   getSoapTemplateById,
+  hasUnresolvedSoapTemplatePrompts,
 } from "@/lib/records/soap-templates";
 
 const SoapNoteEditor = dynamic(
@@ -82,6 +83,13 @@ export default function NewSoapNotePage() {
   );
   const [replaceTemplateContent, setReplaceTemplateContent] = useState(false);
   const canSave = hasSoapContent({ subjective, objective, assessment, plan });
+  const hasTemplatePrompts = hasUnresolvedSoapTemplatePrompts({
+    subjective,
+    objective,
+    assessment,
+    plan,
+  });
+  const canSubmit = canSave && !hasTemplatePrompts;
   const selectedTemplate = getSoapTemplateById(selectedTemplateId);
 
   const {
@@ -144,6 +152,10 @@ export default function NewSoapNotePage() {
       toast.error("Add at least one SOAP section before saving");
       return;
     }
+    if (hasTemplatePrompts) {
+      toast.error("Replace or delete every draft prompt before saving");
+      return;
+    }
     createNote.mutate({
       patientId: params.patientId,
       appointmentId,
@@ -165,10 +177,10 @@ export default function NewSoapNotePage() {
     setObjective(next.objective);
     setAssessment(next.assessment);
     setPlan(next.plan);
-    toast.success(
+    toast.info(
       replaceTemplateContent || !canSave
-        ? `${selectedTemplate.name} template applied`
-        : `${selectedTemplate.name} template filled blank sections`
+        ? `${selectedTemplate.name} draft prompts applied`
+        : `${selectedTemplate.name} draft prompts filled blank sections`
     );
   }
 
@@ -335,7 +347,22 @@ export default function NewSoapNotePage() {
               Apply template
             </Button>
           </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Templates add drafting prompts, not assumed findings. Replace or
+            delete every prompt before saving the clinical record.
+          </p>
         </div>
+
+        {hasTemplatePrompts ? (
+          <div
+            role="alert"
+            className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950 dark:border-amber-800 dark:bg-amber-950/30 dark:text-amber-100"
+          >
+            This draft still contains template prompts. Replace each prompt
+            with findings verified during this visit, or delete it if it does
+            not apply.
+          </div>
+        ) : null}
 
         <div className="rounded-lg border border-border bg-card p-6 space-y-6">
           {/* Subjective */}
@@ -403,16 +430,20 @@ export default function NewSoapNotePage() {
         <div className="flex items-center gap-3">
           <Button
             onClick={handleSave}
-            disabled={createNote.isPending || !canSave}
+            disabled={createNote.isPending || !canSubmit}
           >
             <Save className="mr-2 h-4 w-4" />
             {createNote.isPending ? "Saving..." : "Save Note"}
           </Button>
-          {!canSave && (
+          {!canSave ? (
             <p className="text-sm text-muted-foreground">
               Add at least one section to save this note.
             </p>
-          )}
+          ) : hasTemplatePrompts ? (
+            <p className="text-sm text-amber-700 dark:text-amber-300">
+              Replace or delete every draft prompt before saving.
+            </p>
+          ) : null}
           <Button variant="outline" onClick={() => router.push(returnPath)}>
             Cancel
           </Button>

--- a/apps/web/app/api/v1/soap-notes/route.test.ts
+++ b/apps/web/app/api/v1/soap-notes/route.test.ts
@@ -84,6 +84,7 @@ const { POST } = await import("./route");
 const { appointments, patients, practices, users } =
   await import("@openpims/db");
 const { SOAP_SECTION_MAX_LENGTH } = await import("@/lib/records/soap-content");
+const { SOAP_NOTE_TEMPLATES } = await import("@/lib/records/soap-templates");
 const { JSON_REQUEST_BODY_MAX_BYTES } = await import("@/lib/request-json");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-000000000001";
@@ -204,6 +205,27 @@ describe("POST /api/v1/soap-notes", () => {
     expect(json.error.fields.subjective).toEqual([expect.any(String)]);
     expect(mocks.withTenant).not.toHaveBeenCalled();
     expect(mocks.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects unresolved template prompts before tenant work", async () => {
+    const response = await POST(
+      request(
+        soapBody({
+          author_id: AUTHOR_ID,
+          subjective: SOAP_NOTE_TEMPLATES[0]!.sections.subjective,
+        })
+      )
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        message: "Replace or delete every SOAP template prompt before saving.",
+      },
+    });
+    expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect(mocks.db.insert).not.toHaveBeenCalled();
+    expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
   });
 
   it("requires an appointment before tenant work", async () => {

--- a/apps/web/app/api/v1/soap-notes/route.ts
+++ b/apps/web/app/api/v1/soap-notes/route.ts
@@ -23,6 +23,7 @@ import {
 } from "@/lib/records/soap-content";
 import { assertActivePractice } from "@/lib/compat/shared/active-practice";
 import { lockOpenVisitForClinicalAppend } from "@/lib/records/visit-integrity";
+import { hasUnresolvedSoapTemplatePrompts } from "@/lib/records/soap-templates";
 
 export const dynamic = "force-dynamic";
 
@@ -122,6 +123,12 @@ export async function POST(req: Request) {
     };
     if (!hasSoapContent(normalizedNote)) {
       return apiError("SOAP note must include at least one section.", 400);
+    }
+    if (hasUnresolvedSoapTemplatePrompts(normalizedNote)) {
+      return apiError(
+        "Replace or delete every SOAP template prompt before saving.",
+        400
+      );
     }
     const result = await withTenant(db, auth.ctx.practiceId, async (tx) => {
       const activePractice = await assertActivePractice(tx, auth.ctx.practiceId);

--- a/apps/web/lib/__tests__/soap-editor-ui.test.ts
+++ b/apps/web/lib/__tests__/soap-editor-ui.test.ts
@@ -72,14 +72,21 @@ describe("SOAP note editor UX", () => {
     expect(source).not.toContain("`<p>${placeholder}</p>`");
   });
 
-  it("disables SOAP note save until at least one section has content", () => {
+  it("disables SOAP note save until content exists and template prompts are resolved", () => {
     const source = readFileSync(
       "app/(dashboard)/records/new-soap/[patientId]/page.tsx",
       "utf8"
     );
 
     expect(source).toContain("const canSave = hasSoapContent");
-    expect(source).toContain("disabled={createNote.isPending || !canSave}");
+    expect(source).toContain(
+      "const hasTemplatePrompts = hasUnresolvedSoapTemplatePrompts"
+    );
+    expect(source).toContain("const canSubmit = canSave && !hasTemplatePrompts");
+    expect(source).toContain("disabled={createNote.isPending || !canSubmit}");
+    expect(source).toContain(
+      "Replace or delete every draft prompt before saving"
+    );
     expect(source).toContain("normalizeSoapSection(subjective)");
   });
 
@@ -103,6 +110,9 @@ describe("SOAP note editor UX", () => {
     expect(source).toContain("setPlan(next.plan)");
     expect(source).toContain("Replace existing content");
     expect(source).toContain("Apply template");
+    expect(source).toContain(
+      "Templates add drafting prompts, not assumed findings"
+    );
   });
 
   it("keeps the SOAP author access gate after hooks are declared", () => {

--- a/apps/web/lib/records/__tests__/soap-templates.test.ts
+++ b/apps/web/lib/records/__tests__/soap-templates.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { soapSectionText } from "../soap-content";
 import {
   SOAP_NOTE_TEMPLATES,
+  SOAP_TEMPLATE_PROMPT_MARKER,
   applySoapTemplateToSections,
   getSoapTemplateById,
+  hasUnresolvedSoapTemplatePrompts,
   soapTemplateSectionsFit,
 } from "../soap-templates";
 
@@ -21,6 +23,59 @@ describe("SOAP note templates", () => {
       expect(soapSectionText(template.sections.assessment)).not.toBe("");
       expect(soapSectionText(template.sections.plan)).not.toBe("");
     }
+  });
+
+  it("uses unresolved drafting prompts instead of affirmative clinical claims", () => {
+    for (const template of SOAP_NOTE_TEMPLATES) {
+      for (const section of Object.values(template.sections)) {
+        const sectionText = soapSectionText(section);
+        const promptCount = sectionText.split(SOAP_TEMPLATE_PROMPT_MARKER).length - 1;
+        const itemCount = section.match(/<li>/g)?.length ?? 0;
+
+        expect(promptCount).toBe(itemCount);
+        expect(promptCount).toBeGreaterThan(0);
+        expect(sectionText).not.toMatch(
+          /\b(vitals? (?:and (?:pain score|weight) )?recorded|exam performed|findings reviewed|needs assessed|procedure completed|instructions (?:reviewed|provided))\b/i
+        );
+      }
+
+      expect(hasUnresolvedSoapTemplatePrompts(template.sections)).toBe(true);
+    }
+  });
+
+  it("detects prompt bodies even if their visual markers are removed", () => {
+    const template = getSoapTemplateById("wellness-exam");
+    expect(template).toBeDefined();
+    expect(hasUnresolvedSoapTemplatePrompts(template!.sections)).toBe(true);
+    expect(
+      hasUnresolvedSoapTemplatePrompts({
+        subjective: template!.sections.subjective.replaceAll(
+          SOAP_TEMPLATE_PROMPT_MARKER,
+          ""
+        ),
+        objective: template!.sections.objective.replaceAll(
+          SOAP_TEMPLATE_PROMPT_MARKER,
+          ""
+        ),
+        assessment: template!.sections.assessment.replaceAll(
+          SOAP_TEMPLATE_PROMPT_MARKER,
+          ""
+        ),
+        plan: template!.sections.plan.replaceAll(
+          SOAP_TEMPLATE_PROMPT_MARKER,
+          ""
+        ),
+      })
+    ).toBe(true);
+
+    expect(
+      hasUnresolvedSoapTemplatePrompts({
+        subjective: "<p>Owner reports normal appetite.</p>",
+        objective: "<p>T 101.2 F; HR 88; RR 20.</p>",
+        assessment: "<p>Healthy adult dog.</p>",
+        plan: "<p>Return in 12 months.</p>",
+      })
+    ).toBe(false);
   });
 
   it("fills blank SOAP sections without overwriting drafted sections by default", () => {

--- a/apps/web/lib/records/soap-templates.ts
+++ b/apps/web/lib/records/soap-templates.ts
@@ -17,61 +17,121 @@ export type SoapTemplate = {
   sections: SoapSections;
 };
 
+export const SOAP_TEMPLATE_PROMPT_MARKER =
+  "[DRAFT PROMPT — REPLACE OR DELETE]";
+
+const soapTemplatePromptTexts: string[] = [];
+
+function promptList(...prompts: string[]): string {
+  for (const prompt of prompts) {
+    soapTemplatePromptTexts.push(prompt);
+  }
+
+  return `<ul>${prompts
+    .map(
+      (prompt) =>
+        `<li><strong>${SOAP_TEMPLATE_PROMPT_MARKER}</strong> ${prompt}</li>`
+    )
+    .join("")}</ul>`;
+}
+
 export const SOAP_NOTE_TEMPLATES: SoapTemplate[] = [
   {
     id: "wellness-exam",
     name: "Wellness Exam",
     sections: {
-      subjective:
-        "<ul><li>Presenting for routine wellness exam.</li><li>Appetite, thirst, urination, defecation, activity, and behavior reviewed.</li><li>Current medications, diet, parasite prevention, and vaccine status reviewed.</li></ul>",
-      objective:
-        "<ul><li>General: Bright, alert, and responsive.</li><li>Vitals: Temperature, pulse, respiration, weight, BCS recorded.</li><li>Physical exam: Eyes, ears, oral cavity, heart/lungs, abdomen, skin/coat, musculoskeletal, neurologic, and lymph nodes assessed.</li></ul>",
-      assessment:
-        "<ul><li>Wellness examination findings reviewed.</li><li>Preventive-care needs assessed.</li></ul>",
-      plan:
-        "<ul><li>Update vaccines, diagnostics, and parasite prevention as indicated.</li><li>Discuss nutrition, dental care, weight management, and home monitoring.</li><li>Return for routine wellness follow-up or sooner if concerns develop.</li></ul>",
+      subjective: promptList(
+        "Document today's presenting reason in the owner's words.",
+        "Document only the appetite, thirst, elimination, activity, or behavior history actually reported today.",
+        "Document the medications, diet, parasite prevention, and vaccine history actually reviewed today."
+      ),
+      objective: promptList(
+        "Enter measured vital values and body condition score; do not infer or assume normal findings.",
+        "Document the patient's observed general appearance.",
+        "Document the systems actually examined and their specific findings, including pertinent negatives."
+      ),
+      assessment: promptList(
+        "Enter the clinician's interpretation of today's wellness findings.",
+        "Enter the preventive-care needs identified from today's history and exam."
+      ),
+      plan: promptList(
+        "Document the vaccines, diagnostics, and parasite-prevention decisions made today.",
+        "Document the nutrition, dental, weight, or home-monitoring guidance actually discussed.",
+        "Document the follow-up interval and return precautions actually provided."
+      ),
     },
   },
   {
     id: "sick-visit",
     name: "Sick Visit",
     sections: {
-      subjective:
-        "<ul><li>Chief complaint, onset, duration, progression, and severity reviewed.</li><li>Appetite, water intake, energy, vomiting, diarrhea, coughing/sneezing, urination, and pain signs discussed.</li><li>Current medications, recent travel/boarding/exposures, and relevant history reviewed.</li></ul>",
-      objective:
-        "<ul><li>Vitals and pain score recorded.</li><li>Focused physical exam performed with abnormal findings documented.</li><li>Diagnostics recommended or performed based on presenting complaint.</li></ul>",
-      assessment:
-        "<ul><li>Primary problem list and differential diagnoses reviewed.</li><li>Patient stability and urgency assessed.</li></ul>",
-      plan:
-        "<ul><li>Treatment options, diagnostics, risks, and estimated costs discussed.</li><li>Medications, home care, monitoring instructions, and recheck timing provided.</li><li>Owner advised to seek urgent care if condition worsens.</li></ul>",
+      subjective: promptList(
+        "Document the chief complaint, onset, duration, progression, and severity actually reported.",
+        "Document pertinent positive and negative symptoms actually reported by the owner.",
+        "Document current medications, exposures, and relevant history actually reviewed."
+      ),
+      objective: promptList(
+        "Enter measured vital values and pain score; do not infer or assume normal findings.",
+        "Document the focused physical exam actually performed and its specific findings.",
+        "Document available diagnostic results; keep recommendations in the Plan section."
+      ),
+      assessment: promptList(
+        "Enter the clinician's problem list and supported differential diagnoses.",
+        "Enter the clinician's assessment of stability and urgency."
+      ),
+      plan: promptList(
+        "Document the diagnostics and treatment options actually discussed or selected.",
+        "Document medications, home care, monitoring, and recheck instructions actually provided.",
+        "Document the return precautions and emergency guidance actually provided."
+      ),
     },
   },
   {
     id: "recheck",
     name: "Recheck",
     sections: {
-      subjective:
-        "<ul><li>Reason for recheck and response to prior treatment reviewed.</li><li>Medication adherence, side effects, appetite, energy, and owner concerns discussed.</li></ul>",
-      objective:
-        "<ul><li>Vitals and weight recorded.</li><li>Focused recheck exam performed.</li><li>Follow-up diagnostics or monitoring results reviewed when available.</li></ul>",
-      assessment:
-        "<ul><li>Problem status updated: improved, unchanged, or worsened.</li><li>Current treatment response assessed.</li></ul>",
-      plan:
-        "<ul><li>Continue, adjust, or discontinue treatment as indicated.</li><li>Additional diagnostics, monitoring, and next recheck timing discussed.</li><li>Owner questions addressed.</li></ul>",
+      subjective: promptList(
+        "Document the reason for recheck and treatment response actually reported.",
+        "Document adherence, side effects, appetite, energy, and owner concerns actually reported."
+      ),
+      objective: promptList(
+        "Enter measured vital values and weight; do not infer or assume normal findings.",
+        "Document the focused recheck exam actually performed and its specific findings.",
+        "Document follow-up diagnostic or monitoring results available today."
+      ),
+      assessment: promptList(
+        "Enter whether each problem is improved, unchanged, worsened, or otherwise characterized.",
+        "Enter the clinician's interpretation of treatment response."
+      ),
+      plan: promptList(
+        "Document the treatment decisions made today, including any continuation, change, or discontinuation.",
+        "Document additional diagnostics, monitoring, and recheck timing actually discussed.",
+        "Document owner questions and the answers actually provided."
+      ),
     },
   },
   {
     id: "procedure-discharge",
     name: "Procedure Discharge",
     sections: {
-      subjective:
-        "<ul><li>Procedure reason and pre-procedure history reviewed.</li><li>Fasting status, current medications, and owner concerns confirmed.</li></ul>",
-      objective:
-        "<ul><li>Pre-procedure exam, vitals, and anesthetic risk assessment completed.</li><li>Procedure performed and intraoperative findings documented.</li><li>Recovery status, pain score, and discharge readiness assessed.</li></ul>",
-      assessment:
-        "<ul><li>Procedure completed and recovery status assessed.</li><li>Complications, if any, documented.</li></ul>",
-      plan:
-        "<ul><li>Discharge medications, activity restriction, incision/procedure-site monitoring, and diet instructions reviewed.</li><li>Emergency warning signs and contact instructions provided.</li><li>Follow-up or recheck appointment timing documented.</li></ul>",
+      subjective: promptList(
+        "Document the procedure indication and pre-procedure history actually reviewed.",
+        "Document fasting status, current medications, and owner concerns actually confirmed."
+      ),
+      objective: promptList(
+        "Enter measured pre-procedure vitals, exam findings, and the clinician's anesthetic risk assessment.",
+        "Document the procedure actually performed and its specific intraoperative findings.",
+        "Document observed recovery status, measured pain score, and discharge-readiness findings."
+      ),
+      assessment: promptList(
+        "Enter the clinician's assessment of the procedure outcome and recovery status.",
+        "Document observed complications, or explicitly state none only when clinically verified."
+      ),
+      plan: promptList(
+        "Document the medications, restrictions, site monitoring, and diet instructions actually provided.",
+        "Document the emergency warning signs and contact instructions actually provided.",
+        "Document the follow-up or recheck timing actually arranged or recommended."
+      ),
     },
   },
 ];
@@ -105,6 +165,18 @@ export function applySoapTemplateToSections(
         ? template.sections.plan
         : current.plan,
   };
+}
+
+export function hasUnresolvedSoapTemplatePrompts(
+  sections: Partial<SoapSections>
+): boolean {
+  return Object.values(sections).some((section) => {
+    const text = soapSectionText(section ?? "");
+    return (
+      text.includes(SOAP_TEMPLATE_PROMPT_MARKER) ||
+      soapTemplatePromptTexts.some((prompt) => text.includes(prompt))
+    );
+  });
 }
 
 export function soapTemplateSectionsFit(template: SoapTemplate): boolean {

--- a/apps/web/server/__tests__/ai-safety.test.ts
+++ b/apps/web/server/__tests__/ai-safety.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { SOAP_SECTION_MAX_LENGTH } from "@/lib/records/soap-content";
+import { SOAP_NOTE_TEMPLATES } from "@/lib/records/soap-templates";
 
 const mocks = vi.hoisted(() => ({
   recordAuditLog: vi.fn(async () => undefined),
@@ -178,6 +179,25 @@ describe("AI SOAP note safety", () => {
       })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects unresolved template prompts before DB work", async () => {
+    const { db, select, insertValues } = createDb();
+
+    await expect(
+      callerWithDb(db).createSoapFromAI({
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        subjective: SOAP_NOTE_TEMPLATES[0]!.sections.subjective,
+        source: "scribe",
+      })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Replace or delete every SOAP template prompt before saving.",
+    });
+
+    expect(select).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
   });
 

--- a/apps/web/server/__tests__/records-target-safety.test.ts
+++ b/apps/web/server/__tests__/records-target-safety.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { SOAP_SECTION_MAX_LENGTH } from "@/lib/records/soap-content";
+import { SOAP_NOTE_TEMPLATES } from "@/lib/records/soap-templates";
 import {
   LAB_RESULT_VALUE_MAX_LENGTH,
   LAB_TEST_NAME_MAX_LENGTH,
@@ -446,6 +447,25 @@ describe("records target safety", () => {
       })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects unresolved template prompts before DB work", async () => {
+    const { db, select, insertValues } = createDb();
+
+    await expect(
+      callerWithDb(db).createSoapNote({
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        subjective: SOAP_NOTE_TEMPLATES[0]!.sections.subjective,
+      })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Replace or delete every SOAP template prompt before saving.",
+    });
+
+    expect(select).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
   });

--- a/apps/web/server/routers/ai.ts
+++ b/apps/web/server/routers/ai.ts
@@ -39,6 +39,7 @@ import {
 } from "@/lib/records/soap-content";
 import { optionalClinicalTextInput } from "@/lib/records/clinical-inputs";
 import { lockOpenVisitForClinicalAppend } from "@/lib/records/visit-integrity";
+import { hasUnresolvedSoapTemplatePrompts } from "@/lib/records/soap-templates";
 import { AI_SOURCE_MAX_LENGTH } from "@/lib/ai/soap";
 
 export { AI_SOURCE_MAX_LENGTH };
@@ -195,6 +196,12 @@ export const aiRouter = createRouter({
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "SOAP note must include at least one section.",
+        });
+      }
+      if (hasUnresolvedSoapTemplatePrompts(normalizedNote)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Replace or delete every SOAP template prompt before saving.",
         });
       }
       await assertActivePractice(ctx);

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -29,6 +29,7 @@ import {
   normalizeSoapSection,
   SOAP_SECTION_MAX_LENGTH,
 } from "@/lib/records/soap-content";
+import { hasUnresolvedSoapTemplatePrompts } from "@/lib/records/soap-templates";
 import {
   clinicalDateInput,
   clinicalTextInput,
@@ -659,6 +660,12 @@ export const recordsRouter = createRouter({
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "SOAP note must include at least one section.",
+        });
+      }
+      if (hasUnresolvedSoapTemplatePrompts(normalizedNote)) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Replace or delete every SOAP template prompt before saving.",
         });
       }
       await assertPatientBelongsToPractice(ctx, input.patientId);


### PR DESCRIPTION
## Summary
- replace affirmative clinical claims in all 4 SOAP templates / 16 sections with 42 explicit unresolved drafting prompts
- tell clinicians that templates never assume findings and require every prompt to be replaced or deleted
- disable dashboard save while prompts remain
- reject unresolved marker or copied prompt bodies in every live SOAP writer: dashboard, AI tRPC, and REST
- keep historical import/restore paths unchanged
- add template, UI, dashboard, AI, and REST regression coverage

## Patient-safety rationale
The former Wellness template could insert claims such as vitals being recorded before any vitals existed. These templates now ask for specific verified findings and cannot be saved unchanged.

## Verification
- 98 focused template/editor/dashboard/AI/REST tests passed after final review
- full web suite passed in implementation review: 278 files / 2,585 tests
- web TypeScript check passed
- production Next.js build passed in implementation review
- git diff check passed

Existing historical notes are intentionally not rewritten; they require the separate attributed correction workflow.