### PR TITLE
Let demo visitors explore each clinic role

### DIFF
--- a/apps/web/components/demo/demo-conversion-bar.tsx
+++ b/apps/web/components/demo/demo-conversion-bar.tsx
@@ -10,6 +10,7 @@ import {
 import { trackFunnelEvent } from "@/lib/track-funnel-event";
 import { useFunnelVisitorId } from "@/lib/funnel-visitor";
 import { usePathname } from "next/navigation";
+import { DemoRoleSwitcher } from "@/components/demo/demo-role-switcher";
 
 /**
  * Persistent demo → Cloud signup bridge. Job language on purpose: we sell a
@@ -38,18 +39,21 @@ export function DemoConversionBar() {
           Start a free Cloud trial with your own clinic data.
         </span>
       </p>
-      <a
-        href={href}
-        onClick={() =>
-          trackFunnelEvent(FUNNEL_EVENTS.demoCtaStartClinic, {
-            tool,
-            path: pathname,
-          })
-        }
-        className="inline-flex h-8 shrink-0 items-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-      >
-        Start my clinic
-      </a>
+      <div className="flex flex-wrap items-center gap-3">
+        <DemoRoleSwitcher />
+        <a
+          href={href}
+          onClick={() =>
+            trackFunnelEvent(FUNNEL_EVENTS.demoCtaStartClinic, {
+              tool,
+              path: pathname,
+            })
+          }
+          className="inline-flex h-8 shrink-0 items-center rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Start my clinic
+        </a>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/demo/demo-role-switcher.tsx
+++ b/apps/web/components/demo/demo-role-switcher.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import * as React from "react";
+import { usePathname } from "next/navigation";
+import { signIn, useSession } from "next-auth/react";
+import { Loader2, UserRoundCog } from "lucide-react";
+import {
+  DEMO_ROLE_OPTIONS,
+  type DemoSwitcherRole,
+  demoRoleDestination,
+  demoRoleLabel,
+  isDemoSwitcherRole,
+  requestDemoRoleSwitch,
+  shouldShowDemoRoleSwitcher,
+} from "@/lib/demo-role-switcher";
+
+const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE?.trim() === "true";
+
+type DemoRoleSwitcherViewProps = {
+  currentRole: DemoSwitcherRole;
+  pendingRole: DemoSwitcherRole | null;
+  error: string | null;
+  onRoleChange: (role: DemoSwitcherRole) => void;
+};
+
+export function DemoRoleSwitcherView({
+  currentRole,
+  pendingRole,
+  error,
+  onRoleChange,
+}: DemoRoleSwitcherViewProps) {
+  const isSwitching = pendingRole !== null;
+  const currentLabel = demoRoleLabel(currentRole);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <div className="flex items-center gap-2">
+        <label
+          htmlFor="demo-role-switcher"
+          className="shrink-0 text-xs font-medium text-muted-foreground"
+        >
+          Explore as
+        </label>
+        <div className="relative">
+          <UserRoundCog
+            aria-hidden="true"
+            className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+          />
+          <select
+            id="demo-role-switcher"
+            value={currentRole}
+            disabled={isSwitching}
+            aria-label={`Demo role. Current role: ${currentLabel}`}
+            onChange={(event) => {
+              const nextRole = event.currentTarget.value;
+              if (isDemoSwitcherRole(nextRole)) onRoleChange(nextRole);
+            }}
+            className="h-8 max-w-40 appearance-none rounded-md border border-input bg-background py-1 pl-7 pr-7 text-xs font-medium text-foreground disabled:cursor-wait disabled:opacity-60"
+          >
+            {DEMO_ROLE_OPTIONS.map((role) => (
+              <option key={role.value} value={role.value}>
+                {role.label}
+              </option>
+            ))}
+          </select>
+          {isSwitching ? (
+            <Loader2
+              aria-hidden="true"
+              className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 animate-spin text-muted-foreground"
+            />
+          ) : (
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-muted-foreground"
+            >
+              ▾
+            </span>
+          )}
+        </div>
+      </div>
+      <span className="sr-only" aria-live="polite">
+        {pendingRole
+          ? `Switching to ${demoRoleLabel(pendingRole)}`
+          : `Viewing demo as ${currentLabel}`}
+      </span>
+      {error ? (
+        <p role="alert" className="max-w-64 text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export function DemoRoleSwitcher() {
+  const pathname = usePathname();
+  const { data: session, status } = useSession();
+  const [pendingRole, setPendingRole] =
+    React.useState<DemoSwitcherRole | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const sessionRole = session?.user?.role;
+
+  if (!shouldShowDemoRoleSwitcher(DEMO_MODE, status, sessionRole)) {
+    return null;
+  }
+
+  async function handleRoleChange(nextRole: DemoSwitcherRole) {
+    if (pendingRole || nextRole === sessionRole) return;
+
+    setError(null);
+    setPendingRole(nextRole);
+    const switched = await requestDemoRoleSwitch(
+      nextRole,
+      (provider, options) => signIn(provider, options),
+    );
+    if (!switched) {
+      setPendingRole(null);
+      setError(
+        "We couldn't switch roles. Your current role is unchanged. Try again.",
+      );
+      return;
+    }
+
+    try {
+      const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      const destination = demoRoleDestination(
+        nextRole,
+        pathname,
+        currentPath,
+      );
+      // A full local navigation reloads the JWT-backed session before any
+      // role-gated page or query can render under the new identity.
+      window.location.assign(destination);
+    } catch {
+      setPendingRole(null);
+      setError("Role changed. Refresh this page to finish switching views.");
+    }
+  }
+
+  return (
+    <DemoRoleSwitcherView
+      currentRole={sessionRole}
+      pendingRole={pendingRole}
+      error={error}
+      onRoleChange={handleRoleChange}
+    />
+  );
+}

--- a/apps/web/lib/__tests__/demo-role-switcher.test.ts
+++ b/apps/web/lib/__tests__/demo-role-switcher.test.ts
@@ -1,0 +1,149 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { DemoRoleSwitcherView } from "@/components/demo/demo-role-switcher";
+import {
+  DEMO_ROLE_OPTIONS,
+  canPreserveDemoPath,
+  demoRoleDestination,
+  requestDemoRoleSwitch,
+  shouldShowDemoRoleSwitcher,
+} from "@/lib/demo-role-switcher";
+
+describe("post-gate demo role switcher", () => {
+  it("offers every seeded clinic role with a human-readable label", () => {
+    expect(DEMO_ROLE_OPTIONS).toEqual([
+      { value: "admin", label: "Practice Admin" },
+      { value: "veterinarian", label: "Veterinarian" },
+      { value: "technician", label: "Technician" },
+      { value: "front_desk", label: "Front Desk" },
+    ]);
+  });
+
+  it("is fail-closed outside an authenticated demo-role session", () => {
+    expect(shouldShowDemoRoleSwitcher(false, "authenticated", "admin")).toBe(
+      false,
+    );
+    expect(shouldShowDemoRoleSwitcher(true, "loading", "admin")).toBe(false);
+    expect(
+      shouldShowDemoRoleSwitcher(true, "unauthenticated", "admin"),
+    ).toBe(false);
+    expect(shouldShowDemoRoleSwitcher(true, "authenticated", "viewer")).toBe(
+      false,
+    );
+    expect(
+      shouldShowDemoRoleSwitcher(true, "authenticated", "veterinarian"),
+    ).toBe(true);
+  });
+
+  it("uses only the existing demo provider and treats every uncertain result as failure", async () => {
+    const signInDemo = vi.fn(async () => ({ ok: true, error: null }));
+
+    await expect(
+      requestDemoRoleSwitch("technician", signInDemo),
+    ).resolves.toBe(true);
+    expect(signInDemo).toHaveBeenCalledWith("demo", {
+      role: "technician",
+      redirect: false,
+    });
+
+    await expect(
+      requestDemoRoleSwitch("admin", async () => ({
+        ok: false,
+        error: "CredentialsSignin",
+      })),
+    ).resolves.toBe(false);
+    await expect(
+      requestDemoRoleSwitch("admin", async () => undefined),
+    ).resolves.toBe(false);
+    await expect(
+      requestDemoRoleSwitch("admin", async () => {
+        throw new Error("network down");
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("preserves a safe current route and falls back to the dashboard after privilege changes", () => {
+    expect(canPreserveDemoPath("technician", "/patients/abc")).toBe(true);
+    expect(canPreserveDemoPath("veterinarian", "/records/new-soap/abc")).toBe(
+      true,
+    );
+    expect(canPreserveDemoPath("front_desk", "/settings")).toBe(false);
+    expect(canPreserveDemoPath("technician", "/billing/new")).toBe(false);
+    expect(canPreserveDemoPath("admin", "/admin")).toBe(false);
+    expect(
+      demoRoleDestination(
+        "veterinarian",
+        "/encounters/abc",
+        "/encounters/abc?tab=soap#draft",
+      ),
+    ).toBe("/encounters/abc?tab=soap#draft");
+    expect(
+      demoRoleDestination("front_desk", "/settings", "/settings?tab=staff"),
+    ).toBe("/");
+    expect(
+      demoRoleDestination("admin", "/patients", "//outside.example/path"),
+    ).toBe("/");
+  });
+
+  it("shows the current role and disables switching while a role change is pending", () => {
+    const currentMarkup = renderToStaticMarkup(
+      createElement(DemoRoleSwitcherView, {
+        currentRole: "front_desk",
+        pendingRole: null,
+        error: null,
+        onRoleChange: vi.fn(),
+      }),
+    );
+    expect(currentMarkup).toContain("Explore as");
+    expect(currentMarkup).toContain("Current role: Front Desk");
+    expect(currentMarkup).toContain("Viewing demo as Front Desk");
+    expect(currentMarkup).toContain('value="front_desk" selected=""');
+    expect(currentMarkup).not.toContain(' disabled=""');
+
+    const pendingMarkup = renderToStaticMarkup(
+      createElement(DemoRoleSwitcherView, {
+        currentRole: "admin",
+        pendingRole: "technician",
+        error: null,
+        onRoleChange: vi.fn(),
+      }),
+    );
+    expect(pendingMarkup).toContain(' disabled=""');
+    expect(pendingMarkup).toContain("Switching to Technician");
+    expect(pendingMarkup).toContain("animate-spin");
+  });
+
+  it("surfaces role-switch failures without touching the pre-gate flow or funnel", () => {
+    const failureMarkup = renderToStaticMarkup(
+      createElement(DemoRoleSwitcherView, {
+        currentRole: "admin",
+        pendingRole: null,
+        error: "Your current role is unchanged.",
+        onRoleChange: vi.fn(),
+      }),
+    );
+    expect(failureMarkup).toContain('role="alert"');
+    expect(failureMarkup).toContain("Your current role is unchanged.");
+
+    const componentSource = readFileSync(
+      "components/demo/demo-role-switcher.tsx",
+      "utf8",
+    );
+    const barSource = readFileSync(
+      "components/demo/demo-conversion-bar.tsx",
+      "utf8",
+    );
+    const loginSource = readFileSync("app/(auth)/login/page.tsx", "utf8");
+
+    expect(componentSource).toContain("NEXT_PUBLIC_DEMO_MODE");
+    expect(componentSource).toContain("signIn(provider, options)");
+    expect(componentSource).toContain("window.location.assign(destination)");
+    expect(componentSource).not.toContain("/api/demo-access");
+    expect(componentSource).not.toContain("trackFunnelEvent");
+    expect(componentSource).not.toContain("FUNNEL_EVENTS");
+    expect(barSource).toContain("<DemoRoleSwitcher />");
+    expect(loginSource).not.toContain("DemoRoleSwitcher");
+  });
+});

--- a/apps/web/lib/demo-role-switcher.ts
+++ b/apps/web/lib/demo-role-switcher.ts
@@ -1,0 +1,123 @@
+export const DEMO_ROLE_OPTIONS = [
+  { value: "admin", label: "Practice Admin" },
+  { value: "veterinarian", label: "Veterinarian" },
+  { value: "technician", label: "Technician" },
+  { value: "front_desk", label: "Front Desk" },
+] as const;
+
+export type DemoSwitcherRole = (typeof DEMO_ROLE_OPTIONS)[number]["value"];
+
+type DemoSignInResult = {
+  ok?: boolean;
+  error?: string | null;
+};
+
+type DemoSignIn = (
+  provider: "demo",
+  options: { role: DemoSwitcherRole; redirect: false },
+) => Promise<DemoSignInResult | undefined>;
+
+const ALL_DEMO_ROLES: readonly DemoSwitcherRole[] = DEMO_ROLE_OPTIONS.map(
+  ({ value }) => value,
+);
+const ADMIN_ONLY: readonly DemoSwitcherRole[] = ["admin"];
+const CLINICAL_LEAD_ROLES: readonly DemoSwitcherRole[] = [
+  "admin",
+  "veterinarian",
+];
+const RECALL_ROLES: readonly DemoSwitcherRole[] = [
+  "admin",
+  "veterinarian",
+  "front_desk",
+];
+const BILLING_WRITE_ROLES: readonly DemoSwitcherRole[] = [
+  "admin",
+  "front_desk",
+];
+
+const DEMO_ROUTE_ACCESS: ReadonlyArray<{
+  prefix: string;
+  roles: readonly DemoSwitcherRole[];
+}> = [
+  { prefix: "/settings", roles: ADMIN_ONLY },
+  { prefix: "/agent", roles: CLINICAL_LEAD_ROLES },
+  { prefix: "/controlled-substances", roles: CLINICAL_LEAD_ROLES },
+  { prefix: "/reports", roles: CLINICAL_LEAD_ROLES },
+  { prefix: "/records/new-soap", roles: CLINICAL_LEAD_ROLES },
+  { prefix: "/billing/new", roles: BILLING_WRITE_ROLES },
+  { prefix: "/recalls", roles: RECALL_ROLES },
+  { prefix: "/patients", roles: ALL_DEMO_ROLES },
+  { prefix: "/clients", roles: ALL_DEMO_ROLES },
+  { prefix: "/schedule", roles: ALL_DEMO_ROLES },
+  { prefix: "/records", roles: ALL_DEMO_ROLES },
+  { prefix: "/billing", roles: ALL_DEMO_ROLES },
+  { prefix: "/inventory", roles: ALL_DEMO_ROLES },
+  { prefix: "/inbox", roles: ALL_DEMO_ROLES },
+  { prefix: "/whiteboard", roles: ALL_DEMO_ROLES },
+  { prefix: "/encounters", roles: ALL_DEMO_ROLES },
+];
+
+function matchesPathPrefix(pathname: string, prefix: string): boolean {
+  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+}
+
+export function isDemoSwitcherRole(
+  value: string | null | undefined,
+): value is DemoSwitcherRole {
+  return DEMO_ROLE_OPTIONS.some((role) => role.value === value);
+}
+
+export function demoRoleLabel(role: DemoSwitcherRole): string {
+  return (
+    DEMO_ROLE_OPTIONS.find((option) => option.value === role)?.label ?? role
+  );
+}
+
+export function shouldShowDemoRoleSwitcher(
+  demoMode: boolean,
+  sessionStatus: "authenticated" | "loading" | "unauthenticated",
+  role: string | null | undefined,
+): role is DemoSwitcherRole {
+  return (
+    demoMode &&
+    sessionStatus === "authenticated" &&
+    isDemoSwitcherRole(role)
+  );
+}
+
+export function canPreserveDemoPath(
+  role: DemoSwitcherRole,
+  pathname: string,
+): boolean {
+  if (pathname === "/") return true;
+  if (!pathname.startsWith("/") || pathname.startsWith("//")) return false;
+
+  const access = DEMO_ROUTE_ACCESS.find(({ prefix }) =>
+    matchesPathPrefix(pathname, prefix),
+  );
+  return access?.roles.includes(role) ?? false;
+}
+
+export function demoRoleDestination(
+  role: DemoSwitcherRole,
+  pathname: string,
+  currentPath: string,
+): string {
+  const currentPathIsLocal =
+    currentPath.startsWith("/") && !currentPath.startsWith("//");
+  return currentPathIsLocal && canPreserveDemoPath(role, pathname)
+    ? currentPath
+    : "/";
+}
+
+export async function requestDemoRoleSwitch(
+  role: DemoSwitcherRole,
+  signInDemo: DemoSignIn,
+): Promise<boolean> {
+  try {
+    const result = await signInDemo("demo", { role, redirect: false });
+    return result?.ok === true && !result.error;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add a persistent post-gate demo role selector for Practice Admin, Veterinarian, Technician, and Front Desk
- reuse the existing signed demo provider without another email gate or funnel event
- refresh the JWT-backed session after switching and preserve only routes safe for the destination role
- fail closed outside the hosted demo and surface loading/failure states without replacing the current identity

## Verification
- focused auth, conversion, and role-switch tests: 16 passed
- full web suite: 2,594 passed
- web type check passed
- production build passed
- `git diff --check` clean