### PR TITLE
Keep demo role exploration interruption-free

### DIFF
--- a/apps/web/components/demo/demo-role-switcher.tsx
+++ b/apps/web/components/demo/demo-role-switcher.tsx
@@ -6,6 +6,7 @@ import { signIn, useSession } from "next-auth/react";
 import { Loader2, UserRoundCog } from "lucide-react";
 import {
   DEMO_ROLE_OPTIONS,
+  addDemoRoleSwitchMarker,
   type DemoSwitcherRole,
   demoRoleDestination,
   demoRoleLabel,
@@ -130,7 +131,7 @@ export function DemoRoleSwitcher() {
       );
       // A full local navigation reloads the JWT-backed session before any
       // role-gated page or query can render under the new identity.
-      window.location.assign(destination);
+      window.location.assign(addDemoRoleSwitchMarker(destination));
     } catch {
       setPendingRole(null);
       setError("Role changed. Refresh this page to finish switching views.");

--- a/apps/web/components/welcome/welcome-provider.tsx
+++ b/apps/web/components/welcome/welcome-provider.tsx
@@ -34,6 +34,9 @@ import {
 import { WelcomeSurface } from "./welcome-surface";
 import type { WelcomeVariant } from "./polaroid-card";
 import { WELCOME_COPY } from "./welcome-copy";
+import { stripDemoRoleSwitchMarker } from "@/lib/demo-role-switcher";
+
+const DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE?.trim() === "true";
 
 interface WelcomeContextValue {
   openWelcome: () => void;
@@ -109,6 +112,18 @@ export function WelcomeProvider({ children }: { children: React.ReactNode }) {
     const wantGuides =
       typeof window !== "undefined" &&
       new URLSearchParams(window.location.search).get("guides") === "1";
+
+    if (DEMO_MODE && typeof window !== "undefined") {
+      const roleSwitchLanding = stripDemoRoleSwitchMarker(
+        `${window.location.pathname}${window.location.search}${window.location.hash}`,
+      );
+      if (roleSwitchLanding.hadMarker) {
+        autoDecided.current = true;
+        router.replace(roleSwitchLanding.path);
+        return;
+      }
+    }
+
     if (wantGuides) {
       autoDecided.current = true;
       router.replace(pathname); // strip so refresh does not relaunch

--- a/apps/web/lib/__tests__/demo-role-switcher.test.ts
+++ b/apps/web/lib/__tests__/demo-role-switcher.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it, vi } from "vitest";
 import { DemoRoleSwitcherView } from "@/components/demo/demo-role-switcher";
 import {
   DEMO_ROLE_OPTIONS,
+  addDemoRoleSwitchMarker,
   canPreserveDemoPath,
   demoRoleDestination,
   requestDemoRoleSwitch,
   shouldShowDemoRoleSwitcher,
+  stripDemoRoleSwitchMarker,
 } from "@/lib/demo-role-switcher";
 
 describe("post-gate demo role switcher", () => {
@@ -87,6 +89,26 @@ describe("post-gate demo role switcher", () => {
     ).toBe("/");
   });
 
+  it("marks role-switch landings and strips only the one-time marker", () => {
+    expect(
+      addDemoRoleSwitchMarker("/encounters/abc?tab=soap#draft"),
+    ).toBe("/encounters/abc?tab=soap&demo_role_switch=1#draft");
+    expect(addDemoRoleSwitchMarker("https://outside.example/path")).toBe("/");
+
+    expect(
+      stripDemoRoleSwitchMarker(
+        "/encounters/abc?tab=soap&demo_role_switch=1#draft",
+      ),
+    ).toEqual({
+      hadMarker: true,
+      path: "/encounters/abc?tab=soap#draft",
+    });
+    expect(stripDemoRoleSwitchMarker("/encounters/abc?tab=soap")).toEqual({
+      hadMarker: false,
+      path: "/encounters/abc?tab=soap",
+    });
+  });
+
   it("shows the current role and disables switching while a role change is pending", () => {
     const currentMarkup = renderToStaticMarkup(
       createElement(DemoRoleSwitcherView, {
@@ -136,14 +158,22 @@ describe("post-gate demo role switcher", () => {
       "utf8",
     );
     const loginSource = readFileSync("app/(auth)/login/page.tsx", "utf8");
+    const welcomeSource = readFileSync(
+      "components/welcome/welcome-provider.tsx",
+      "utf8",
+    );
 
     expect(componentSource).toContain("NEXT_PUBLIC_DEMO_MODE");
     expect(componentSource).toContain("signIn(provider, options)");
-    expect(componentSource).toContain("window.location.assign(destination)");
+    expect(componentSource).toContain(
+      "window.location.assign(addDemoRoleSwitchMarker(destination))",
+    );
     expect(componentSource).not.toContain("/api/demo-access");
     expect(componentSource).not.toContain("trackFunnelEvent");
     expect(componentSource).not.toContain("FUNNEL_EVENTS");
     expect(barSource).toContain("<DemoRoleSwitcher />");
     expect(loginSource).not.toContain("DemoRoleSwitcher");
+    expect(welcomeSource).toContain("stripDemoRoleSwitchMarker");
+    expect(welcomeSource).toContain("autoDecided.current = true");
   });
 });

--- a/apps/web/lib/demo-role-switcher.ts
+++ b/apps/web/lib/demo-role-switcher.ts
@@ -7,6 +7,8 @@ export const DEMO_ROLE_OPTIONS = [
 
 export type DemoSwitcherRole = (typeof DEMO_ROLE_OPTIONS)[number]["value"];
 
+export const DEMO_ROLE_SWITCH_QUERY_PARAM = "demo_role_switch";
+
 type DemoSignInResult = {
   ok?: boolean;
   error?: string | null;
@@ -108,6 +110,30 @@ export function demoRoleDestination(
   return currentPathIsLocal && canPreserveDemoPath(role, pathname)
     ? currentPath
     : "/";
+}
+
+export function addDemoRoleSwitchMarker(destination: string): string {
+  if (!destination.startsWith("/") || destination.startsWith("//")) return "/";
+  const url = new URL(destination, "https://demo.openvpm.local");
+  url.searchParams.set(DEMO_ROLE_SWITCH_QUERY_PARAM, "1");
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function stripDemoRoleSwitchMarker(currentPath: string): {
+  hadMarker: boolean;
+  path: string;
+} {
+  if (!currentPath.startsWith("/") || currentPath.startsWith("//")) {
+    return { hadMarker: false, path: "/" };
+  }
+  const url = new URL(currentPath, "https://demo.openvpm.local");
+  const hadMarker = url.searchParams.get(DEMO_ROLE_SWITCH_QUERY_PARAM) === "1";
+  if (!hadMarker) return { hadMarker: false, path: currentPath };
+  url.searchParams.delete(DEMO_ROLE_SWITCH_QUERY_PARAM);
+  return {
+    hadMarker: true,
+    path: `${url.pathname}${url.search}${url.hash}`,
+  };
 }
 
 export async function requestDemoRoleSwitch(


### PR DESCRIPTION
## Summary
- mark post-gate demo role-switch landings with a one-time local query parameter
- suppress the destination seeded user's automatic welcome overlay for that landing
- remove only the marker while preserving the evaluator's safe route, query, and hash
- leave explicit Guides entry and non-demo onboarding behavior unchanged

## Evidence
The production clinic-day smoke showed each newly selected seeded role opening its own welcome overlay over the active encounter.

## Verification
- focused demo-role and onboarding/welcome tests: 22 passed
- web type check passed
- `git diff --check` clean