### PR TITLE
Replace native billing action prompts

### DIFF
--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -29,6 +29,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { EmptyState } from "@/components/common/empty-state";
+import { ActionConfirmationDialog } from "@/components/common/action-confirmation-dialog";
 import { TableSkeleton } from "@/components/common/loading";
 import { TableScroll } from "@/components/common/table-scroll";
 import {
@@ -69,6 +70,9 @@ const PAYMENT_METHODS = [
   { label: "Online", value: "online" },
   { label: "Other", value: "other" },
 ] as const;
+
+const BILLING_ACTION_REASON_MIN_LENGTH = 5;
+const BILLING_ACTION_REASON_MAX_LENGTH = 500;
 
 function canManageBillingRole(role?: string | null): boolean {
   return role === "admin" || role === "front_desk";
@@ -152,6 +156,10 @@ export default function BillingPage() {
   const [activeTab, setActiveTab] = useState(0);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
+  const [pendingInvoiceVoidId, setPendingInvoiceVoidId] = useState<
+    string | null
+  >(null);
+  const [invoiceVoidReason, setInvoiceVoidReason] = useState("");
   const limit = 25;
 
   // Deep link: /billing?expand=<invoiceId> opens that invoice's detail (the
@@ -242,11 +250,33 @@ export default function BillingPage() {
 
   const handleVoidInvoice = (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
-    const reason = window.prompt(
-      "Why is this invoice being voided? Dispensed medication charges will return to the work queue.",
+    setInvoiceVoidReason("");
+    setPendingInvoiceVoidId(id);
+  };
+
+  const closeInvoiceVoidDialog = () => {
+    if (voidInvoice.isPending) return;
+    setPendingInvoiceVoidId(null);
+    setInvoiceVoidReason("");
+  };
+
+  const confirmInvoiceVoid = () => {
+    const reason = invoiceVoidReason.trim();
+    if (
+      !pendingInvoiceVoidId ||
+      reason.length < BILLING_ACTION_REASON_MIN_LENGTH
+    ) {
+      return;
+    }
+    voidInvoice.mutate(
+      { id: pendingInvoiceVoidId, reason },
+      {
+        onSuccess: () => {
+          setPendingInvoiceVoidId(null);
+          setInvoiceVoidReason("");
+        },
+      },
     );
-    if (!reason?.trim()) return;
-    voidInvoice.mutate({ id, reason: reason.trim() });
   };
 
   return (
@@ -462,6 +492,25 @@ export default function BillingPage() {
           }
         />
       )}
+
+      <ActionConfirmationDialog
+        open={pendingInvoiceVoidId !== null}
+        title="Void invoice?"
+        description="This cannot be undone. Any dispensed medication charges on this invoice will return to the billing work queue; inventory will not move again."
+        confirmLabel="Void invoice"
+        confirmVariant="destructive"
+        isPending={voidInvoice.isPending}
+        reason={{
+          label: "Reason for voiding",
+          value: invoiceVoidReason,
+          onChange: setInvoiceVoidReason,
+          placeholder: "Explain the correction for the audit trail",
+          minLength: BILLING_ACTION_REASON_MIN_LENGTH,
+          maxLength: BILLING_ACTION_REASON_MAX_LENGTH,
+        }}
+        onCancel={closeInvoiceVoidDialog}
+        onConfirm={confirmInvoiceVoid}
+      />
     </div>
   );
 }
@@ -480,6 +529,11 @@ function DispenseChargeQueuePanel({
   const router = useRouter();
   const formatCurrency = useCurrencyFormatter();
   const utils = trpc.useUtils();
+  const [waiveTargetId, setWaiveTargetId] = useState<string | null>(null);
+  const [waiveReason, setWaiveReason] = useState("");
+  const [legacyReviewTargetId, setLegacyReviewTargetId] = useState<
+    string | null
+  >(null);
   const pending = trpc.billing.listDispenseChargeQueue.useQuery({
     status: "pending",
     limit: 50,
@@ -518,30 +572,58 @@ function DispenseChargeQueuePanel({
   const isMutating =
     createInvoice.isPending || waiveCharge.isPending || reopenCharge.isPending;
 
-  function waive(id: string) {
-    const reason = window.prompt(
-      "Why should this clinic-stock dispense not be charged?",
-    );
-    if (!reason?.trim()) return;
-    waiveCharge.mutate({ id, reason: reason.trim() });
+  function openWaiveDialog(id: string) {
+    setWaiveReason("");
+    setWaiveTargetId(id);
   }
 
-  function createDraftForDispense(item: {
-    id: string;
-    legacyReview: boolean;
-  }) {
-    if (
-      item.legacyReview &&
-      !window.confirm(
-        "This dispense predates the billing ledger. Verify it was not already billed before creating a draft invoice.",
-      )
-    ) {
+  function closeWaiveDialog() {
+    if (waiveCharge.isPending) return;
+    setWaiveTargetId(null);
+    setWaiveReason("");
+  }
+
+  function confirmWaive() {
+    const reason = waiveReason.trim();
+    if (!waiveTargetId || reason.length < BILLING_ACTION_REASON_MIN_LENGTH) {
+      return;
+    }
+    waiveCharge.mutate(
+      { id: waiveTargetId, reason },
+      {
+        onSuccess: () => {
+          setWaiveTargetId(null);
+          setWaiveReason("");
+        },
+      },
+    );
+  }
+
+  function createDraftForDispense(item: { id: string; legacyReview: boolean }) {
+    if (item.legacyReview) {
+      setLegacyReviewTargetId(item.id);
       return;
     }
     createInvoice.mutate({
       id: item.id,
-      acknowledgeLegacyReview: item.legacyReview,
+      acknowledgeLegacyReview: false,
     });
+  }
+
+  function closeLegacyReviewDialog() {
+    if (createInvoice.isPending) return;
+    setLegacyReviewTargetId(null);
+  }
+
+  function confirmLegacyReview() {
+    if (!legacyReviewTargetId) return;
+    createInvoice.mutate(
+      {
+        id: legacyReviewTargetId,
+        acknowledgeLegacyReview: true,
+      },
+      { onSuccess: () => setLegacyReviewTargetId(null) },
+    );
   }
 
   return (
@@ -625,7 +707,7 @@ function DispenseChargeQueuePanel({
                       size="sm"
                       variant="outline"
                       disabled={isMutating}
-                      onClick={() => waive(item.id)}
+                      onClick={() => openWaiveDialog(item.id)}
                     >
                       Waive
                     </Button>
@@ -672,6 +754,35 @@ function DispenseChargeQueuePanel({
           </div>
         </details>
       ) : null}
+      <ActionConfirmationDialog
+        open={legacyReviewTargetId !== null}
+        title="Review legacy dispense"
+        description="This dispense predates the billing ledger. Verify it was not already billed before creating a draft invoice."
+        confirmLabel="Verified — create draft"
+        isPending={createInvoice.isPending}
+        onCancel={closeLegacyReviewDialog}
+        onConfirm={confirmLegacyReview}
+      />
+
+      <ActionConfirmationDialog
+        open={waiveTargetId !== null}
+        title="Waive medication charge?"
+        description="No invoice will be created. Inventory remains deducted, and the reason is saved to the audit trail so an admin can review or reopen this charge later."
+        confirmLabel="Waive charge"
+        confirmVariant="destructive"
+        isPending={waiveCharge.isPending}
+        reason={{
+          label: "Reason for no charge",
+          value: waiveReason,
+          onChange: setWaiveReason,
+          placeholder: "Explain why this dispense should not be billed",
+          minLength: BILLING_ACTION_REASON_MIN_LENGTH,
+          maxLength: BILLING_ACTION_REASON_MAX_LENGTH,
+        }}
+        onCancel={closeWaiveDialog}
+        onConfirm={confirmWaive}
+      />
+
     </section>
   );
 }
@@ -1348,6 +1459,10 @@ function PaymentSection({
   );
   const [adjustmentAmount, setAdjustmentAmount] = useState("");
   const [adjustmentReason, setAdjustmentReason] = useState("");
+  const [refundTarget, setRefundTarget] = useState<{
+    paymentId: string;
+    amount: string;
+  } | null>(null);
   const paymentOperationId = useRef<string | null>(null);
   const adjustmentOperationId = useRef<string | null>(null);
 
@@ -1410,6 +1525,7 @@ function PaymentSection({
   const refundPayment = trpc.billing.refundPayment.useMutation({
     onSuccess: () => {
       toast.success("Payment refunded");
+      setRefundTarget(null);
       utils.billing.listPayments.invalidate({ invoiceId });
       utils.billing.listInvoices.invalidate();
       utils.billing.getInvoice.invalidate({ id: invoiceId });
@@ -1492,6 +1608,16 @@ function PaymentSection({
       amount: adjustmentAmount.trim(),
       reason: adjustmentReason.trim() || undefined,
     });
+  };
+
+  const closeRefundDialog = () => {
+    if (refundPayment.isPending) return;
+    setRefundTarget(null);
+  };
+
+  const confirmRefund = () => {
+    if (!refundTarget) return;
+    refundPayment.mutate({ paymentId: refundTarget.paymentId });
   };
 
   return (
@@ -1760,16 +1886,12 @@ function PaymentSection({
                         size="sm"
                         className="h-7 px-2 text-xs text-muted-foreground hover:text-destructive"
                         disabled={refundPayment.isPending}
-                        onClick={() => {
-                          if (
-                            !window.confirm(
-                              `Refund ${formatCurrency(payment.amount)}? Card payments are refunded through Stripe.`
-                            )
-                          ) {
-                            return;
-                          }
-                          refundPayment.mutate({ paymentId: payment.id });
-                        }}
+                        onClick={() =>
+                          setRefundTarget({
+                            paymentId: payment.id,
+                            amount: payment.amount,
+                          })
+                        }
                       >
                         Refund
                       </Button>
@@ -1845,6 +1967,16 @@ function PaymentSection({
           No credits or write-offs recorded.
         </p>
       )}
+      <ActionConfirmationDialog
+        open={refundTarget !== null}
+        title="Refund payment?"
+        description={`Refund ${formatCurrency(refundTarget?.amount ?? "0")}? Card payments are refunded through Stripe.`}
+        confirmLabel="Refund payment"
+        confirmVariant="destructive"
+        isPending={refundPayment.isPending}
+        onCancel={closeRefundDialog}
+        onConfirm={confirmRefund}
+      />
     </div>
   );
 }

--- a/apps/web/components/common/action-confirmation-dialog.tsx
+++ b/apps/web/components/common/action-confirmation-dialog.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useId, useRef } from "react";
+import { createPortal } from "react-dom";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+type ReasonInput = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  minLength?: number;
+  maxLength?: number;
+};
+
+export function ActionConfirmationDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  confirmVariant = "default",
+  isPending = false,
+  reason,
+  onCancel,
+  onConfirm,
+}: {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  confirmVariant?: "default" | "destructive";
+  isPending?: boolean;
+  reason?: ReasonInput;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const titleId = useId();
+  const descriptionId = useId();
+  const reasonId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const reasonRef = useRef<HTMLTextAreaElement>(null);
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef(onCancel);
+  const pendingRef = useRef(isPending);
+  const hasReason = reason !== undefined;
+  cancelRef.current = onCancel;
+  pendingRef.current = isPending;
+
+  useEffect(() => {
+    if (!open) return;
+    const previousFocus = document.activeElement as HTMLElement | null;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const focusFrame = window.requestAnimationFrame(() => {
+      (hasReason ? reasonRef.current : confirmRef.current)?.focus();
+    });
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !pendingRef.current) {
+        cancelRef.current();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(
+          "button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), a[href]",
+        ) ?? [],
+      ).filter((element) => element.tabIndex !== -1);
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.cancelAnimationFrame(focusFrame);
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+      previousFocus?.focus();
+    };
+  }, [hasReason, open]);
+
+  if (!open) return null;
+
+  const trimmedReason = reason?.value.trim() ?? "";
+  const reasonIsValid = reason
+    ? trimmedReason.length >= (reason.minLength ?? 1) &&
+      trimmedReason.length <= (reason.maxLength ?? Number.POSITIVE_INFINITY)
+    : true;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/55 p-4"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget && !isPending) onCancel();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className="w-full max-w-lg rounded-xl border border-border bg-card p-5 shadow-2xl"
+      >
+        <h2 id={titleId} className="font-heading text-lg font-semibold">
+          {title}
+        </h2>
+        <p id={descriptionId} className="mt-2 text-sm text-muted-foreground">
+          {description}
+        </p>
+
+        {reason ? (
+          <div className="mt-4">
+            <label htmlFor={reasonId} className="text-sm font-medium">
+              {reason.label}
+            </label>
+            <Textarea
+              ref={reasonRef}
+              id={reasonId}
+              className="mt-2"
+              value={reason.value}
+              placeholder={reason.placeholder}
+              minLength={reason.minLength}
+              maxLength={reason.maxLength}
+              aria-invalid={reason.value.length > 0 && !reasonIsValid}
+              onChange={(event) => reason.onChange(event.target.value)}
+            />
+            <p className="mt-1 text-xs text-muted-foreground">
+              {reason.minLength
+                ? `${reason.minLength} characters minimum. `
+                : null}
+              {reason.maxLength
+                ? `${reason.value.length}/${reason.maxLength}`
+                : null}
+            </p>
+          </div>
+        ) : null}
+
+        <div className="mt-5 flex justify-end gap-2">
+          <Button variant="outline" disabled={isPending} onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            ref={confirmRef}
+            variant={confirmVariant}
+            disabled={isPending || !reasonIsValid}
+            onClick={onConfirm}
+          >
+            {isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/lib/__tests__/action-confirmation-dialog-ui.test.ts
+++ b/apps/web/lib/__tests__/action-confirmation-dialog-ui.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("action confirmation dialog", () => {
+  const source = readFileSync(
+    "components/common/action-confirmation-dialog.tsx",
+    "utf8",
+  );
+
+  it("exposes modal semantics and keeps keyboard focus inside", () => {
+    expect(source).toContain('role="dialog"');
+    expect(source).toContain('aria-modal="true"');
+    expect(source).toContain("aria-labelledby={titleId}");
+    expect(source).toContain("aria-describedby={descriptionId}");
+    expect(source).toContain('event.key === "Escape"');
+    expect(source).toContain('event.key !== "Tab"');
+    expect(source).toContain("event.preventDefault()");
+    expect(source).toContain("previousFocus?.focus()");
+  });
+
+  it("blocks invalid reasons and prevents background interaction", () => {
+    expect(source).toContain('document.body.style.overflow = "hidden"');
+    expect(source).toContain("reason.minLength");
+    expect(source).toContain("reason.maxLength");
+    expect(source).toContain("disabled={isPending || !reasonIsValid}");
+    expect(source).toContain("createPortal(");
+  });
+});

--- a/apps/web/lib/__tests__/billing-ui.test.ts
+++ b/apps/web/lib/__tests__/billing-ui.test.ts
@@ -203,6 +203,16 @@ describe("billing invoice payment actions", () => {
     expect(source).toContain("Take Card");
   });
 
+  it("uses accessible in-app dialogs for irreversible billing actions", () => {
+    expect(source).toContain("<ActionConfirmationDialog");
+    expect(source).toContain('title="Void invoice?"');
+    expect(source).toContain('label: "Reason for voiding"');
+    expect(source).toContain('title="Refund payment?"');
+    expect(source).toContain('confirmLabel="Refund payment"');
+    expect(source).not.toContain("window.prompt");
+    expect(source).not.toContain("window.confirm");
+  });
+
   it("keeps one operation ID across payment and adjustment retries", () => {
     expect(source).toContain("paymentOperationId.current ??= crypto.randomUUID()");
     expect(source).toContain("operationId: paymentOperationId.current");
@@ -344,9 +354,14 @@ describe("medication dispense billing queue", () => {
     expect(source).toContain("Create draft");
     expect(source).toContain("Review & create");
     expect(source).toContain("Verify it was not already billed");
+    expect(source).toContain('title="Review legacy dispense"');
+    expect(source).toContain('confirmLabel="Verified — create draft"');
     expect(source).toContain("Open visit");
     expect(source).toContain("Standalone refill");
     expect(source).toContain("Waive");
+    expect(source).toContain('title="Waive medication charge?"');
+    expect(source).toContain('label: "Reason for no charge"');
+    expect(source).toContain("the audit trail");
     expect(source).toContain("Inventory has");
     expect(source).toContain("already been deducted and will not move again");
   });


### PR DESCRIPTION
## Summary
- replace browser-native invoice void, medication waiver, legacy dispense review, and payment refund prompts with a shared in-app confirmation dialog
- require and bound auditable reasons for invoice voids and no-charge medication decisions
- add modal semantics, focus entry/restore, keyboard focus containment, Escape handling, and background scroll lock
- explain inventory and billing consequences before irreversible actions

## Verification
- `pnpm --filter @openpims/web test` — 287 files / 2,666 tests passed
- `pnpm --filter @openpims/web type-check`
- `pnpm --filter @openpims/web build`
- `git diff --check`

## Live verification plan
After merge and deployment to demo: void the synthetic Cerenia draft, confirm the dispense returns to the unbilled queue without a second inventory movement, waive it with an audit reason, and verify it appears under Recently waived.