### PR TITLE
Make clinic record migration onboarding safe

### DIFF
--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -89,7 +89,11 @@ import {
   IMPORT_CSV_MAX_BYTES,
   isImportCsvSizeValid,
 } from "@/lib/import/policy";
-import { MIGRATION_SOURCES } from "@/lib/import/sources";
+import {
+  MIGRATION_SOURCES,
+  MIGRATION_STEPS,
+  type MigrationImportMode,
+} from "@/lib/import/sources";
 import {
   AUTH_PASSWORD_MAX_LENGTH,
   AUTH_PASSWORD_MIN_LENGTH,
@@ -2777,7 +2781,7 @@ type ImportPreview = {
   unmatchedPatient?: number;
   errors: string[];
 };
-type ImportMode = "clients" | "patients" | "vaccinations" | "soapNotes";
+type ImportMode = MigrationImportMode;
 const IMPORT_CSV_SIZE_MESSAGE = "CSV imports must be 5 MB or less.";
 function importPreviewRequestKey(
   mode: ImportMode,
@@ -2792,17 +2796,6 @@ function importPreviewRequestKey(
   }
   return `${mode}:${source}:${csv.length}:${(hash >>> 0).toString(16)}`;
 }
-const IMPORT_COLUMN_HINTS: Record<ImportMode, string> = {
-  clients:
-    "Expected columns: firstName, lastName, plus email or client ID. Optional: phone, address, city, state, zip",
-  patients:
-    "Expected columns: clientEmail or client ID, name, species. Patient ID is recommended. Optional: breed, sex, dob, color, microchipNumber",
-  vaccinations:
-    "Expected columns: patient ID, or an owner reference plus patientName; vaccineName and dateGiven. Optional: nextDueDate, lotNumber, manufacturer",
-  soapNotes:
-    "Expected columns: patient ID, or an owner reference plus patientName; date, and either subjective, objective, assessment, plan or a single notes column",
-};
-
 // ── Data Tab ─────────────────────────────────────────────────
 function DataTab() {
   const [exportingType, setExportingType] = useState<string | null>(null);
@@ -3924,18 +3917,7 @@ function DataTab() {
 
         {/* Import mode selector */}
         <div className="flex flex-wrap gap-2 mb-4">
-          {[
-            { mode: "clients" as const, label: "1. Import Clients" },
-            { mode: "patients" as const, label: "2. Import Patients" },
-            {
-              mode: "vaccinations" as const,
-              label: "3. Import Vaccine History",
-            },
-            {
-              mode: "soapNotes" as const,
-              label: "4. Import Medical History",
-            },
-          ].map(({ mode, label }) => (
+          {MIGRATION_STEPS.map(({ mode, label }, index) => (
             <Button
               key={mode}
               variant={importMode === mode ? "default" : "outline"}
@@ -3952,7 +3934,7 @@ function DataTab() {
               }}
             >
               <Upload className="mr-2 h-4 w-4" />
-              {label}
+              {index + 1}. Import {label}
             </Button>
           ))}
         </div>
@@ -3961,7 +3943,11 @@ function DataTab() {
           <div className="max-w-2xl space-y-4">
             {/* Expected columns hint */}
             <p className="text-xs text-muted-foreground">
-              {IMPORT_COLUMN_HINTS[importMode]}
+              Expected columns:{" "}
+              {
+                MIGRATION_STEPS.find((step) => step.mode === importMode)!
+                  .columnHint
+              }
             </p>
 
             {/* Drop zone */}

--- a/apps/web/components/onboarding/journey-overlay.tsx
+++ b/apps/web/components/onboarding/journey-overlay.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import { useSession } from "next-auth/react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { ArrowLeft, ArrowRight, Loader2, PawPrint } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
@@ -59,7 +60,7 @@ function buildSteps(billingEnforced: boolean): StepDef[] {
     { id: "basics", title: "Tell us about your clinic." },
     { id: "branding", title: "Make it feel like yours." },
     { id: "team", title: "Bring your team in." },
-    { id: "data", title: "Add your real clients and pets." },
+    { id: "data", title: "Bring your clinic records." },
     { id: "agent", title: "Try your AI helper." },
     { id: "phone", title: "Set up texting." },
     ...(billingEnforced
@@ -193,6 +194,16 @@ export function OnboardingJourneyProvider({
           index={index!}
           setIndex={setIndex}
           initialIntent={onboardingIntent ?? DEFAULT_ONBOARDING_INTENT}
+          initialMigrationHasCommittedChanges={
+            onboardingState.data?.migrationHasCommittedChanges === true
+          }
+          initialMigrationSource={onboardingState.data?.migrationSource ?? null}
+          initialMigrationSourceHasCommittedChanges={
+            onboardingState.data?.migrationSourceHasCommittedChanges === true
+          }
+          initialMigrationCompletedModes={
+            onboardingState.data?.migrationCompletedModes ?? []
+          }
         />
       ) : null}
     </OnboardingJourneyContext.Provider>
@@ -208,11 +219,21 @@ function JourneyShell({
   index,
   setIndex,
   initialIntent,
+  initialMigrationHasCommittedChanges,
+  initialMigrationSource,
+  initialMigrationSourceHasCommittedChanges,
+  initialMigrationCompletedModes,
 }: {
   steps: StepDef[];
   index: number;
   setIndex: (i: number | null) => void;
   initialIntent: OnboardingIntent;
+  initialMigrationHasCommittedChanges: boolean;
+  initialMigrationSource: JourneyState["migrationSource"];
+  initialMigrationSourceHasCommittedChanges: boolean;
+  initialMigrationCompletedModes: NonNullable<
+    JourneyState["migrationCompletedModes"]
+  >;
 }) {
   const utils = trpc.useUtils();
   const { start: startTour } = useTour();
@@ -223,8 +244,14 @@ function JourneyShell({
   // Shared step state. Default to keeping sample data and offering the tour.
   const [state, setStateRaw] = useState<JourneyState>({
     onboardingIntent: initialIntent,
-    keepSampleData: true,
+    keepSampleData: !initialMigrationHasCommittedChanges,
     startTourAfter: true,
+    hasPartialImport: false,
+    hasImportedData: initialMigrationHasCommittedChanges,
+    migrationSource: initialMigrationSource,
+    migrationSourceHasCommittedChanges:
+      initialMigrationSourceHasCommittedChanges,
+    migrationCompletedModes: initialMigrationCompletedModes,
   });
   const setState = useCallback(
     (patch: Partial<JourneyState>) =>
@@ -323,14 +350,23 @@ function JourneyShell({
   ]);
 
   const handleBack = useCallback(() => {
-    if (busy || continueDisabled || index === 0) return;
+    if (busy || continueDisabled || state.hasPartialImport || index === 0)
+      return;
     handleRef.current = null;
     setContinueLabel(null);
     setContinueDisabled(false);
     const prev = index - 1;
     persistCursor(steps[prev]!.id);
     setIndex(prev);
-  }, [busy, continueDisabled, index, steps, persistCursor, setIndex]);
+  }, [
+    busy,
+    continueDisabled,
+    state.hasPartialImport,
+    index,
+    steps,
+    persistCursor,
+    setIndex,
+  ]);
 
   const handleFinishLater = useCallback(() => {
     if (busy || continueDisabled) return;
@@ -342,124 +378,178 @@ function JourneyShell({
     );
     setJourneyProgress.mutate({ stepId: step.id, dismissed: true });
     setIndex(null);
-  }, [busy, continueDisabled, step.id, utils, setJourneyProgress, setIndex]);
+    if (state.hasPartialImport) {
+      toast.success(
+        "Completed records are saved. Reopen setup or use Settings, then Data, to finish the remaining files.",
+      );
+    }
+  }, [
+    busy,
+    continueDisabled,
+    step.id,
+    state.hasPartialImport,
+    utils,
+    setJourneyProgress,
+    setIndex,
+  ]);
 
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label="Make it yours setup"
-      className="fixed inset-0 z-[80] overflow-y-auto bg-[linear-gradient(135deg,#fff7ed_0%,#fdf2f8_45%,#ecfdf5_100%)] p-4 text-slate-950 sm:p-6"
+    <DialogPrimitive.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) handleFinishLater();
+      }}
     >
-      <div className="flex min-h-full items-center justify-center">
-        <div className="w-full max-w-2xl rounded-2xl border border-white/80 bg-white p-6 shadow-xl shadow-rose-200/30 sm:p-8">
-          {/* Brand mark + progress */}
-          <div className="flex items-center justify-between gap-4">
-            <div className="inline-flex items-center gap-2 text-sm font-medium text-emerald-700">
-              <PawPrint className="h-4 w-4" />
-              Make it yours
-            </div>
-            <span className="text-xs font-medium text-slate-500">
-              Step {index + 1} of {total}
-            </span>
-          </div>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-[80] bg-[linear-gradient(135deg,#fff7ed_0%,#fdf2f8_45%,#ecfdf5_100%)]" />
+        <DialogPrimitive.Content
+          className="fixed inset-0 z-[80] overflow-y-auto p-4 text-slate-950 outline-none sm:p-6"
+          onInteractOutside={(event) => event.preventDefault()}
+          onPointerDownOutside={(event) => event.preventDefault()}
+        >
+          <DialogPrimitive.Description className="sr-only">
+            Guided setup for your OpenVPM clinic.
+          </DialogPrimitive.Description>
+          <div className="flex min-h-full items-center justify-center">
+            <div className="w-full max-w-2xl rounded-2xl border border-white/80 bg-white p-6 shadow-xl shadow-rose-200/30 sm:p-8">
+              {/* Brand mark + progress */}
+              <div className="flex items-center justify-between gap-4">
+                <div className="inline-flex items-center gap-2 text-sm font-medium text-emerald-700">
+                  <PawPrint className="h-4 w-4" />
+                  Make it yours
+                </div>
+                <span className="text-xs font-medium text-slate-500">
+                  Step {index + 1} of {total}
+                </span>
+              </div>
 
-          <div className="mt-3 flex gap-1.5" aria-hidden="true">
-            {steps.map((s, i) => (
-              <span
-                key={s.id}
-                className={cn(
-                  "h-1.5 flex-1 rounded-full transition-colors",
-                  i <= index ? "bg-emerald-500" : "bg-slate-200",
-                )}
-              />
-            ))}
-          </div>
+              <div className="mt-3 flex gap-1.5" aria-hidden="true">
+                {steps.map((s, i) => (
+                  <span
+                    key={s.id}
+                    className={cn(
+                      "h-1.5 flex-1 rounded-full transition-colors",
+                      i <= index ? "bg-emerald-500" : "bg-slate-200",
+                    )}
+                  />
+                ))}
+              </div>
 
-          {/* Title */}
-          <h2 className="mt-6 font-heading text-2xl font-bold tracking-tight text-slate-950">
-            {step.title}
-          </h2>
+              {/* Title */}
+              <DialogPrimitive.Title asChild>
+                <h2 className="mt-6 font-heading text-2xl font-bold tracking-tight text-slate-950">
+                  {step.title}
+                </h2>
+              </DialogPrimitive.Title>
 
-          {/* Active step */}
-          <div className="mt-5">
-            {step.id === "intent" ? (
-              <ChoosePathStep
-                register={register}
-                state={state}
-                setState={setState}
-              />
-            ) : null}
-            {step.id === "basics" ? (
-              <PracticeBasicsStep register={register} />
-            ) : null}
-            {step.id === "branding" ? (
-              <BrandingStep register={register} />
-            ) : null}
-            {step.id === "team" ? <InviteTeamStep register={register} /> : null}
-            {step.id === "data" ? (
-              <BringDataStep
-                register={register}
-                state={state}
-                setState={setState}
-              />
-            ) : null}
-            {step.id === "agent" ? <TryAgentStep register={register} /> : null}
-            {step.id === "phone" ? (
-              <SetUpTextingStep register={register} />
-            ) : null}
-            {step.id === "billing" ? (
-              <AddACardStep register={register} />
-            ) : null}
-            {step.id === "allSet" ? (
-              <AllSetStep
-                register={register}
-                state={state}
-                setState={setState}
-              />
-            ) : null}
-          </div>
+              {/* Active step */}
+              <div className="mt-5">
+                {step.id === "intent" ? (
+                  <ChoosePathStep
+                    register={register}
+                    state={state}
+                    setState={setState}
+                  />
+                ) : null}
+                {step.id === "basics" ? (
+                  <PracticeBasicsStep register={register} />
+                ) : null}
+                {step.id === "branding" ? (
+                  <BrandingStep register={register} />
+                ) : null}
+                {step.id === "team" ? (
+                  <InviteTeamStep register={register} />
+                ) : null}
+                {step.id === "data" ? (
+                  <BringDataStep
+                    register={register}
+                    state={state}
+                    setState={setState}
+                  />
+                ) : null}
+                {step.id === "agent" ? (
+                  <TryAgentStep register={register} />
+                ) : null}
+                {step.id === "phone" ? (
+                  <SetUpTextingStep register={register} />
+                ) : null}
+                {step.id === "billing" ? (
+                  <AddACardStep register={register} />
+                ) : null}
+                {step.id === "allSet" ? (
+                  <AllSetStep
+                    register={register}
+                    state={state}
+                    setState={setState}
+                  />
+                ) : null}
+              </div>
 
-          {/* Footer */}
-          <div className="mt-8 flex items-center justify-between gap-4 border-t border-slate-100 pt-5">
-            <div className="flex items-center gap-3">
-              {index > 0 ? (
+              {/* Footer */}
+              <div className="mt-8 flex flex-col-reverse items-stretch gap-4 border-t border-slate-100 pt-5 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between gap-3 sm:justify-start">
+                    {index > 0 ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={handleBack}
+                        disabled={
+                          busy || continueDisabled || state.hasPartialImport
+                        }
+                        aria-describedby={
+                          state.hasPartialImport
+                            ? "onboarding-back-disabled-reason"
+                            : undefined
+                        }
+                      >
+                        <ArrowLeft className="mr-1.5 h-4 w-4" />
+                        Back
+                      </Button>
+                    ) : null}
+                    {!isLast ? (
+                      <button
+                        type="button"
+                        onClick={handleFinishLater}
+                        disabled={busy || continueDisabled}
+                        className="text-sm font-medium text-slate-500 hover:text-slate-700 disabled:opacity-50"
+                      >
+                        {state.hasPartialImport
+                          ? "Finish remaining import later"
+                          : "I'll finish later"}
+                      </button>
+                    ) : null}
+                  </div>
+                  {state.hasPartialImport ? (
+                    <p
+                      id="onboarding-back-disabled-reason"
+                      className="max-w-sm text-xs leading-5 text-slate-500"
+                    >
+                      Back is unavailable after records are saved. Finish the
+                      remaining import now or continue it later.
+                    </p>
+                  ) : null}
+                </div>
+
                 <Button
                   type="button"
-                  variant="ghost"
-                  onClick={handleBack}
+                  onClick={handleContinue}
                   disabled={busy || continueDisabled}
+                  className="h-auto min-h-10 w-full whitespace-normal py-2 text-center sm:w-auto"
                 >
-                  <ArrowLeft className="mr-1.5 h-4 w-4" />
-                  Back
+                  {busy ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : null}
+                  {isLast ? "Finish" : (continueLabel ?? "Continue")}
+                  {!isLast && !busy ? (
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  ) : null}
                 </Button>
-              ) : null}
-              {!isLast ? (
-                <button
-                  type="button"
-                  onClick={handleFinishLater}
-                  disabled={busy || continueDisabled}
-                  className="text-sm font-medium text-slate-500 hover:text-slate-700 disabled:opacity-50"
-                >
-                  I&apos;ll finish later
-                </button>
-              ) : null}
+              </div>
             </div>
-
-            <Button
-              type="button"
-              onClick={handleContinue}
-              disabled={busy || continueDisabled}
-            >
-              {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
-              {isLast ? "Finish" : (continueLabel ?? "Continue")}
-              {!isLast && !busy ? (
-                <ArrowRight className="ml-2 h-4 w-4" />
-              ) : null}
-            </Button>
           </div>
-        </div>
-      </div>
-    </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 }

--- a/apps/web/components/onboarding/journey-types.ts
+++ b/apps/web/components/onboarding/journey-types.ts
@@ -1,6 +1,7 @@
 /** Shared collected state and the per-step contract for the onboarding journey. */
 
 import type { OnboardingIntent } from "@/lib/onboarding/intent";
+import type { MigrationImportMode } from "@/lib/import/sources";
 
 export interface JourneyState {
   /** The adoption path selected on the first setup step. */
@@ -9,6 +10,16 @@ export interface JourneyState {
   keepSampleData: boolean;
   /** When true, finishing the wizard launches the quick product tour. */
   startTourAfter: boolean;
+  /** A reviewed multi-file migration has committed at least one stage locally. */
+  hasPartialImport: boolean;
+  /** Sticky for this journey once reviewed real data has reached the practice. */
+  hasImportedData: boolean;
+  /** Source used by the latest reviewed migration, safe to persist without CSV data. */
+  migrationSource?: string | null;
+  /** True only when the latest source has committed material record changes. */
+  migrationSourceHasCommittedChanges?: boolean;
+  /** Stages already reviewed and completed in earlier sessions. */
+  migrationCompletedModes?: MigrationImportMode[];
 }
 
 export interface StepHandle {

--- a/apps/web/components/onboarding/steps/bring-data.tsx
+++ b/apps/web/components/onboarding/steps/bring-data.tsx
@@ -5,22 +5,42 @@ import Link from "next/link";
 import {
   ArrowRight,
   Check,
+  ChevronDown,
   FileSpreadsheet,
   Loader2,
   PlugZap,
   Sparkles,
 } from "lucide-react";
-import { trpc } from "@/lib/trpc";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import {
+  isOnboardingImportModeLocked,
+  isOnboardingMigrationSourceLocked,
+  lastCommittedImportIndex,
+  nextOnboardingImportMode,
+  onboardingImportChangeCount,
+  summarizeOnboardingImports,
+  type OnboardingImportCommit,
+  type OnboardingImportCommits,
+  type OnboardingImportSelections,
+  type OnboardingImportSummary,
+} from "@/lib/import/onboarding-workflow";
 import {
   IMPORT_CSV_MAX_BYTES,
   isImportCsvSizeValid,
 } from "@/lib/import/policy";
+import {
+  isValidMigrationSource,
+  MIGRATION_SOURCES,
+  MIGRATION_STEPS,
+  migrationSourceExportHint,
+  migrationSourceName,
+  type MigrationImportMode,
+} from "@/lib/import/sources";
 import { getOnboardingIntentOption } from "@/lib/onboarding/intent";
-import { MIGRATION_SOURCES } from "@/lib/import/sources";
-import { toast } from "sonner";
-import type { StepHandle, StepProps } from "../journey-types";
+import { trpc } from "@/lib/trpc";
+import { cn } from "@/lib/utils";
+import type { StepProps } from "../journey-types";
 
 type Choice = "import" | "api" | "keep";
 type CsvPreview = {
@@ -30,18 +50,26 @@ type CsvPreview = {
   willReconcile?: number;
   duplicates?: number;
   unmatchedClient?: number;
+  unmatchedPatient?: number;
   errors: string[];
 };
-type CommittedCsvImport = {
-  imported: number;
-  reconciled: number;
+type CsvPreviews = Partial<Record<MigrationImportMode, CsvPreview>>;
+type CsvMeta = { hasContent: boolean; sizeValid: boolean };
+type ImportResponse = {
+  dryRun?: boolean;
+  previewToken?: string;
+  total?: number;
+  willInsert?: number;
+  willReconcile?: number;
+  duplicates?: number;
+  unmatchedClient?: number;
+  unmatchedPatient?: number;
+  imported?: number;
+  reconciled?: number;
+  alreadyCommitted?: boolean;
   errors: string[];
 };
 
-const CLIENT_COLUMNS =
-  "firstName, lastName, email or client ID, phone, address, city, state, zip";
-const PET_COLUMNS =
-  "clientEmail or client ID, patient ID, name, species, breed, sex, dob, color, microchipNumber";
 const IMPORT_CSV_SIZE_MESSAGE = "CSV imports must be 5 MB or less.";
 
 const textareaClass =
@@ -50,7 +78,21 @@ const textareaClass =
 const fileInputClass =
   "block w-full text-xs text-slate-600 file:mr-3 file:rounded-md file:border-0 file:bg-emerald-600 file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-white hover:file:bg-emerald-700";
 
-// Read a chosen file to text so we can pass the CSV string to the import calls.
+function importMap<T>(create: () => T): Record<MigrationImportMode, T> {
+  return Object.fromEntries(
+    MIGRATION_STEPS.map(({ mode }) => [mode, create()]),
+  ) as Record<MigrationImportMode, T>;
+}
+
+function migrationModeLabels(modes: readonly MigrationImportMode[]): string {
+  return modes
+    .map(
+      (mode) =>
+        MIGRATION_STEPS.find((step) => step.mode === mode)?.label ?? mode,
+    )
+    .join(", ");
+}
+
 function readFileText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -84,404 +126,464 @@ function downloadIssueReport(errors: string[], fileName: string) {
 }
 
 /**
- * Step 4: choose how real data gets in. Import from a file now, connect by API
- * later, or keep the sample data for now (the default and the skip behavior).
+ * Step 4: choose how real data gets in. Every supplied file is processed in
+ * dependency order and gets its own server preview before an explicit commit.
  */
 export function BringDataStep({ register, state, setState }: StepProps) {
+  const pathway = getOnboardingIntentOption(state.onboardingIntent);
+  const utils = trpc.useUtils();
   const importClientsCsv = trpc.data.importClientsCsv.useMutation();
   const importPatientsCsv = trpc.data.importPatientsCsv.useMutation();
+  const importVaccinationsCsv = trpc.data.importVaccinationsCsv.useMutation();
+  const importSoapNotesCsv = trpc.data.importSoapNotesCsv.useMutation();
 
-  // Default to keeping the sample data; the skip behavior matches this too.
-  const [choice, setChoice] = useState<Choice>("keep");
-  const [migrationSource, setMigrationSource] =
-    useState<(typeof MIGRATION_SOURCES)[number]["id"]>("other");
-  const [clientsCsv, setClientsCsv] = useState("");
-  const [petsCsv, setPetsCsv] = useState("");
-  const [clientsFileName, setClientsFileName] = useState("");
-  const [petsFileName, setPetsFileName] = useState("");
-  const [clientsPreview, setClientsPreview] = useState<CsvPreview | null>(null);
-  const [petsPreview, setPetsPreview] = useState<CsvPreview | null>(null);
-  const [committedClients, setCommittedClients] =
-    useState<CommittedCsvImport | null>(null);
+  const [choice, setChoice] = useState<Choice>(
+    state.hasImportedData || (state.migrationCompletedModes?.length ?? 0) > 0
+      ? "import"
+      : "keep",
+  );
+  const [historyExpanded, setHistoryExpanded] = useState(
+    pathway.value === "replace",
+  );
+  const [migrationSource, setMigrationSource] = useState<string>(() =>
+    isValidMigrationSource(state.migrationSource)
+      ? state.migrationSource
+      : "other",
+  );
+  const [knownCompletedModes, setKnownCompletedModes] = useState<
+    MigrationImportMode[]
+  >(() =>
+    MIGRATION_STEPS.flatMap(({ mode }) =>
+      state.migrationCompletedModes?.includes(mode) ? [mode] : [],
+    ),
+  );
+  const [csvByMode, setCsvByMode] = useState(() => importMap(() => ""));
+  const [csvMetaByMode, setCsvMetaByMode] = useState(() =>
+    importMap<CsvMeta>(() => ({ hasContent: false, sizeValid: true })),
+  );
+  const [fileNameByMode, setFileNameByMode] = useState(() =>
+    importMap(() => ""),
+  );
+  const [previewByMode, setPreviewByMode] = useState<CsvPreviews>({});
+  const [committedByMode, setCommittedByMode] =
+    useState<OnboardingImportCommits>({});
+  const [fileReadPending, setFileReadPending] = useState(() =>
+    importMap(() => false),
+  );
   const [importRecoveryMessage, setImportRecoveryMessage] = useState("");
+  const [result, setResult] = useState<OnboardingImportSummary | null>(null);
   const importReviewVersionRef = useRef(0);
-  const fileReadVersionRef = useRef({ clients: 0, pets: 0 });
-  const [fileReadPending, setFileReadPending] = useState({
-    clients: false,
-    pets: false,
-  });
-  const [result, setResult] = useState<{
-    clients: number;
-    pets: number;
-    reconciled: number;
-    errors: string[];
-  } | null>(null);
-  const importing = importClientsCsv.isPending || importPatientsCsv.isPending;
-  const readingFiles = fileReadPending.clients || fileReadPending.pets;
+  const fileReadVersionRef = useRef(importMap(() => 0));
+
+  const importing =
+    importClientsCsv.isPending ||
+    importPatientsCsv.isPending ||
+    importVaccinationsCsv.isPending ||
+    importSoapNotesCsv.isPending;
+  const readingFiles = Object.values(fileReadPending).some(Boolean);
   const importInputsBusy = importing || readingFiles;
+  const lastCommittedIndex = lastCommittedImportIndex(committedByMode);
+  const migrationSourceLocked = isOnboardingMigrationSourceLocked(
+    state.migrationSourceHasCommittedChanges === true,
+    committedByMode,
+  );
 
-  function clearImportReview() {
+  function clearAllImportReview() {
     importReviewVersionRef.current += 1;
-    setClientsPreview(null);
-    setPetsPreview(null);
-    setCommittedClients(null);
+    setPreviewByMode({});
+    setCommittedByMode({});
     setImportRecoveryMessage("");
     setResult(null);
   }
 
-  function updateClientsCsv(value: string) {
-    fileReadVersionRef.current.clients += 1;
-    setClientsCsv(value);
-    clearImportReview();
-  }
-
-  function updatePetsCsv(value: string) {
-    fileReadVersionRef.current.pets += 1;
-    setPetsCsv(value);
-    clearPetReview();
-  }
-
-  function clearPetReview() {
+  function clearReviewFrom(mode: MigrationImportMode) {
     importReviewVersionRef.current += 1;
-    setPetsPreview(null);
+    const start = MIGRATION_STEPS.findIndex((step) => step.mode === mode);
+    setPreviewByMode(
+      (current) =>
+        Object.fromEntries(
+          Object.entries(current).filter(([key]) => {
+            const index = MIGRATION_STEPS.findIndex(
+              (step) => step.mode === key,
+            );
+            return index < start;
+          }),
+        ) as CsvPreviews,
+    );
+    setCommittedByMode(
+      (current) =>
+        Object.fromEntries(
+          Object.entries(current).filter(([key]) => {
+            const index = MIGRATION_STEPS.findIndex(
+              (step) => step.mode === key,
+            );
+            return index < start;
+          }),
+        ) as OnboardingImportCommits,
+    );
     setImportRecoveryMessage("");
     setResult(null);
+  }
+
+  function updateCsv(mode: MigrationImportMode, value: string) {
+    fileReadVersionRef.current[mode] += 1;
+    setFileReadPending((current) => ({ ...current, [mode]: false }));
+    setCsvByMode((current) => ({ ...current, [mode]: value }));
+    setCsvMetaByMode((current) => ({
+      ...current,
+      [mode]: {
+        hasContent: value.trim().length > 0,
+        sizeValid: isImportCsvSizeValid(value),
+      },
+    }));
+    setFileNameByMode((current) => ({ ...current, [mode]: "" }));
+    clearReviewFrom(mode);
   }
 
   function invalidatePendingFileReads() {
-    fileReadVersionRef.current.clients += 1;
-    fileReadVersionRef.current.pets += 1;
+    for (const { mode } of MIGRATION_STEPS) {
+      fileReadVersionRef.current[mode] += 1;
+    }
+    setFileReadPending(importMap(() => false));
   }
 
   async function onPickFile(
-    e: React.ChangeEvent<HTMLInputElement>,
-    setCsv: (v: string) => void,
-    which: "clients" | "pets",
+    event: React.ChangeEvent<HTMLInputElement>,
+    mode: MigrationImportMode,
   ) {
-    const file = e.target.files?.[0];
+    const input = event.currentTarget;
+    const file = input.files?.[0];
     if (!file) return;
-    if (which === "clients") clearImportReview();
-    else clearPetReview();
-    setFileReadPending((current) => ({ ...current, [which]: true }));
-    const readVersion = ++fileReadVersionRef.current[which];
+    // Let a clinic select the same path again after fixing the file externally.
+    input.value = "";
+    clearReviewFrom(mode);
+    setFileReadPending((current) => ({ ...current, [mode]: true }));
+    const readVersion = ++fileReadVersionRef.current[mode];
+
     function finishFileRead() {
-      setFileReadPending((current) => ({ ...current, [which]: false }));
+      setFileReadPending((current) => ({ ...current, [mode]: false }));
     }
+
     function clearPickedFile() {
-      setCsv("");
-      if (which === "clients") setClientsFileName("");
-      else setPetsFileName("");
-      e.target.value = "";
+      setCsvByMode((current) => ({ ...current, [mode]: "" }));
+      setCsvMetaByMode((current) => ({
+        ...current,
+        [mode]: { hasContent: false, sizeValid: true },
+      }));
+      setFileNameByMode((current) => ({ ...current, [mode]: "" }));
       finishFileRead();
     }
+
     if (file.size > IMPORT_CSV_MAX_BYTES) {
       clearPickedFile();
       toast.error(IMPORT_CSV_SIZE_MESSAGE);
       return;
     }
+
     try {
       const text = await readFileText(file);
-      if (fileReadVersionRef.current[which] !== readVersion) return;
+      if (fileReadVersionRef.current[mode] !== readVersion) return;
+      if (!text.trim()) {
+        clearPickedFile();
+        toast.error("CSV file is empty.");
+        return;
+      }
       if (!isImportCsvSizeValid(text)) {
         clearPickedFile();
         toast.error(IMPORT_CSV_SIZE_MESSAGE);
         return;
       }
-      setCsv(text);
-      if (which === "clients") setClientsFileName(file.name);
-      else setPetsFileName(file.name);
+      setCsvByMode((current) => ({ ...current, [mode]: text }));
+      setCsvMetaByMode((current) => ({
+        ...current,
+        [mode]: { hasContent: text.trim().length > 0, sizeValid: true },
+      }));
+      setFileNameByMode((current) => ({ ...current, [mode]: file.name }));
       finishFileRead();
     } catch {
-      if (fileReadVersionRef.current[which] !== readVersion) return;
+      if (fileReadVersionRef.current[mode] !== readVersion) return;
       finishFileRead();
       toast.error("Could not read that file. Try again.");
     }
   }
 
-  const clientsCsvTooLarge = !isImportCsvSizeValid(clientsCsv);
-  const petsCsvTooLarge = !isImportCsvSizeValid(petsCsv);
-  const importCsvSizeError = [
-    clientsCsvTooLarge ? "Client CSV must be 5 MB or less." : null,
-    petsCsvTooLarge ? "Pet CSV must be 5 MB or less." : null,
-  ]
-    .filter(Boolean)
-    .join(" ");
-  const hasImportCsvSizeError = importCsvSizeError.length > 0;
-  const hasClientsCsv = clientsCsv.trim().length > 0;
-  const hasPetsCsv = petsCsv.trim().length > 0;
-  const hasImportCsv = choice === "import" && (hasClientsCsv || hasPetsCsv);
-  const needsClientPreview =
-    hasClientsCsv && !clientsPreview && !committedClients;
-  const needsClientCommit =
-    hasClientsCsv && Boolean(clientsPreview) && !committedClients;
-  const needsPetsPreview = hasPetsCsv && !petsPreview;
-  const previewReady = Boolean(clientsPreview || petsPreview);
-  const previewWillInsert =
-    (clientsPreview?.willInsert ?? 0) + (petsPreview?.willInsert ?? 0);
-  const previewWillReconcile =
-    (clientsPreview?.willReconcile ?? 0) + (petsPreview?.willReconcile ?? 0);
-  const previewChangeCount = previewWillInsert + previewWillReconcile;
+  async function runImport(
+    mode: MigrationImportMode,
+    input: {
+      csv: string;
+      dryRun: boolean;
+      source: typeof migrationSource;
+      previewToken?: string;
+      migrationProtocol: "reviewed-v1";
+    },
+  ): Promise<ImportResponse> {
+    if (mode === "clients") return importClientsCsv.mutateAsync(input);
+    if (mode === "patients") return importPatientsCsv.mutateAsync(input);
+    if (mode === "vaccinations")
+      return importVaccinationsCsv.mutateAsync(input);
+    return importSoapNotesCsv.mutateAsync(input);
+  }
+
+  async function finishStage(
+    mode: MigrationImportMode,
+    committed: OnboardingImportCommit,
+  ) {
+    const completedChanges = committed.imported + committed.reconciled;
+    const committedAt = new Date().toISOString();
+    const nextKnownCompletedModes = MIGRATION_STEPS.flatMap(
+      ({ mode: currentMode }) =>
+        knownCompletedModes.includes(currentMode) || currentMode === mode
+          ? [currentMode]
+          : [],
+    );
+    setKnownCompletedModes(nextKnownCompletedModes);
+    utils.settings.getOnboardingState.setData(undefined, (previous) =>
+      previous
+        ? {
+            ...previous,
+            migrationSource,
+            migrationCompletedModes: nextKnownCompletedModes,
+            ...(completedChanges > 0
+              ? {
+                  migrationHasCommittedChanges: true,
+                  migrationSourceHasCommittedChanges: true,
+                  migrationLastCommittedAt: committedAt,
+                }
+              : {}),
+          }
+        : previous,
+    );
+    void utils.settings.getOnboardingState.invalidate();
+    setState({
+      migrationSource,
+      migrationCompletedModes: nextKnownCompletedModes,
+      ...(completedChanges > 0
+        ? {
+            keepSampleData: false,
+            hasImportedData: true,
+            migrationSourceHasCommittedChanges: true,
+          }
+        : {}),
+    });
+    const nextCommitted = { ...committedByMode, [mode]: committed };
+    setCommittedByMode(nextCommitted);
+    setPreviewByMode((current) => ({ ...current, [mode]: undefined }));
+    const selectedByMode = Object.fromEntries(
+      MIGRATION_STEPS.map(({ mode }) => [mode, csvMetaByMode[mode].hasContent]),
+    ) as OnboardingImportSelections;
+    const nextMode = nextOnboardingImportMode(selectedByMode, nextCommitted);
+    if (nextMode) {
+      const currentLabel = MIGRATION_STEPS.find(
+        (step) => step.mode === mode,
+      )!.label;
+      const nextLabel = MIGRATION_STEPS.find(
+        (step) => step.mode === nextMode,
+      )!.shortLabel;
+      setImportRecoveryMessage(
+        `${currentLabel} complete (${completedChanges} changes). Check the ${nextLabel} file next.`,
+      );
+      return;
+    }
+
+    const summary = summarizeOnboardingImports(nextCommitted);
+    setImportRecoveryMessage("");
+    setResult(summary);
+    const changeCount = onboardingImportChangeCount(summary);
+    toast.success(
+      changeCount > 0
+        ? `${changeCount.toLocaleString()} clinic record changes completed`
+        : "Import review complete",
+    );
+  }
+
+  const csvSizeErrors = MIGRATION_STEPS.flatMap(({ mode, label }) =>
+    csvMetaByMode[mode].sizeValid ? [] : [`${label} CSV must be 5 MB or less.`],
+  );
+  const hasImportCsvSizeError = csvSizeErrors.length > 0;
+  const selectedByMode = Object.fromEntries(
+    MIGRATION_STEPS.map(({ mode }) => [mode, csvMetaByMode[mode].hasContent]),
+  ) as OnboardingImportSelections;
+  const hasImportCsv = Object.values(selectedByMode).some(Boolean);
+  const activeMode = nextOnboardingImportMode(selectedByMode, committedByMode);
+  const activeStep = activeMode
+    ? MIGRATION_STEPS.find((step) => step.mode === activeMode)!
+    : null;
+  const activePreview = activeMode ? previewByMode[activeMode] : undefined;
+  const previewChangeCount = activePreview
+    ? activePreview.willInsert + (activePreview.willReconcile ?? 0)
+    : 0;
+  const previewReady = Object.values(previewByMode).some(Boolean);
   const continueLabel =
     choice !== "import" || !hasImportCsv || result
       ? "Continue"
-      : needsClientPreview
-        ? "Check client file"
-        : needsClientCommit
-          ? `Import ${previewChangeCount.toLocaleString()} client changes`
-          : needsPetsPreview
-            ? "Check pet file"
-            : previewChangeCount > 0
-              ? `Import ${previewChangeCount.toLocaleString()} pet changes`
-              : "Review import";
+      : !activeStep
+        ? "Finish import review"
+        : !activePreview
+          ? `Check ${activeStep.shortLabel} file`
+          : previewChangeCount > 0
+            ? `Import ${previewChangeCount.toLocaleString()} ${activeStep.shortLabel} ${previewChangeCount === 1 ? "change" : "changes"}`
+            : activePreview.total === 0
+              ? `Skip ${activeStep.shortLabel} file`
+              : `Confirm no ${activeStep.shortLabel} changes`;
 
-  // Finish only clears sample data after real rows have imported. Checking a
-  // CSV or connecting later leaves the demo clinic intact.
+  const currentSummary = summarizeOnboardingImports(committedByMode);
   const hasImportedRows =
-    choice === "import" &&
-    Boolean(
-      (result && result.clients + result.pets + result.reconciled > 0) ||
-      (committedClients &&
-        committedClients.imported + committedClients.reconciled > 0),
-    );
+    choice === "import" && onboardingImportChangeCount(currentSummary) > 0;
+  const hasCommittedStages = Object.keys(committedByMode).length > 0;
   useEffect(() => {
-    setState({ keepSampleData: !hasImportedRows });
-  }, [hasImportedRows, setState]);
+    setState({
+      keepSampleData: state.keepSampleData && !hasImportedRows,
+      hasPartialImport: hasCommittedStages && !result,
+    });
+  }, [
+    hasCommittedStages,
+    hasImportedRows,
+    result,
+    setState,
+    state.keepSampleData,
+  ]);
 
   useEffect(() => {
     register({
       continueLabel,
       continueDisabled: readingFiles,
       async onContinue() {
-        // Only the file path does extra work on Continue; the others just move on.
         if (choice !== "import") return true;
-        if (!hasClientsCsv && !hasPetsCsv) return true;
+        if (!hasImportCsv) return true;
         if (result) return true;
         if (hasImportCsvSizeError) {
-          toast.error(importCsvSizeError || IMPORT_CSV_SIZE_MESSAGE);
+          toast.error(csvSizeErrors.join(" ") || IMPORT_CSV_SIZE_MESSAGE);
           return false;
         }
+        if (!activeMode || !activeStep) return true;
 
-        if (needsClientPreview) {
-          const reviewVersion = importReviewVersionRef.current;
-          setImportRecoveryMessage("");
-          const r = await importClientsCsv.mutateAsync({
-            csv: clientsCsv.trim(),
-            dryRun: true,
-            source: migrationSource,
-            migrationProtocol: "reviewed-v1",
-          });
-          if (importReviewVersionRef.current !== reviewVersion) return false;
-          if ("dryRun" in r && r.dryRun) {
-            setClientsPreview({
-              previewToken: r.previewToken,
-              total: r.total,
-              willInsert: r.willInsert,
-              willReconcile: r.willReconcile,
-              duplicates: r.duplicates,
-              errors: r.errors,
-            });
-          }
-          toast.success(
-            "Client CSV checked. Review the plan before importing.",
-          );
-          return false;
-        }
+        const csv = csvByMode[activeMode].trim();
+        const reviewVersion = importReviewVersionRef.current;
+        setImportRecoveryMessage("");
 
-        if (needsClientCommit) {
-          const preview = clientsPreview!;
-          if (preview.willInsert + (preview.willReconcile ?? 0) === 0) {
-            const committed = {
-              imported: 0,
-              reconciled: 0,
-              errors: preview.errors,
-            };
-            setCommittedClients(committed);
-            setClientsPreview(null);
-            if (hasPetsCsv) {
-              setImportRecoveryMessage(
-                "No client changes were needed. Check the pet file next.",
-              );
-            } else {
-              setResult({
-                clients: 0,
-                pets: 0,
-                reconciled: 0,
-                errors: [
-                  ...preview.errors,
-                  "No new client rows were found to import.",
-                ],
-              });
-            }
-            return false;
-          }
-
+        if (!activePreview) {
           try {
-            const reviewVersion = importReviewVersionRef.current;
-            const r = await importClientsCsv.mutateAsync({
-              csv: clientsCsv.trim(),
-              dryRun: false,
-              source: migrationSource,
-              previewToken: preview.previewToken,
-              migrationProtocol: "reviewed-v1",
-            });
-            if (importReviewVersionRef.current !== reviewVersion) return false;
-            const committed = {
-              imported: r.imported ?? 0,
-              reconciled: r.reconciled ?? 0,
-              errors: r.errors ?? [],
-            };
-            setCommittedClients(committed);
-            setClientsPreview(null);
-            if (hasPetsCsv) {
-              setImportRecoveryMessage(
-                `Clients imported (${committed.imported}). Check the pet file next.`,
-              );
-            } else {
-              setResult({
-                clients: committed.imported,
-                pets: 0,
-                reconciled: committed.reconciled,
-                errors: committed.errors,
-              });
-              toast.success(`Added ${committed.imported} clients`);
-            }
-          } catch (error) {
-            if (isPreviewConflict(error)) {
-              setClientsPreview(null);
-              setImportRecoveryMessage(
-                "Nothing was imported because the client preview expired or changed. Check the same file again.",
-              );
-            } else {
-              setImportRecoveryMessage(
-                "We could not confirm the client import response. Retry the same import; it is safe and will not add the rows twice.",
-              );
-            }
-          }
-          return false;
-        }
-
-        if (needsPetsPreview) {
-          const reviewVersion = importReviewVersionRef.current;
-          setImportRecoveryMessage("");
-          try {
-            const r = await importPatientsCsv.mutateAsync({
-              csv: petsCsv.trim(),
+            const response = await runImport(activeMode, {
+              csv,
               dryRun: true,
               source: migrationSource,
               migrationProtocol: "reviewed-v1",
             });
             if (importReviewVersionRef.current !== reviewVersion) return false;
-            if ("dryRun" in r && r.dryRun) {
-              setPetsPreview({
-                previewToken: r.previewToken,
-                total: r.total,
-                willInsert: r.willInsert,
-                willReconcile: r.willReconcile,
-                unmatchedClient: r.unmatchedClient,
-                errors: r.errors,
-              });
+            if (
+              response.dryRun !== true ||
+              !response.previewToken ||
+              typeof response.total !== "number" ||
+              typeof response.willInsert !== "number"
+            ) {
+              throw new Error("The import preview response was incomplete.");
             }
-            toast.success("Pet CSV checked. Review the plan before importing.");
-          } catch {
-            setPetsPreview(null);
+            setPreviewByMode((current) => ({
+              ...current,
+              [activeMode]: {
+                previewToken: response.previewToken!,
+                total: response.total!,
+                willInsert: response.willInsert!,
+                willReconcile: response.willReconcile,
+                duplicates: response.duplicates,
+                unmatchedClient: response.unmatchedClient,
+                unmatchedPatient: response.unmatchedPatient,
+                errors: response.errors,
+              },
+            }));
+            toast.success(
+              `${activeStep.label} checked. Review the plan before importing.`,
+            );
+          } catch (error) {
+            if (importReviewVersionRef.current !== reviewVersion) return false;
+            setPreviewByMode((current) => ({
+              ...current,
+              [activeMode]: undefined,
+            }));
             setImportRecoveryMessage(
-              committedClients
-                ? `Clients imported (${committedClients.imported}); pets were not checked. Try the pet file again.`
-                : "Pets were not checked. Try the pet file again.",
+              error instanceof Error && error.message.trim()
+                ? error.message
+                : `The ${activeStep.shortLabel} file was not checked. Check your connection and try again.`,
             );
           }
-          return false;
-        }
-
-        if (previewChangeCount === 0) {
-          setResult({
-            clients: committedClients?.imported ?? 0,
-            pets: 0,
-            reconciled: committedClients?.reconciled ?? 0,
-            errors: [
-              "No new rows were found to import. You can adjust the CSV or continue with sample data.",
-            ],
-          });
           return false;
         }
 
         try {
-          const reviewVersion = importReviewVersionRef.current;
-          const r = await importPatientsCsv.mutateAsync({
-            csv: petsCsv.trim(),
+          const response = await runImport(activeMode, {
+            csv,
             dryRun: false,
             source: migrationSource,
-            previewToken: petsPreview!.previewToken,
+            previewToken: activePreview.previewToken,
             migrationProtocol: "reviewed-v1",
           });
           if (importReviewVersionRef.current !== reviewVersion) return false;
-          const clientsImported = committedClients?.imported ?? 0;
-          const petsImported = r.imported ?? 0;
-          const reconciled =
-            (committedClients?.reconciled ?? 0) + (r.reconciled ?? 0);
-          setImportRecoveryMessage("");
-          setResult({
-            clients: clientsImported,
-            pets: petsImported,
-            reconciled,
-            errors: [...(committedClients?.errors ?? []), ...(r.errors ?? [])],
+          if (response.dryRun === true) {
+            throw new Error("The import commit response was incomplete.");
+          }
+          await finishStage(activeMode, {
+            imported: response.imported ?? 0,
+            reconciled: response.reconciled ?? 0,
+            errors:
+              response.alreadyCommitted && response.errors.length === 0
+                ? activePreview.errors
+                : response.errors,
           });
-          toast.success(
-            `Added ${clientsImported} clients and ${petsImported} pets${reconciled > 0 ? `; connected ${reconciled} IDs` : ""}`,
-          );
         } catch (error) {
+          if (importReviewVersionRef.current !== reviewVersion) return false;
           if (isPreviewConflict(error)) {
-            setPetsPreview(null);
+            setPreviewByMode((current) => ({
+              ...current,
+              [activeMode]: undefined,
+            }));
             setImportRecoveryMessage(
-              committedClients
-                ? `Clients imported (${committedClients.imported}); nothing was imported from the pet file because its preview expired or changed. Check the pet file again.`
-                : "Nothing was imported because the pet preview expired or changed. Check the pet file again.",
+              `Nothing was imported from the ${activeStep.shortLabel} file because its preview expired or clinic records changed. Check the same file again. Earlier completed stages are safe.`,
             );
           } else {
             setImportRecoveryMessage(
-              committedClients
-                ? `Clients imported (${committedClients.imported}); we could not confirm the pet import response. Retry the same pet import—it is safe and will not add rows twice.`
-                : "We could not confirm the pet import response. Retry the same import; it is safe and will not add rows twice.",
+              `We could not confirm the ${activeStep.shortLabel} import response. Retry the same import. It is safe and will not add the rows twice. Earlier completed stages are safe.`,
             );
           }
         }
-        // Stay on the step so they can see the result before moving on.
         return false;
       },
     });
   }, [
     register,
     choice,
-    clientsCsv,
-    petsCsv,
-    hasClientsCsv,
-    hasPetsCsv,
+    hasImportCsv,
+    result,
     hasImportCsvSizeError,
-    importCsvSizeError,
-    needsClientPreview,
-    needsClientCommit,
-    needsPetsPreview,
+    csvSizeErrors,
+    activeMode,
+    activeStep,
+    activePreview,
     previewChangeCount,
+    csvByMode,
+    csvMetaByMode,
+    migrationSource,
     continueLabel,
     readingFiles,
-    clientsPreview,
-    petsPreview,
-    committedClients,
-    migrationSource,
-    result,
+    committedByMode,
     importClientsCsv,
     importPatientsCsv,
+    importVaccinationsCsv,
+    importSoapNotesCsv,
+    setState,
+    utils,
   ]);
 
-  const pathway = getOnboardingIntentOption(state.onboardingIntent);
-  const selectedMigrationSource = MIGRATION_SOURCES.find(
+  const selectedMigrationSourceName = migrationSourceName(migrationSource);
+  const selectedMigrationSourceHint =
+    migrationSourceExportHint(migrationSource);
+  const isCustomMigrationSource = !MIGRATION_SOURCES.some(
     (source) => source.id === migrationSource,
-  )!;
+  );
   const pathwayIntro =
     pathway.value === "alongside"
-      ? "Start small: bring in a few real clients and pets while your current PIMS stays in place."
+      ? "Start small: bring a few real records over while your current PIMS stays in place."
       : pathway.value === "replace"
-        ? "Make the move in stages: check a client and pet export before any live workflow changes."
+        ? "Move in stages: check owners, pets, vaccines, and visit notes before your team changes live workflows."
         : pathway.value === "self_host"
           ? "The same import and export tools work in hosted and self-hosted OpenVPM."
           : "Keep the sample clinic as long as you need, or try an import when you are ready.";
@@ -497,52 +599,79 @@ export function BringDataStep({ register, state, setState }: StepProps) {
           active={choice === "import"}
           icon={<FileSpreadsheet className="h-5 w-5" />}
           title="Import from a file"
-          subtitle="Paste your clients and pets from a spreadsheet."
+          subtitle="Bring clients, pets, vaccine history, and visit notes."
           onClick={() => {
             if (
               importInputsBusy ||
               choice === "import" ||
-              committedClients ||
+              lastCommittedIndex >= 0 ||
               result
             )
               return;
             invalidatePendingFileReads();
             setChoice("import");
-            clearImportReview();
           }}
           disabled={
-            importInputsBusy || Boolean(committedClients) || Boolean(result)
+            importInputsBusy || lastCommittedIndex >= 0 || Boolean(result)
           }
         />
         {choice === "import" ? (
           <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50/70 p-4">
-            <p className="text-xs text-slate-500">
-              Pick a CSV file for each one, or paste the rows below. Continue
-              checks the files first; nothing imports until you review the plan.
-            </p>
-            <p className="text-xs text-slate-500">
-              Existing owners connect by one exact email. Existing pets need a
-              matching microchip or date of birth before an ID is connected.
-            </p>
+            <div className="space-y-1 text-xs text-slate-500">
+              {knownCompletedModes.length > 0 ? (
+                <p className="rounded-md border border-emerald-200 bg-emerald-50 p-3 font-medium text-emerald-900">
+                  Already reviewed: {migrationModeLabels(knownCompletedModes)}. Reselect
+                  only the files you still need to finish. {" "}
+                  {migrationSourceLocked
+                    ? `This migration will keep using ${selectedMigrationSourceName} so saved owner and patient IDs stay linked.`
+                    : "No clinic records changed, so you can still choose a different source."}
+                </p>
+              ) : state.hasImportedData ? (
+                <p className="rounded-md border border-emerald-200 bg-emerald-50 p-3 font-medium text-emerald-900">
+                  Earlier import changes are already saved. If you are unsure
+                  which file finished, reselecting it is safe because duplicate
+                  rows are skipped.
+                </p>
+              ) : null}
+              <p>
+                Add any files you have. OpenVPM checks each one in order. No
+                records import until you review that file's plan.
+              </p>
+              <p>
+                Keep the same source for all four files so owner and patient IDs
+                stay linked. Rows with issues are shown before you confirm.
+              </p>
+              <p>
+                Completed stages stay saved. Unfinished files stay only in this
+                setup, so reselect them if you leave and return.
+              </p>
+            </div>
             <label className="block space-y-1.5 text-sm font-medium text-slate-700">
               <span>Which system are you moving from?</span>
               <select
                 value={migrationSource}
-                disabled={
-                  importInputsBusy ||
-                  Boolean(committedClients) ||
-                  Boolean(result)
-                }
+                disabled={importInputsBusy || migrationSourceLocked}
                 onChange={(event) => {
+                  const nextSource = event.target.value;
+                  if (!isValidMigrationSource(nextSource)) return;
                   invalidatePendingFileReads();
-                  setMigrationSource(
-                    event.target
-                      .value as (typeof MIGRATION_SOURCES)[number]["id"],
-                  );
-                  clearImportReview();
+                  setMigrationSource(nextSource);
+                  setKnownCompletedModes([]);
+                  clearAllImportReview();
+                  setState({
+                    migrationSource: nextSource,
+                    migrationSourceHasCommittedChanges: false,
+                    migrationCompletedModes: [],
+                    hasPartialImport: false,
+                  });
                 }}
                 className="h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm font-normal"
               >
+                {isCustomMigrationSource ? (
+                  <option value={migrationSource}>
+                    {selectedMigrationSourceName}
+                  </option>
+                ) : null}
                 {MIGRATION_SOURCES.map((source) => (
                   <option key={source.id} value={source.id}>
                     {source.name}
@@ -551,169 +680,162 @@ export function BringDataStep({ register, state, setState }: StepProps) {
               </select>
             </label>
             <div className="rounded-md border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600">
-              <p>{selectedMigrationSource.exportHint}</p>
-              {migrationSource === "shepherd" ? (
-                <a
-                  href="mailto:support@openvpm.com?subject=Assisted%20Shepherd%20migration"
-                  className="mt-2 inline-flex font-medium text-emerald-700 hover:underline"
-                >
-                  Request a migration review before the full import
-                </a>
-              ) : null}
+              <p>{selectedMigrationSourceHint}</p>
+              <a
+                href={`mailto:support@openvpm.com?subject=${encodeURIComponent(`${selectedMigrationSourceName} full history migration review`)}`}
+                className="mt-2 inline-flex font-medium text-emerald-700 hover:underline"
+              >
+                Ask us to review your full-history export before import
+              </a>
             </div>
-            <div className="space-y-1.5">
-              <span className="text-sm font-medium text-slate-700">
-                Clients
-              </span>
-              <p className="text-xs text-slate-500">
-                Columns: {CLIENT_COLUMNS}
-              </p>
-              <input
-                type="file"
-                disabled={
-                  importInputsBusy ||
-                  Boolean(committedClients) ||
-                  Boolean(result)
-                }
-                accept=".csv,text/csv"
-                onChange={(e) => onPickFile(e, updateClientsCsv, "clients")}
-                className={fileInputClass}
-                aria-label="Choose a clients CSV file"
-              />
-              {clientsFileName ? (
-                <p className="text-xs text-emerald-700">
-                  Loaded {clientsFileName}
-                </p>
-              ) : null}
-              <textarea
-                rows={4}
-                className={textareaClass}
-                value={clientsCsv}
-                disabled={
-                  importInputsBusy ||
-                  Boolean(committedClients) ||
-                  Boolean(result)
-                }
-                maxLength={IMPORT_CSV_MAX_BYTES}
-                aria-invalid={clientsCsvTooLarge || undefined}
-                aria-describedby={
-                  clientsCsvTooLarge ? "clients-csv-size-error" : undefined
-                }
-                onChange={(e) => updateClientsCsv(e.target.value)}
-                placeholder={`firstName,lastName,email,phone,address,city,state,zip`}
-              />
-              {clientsCsvTooLarge ? (
-                <p id="clients-csv-size-error" className="text-xs text-red-700">
-                  Client CSV must be 5 MB or less.
-                </p>
-              ) : null}
+
+            <div className="space-y-4">
+              {MIGRATION_STEPS.slice(0, 2).map((step, index) => (
+                <ImportFileFields
+                  key={step.mode}
+                  stepNumber={index + 1}
+                  step={step}
+                  csv={csvByMode[step.mode]}
+                  tooLarge={!csvMetaByMode[step.mode].sizeValid}
+                  fileName={fileNameByMode[step.mode]}
+                  locked={
+                    importInputsBusy ||
+                    isOnboardingImportModeLocked(
+                      step.mode,
+                      committedByMode,
+                      Boolean(result),
+                    )
+                  }
+                  onPickFile={(event) => onPickFile(event, step.mode)}
+                  onChangeCsv={(value) => updateCsv(step.mode, value)}
+                />
+              ))}
             </div>
-            <div className="space-y-1.5">
-              <span className="text-sm font-medium text-slate-700">Pets</span>
-              <p className="text-xs text-slate-500">Columns: {PET_COLUMNS}</p>
-              <input
-                type="file"
-                disabled={importInputsBusy || Boolean(result)}
-                accept=".csv,text/csv"
-                onChange={(e) => onPickFile(e, updatePetsCsv, "pets")}
-                className={fileInputClass}
-                aria-label="Choose a pets CSV file"
-              />
-              {petsFileName ? (
-                <p className="text-xs text-emerald-700">
-                  Loaded {petsFileName}
+
+            <details
+              className="group rounded-lg border border-slate-200 bg-white"
+              open={historyExpanded}
+              onToggle={(event) => setHistoryExpanded(event.currentTarget.open)}
+            >
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-3 p-3 text-sm font-medium text-slate-800">
+                <span>
+                  Also bring vaccine and visit history
+                  <span className="ml-1 font-normal text-slate-500">
+                    (optional)
+                  </span>
+                </span>
+                <ChevronDown className="h-4 w-4 text-slate-500 transition-transform group-open:rotate-180" />
+              </summary>
+              <div className="space-y-4 border-t border-slate-200 p-3">
+                <p className="text-xs text-slate-500">
+                  History attaches only to a safely matched real patient. Use
+                  the same patient ID from the pet file whenever possible.
+                  Existing OpenVPM pets can also match by owner email or client
+                  ID plus patient name.
                 </p>
-              ) : null}
-              <textarea
-                rows={4}
-                className={textareaClass}
-                value={petsCsv}
-                disabled={importInputsBusy || Boolean(result)}
-                maxLength={IMPORT_CSV_MAX_BYTES}
-                aria-invalid={petsCsvTooLarge || undefined}
-                aria-describedby={
-                  petsCsvTooLarge ? "pets-csv-size-error" : undefined
-                }
-                onChange={(e) => updatePetsCsv(e.target.value)}
-                placeholder={`clientEmail,name,species,breed,sex,dob,color,microchipNumber`}
-              />
-              {petsCsvTooLarge ? (
-                <p id="pets-csv-size-error" className="text-xs text-red-700">
-                  Pet CSV must be 5 MB or less.
-                </p>
-              ) : null}
-            </div>
-            {clientsPreview || petsPreview ? (
-              <div className="space-y-3">
+                {MIGRATION_STEPS.slice(2).map((step, index) => (
+                  <ImportFileFields
+                    key={step.mode}
+                    stepNumber={index + 3}
+                    step={step}
+                    csv={csvByMode[step.mode]}
+                    tooLarge={!csvMetaByMode[step.mode].sizeValid}
+                    fileName={fileNameByMode[step.mode]}
+                    locked={
+                      importInputsBusy ||
+                      isOnboardingImportModeLocked(
+                        step.mode,
+                        committedByMode,
+                        Boolean(result),
+                      )
+                    }
+                    onPickFile={(event) => onPickFile(event, step.mode)}
+                    onChangeCsv={(value) => updateCsv(step.mode, value)}
+                  />
+                ))}
+              </div>
+            </details>
+
+            {activeMode && activePreview ? (
+              <div className="space-y-3" aria-live="polite">
                 <div>
                   <p className="text-sm font-medium text-slate-800">
                     Dry-run preview
                   </p>
                   <p className="mt-1 text-xs text-slate-500">
-                    No data in this preview has been imported yet. Only the
-                    listed changes will be saved; issue rows will be skipped.
+                    No data in this preview has been imported yet. Review the
+                    planned changes and every issue before you confirm.
                   </p>
                 </div>
-                {clientsPreview ? (
-                  <CsvPreviewCard
-                    title="Clients"
-                    preview={clientsPreview}
-                    duplicateLabel="Duplicates"
-                    duplicateValue={clientsPreview.duplicates ?? 0}
-                  />
+                <CsvPreviewCard mode={activeMode} preview={activePreview} />
+                {previewChangeCount > 0 && activePreview.errors.length > 0 ? (
+                  <p className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+                    {previewChangeCount.toLocaleString()} valid changes can
+                    import. Review{" "}
+                    {activePreview.errors.length.toLocaleString()}{" "}
+                    {activePreview.errors.length === 1 ? "issue" : "issues"}.
+                    Some affected rows may be skipped or imported without an
+                    optional field. Edit the file above to fix them, or import
+                    the valid changes now.
+                  </p>
                 ) : null}
-                {petsPreview ? (
-                  <CsvPreviewCard
-                    title="Pets"
-                    preview={petsPreview}
-                    duplicateLabel="Missing owners"
-                    duplicateValue={petsPreview.unmatchedClient ?? 0}
-                  />
+                {previewChangeCount === 0 && activePreview.total === 0 ? (
+                  <p className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+                    Nothing in this file can be imported yet. Edit the file to
+                    fix the listed issues, or use Skip file to continue without
+                    it.
+                  </p>
+                ) : null}
+                {previewChangeCount === 0 && activePreview.total > 0 ? (
+                  <p className="rounded-md border border-slate-200 bg-slate-50 p-3 text-xs text-slate-700">
+                    These rows are already present or cannot be matched. Confirm
+                    the reviewed no-change plan to continue, or edit the file
+                    above.
+                  </p>
                 ) : null}
               </div>
             ) : null}
+
             {readingFiles ? (
-              <p className="flex items-center gap-2 text-xs text-slate-500">
+              <p
+                className="flex items-center gap-2 text-xs text-slate-500"
+                role="status"
+              >
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 Reading the selected file
               </p>
             ) : importing ? (
-              <p className="flex items-center gap-2 text-xs text-slate-500">
+              <p
+                className="flex items-center gap-2 text-xs text-slate-500"
+                role="status"
+              >
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 {previewReady ? "Importing your data" : "Checking your data"}
               </p>
             ) : null}
+
             {importRecoveryMessage ? (
-              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+              <div
+                className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900"
+                role="status"
+                aria-live="polite"
+              >
                 {importRecoveryMessage}
               </div>
             ) : null}
-            {result ? (
-              <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-900">
-                <p className="font-medium">
-                  Added {result.clients} clients and {result.pets} pets.
-                  {result.reconciled > 0
-                    ? ` Connected ${result.reconciled} existing record IDs.`
-                    : ""}
-                </p>
-                {result.errors.length > 0 ? (
-                  <>
-                    <ImportIssues
-                      errors={result.errors}
-                      fileName="openvpm-import-issues.txt"
-                    />
-                    <p className="mt-2">Press Continue when you are ready.</p>
-                  </>
-                ) : (
-                  <p className="mt-1">Press Continue when you are ready.</p>
-                )}
-              </div>
-            ) : null}
+
+            {result ? <ImportResultCard result={result} /> : null}
+
             {!importRecoveryMessage &&
-            (importClientsCsv.error || importPatientsCsv.error) ? (
-              <p className="text-xs text-red-700">
+            (importClientsCsv.error ||
+              importPatientsCsv.error ||
+              importVaccinationsCsv.error ||
+              importSoapNotesCsv.error) ? (
+              <p className="text-xs text-red-700" role="alert">
                 {importClientsCsv.error?.message ??
-                  importPatientsCsv.error?.message}
+                  importPatientsCsv.error?.message ??
+                  importVaccinationsCsv.error?.message ??
+                  importSoapNotesCsv.error?.message}
               </p>
             ) : null}
           </div>
@@ -725,13 +847,13 @@ export function BringDataStep({ register, state, setState }: StepProps) {
           title="Connect later by API"
           subtitle="Move data in from another system whenever you want."
           onClick={() => {
-            if (importInputsBusy || committedClients || result) return;
+            if (importInputsBusy || lastCommittedIndex >= 0 || result) return;
             invalidatePendingFileReads();
             setChoice("api");
-            clearImportReview();
+            clearAllImportReview();
           }}
           disabled={
-            importInputsBusy || Boolean(committedClients) || Boolean(result)
+            importInputsBusy || lastCommittedIndex >= 0 || Boolean(result)
           }
         />
         {choice === "api" ? (
@@ -754,15 +876,29 @@ export function BringDataStep({ register, state, setState }: StepProps) {
           active={choice === "keep"}
           icon={<Sparkles className="h-5 w-5" />}
           title="Keep the sample data for now"
-          subtitle="Explore with the example pets we set up for you."
+          subtitle={
+            state.hasImportedData
+              ? "Real data is saved, so sample records will be removed when setup finishes."
+              : "Explore with the example pets we set up for you."
+          }
           onClick={() => {
-            if (importInputsBusy || committedClients || result) return;
+            if (
+              state.hasImportedData ||
+              importInputsBusy ||
+              lastCommittedIndex >= 0 ||
+              result
+            )
+              return;
             invalidatePendingFileReads();
             setChoice("keep");
-            clearImportReview();
+            clearAllImportReview();
+            setState({ keepSampleData: true, hasPartialImport: false });
           }}
           disabled={
-            importInputsBusy || Boolean(committedClients) || Boolean(result)
+            state.hasImportedData ||
+            importInputsBusy ||
+            lastCommittedIndex >= 0 ||
+            Boolean(result)
           }
         />
       </div>
@@ -770,38 +906,129 @@ export function BringDataStep({ register, state, setState }: StepProps) {
   );
 }
 
-function CsvPreviewCard({
-  title,
-  preview,
-  duplicateLabel,
-  duplicateValue,
+function ImportFileFields({
+  stepNumber,
+  step,
+  csv,
+  tooLarge,
+  fileName,
+  locked,
+  onPickFile,
+  onChangeCsv,
 }: {
-  title: string;
-  preview: CsvPreview;
-  duplicateLabel: string;
-  duplicateValue: number;
+  stepNumber: number;
+  step: (typeof MIGRATION_STEPS)[number];
+  csv: string;
+  tooLarge: boolean;
+  fileName: string;
+  locked: boolean;
+  onPickFile: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onChangeCsv: (value: string) => void;
 }) {
+  const [showPasteEditor, setShowPasteEditor] = useState(false);
+  useEffect(() => {
+    if (fileName) setShowPasteEditor(false);
+  }, [fileName]);
+  const textareaId = `${step.mode}-csv-text`;
+  const errorId = `${step.mode}-csv-size-error`;
+  return (
+    <div className="space-y-1.5 rounded-md border border-slate-200 bg-white p-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm font-medium text-slate-700">
+          {stepNumber}. {step.label}
+        </span>
+        <span className="text-[11px] text-slate-400">CSV</span>
+      </div>
+      <p className="text-xs text-slate-500">Columns: {step.columnHint}</p>
+      <input
+        type="file"
+        disabled={locked}
+        accept=".csv,text/csv"
+        onChange={onPickFile}
+        className={fileInputClass}
+        aria-label={`Choose a ${step.label.toLowerCase()} CSV file`}
+      />
+      {fileName ? (
+        <p className="text-xs text-emerald-700">Loaded {fileName}</p>
+      ) : null}
+      {!locked ? (
+        <button
+          type="button"
+          className="text-xs font-medium text-emerald-700 underline underline-offset-2"
+          onClick={() => setShowPasteEditor((current) => !current)}
+          aria-expanded={showPasteEditor}
+        >
+          {showPasteEditor
+            ? "Hide CSV text"
+            : fileName
+              ? "Review or edit file text"
+              : "Paste CSV text instead"}
+        </button>
+      ) : null}
+      {showPasteEditor ? (
+        <textarea
+          id={textareaId}
+          rows={3}
+          className={textareaClass}
+          value={csv}
+          disabled={locked}
+          maxLength={IMPORT_CSV_MAX_BYTES}
+          aria-label={`Paste ${step.label.toLowerCase()} CSV text`}
+          aria-invalid={tooLarge || undefined}
+          aria-describedby={tooLarge ? errorId : undefined}
+          onChange={(event) => onChangeCsv(event.target.value)}
+          placeholder={step.placeholder}
+        />
+      ) : null}
+      {tooLarge ? (
+        <p id={errorId} className="text-xs text-red-700">
+          {step.label} CSV must be 5 MB or less.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function CsvPreviewCard({
+  mode,
+  preview,
+}: {
+  mode: MigrationImportMode;
+  preview: CsvPreview;
+}) {
+  const step = MIGRATION_STEPS.find((candidate) => candidate.mode === mode)!;
+  const unmatched =
+    mode === "patients"
+      ? preview.unmatchedClient
+      : mode === "vaccinations" || mode === "soapNotes"
+        ? preview.unmatchedPatient
+        : undefined;
+  const needsAttention =
+    preview.errors.length > 0 ||
+    (preview.duplicates ?? 0) > 0 ||
+    (unmatched ?? 0) > 0;
+
   return (
     <div className="rounded-md border border-slate-200 bg-white p-3">
       <div className="flex items-center justify-between gap-3">
-        <p className="text-sm font-medium text-slate-800">{title}</p>
+        <p className="text-sm font-medium text-slate-800">{step.label}</p>
         <span
           className={cn(
             "rounded-full px-2 py-0.5 text-xs font-medium",
-            preview.errors.length > 0 || duplicateValue > 0
+            needsAttention
               ? "bg-amber-50 text-amber-700"
               : "bg-emerald-50 text-emerald-700",
           )}
         >
-          {preview.errors.length > 0 || duplicateValue > 0
-            ? "Ready with skipped rows"
+          {needsAttention
+            ? "Ready with issues to review"
             : preview.willInsert + (preview.willReconcile ?? 0) > 0
               ? "Ready"
-              : "Review"}
+              : "No changes needed"}
         </span>
       </div>
       <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
-        <ImportStat label="Rows" value={preview.total} />
+        <ImportStat label="Valid rows parsed" value={preview.total} />
         <ImportStat label="Will import" value={preview.willInsert} />
         {(preview.willReconcile ?? 0) > 0 ? (
           <ImportStat
@@ -809,15 +1036,67 @@ function CsvPreviewCard({
             value={preview.willReconcile ?? 0}
           />
         ) : null}
-        <ImportStat label={duplicateLabel} value={duplicateValue} />
+        {typeof preview.duplicates === "number" ? (
+          <ImportStat label="Duplicates" value={preview.duplicates} />
+        ) : null}
+        {typeof unmatched === "number" ? (
+          <ImportStat
+            label={step.unmatchedLabel ?? "Unmatched"}
+            value={unmatched}
+          />
+        ) : null}
         <ImportStat label="Issues" value={preview.errors.length} />
       </div>
       {preview.errors.length > 0 ? (
         <ImportIssues
           errors={preview.errors}
-          fileName={`openvpm-${title.toLowerCase()}-preview-issues.txt`}
+          fileName={`openvpm-${mode}-preview-issues.txt`}
         />
       ) : null}
+    </div>
+  );
+}
+
+function ImportResultCard({ result }: { result: OnboardingImportSummary }) {
+  const changeCount = onboardingImportChangeCount(result);
+  const hasIssues = result.errors.length > 0;
+  return (
+    <div
+      className={cn(
+        "rounded-md border p-3 text-xs",
+        hasIssues
+          ? "border-amber-200 bg-amber-50 text-amber-900"
+          : "border-emerald-200 bg-emerald-50 text-emerald-900",
+      )}
+      aria-live="polite"
+    >
+      <p className="font-medium">
+        {hasIssues ? "Review completed with issues. " : ""}
+        {changeCount > 0
+          ? `Added ${result.imported.clients} clients, ${result.imported.patients} pets, ${result.imported.vaccinations} vaccine records, and ${result.imported.soapNotes} visit notes.`
+          : "Review complete. No new records were needed."}
+        {result.reconciled > 0
+          ? ` Connected ${result.reconciled} existing record IDs.`
+          : ""}
+      </p>
+      {result.errors.length > 0 ? (
+        <>
+          <ImportIssues
+            errors={result.errors}
+            fileName="openvpm-import-issues.txt"
+          />
+          <Link
+            href="/settings?tab=data"
+            target="_blank"
+            rel="noreferrer"
+            className="mt-3 inline-flex items-center gap-1 font-medium text-amber-950 underline underline-offset-2"
+          >
+            Fix skipped records in Settings, then Data
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        </>
+      ) : null}
+      <p className="mt-2">Press Continue when you are ready.</p>
     </div>
   );
 }
@@ -837,13 +1116,14 @@ function ImportIssues({
           <li key={index}>{error}</li>
         ))}
       </ul>
-      {errors.length > visibleErrors.length ? (
+      {errors.length > 0 ? (
         <button
           type="button"
           className="mt-2 font-medium text-amber-900 underline underline-offset-2"
           onClick={() => downloadIssueReport(errors, fileName)}
         >
-          Download all {errors.length} issues
+          Download{" "}
+          {errors.length === 1 ? "issue report" : `all ${errors.length} issues`}
         </button>
       ) : null}
     </div>
@@ -881,6 +1161,7 @@ function ChoiceCard({
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-pressed={active}
       className={cn(
         "flex items-start gap-3 rounded-lg border bg-white p-4 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60",
         active

--- a/apps/web/components/tour/tour-provider.tsx
+++ b/apps/web/components/tour/tour-provider.tsx
@@ -74,8 +74,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const { data: session, status } = useSession();
-  const isAdmin =
-    status === "authenticated" && session?.user?.role === "admin";
+  const isAdmin = status === "authenticated" && session?.user?.role === "admin";
   const userId = session?.user?.id ?? null;
 
   const utils = trpc.useUtils();
@@ -112,15 +111,21 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
         journeyDismissed: prev?.journeyDismissed ?? false,
         ...prev,
         onboardingIntent: prev?.onboardingIntent ?? null,
-        onboardingIntentSelectedAt:
-          prev?.onboardingIntentSelectedAt ?? null,
+        onboardingIntentSelectedAt: prev?.onboardingIntentSelectedAt ?? null,
+        migrationHasCommittedChanges:
+          prev?.migrationHasCommittedChanges ?? false,
+        migrationLastCommittedAt: prev?.migrationLastCommittedAt ?? null,
+        migrationSource: prev?.migrationSource ?? null,
+        migrationSourceHasCommittedChanges:
+          prev?.migrationSourceHasCommittedChanges ?? false,
+        migrationCompletedModes: prev?.migrationCompletedModes ?? [],
         tourStatus: status,
         lastStepId: stepId ?? prev?.lastStepId ?? null,
         setupDismissed: prev?.setupDismissed ?? false,
       }));
       setTourStatus.mutate({ status, lastStepId: stepId ?? null });
     },
-    [isAdmin, setTourStatus, utils]
+    [isAdmin, setTourStatus, utils],
   );
 
   // Warm every route a guide will visit so each Next paints immediately
@@ -131,7 +136,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
         if (s.route) router.prefetch(s.route.split("?")[0]!);
       }
     },
-    [router]
+    [router],
   );
 
   const start = useCallback(
@@ -147,8 +152,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
             ctx.demoPatientName ?? welcomeCtx.data?.demoPatientName,
           demoPatientId: welcomeCtx.data?.demoPatientId,
           demoInvoiceId: welcomeCtx.data?.demoInvoiceId,
-          agentConfigured:
-            ctx.agentConfigured ?? agentStatus.data?.configured,
+          agentConfigured: ctx.agentConfigured ?? agentStatus.data?.configured,
         });
         prefetchSteps(steps);
         setRun({ recipe, steps, index: 0 });
@@ -160,7 +164,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
       prefetchSteps(steps);
       setRun({ recipe, steps, index: 0 });
     },
-    [isAdmin, persist, prefetchSteps, welcomeCtx.data, agentStatus.data]
+    [isAdmin, persist, prefetchSteps, welcomeCtx.data, agentStatus.data],
   );
 
   // Start ONLY on an explicit ?tour=start deep-link. Onboarding is opt-in: a
@@ -180,9 +184,16 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
       start();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isAdmin, stateQuery.data, pathname, run, welcomeCtx.isLoading, agentStatus.isLoading]);
+  }, [
+    isAdmin,
+    stateQuery.data,
+    pathname,
+    run,
+    welcomeCtx.isLoading,
+    agentStatus.isLoading,
+  ]);
 
-  const step = run ? run.steps[run.index] ?? null : null;
+  const step = run ? (run.steps[run.index] ?? null) : null;
 
   // Navigate to the step's route when the step changes. Routes may carry a
   // one-shot query string (e.g. /agent?ask=...); compare on the path only.
@@ -225,7 +236,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
         if (prevStep.route) router.push(prevStep.route);
         return { ...r, index: prev };
       }),
-    [router]
+    [router],
   );
 
   const onSkip = useCallback(() => {
@@ -254,7 +265,11 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <TourContext.Provider
-      value={{ start, isActive: run !== null, activeGuide: run?.recipe ?? null }}
+      value={{
+        start,
+        isActive: run !== null,
+        activeGuide: run?.recipe ?? null,
+      }}
     >
       {children}
       {run && step ? (

--- a/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
@@ -103,6 +103,15 @@ describe("dashboard onboarding UI states", () => {
     expect(tourProviderSource).toContain("enabled: isAdmin");
     expect(tourProviderSource).toContain("if (!isAdmin) return;");
     expect(tourProviderSource).toContain(
+      "migrationSource: prev?.migrationSource ?? null"
+    );
+    expect(tourProviderSource).toContain(
+      "prev?.migrationSourceHasCommittedChanges ?? false"
+    );
+    expect(tourProviderSource).toContain(
+      "migrationCompletedModes: prev?.migrationCompletedModes ?? []"
+    );
+    expect(tourProviderSource).toContain(
       "setTourStatus.mutate({ status, lastStepId: stepId ?? null })"
     );
     expect(settingsRouter).toContain("setTourStatus: adminProcedure");

--- a/apps/web/lib/__tests__/onboarding-import-ui.test.ts
+++ b/apps/web/lib/__tests__/onboarding-import-ui.test.ts
@@ -5,65 +5,105 @@ import {
   csvByteLength,
   isImportCsvSizeValid,
 } from "../import/policy";
+import { MIGRATION_STEPS } from "../import/sources";
 
 describe("onboarding import UI", () => {
   const source = readFileSync(
     "components/onboarding/steps/bring-data.tsx",
     "utf8",
   );
+  const journeySource = readFileSync(
+    "components/onboarding/journey-overlay.tsx",
+    "utf8",
+  );
 
-  it("dry-runs CSV imports before committing first-run data", () => {
+  it("offers the complete four-stage clinic migration in safe order", () => {
+    expect(MIGRATION_STEPS.map((step) => step.mode)).toEqual([
+      "clients",
+      "patients",
+      "vaccinations",
+      "soapNotes",
+    ]);
     expect(source).toContain(
       "const importClientsCsv = trpc.data.importClientsCsv.useMutation",
     );
     expect(source).toContain(
       "const importPatientsCsv = trpc.data.importPatientsCsv.useMutation",
     );
+    expect(source).toContain(
+      "const importVaccinationsCsv = trpc.data.importVaccinationsCsv.useMutation",
+    );
+    expect(source).toContain(
+      "const importSoapNotesCsv = trpc.data.importSoapNotesCsv.useMutation",
+    );
+    expect(source).toContain("MIGRATION_STEPS.slice(0, 2)");
+    expect(source).toContain("MIGRATION_STEPS.slice(2)");
+    expect(source).toContain("Also bring vaccine and visit history");
+    expect(source).toContain(
+      "History attaches only to a safely matched real patient",
+    );
+    expect(journeySource).toContain('title: "Bring your clinic records."');
+    expect(journeySource).not.toContain(
+      'title: "Add your real clients and pets."',
+    );
+  });
+
+  it("previews every supplied file before its exact reviewed commit", () => {
     expect(source).toContain("dryRun: true");
     expect(source).toContain("dryRun: false");
-    expect(source).toContain("setClientsPreview");
-    expect(source).toContain("setPetsPreview");
-    expect(source).toContain("previewToken: string;");
-    expect(source.match(/previewToken: r\.previewToken/g)).toHaveLength(2);
-    expect(source).toContain("previewToken: preview.previewToken");
-    expect(source).toContain("previewToken: petsPreview!.previewToken");
+    expect(source).toContain('migrationProtocol: "reviewed-v1"');
+    expect(source).toContain("previewToken: activePreview.previewToken");
+    expect(source).toContain(
+      "nextOnboardingImportMode(selectedByMode, committedByMode)",
+    );
+    expect(source).toContain("setPreviewByMode");
+    expect(source).toContain("setCommittedByMode");
     expect(source).toContain("if (result) return true");
-    expect(source).toContain("Only the");
-    expect(source).toContain("issue rows will be skipped.");
-    expect(source).toContain("source: migrationSource");
-    expect(source.match(/migrationProtocol: "reviewed-v1"/g)).toHaveLength(4);
-    expect(source).toContain("Which system are you moving from?");
-    expect(source).toContain("MIGRATION_SOURCES.map");
+    expect(source).toContain(
+      "planned changes and every issue before you confirm",
+    );
+    expect(source).toContain("Earlier completed stages are safe");
+    expect(source).toContain("Retry the same import. It is safe");
+    expect(source).toContain(
+      "response.alreadyCommitted && response.errors.length === 0",
+    );
+    expect(source).toContain("? activePreview.errors");
+    expect(source).not.toContain("if (activePreview.total === 0) {");
+    expect(source).toContain("`all ${errors.length} issues`");
     expect(source).not.toContain("clientCsv:");
-    expect(source).toContain('? "Check client file"');
-    expect(source).toContain('"Check pet file"');
-    expect(source).toContain("setCommittedClients(committed)");
-    expect(source).toContain("Retry the same import; it is safe");
-    expect(source).toContain("Download all {errors.length} issues");
-    expect(source).toContain(
-      "const importInputsBusy = importing || readingFiles",
-    );
-    expect(source).toContain("continueDisabled: readingFiles");
-    expect(source).toContain("if (which === \"clients\") clearImportReview()");
-    expect(source).toContain("else clearPetReview()");
-    expect(source).toContain("setFileReadPending");
-    expect(source).toContain("Request a migration review before the full import");
-    expect(source).toContain("willReconcile");
-    expect(source).toContain(
-      "const fileReadVersionRef = useRef({ clients: 0, pets: 0 })",
-    );
-    expect(source).toContain(
-      "const readVersion = ++fileReadVersionRef.current[which]",
-    );
-    expect(source).toContain(
-      "if (fileReadVersionRef.current[which] !== readVersion) return;",
-    );
-    expect(source).toContain("invalidatePendingFileReads()");
     expect(source).not.toContain("function parseCSV");
     expect(source).not.toContain("row.first_name");
   });
 
-  it("uses the shared CSV size policy before import dry-runs", () => {
+  it("guards stale file reads and preserves committed upstream stages", () => {
+    expect(source).toContain(
+      "const fileReadVersionRef = useRef(importMap(() => 0))",
+    );
+    expect(source).toContain(
+      "const readVersion = ++fileReadVersionRef.current[mode]",
+    );
+    expect(source).toContain(
+      "if (fileReadVersionRef.current[mode] !== readVersion) return;",
+    );
+    expect(source).toContain("clearReviewFrom(mode)");
+    expect(source).toContain("isOnboardingImportModeLocked");
+    expect(source).toContain("lastCommittedImportIndex");
+    expect(source).toContain("continueDisabled: readingFiles");
+    expect(source).toContain("setFileReadPending");
+    expect(source).toContain("invalidatePendingFileReads()");
+    expect(source).toContain('input.value = ""');
+    expect(source).toContain("state.migrationSource");
+    expect(source).toContain(
+      "migrationCompletedModes: nextKnownCompletedModes",
+    );
+    expect(source).toContain("Already reviewed:");
+    expect(source.match(/clearAllImportReview\(\)/g)).toHaveLength(4);
+    expect(source).toContain(
+      "Ask us to review your full-history export before import",
+    );
+  });
+
+  it("uses the shared UTF-8 CSV size policy on all stages", () => {
     expect(IMPORT_CSV_MAX_BYTES).toBe(5_000_000);
     expect(csvByteLength("é")).toBe(2);
     expect(isImportCsvSizeValid("a".repeat(IMPORT_CSV_MAX_BYTES))).toBe(true);
@@ -74,17 +114,46 @@ describe("onboarding import UI", () => {
     expect(source).toContain('from "@/lib/import/policy"');
     expect(source).toContain("file.size > IMPORT_CSV_MAX_BYTES");
     expect(source).toContain("isImportCsvSizeValid(text)");
+    expect(source).toContain("csvMetaByMode[mode].sizeValid");
+    expect(source).toContain("maxLength={IMPORT_CSV_MAX_BYTES}");
+    expect(source).toContain("aria-invalid={tooLarge || undefined}");
     expect(source).toContain(
-      "const clientsCsvTooLarge = !isImportCsvSizeValid(clientsCsv);",
+      "aria-label={`Paste ${step.label.toLowerCase()} CSV text`}",
     );
+    expect(source).toContain("aria-pressed={active}");
+    expect(source).toContain("`${step.mode}-csv-size-error`");
+  });
+
+  it("shows complete result and issue summaries", () => {
+    expect(source).toContain("result.imported.clients");
+    expect(source).toContain("result.imported.patients");
+    expect(source).toContain("result.imported.vaccinations");
+    expect(source).toContain("result.imported.soapNotes");
+    expect(source).toContain("result.reconciled");
+    expect(source).toContain("result.errors");
+    expect(
+      MIGRATION_STEPS.find((step) => step.mode === "patients")?.unmatchedLabel,
+    ).toBe("Missing owners");
+    expect(
+      MIGRATION_STEPS.find((step) => step.mode === "vaccinations")
+        ?.unmatchedLabel,
+    ).toBe("Missing pets");
+    expect(source).toContain("Ready with issues to review");
+    expect(source).toContain('label="Valid rows parsed"');
+    expect(source).not.toContain("issue rows will be skipped");
+    expect(source).toContain("Review completed with issues");
+    expect(source).toContain("Fix skipped records in Settings, then Data");
+    expect(source).toContain("migrationHasCommittedChanges: true");
+    expect(source).toContain("migrationSourceHasCommittedChanges: true");
     expect(source).toContain(
-      "const petsCsvTooLarge = !isImportCsvSizeValid(petsCsv);",
+      "disabled={importInputsBusy || migrationSourceLocked}",
     );
-    expect(source).toContain("if (hasImportCsvSizeError) {");
-    expect(source.match(/maxLength={IMPORT_CSV_MAX_BYTES}/g)).toHaveLength(2);
-    expect(source).toContain("aria-invalid={clientsCsvTooLarge || undefined}");
-    expect(source).toContain("aria-invalid={petsCsvTooLarge || undefined}");
-    expect(source).toContain('id="clients-csv-size-error"');
-    expect(source).toContain('id="pets-csv-size-error"');
+    expect(source).toContain("isCustomMigrationSource ? (");
+    expect(source).toContain("<option value={migrationSource}>");
+    expect(source).toContain("setKnownCompletedModes([])");
+    expect(source).toContain("migrationCompletedModes: []");
+    expect(source).not.toContain("knownCompletedModes.length > 0 ||");
+    expect(source).toContain("state.keepSampleData && !hasImportedRows");
+    expect(source).toContain("hasPartialImport: hasCommittedStages && !result");
   });
 });

--- a/apps/web/lib/__tests__/onboarding-ui-states.test.ts
+++ b/apps/web/lib/__tests__/onboarding-ui-states.test.ts
@@ -12,43 +12,41 @@ import {
 describe("onboarding UI states", () => {
   const onboardingPage = readFileSync(
     "app/(dashboard)/onboarding/page.tsx",
-    "utf8"
+    "utf8",
   );
   const practiceBasics = readFileSync(
     "components/onboarding/steps/practice-basics.tsx",
-    "utf8"
+    "utf8",
   );
   const branding = readFileSync(
     "components/onboarding/steps/branding.tsx",
-    "utf8"
+    "utf8",
   );
   const tryAgent = readFileSync(
     "components/onboarding/steps/try-agent.tsx",
-    "utf8"
+    "utf8",
   );
   const inviteTeam = readFileSync(
     "components/onboarding/steps/invite-team.tsx",
-    "utf8"
+    "utf8",
   );
   const choosePath = readFileSync(
     "components/onboarding/steps/choose-path.tsx",
-    "utf8"
+    "utf8",
   );
-  const onboardingIntent = readFileSync(
-    "lib/onboarding/intent.ts",
-    "utf8"
-  );
+  const onboardingIntent = readFileSync("lib/onboarding/intent.ts", "utf8");
   const journeyOverlay = readFileSync(
     "components/onboarding/journey-overlay.tsx",
-    "utf8"
+    "utf8",
   );
   const settingsRouter = readFileSync("server/routers/settings.ts", "utf8");
+  const dataRouter = readFileSync("server/routers/data.ts", "utf8");
 
   it("retires the standalone onboarding page as a redirect to the dashboard", () => {
     // The static "Your OpenVPM workspace is ready" page was replaced by the
     // auto-opening setup wizard; this route is now just a redirect stub.
     expect(onboardingPage).toContain(
-      'import { redirect } from "next/navigation"'
+      'import { redirect } from "next/navigation"',
     );
     expect(onboardingPage).toContain('redirect("/")');
     expect(onboardingPage).not.toContain("Your OpenVPM workspace is ready");
@@ -59,35 +57,77 @@ describe("onboarding UI states", () => {
   it("keeps onboarding mutations admin-only at the settings router", () => {
     expect(settingsRouter).toContain("onboardingStatus: adminProcedure.query");
     expect(settingsRouter).toContain(
-      "completeOnboarding: adminProcedure.mutation"
+      "completeOnboarding: adminProcedure.mutation",
     );
     expect(settingsRouter).toContain("clearDemoData: adminProcedure.mutation");
     expect(settingsRouter).toContain("setOnboardingIntent: adminProcedure");
     expect(settingsRouter).toContain("setJourneyProgress: adminProcedure");
     expect(settingsRouter).toContain("hasRealData: existingPatients.some(");
     expect(settingsRouter).toContain(
-      "hasRealAppointment: firstRealAppointment.length > 0"
+      "hasRealAppointment: firstRealAppointment.length > 0",
     );
     expect(settingsRouter).toContain(
-      "hasCompletedRealAppointment: completedRealAppointment.length > 0"
+      "hasCompletedRealAppointment: completedRealAppointment.length > 0",
     );
   });
 
   it("starts with a persisted adoption pathway and recommends running alongside", () => {
     expect(journeyOverlay).toContain(
-      '{ id: "intent", title: "How do you want to start?" }'
+      '{ id: "intent", title: "How do you want to start?" }',
     );
     expect(journeyOverlay).toContain(
-      "initialIntent={onboardingIntent ?? DEFAULT_ONBOARDING_INTENT}"
+      "initialIntent={onboardingIntent ?? DEFAULT_ONBOARDING_INTENT}",
     );
     expect(onboardingIntent).toContain(
-      'label: "Run alongside my current PIMS"'
+      'label: "Run alongside my current PIMS"',
     );
     expect(choosePath).toContain("Recommended");
     expect(choosePath).toContain(
-      "saveIntent.mutateAsync({ intent: state.onboardingIntent })"
+      "saveIntent.mutateAsync({ intent: state.onboardingIntent })",
     );
     expect(settingsRouter).toContain("onboardingIntentSelectedAt");
+  });
+
+  it("keeps imported-real-data cleanup sticky across setup resumes", () => {
+    expect(settingsRouter).toContain("migrationHasCommittedChanges: false");
+    expect(settingsRouter).toContain("migrationLastCommittedAt: null");
+    expect(dataRouter).toContain("migrationHasCommittedChanges', true");
+    expect(dataRouter).toContain("migrationLastCommittedAt', ${committedAt}");
+    expect(journeyOverlay).toContain("initialMigrationHasCommittedChanges={");
+    expect(journeyOverlay).toContain(
+      "keepSampleData: !initialMigrationHasCommittedChanges",
+    );
+    expect(journeyOverlay).toContain(
+      "hasImportedData: initialMigrationHasCommittedChanges",
+    );
+    expect(journeyOverlay).toContain(
+      "initialMigrationSource={onboardingState.data?.migrationSource ?? null}",
+    );
+    expect(journeyOverlay).toContain(
+      "onboardingState.data?.migrationSourceHasCommittedChanges === true",
+    );
+    expect(journeyOverlay).toContain("initialMigrationCompletedModes={");
+  });
+
+  it("uses a keyboard-complete modal with responsive and explained actions", () => {
+    expect(journeyOverlay).toContain(
+      'import * as DialogPrimitive from "@radix-ui/react-dialog"',
+    );
+    expect(journeyOverlay).toContain("<DialogPrimitive.Root");
+    expect(journeyOverlay).toContain("<DialogPrimitive.Portal>");
+    expect(journeyOverlay).toContain("<DialogPrimitive.Overlay");
+    expect(journeyOverlay).toContain("<DialogPrimitive.Content");
+    expect(journeyOverlay).toContain("<DialogPrimitive.Title asChild>");
+    expect(journeyOverlay).toContain(
+      "onInteractOutside={(event) => event.preventDefault()}",
+    );
+    expect(journeyOverlay).toContain(
+      "aria-describedby={\n                          state.hasPartialImport",
+    );
+    expect(journeyOverlay).toContain('id="onboarding-back-disabled-reason"');
+    expect(journeyOverlay).toContain("whitespace-normal");
+    expect(journeyOverlay).toContain('"I\'ll finish later"');
+    expect(journeyOverlay).not.toContain("I&apos;ll finish later");
   });
 
   it("surfaces guided setup query failures instead of showing default step states", () => {
@@ -96,36 +136,36 @@ describe("onboarding UI states", () => {
     expect(practiceBasics).toContain("onRetry={() => void refetch()}");
     expect(practiceBasics).toContain("if (error || isLoading) return false;");
     expect(practiceBasics.indexOf("if (error)")).toBeLessThan(
-      practiceBasics.indexOf("if (isLoading)")
+      practiceBasics.indexOf("if (isLoading)"),
     );
     expect(
-      practiceBasics.indexOf("if (error || isLoading) return false;")
+      practiceBasics.indexOf("if (error || isLoading) return false;"),
     ).toBeLessThan(
-      practiceBasics.indexOf("if (practiceNameInvalid) return false")
+      practiceBasics.indexOf("if (practiceNameInvalid) return false"),
     );
 
     expect(branding).toContain("error: practiceError");
     expect(branding).toContain("Saved branding could not load");
     expect(branding).toContain("onClick={() => void refetchPractice()}");
     expect(branding.indexOf("{practiceError ? (")).toBeLessThan(
-      branding.indexOf("{currentLogo ? (")
+      branding.indexOf("{currentLogo ? ("),
     );
 
     expect(tryAgent).toContain("AI helper status could not load");
     expect(tryAgent).toContain("AI helper status is unavailable");
     expect(tryAgent).toContain(
-      "AI helper configuration could not be verified. Please retry before asking the helper."
+      "AI helper configuration could not be verified. Please retry before asking the helper.",
     );
     expect(tryAgent).toContain("const verifiedAgentStatus =");
     expect(tryAgent).toContain(
-      "status.error || statusMissing || !status.data ? null : status.data"
+      "status.error || statusMissing || !status.data ? null : status.data",
     );
     expect(tryAgent).toContain(
-      "const configured = verifiedAgentStatus\n    ? verifiedAgentStatus.configured\n    : false"
+      "const configured = verifiedAgentStatus\n    ? verifiedAgentStatus.configured\n    : false",
     );
     expect(tryAgent).toContain("onClick={() => void status.refetch()}");
     expect(tryAgent.indexOf("if (status.error || statusMissing)")).toBeLessThan(
-      tryAgent.indexOf("if (!configured)")
+      tryAgent.indexOf("if (!configured)"),
     );
     expect(tryAgent).not.toContain("status.data?.configured");
   });
@@ -134,30 +174,30 @@ describe("onboarding UI states", () => {
     expect(PRACTICE_NAME_MAX_LENGTH).toBe(255);
     expect(practiceBasics).toContain('from "@/lib/settings-policy"');
     expect(practiceBasics).toContain(
-      "trimmedName.length > 0 && trimmedName.length > PRACTICE_NAME_MAX_LENGTH"
+      "trimmedName.length > 0 && trimmedName.length > PRACTICE_NAME_MAX_LENGTH",
     );
     expect(practiceBasics).toContain("if (practiceNameInvalid) return false");
     expect(practiceBasics).toContain("name: trimmedName");
     expect(practiceBasics).toContain("maxLength={PRACTICE_NAME_MAX_LENGTH}");
     expect(practiceBasics).toContain(
-      "aria-invalid={practiceNameInvalid || undefined}"
+      "aria-invalid={practiceNameInvalid || undefined}",
     );
     expect(practiceBasics).toContain('id="ob-practice-name-error"');
     expect(practiceBasics).toContain(
-      "Practice name must be at most {PRACTICE_NAME_MAX_LENGTH} characters."
+      "Practice name must be at most {PRACTICE_NAME_MAX_LENGTH} characters.",
     );
   });
 
   it("bounds onboarding AI helper prompts with the shared agent policy", () => {
     expect(AGENT_INSTRUCTION_MAX_LENGTH).toBe(2000);
-    expect(isAgentInstructionValid("Which pets are overdue for vaccines?")).toBe(
-      true
-    );
+    expect(
+      isAgentInstructionValid("Which pets are overdue for vaccines?"),
+    ).toBe(true);
     expect(isAgentInstructionValid(" ".repeat(8))).toBe(false);
 
     expect(tryAgent).toContain('from "@/lib/agent/policy"');
     expect(tryAgent).toContain(
-      "const canAsk = Boolean(\n    verifiedAgentStatus &&\n    configured &&\n    isAgentInstructionValid(question) &&\n    !run.isPending\n  )"
+      "const canAsk = Boolean(\n    verifiedAgentStatus &&\n    configured &&\n    isAgentInstructionValid(question) &&\n    !run.isPending\n  )",
     );
     expect(tryAgent).toContain("if (!canAsk) return");
     expect(tryAgent).toContain("instruction: question.trim()");
@@ -165,7 +205,7 @@ describe("onboarding UI states", () => {
     expect(tryAgent).toContain("aria-invalid={questionInvalid || undefined}");
     expect(tryAgent).toContain("disabled={!canAsk}");
     expect(tryAgent).not.toContain(
-      "disabled={!question.trim() || run.isPending}"
+      "disabled={!question.trim() || run.isPending}",
     );
   });
 
@@ -173,24 +213,22 @@ describe("onboarding UI states", () => {
     expect(SETTINGS_EMAIL_MAX_LENGTH).toBe(255);
     expect(inviteTeam).toContain('from "@/lib/settings-policy"');
     expect(inviteTeam).toContain("function getInviteEmailError");
+    expect(inviteTeam).toContain("trimmed.length > SETTINGS_EMAIL_MAX_LENGTH");
     expect(inviteTeam).toContain(
-      "trimmed.length > SETTINGS_EMAIL_MAX_LENGTH"
-    );
-    expect(inviteTeam).toContain(
-      "const invalidRows = rows.filter((r) => getInviteEmailError(r.email));"
+      "const invalidRows = rows.filter((r) => getInviteEmailError(r.email));",
     );
     expect(inviteTeam).toContain("if (invalidRows.length > 0) {");
     expect(inviteTeam).toContain(
-      "const toInvite = rows.filter((r) => isInviteEmailValid(r.email));"
+      "const toInvite = rows.filter((r) => isInviteEmailValid(r.email));",
     );
     expect(inviteTeam).toContain("email: row.email.trim().toLowerCase()");
     expect(inviteTeam).toContain("maxLength={SETTINGS_EMAIL_MAX_LENGTH}");
     expect(inviteTeam).toContain(
-      "aria-invalid={Boolean(emailError) || undefined}"
+      "aria-invalid={Boolean(emailError) || undefined}",
     );
     expect(inviteTeam).toContain("id={emailErrorId}");
     expect(inviteTeam).not.toContain(
-      "rows.filter((r) => isValidEmail(r.email))"
+      "rows.filter((r) => isValidEmail(r.email))",
     );
   });
 });

--- a/apps/web/lib/__tests__/settings-ui-states.test.ts
+++ b/apps/web/lib/__tests__/settings-ui-states.test.ts
@@ -349,6 +349,13 @@ describe("settings UI states", () => {
     expect(source).toContain(
       "const importPatientsCsv = trpc.data.importPatientsCsv.useMutation",
     );
+    expect(source).toContain(
+      "const importVaccinationsCsv = trpc.data.importVaccinationsCsv.useMutation",
+    );
+    expect(source).toContain(
+      "const importSoapNotesCsv = trpc.data.importSoapNotesCsv.useMutation",
+    );
+    expect(source).toContain("MIGRATION_STEPS.map");
     expect(source).toContain('from "@/lib/import/policy"');
     expect(source).toContain("file.size > IMPORT_CSV_MAX_BYTES");
     expect(source).toContain("isImportCsvSizeValid(text)");
@@ -358,6 +365,8 @@ describe("settings UI states", () => {
     expect(source).toContain('const importSource = migrationSource ?? "other"');
     expect(source).toContain("importClientsCsv.mutate({");
     expect(source).toContain("importPatientsCsv.mutate({");
+    expect(source).toContain("importVaccinationsCsv.mutate({");
+    expect(source).toContain("importSoapNotesCsv.mutate({");
     expect(source).toContain("source: importSource");
     expect(source.match(/migrationProtocol: "reviewed-v1"/g)).toHaveLength(5);
     expect(source).toContain("previewToken: string;");

--- a/apps/web/lib/billing/subscription-sync.ts
+++ b/apps/web/lib/billing/subscription-sync.ts
@@ -64,17 +64,12 @@ async function writeBillingSyncState(
   practiceId: string,
   state: BillingSyncState
 ): Promise<void> {
-  const [practice] = await db
-    .select({ settings: practices.settings })
-    .from(practices)
-    .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)))
-    .limit(1);
-  if (!practice) return;
-
-  const settings = (practice.settings ?? {}) as PracticeSettings;
   await db
     .update(practices)
-    .set({ settings: { ...settings, billingSync: state } })
+    .set({
+      settings: sql`coalesce(${practices.settings}, '{}'::jsonb)
+        || ${JSON.stringify({ billingSync: state })}::jsonb`,
+    })
     .where(and(eq(practices.id, practiceId), isNull(practices.deletedAt)));
 }
 

--- a/apps/web/lib/import/__tests__/fingerprint.test.ts
+++ b/apps/web/lib/import/__tests__/fingerprint.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { migrationImportFingerprint } from "../fingerprint";
+
+describe("migration import fingerprints", () => {
+  it("is deterministic, versioned by mode, and delimiter-safe", () => {
+    const first = migrationImportFingerprint("clients", ["a|b", "c"]);
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(migrationImportFingerprint("clients", ["a|b", "c"])).toBe(first);
+    expect(migrationImportFingerprint("clients", ["a", "b|c"])).not.toBe(first);
+    expect(migrationImportFingerprint("patients", ["a|b", "c"])).not.toBe(
+      first,
+    );
+  });
+
+  it("ships partial tenant-scoped uniqueness for all four import destinations", () => {
+    const migration = readFileSync(
+      resolve(process.cwd(), "../../packages/db/drizzle/0051_wide_maximus.sql"),
+      "utf8",
+    );
+
+    for (const table of [
+      "clients",
+      "patients",
+      "soap_notes",
+      "vaccination_records",
+    ]) {
+      expect(migration).toContain(
+        `CREATE UNIQUE INDEX "${table}_import_fingerprint_uq"`,
+      );
+      expect(migration).toContain(
+        `("practice_id","import_fingerprint") WHERE "${table}"."import_fingerprint" is not null and "${table}"."deleted_at" is null`,
+      );
+      expect(migration).toContain(
+        `CONSTRAINT "${table}_import_fingerprint_check"`,
+      );
+    }
+  });
+});

--- a/apps/web/lib/import/__tests__/onboarding-workflow.test.ts
+++ b/apps/web/lib/import/__tests__/onboarding-workflow.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOnboardingImportModeLocked,
+  isOnboardingMigrationSourceLocked,
+  lastCommittedImportIndex,
+  nextOnboardingImportMode,
+  onboardingImportChangeCount,
+  summarizeOnboardingImports,
+  type OnboardingImportCommits,
+  type OnboardingImportSelections,
+} from "../onboarding-workflow";
+
+const emptySelection = (): OnboardingImportSelections => ({
+  clients: false,
+  patients: false,
+  vaccinations: false,
+  soapNotes: false,
+});
+
+describe("onboarding migration workflow", () => {
+  it("processes only supplied files in dependency order", () => {
+    const selected = {
+      ...emptySelection(),
+      soapNotes: true,
+      patients: true,
+      vaccinations: true,
+    };
+    const committed: OnboardingImportCommits = {};
+
+    expect(nextOnboardingImportMode(selected, committed)).toBe("patients");
+    committed.patients = { imported: 2, reconciled: 0, errors: [] };
+    expect(nextOnboardingImportMode(selected, committed)).toBe("vaccinations");
+    committed.vaccinations = { imported: 3, reconciled: 0, errors: [] };
+    expect(nextOnboardingImportMode(selected, committed)).toBe("soapNotes");
+    committed.soapNotes = { imported: 4, reconciled: 0, errors: [] };
+    expect(nextOnboardingImportMode(selected, committed)).toBeNull();
+  });
+
+  it("treats a reviewed zero-change stage as complete", () => {
+    const selected = {
+      ...emptySelection(),
+      clients: true,
+      patients: true,
+    };
+    const committed: OnboardingImportCommits = {
+      clients: { imported: 0, reconciled: 0, errors: ["duplicate"] },
+    };
+
+    expect(nextOnboardingImportMode(selected, committed)).toBe("patients");
+    expect(isOnboardingMigrationSourceLocked(false, committed)).toBe(false);
+  });
+
+  it("locks the source for prior or current-session material changes", () => {
+    expect(isOnboardingMigrationSourceLocked(true, {})).toBe(true);
+    expect(
+      isOnboardingMigrationSourceLocked(false, {
+        patients: { imported: 0, reconciled: 1, errors: [] },
+      }),
+    ).toBe(true);
+  });
+
+  it("freezes committed and skipped upstream stages but leaves later fixes open", () => {
+    const committed: OnboardingImportCommits = {
+      patients: { imported: 2, reconciled: 0, errors: [] },
+    };
+
+    expect(lastCommittedImportIndex(committed)).toBe(1);
+    expect(isOnboardingImportModeLocked("clients", committed, false)).toBe(
+      true,
+    );
+    expect(isOnboardingImportModeLocked("patients", committed, false)).toBe(
+      true,
+    );
+    expect(isOnboardingImportModeLocked("vaccinations", committed, false)).toBe(
+      false,
+    );
+    expect(isOnboardingImportModeLocked("soapNotes", committed, true)).toBe(
+      true,
+    );
+  });
+
+  it("summarizes partial commits without dropping earlier issues", () => {
+    const summary = summarizeOnboardingImports({
+      clients: { imported: 3, reconciled: 1, errors: ["client issue"] },
+      patients: { imported: 2, reconciled: 2, errors: [] },
+      vaccinations: {
+        imported: 4,
+        reconciled: 0,
+        errors: ["vaccine issue"],
+      },
+    });
+
+    expect(summary).toEqual({
+      imported: {
+        clients: 3,
+        patients: 2,
+        vaccinations: 4,
+        soapNotes: 0,
+      },
+      reconciled: 3,
+      errors: ["client issue", "vaccine issue"],
+    });
+    expect(onboardingImportChangeCount(summary)).toBe(12);
+  });
+});

--- a/apps/web/lib/import/__tests__/run-ledger.test.ts
+++ b/apps/web/lib/import/__tests__/run-ledger.test.ts
@@ -275,6 +275,88 @@ describe("migrationReviewedPlanHash", () => {
     expect(swapped).not.toBe(first);
   });
 
+  it("binds history row dispositions and versioned patient targets", () => {
+    const history = {
+      mode: "vaccinations" as const,
+      source: "shepherd",
+      csv: [
+        "Patient ID,Vaccine,Date Given",
+        "P-1,Rabies,2025-01-01",
+        "P-2,DHPP,2025-01-02",
+      ].join("\n"),
+      summary: {
+        sourceRowCount: 2,
+        plannedInsertCount: 1,
+        duplicateCount: 1,
+        unmatchedCount: 0,
+        errorCount: 1,
+      },
+    };
+    const reviewedPlan = {
+      plannerVersion: "vaccinations-v1",
+      dispositions: [
+        {
+          rowIndex: 0,
+          entityKind: "vaccination" as const,
+          action: "insert" as const,
+        },
+        {
+          rowIndex: 1,
+          entityKind: "vaccination" as const,
+          action: "duplicate" as const,
+        },
+      ],
+      targets: [
+        {
+          rowIndex: 0,
+          kind: "patient" as const,
+          role: "external_match" as const,
+          targetId: "00000000-0000-0000-0000-0000000000d1",
+          targetVersion: "2026-08-08T12:00:00.000Z",
+        },
+        {
+          rowIndex: 1,
+          kind: "patient" as const,
+          role: "external_match" as const,
+          targetId: "00000000-0000-0000-0000-0000000000d2",
+          targetVersion: "2026-08-08T12:00:00.000Z",
+        },
+      ],
+    };
+    const reviewedHash = migrationReviewedPlanHash({
+      ...history,
+      reviewedPlan,
+    });
+
+    expect(
+      migrationReviewedPlanHash({
+        ...history,
+        reviewedPlan: {
+          ...reviewedPlan,
+          dispositions: [
+            { ...reviewedPlan.dispositions[0], action: "duplicate" as const },
+            { ...reviewedPlan.dispositions[1], action: "insert" as const },
+          ],
+        },
+      }),
+    ).not.toBe(reviewedHash);
+    expect(
+      migrationReviewedPlanHash({
+        ...history,
+        reviewedPlan: {
+          ...reviewedPlan,
+          targets: [
+            {
+              ...reviewedPlan.targets[0],
+              targetVersion: "2026-08-08T12:01:00.000Z",
+            },
+            reviewedPlan.targets[1],
+          ],
+        },
+      }),
+    ).not.toBe(reviewedHash);
+  });
+
   it("requires a deliberate planner version and schema version", () => {
     expect(MIGRATION_REVIEWED_PLAN_SCHEMA_VERSION).toBe(1);
     expect(

--- a/apps/web/lib/import/__tests__/sources.test.ts
+++ b/apps/web/lib/import/__tests__/sources.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  isValidMigrationSource,
+  migrationSourceExportHint,
+  migrationSourceName,
+} from "../sources";
+
+describe("migration source identity", () => {
+  it("preserves valid custom source IDs with a safe resume label", () => {
+    expect(isValidMigrationSource("legacy_pims")).toBe(true);
+    expect(migrationSourceName("legacy_pims")).toBe(
+      "Previous source (legacy_pims)",
+    );
+    expect(migrationSourceExportHint("legacy_pims")).toContain(
+      "Keep using this exact source",
+    );
+  });
+
+  it("rejects source values outside the import contract", () => {
+    expect(isValidMigrationSource("Legacy PIMS")).toBe(false);
+    expect(isValidMigrationSource("<script>")).toBe(false);
+    expect(isValidMigrationSource("a".repeat(65))).toBe(false);
+  });
+
+  it("keeps preset display copy unchanged", () => {
+    expect(migrationSourceName("shepherd")).toBe("Shepherd");
+    expect(migrationSourceExportHint("shepherd")).toContain("Reports");
+  });
+});

--- a/apps/web/lib/import/fingerprint.ts
+++ b/apps/web/lib/import/fingerprint.ts
@@ -1,0 +1,30 @@
+import { createHash } from "node:crypto";
+
+export type ImportFingerprintMode =
+  | "clients"
+  | "patients"
+  | "vaccinations"
+  | "soap_notes";
+
+const IMPORT_FINGERPRINT_SCHEMA_VERSION = 1;
+
+/**
+ * Privacy-minimized, deterministic identity for rows created by migration.
+ * Only the digest is persisted. The versioned JSON envelope avoids delimiter
+ * ambiguity and permits an intentional future identity-policy migration.
+ */
+export function migrationImportFingerprint(
+  mode: ImportFingerprintMode,
+  identityParts: readonly (string | null)[],
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        schemaVersion: IMPORT_FINGERPRINT_SCHEMA_VERSION,
+        mode,
+        identityParts,
+      }),
+      "utf8",
+    )
+    .digest("hex");
+}

--- a/apps/web/lib/import/onboarding-workflow.ts
+++ b/apps/web/lib/import/onboarding-workflow.ts
@@ -1,0 +1,101 @@
+import { MIGRATION_STEPS, type MigrationImportMode } from "./sources";
+
+export type OnboardingImportCommit = {
+  imported: number;
+  reconciled: number;
+  errors: string[];
+};
+
+export type OnboardingImportCommits = Partial<
+  Record<MigrationImportMode, OnboardingImportCommit>
+>;
+
+export type OnboardingImportSelections = Record<MigrationImportMode, boolean>;
+
+export function nextOnboardingImportMode(
+  selectedByMode: OnboardingImportSelections,
+  committedByMode: OnboardingImportCommits,
+): MigrationImportMode | null {
+  return (
+    MIGRATION_STEPS.find(
+      ({ mode }) => selectedByMode[mode] && !committedByMode[mode],
+    )?.mode ?? null
+  );
+}
+
+export function lastCommittedImportIndex(
+  committedByMode: OnboardingImportCommits,
+): number {
+  return MIGRATION_STEPS.reduce(
+    (last, { mode }, index) =>
+      committedByMode[mode] ? Math.max(last, index) : last,
+    -1,
+  );
+}
+
+export function isOnboardingMigrationSourceLocked(
+  latestSourceHasCommittedChanges: boolean,
+  committedByMode: OnboardingImportCommits,
+): boolean {
+  return (
+    latestSourceHasCommittedChanges ||
+    MIGRATION_STEPS.some(({ mode }) => {
+      const committed = committedByMode[mode];
+      return Boolean(
+        committed && committed.imported + committed.reconciled > 0,
+      );
+    })
+  );
+}
+
+/**
+ * Once a stage commits, it and every skipped stage before it stay frozen.
+ * Later stages remain editable so a clinic can fix a history file without
+ * losing owner and patient work that already succeeded.
+ */
+export function isOnboardingImportModeLocked(
+  mode: MigrationImportMode,
+  committedByMode: OnboardingImportCommits,
+  finished: boolean,
+): boolean {
+  if (finished) return true;
+  const index = MIGRATION_STEPS.findIndex((step) => step.mode === mode);
+  return index <= lastCommittedImportIndex(committedByMode);
+}
+
+export type OnboardingImportSummary = {
+  imported: Record<MigrationImportMode, number>;
+  reconciled: number;
+  errors: string[];
+};
+
+export function summarizeOnboardingImports(
+  committedByMode: OnboardingImportCommits,
+): OnboardingImportSummary {
+  const imported = Object.fromEntries(
+    MIGRATION_STEPS.map(({ mode }) => [
+      mode,
+      committedByMode[mode]?.imported ?? 0,
+    ]),
+  ) as Record<MigrationImportMode, number>;
+
+  return {
+    imported,
+    reconciled: MIGRATION_STEPS.reduce(
+      (count, { mode }) => count + (committedByMode[mode]?.reconciled ?? 0),
+      0,
+    ),
+    errors: MIGRATION_STEPS.flatMap(
+      ({ mode }) => committedByMode[mode]?.errors ?? [],
+    ),
+  };
+}
+
+export function onboardingImportChangeCount(
+  summary: OnboardingImportSummary,
+): number {
+  return (
+    Object.values(summary.imported).reduce((total, count) => total + count, 0) +
+    summary.reconciled
+  );
+}

--- a/apps/web/lib/import/run-ledger.ts
+++ b/apps/web/lib/import/run-ledger.ts
@@ -37,7 +37,7 @@ export type MigrationReviewedTarget = {
 
 export type MigrationReviewedDisposition = {
   rowIndex: number;
-  entityKind: "client" | "patient";
+  entityKind: "client" | "patient" | "vaccination" | "soap_note";
   action:
     | "insert"
     | "reconcile"

--- a/apps/web/lib/import/sources.ts
+++ b/apps/web/lib/import/sources.ts
@@ -6,8 +6,15 @@
  * Voice: fourth grade, no em dashes.
  */
 
+export type MigrationSourcePresetId =
+  | "avimark"
+  | "cornerstone"
+  | "ezyvet"
+  | "shepherd"
+  | "other";
+
 export interface MigrationSource {
-  id: "avimark" | "cornerstone" | "ezyvet" | "shepherd" | "other";
+  id: MigrationSourcePresetId;
   name: string;
   /** How to get CSV exports out of that system, in one breath. */
   exportHint: string;
@@ -46,10 +53,88 @@ export const MIGRATION_SOURCES: MigrationSource[] = [
   },
 ];
 
-/** Import order that always works: owners first, then pets, then history. */
-export const MIGRATION_STEPS = [
-  { mode: "clients" as const, label: "1. Clients (pet owners)" },
-  { mode: "patients" as const, label: "2. Patients (pets)" },
-  { mode: "vaccinations" as const, label: "3. Vaccine history" },
-  { mode: "soapNotes" as const, label: "4. Medical history (visit notes)" },
+/**
+ * Source IDs namespace external client and patient IDs across staged imports.
+ * Keep this in sync with the server input so a resumed custom migration can
+ * safely reuse its exact source instead of being collapsed into `other`.
+ */
+export const MIGRATION_SOURCE_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export function isValidMigrationSource(value: unknown): value is string {
+  return typeof value === "string" && MIGRATION_SOURCE_PATTERN.test(value);
+}
+
+export function migrationSourceName(sourceId: string): string {
+  return (
+    MIGRATION_SOURCES.find((source) => source.id === sourceId)?.name ??
+    `Previous source (${sourceId})`
+  );
+}
+
+export function migrationSourceExportHint(sourceId: string): string {
+  return (
+    MIGRATION_SOURCES.find((source) => source.id === sourceId)?.exportHint ??
+    "Keep using this exact source for the rest of this migration so saved owner and patient IDs stay linked. Ask OpenVPM support if you need help exporting another file."
+  );
+}
+
+export type MigrationImportMode =
+  | "clients"
+  | "patients"
+  | "vaccinations"
+  | "soapNotes";
+
+export interface MigrationStep {
+  mode: MigrationImportMode;
+  label: string;
+  shortLabel: string;
+  columnHint: string;
+  placeholder: string;
+  unmatchedLabel?: string;
+}
+
+/**
+ * One shared contract for every migration surface. The order is deliberate:
+ * history can only attach safely after owner and patient identities exist.
+ */
+export const MIGRATION_STEPS: readonly MigrationStep[] = [
+  {
+    mode: "clients",
+    label: "Clients (pet owners)",
+    shortLabel: "client",
+    columnHint:
+      "firstName, lastName, plus email or client ID. Optional: phone, address, city, state, zip",
+    placeholder:
+      "clientId,firstName,lastName,email,phone,address,city,state,zip",
+  },
+  {
+    mode: "patients",
+    label: "Patients (pets)",
+    shortLabel: "pet",
+    columnHint:
+      "clientEmail or client ID, name, species. Patient ID is recommended. Optional: breed, sex, dob, color, microchipNumber",
+    placeholder:
+      "clientId,clientEmail,patientId,name,species,breed,sex,dob,color,microchipNumber",
+    unmatchedLabel: "Missing owners",
+  },
+  {
+    mode: "vaccinations",
+    label: "Vaccine history",
+    shortLabel: "vaccine history",
+    columnHint:
+      "patient ID, or an owner reference plus patientName; vaccineName and dateGiven. Optional: nextDueDate, lotNumber, manufacturer",
+    placeholder:
+      "patientId,clientId,clientEmail,patientName,vaccineName,dateGiven,nextDueDate,lotNumber,manufacturer",
+    unmatchedLabel: "Missing pets",
+  },
+  {
+    mode: "soapNotes",
+    label: "Medical history (visit notes)",
+    shortLabel: "medical history",
+    columnHint:
+      "patient ID, or an owner reference plus patientName; date, and either subjective, objective, assessment, plan or a single notes column",
+    placeholder:
+      "patientId,clientId,clientEmail,patientName,date,subjective,objective,assessment,plan",
+    unmatchedLabel: "Missing pets",
+  },
 ];

--- a/apps/web/server/__tests__/data-import-dedup.test.ts
+++ b/apps/web/server/__tests__/data-import-dedup.test.ts
@@ -100,16 +100,25 @@ function createDb(
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
+  const execute = vi.fn(async () => undefined);
 
   const db: Record<string, unknown> = {
     transaction: async (fn: (tx: unknown) => unknown) => fn(db),
-    execute: vi.fn(async () => undefined),
+    execute,
     select,
     insert,
     update,
   };
 
-  return { db, insertValues, select, update, updateSet, updateReturning };
+  return {
+    db,
+    execute,
+    insertValues,
+    select,
+    update,
+    updateSet,
+    updateReturning,
+  };
 }
 
 afterEach(() => {
@@ -307,6 +316,56 @@ describe("data import duplicate handling", () => {
 
     expect(select).toHaveBeenCalledTimes(1);
     expect(insertValues).not.toHaveBeenCalled();
+    expect(
+      migrationRunMocks.createMigrationPreview.mock.calls.at(-1)?.[1],
+    ).toMatchObject({
+      mode: "clients",
+      reviewedPlan: {
+        plannerVersion: "clients-v1",
+        dispositions: [],
+        targets: [],
+      },
+    });
+  });
+
+  it("commits a malformed client CSV as an explicit zero-write skip", async () => {
+    const { db, execute, insertValues } = createDb([]);
+    const csv = 'firstName,lastName,email\n"Jane,Doe,jane@example.com';
+
+    await expect(
+      callerWithDb(db).importClientsCsv({
+        csv,
+        source: "shepherd",
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
+        migrationProtocol: "reviewed-v1",
+      }),
+    ).resolves.toEqual({
+      imported: 0,
+      reconciled: 0,
+      errors: ["CSV has an unterminated quoted field."],
+    });
+
+    expect(migrationRunMocks.claimMigrationPreview).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        mode: "clients",
+        summary: expect.objectContaining({ plannedInsertCount: 0 }),
+        reviewedPlan: {
+          plannerVersion: "clients-v1",
+          dispositions: [],
+          targets: [],
+        },
+      }),
+    );
+    expect(migrationRunMocks.completeMigrationRun).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ importedCount: 0, reconciledCount: 0 }),
+    );
+    // Tenant scoping plus SERIALIZABLE isolation both execute inside the same
+    // transaction before the ledger is completed.
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("skips existing and in-file duplicate client emails", async () => {
@@ -355,6 +414,7 @@ describe("data import duplicate handling", () => {
         city: "Boston",
         state: "MA",
         zip: "02110",
+        importFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/),
       },
       {
         practiceId: PRACTICE_ID,
@@ -366,6 +426,7 @@ describe("data import duplicate handling", () => {
         city: null,
         state: null,
         zip: null,
+        importFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/),
       },
     ]);
   });
@@ -406,6 +467,7 @@ describe("data import duplicate handling", () => {
         city: null,
         state: null,
         zip: null,
+        importFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/),
       },
     ]);
   });
@@ -441,8 +503,39 @@ describe("data import duplicate handling", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
+  it("does not reconcile a real client import onto a disposable demo owner", async () => {
+    const { db, insertValues } = createDb([
+      [
+        {
+          id: CLIENT_ID,
+          email: "owner@example.com",
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+          isDemo: true,
+        },
+      ],
+    ]);
+
+    const result = await callerWithDb(db).importClientsCsv({
+      csv: "Client ID,First Name,Last Name,Email\nC-42,Ada,Client,owner@example.com",
+      source: "shepherd",
+      dryRun: true,
+      migrationProtocol: "reviewed-v1",
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      willInsert: 1,
+      willReconcile: 0,
+      duplicates: 0,
+      errors: [],
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("imports an ID-only client with a source-scoped external identity", async () => {
-    const { db, insertValues } = createDb([[]]);
+    const { db, execute, insertValues } = createDb([[]]);
 
     await expect(
       callerWithDb(db).importClientsCsv({
@@ -463,6 +556,7 @@ describe("data import duplicate handling", () => {
         email: null,
       }),
     ]);
+    expect(execute).toHaveBeenCalled();
   });
 
   it("merges a later external ID into the pending client insert", async () => {
@@ -687,6 +781,7 @@ describe("data import duplicate handling", () => {
         dob: "2021-03-04",
         color: "Black",
         microchipNumber: "985112003009999",
+        importFingerprint: expect.stringMatching(/^[0-9a-f]{64}$/),
       },
     ]);
   });
@@ -1040,6 +1135,54 @@ describe("data import duplicate handling", () => {
 
     expect(select).toHaveBeenCalledTimes(1);
     expect(insertValues).not.toHaveBeenCalled();
+    expect(
+      migrationRunMocks.createMigrationPreview.mock.calls.at(-1)?.[1],
+    ).toMatchObject({
+      mode: "patients",
+      reviewedPlan: {
+        plannerVersion: "patients-v1",
+        dispositions: [],
+        targets: [],
+      },
+    });
+  });
+
+  it("commits a malformed patient CSV as an explicit zero-write skip", async () => {
+    const { db, execute, insertValues } = createDb([]);
+    const csv = 'clientEmail,name,species\n"owner@example.com,Rex,canine';
+
+    await expect(
+      callerWithDb(db).importPatientsCsv({
+        csv,
+        source: "shepherd",
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
+        migrationProtocol: "reviewed-v1",
+      }),
+    ).resolves.toEqual({
+      imported: 0,
+      reconciled: 0,
+      errors: ["CSV has an unterminated quoted field."],
+    });
+
+    expect(migrationRunMocks.claimMigrationPreview).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        mode: "patients",
+        summary: expect.objectContaining({ plannedInsertCount: 0 }),
+        reviewedPlan: {
+          plannerVersion: "patients-v1",
+          dispositions: [],
+          targets: [],
+        },
+      }),
+    );
+    expect(migrationRunMocks.completeMigrationRun).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ importedCount: 0, reconciledCount: 0 }),
+    );
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("dry-runs patient CSV imports with duplicate planning and no inserts", async () => {
@@ -1081,6 +1224,53 @@ describe("data import duplicate handling", () => {
       ],
     });
 
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("does not reconcile a real patient import onto a disposable demo pet", async () => {
+    const { db, insertValues } = createDb([
+      [
+        {
+          id: CLIENT_ID,
+          email: "owner@example.com",
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+        },
+      ],
+      [
+        {
+          id: PATIENT_ID,
+          clientId: CLIENT_ID,
+          name: "Rex",
+          species: "canine",
+          dob: "2020-01-01",
+          microchipNumber: null,
+          externalSource: null,
+          externalId: null,
+          deletedAt: null,
+          isDemo: true,
+        },
+      ],
+    ]);
+
+    const result = await callerWithDb(db).importPatientsCsv({
+      csv: [
+        "Patient ID,Client Email,Name,Species,DOB",
+        "P-42,owner@example.com,Rex,canine,2020-01-01",
+      ].join("\n"),
+      source: "shepherd",
+      dryRun: true,
+      migrationProtocol: "reviewed-v1",
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      willInsert: 1,
+      willReconcile: 0,
+      duplicates: 0,
+      errors: [],
+    });
     expect(insertValues).not.toHaveBeenCalled();
   });
 

--- a/apps/web/server/__tests__/data-import-soap.test.ts
+++ b/apps/web/server/__tests__/data-import-soap.test.ts
@@ -1,25 +1,37 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+type MigrationMockInput = {
+  summary: { plannedInsertCount: number };
+  reviewedPlan?: {
+    plannerVersion: string;
+    dispositions: Array<Record<string, unknown>>;
+    targets: Array<Record<string, unknown>>;
+  };
+};
+
 vi.mock("@/lib/audit", () => ({
   recordAuditLog: vi.fn(async () => undefined),
 }));
 
 const migrationRunMocks = vi.hoisted(() => ({
+  MigrationPreviewError: class MigrationPreviewError extends Error {},
   createMigrationPreview: vi.fn(
-    async () => "00000000-0000-0000-0000-0000000000f1",
+    async (_db: unknown, _input: MigrationMockInput) =>
+      "00000000-0000-0000-0000-0000000000f1",
   ),
-  claimMigrationPreview: vi.fn(async () => ({
-    alreadyCommitted: false,
-    importedCount: 0,
-    reconciledCount: 0,
-    errorCount: 0,
-  })),
+  claimMigrationPreview: vi.fn(
+    async (_db: unknown, _input: MigrationMockInput) => ({
+      alreadyCommitted: false,
+      importedCount: 0,
+      reconciledCount: 0,
+      errorCount: 0,
+    }),
+  ),
   completeMigrationRun: vi.fn(async () => undefined),
   lockMigrationPractice: vi.fn(async () => undefined),
 }));
 
 vi.mock("@/lib/import/run-ledger", () => ({
-  MigrationPreviewError: class MigrationPreviewError extends Error {},
   ...migrationRunMocks,
 }));
 
@@ -44,13 +56,16 @@ function callerWithDb(db: Record<string, unknown>, role = "admin") {
 }
 
 function thenableRows(result: unknown[]) {
-  return {
+  const rows = {
     limit: vi.fn(async () => result),
+    orderBy: vi.fn(() => rows),
+    for: vi.fn(async () => result),
     then: (
       resolve: (value: unknown[]) => unknown,
       reject?: (error: unknown) => unknown,
     ) => Promise.resolve(result).then(resolve, reject),
   };
+  return rows;
 }
 
 function createDb(
@@ -137,6 +152,50 @@ describe("medical history (SOAP notes) import", () => {
     });
     expect(select).toHaveBeenCalledTimes(1);
     expect(insertValues).not.toHaveBeenCalled();
+    expect(
+      migrationRunMocks.createMigrationPreview.mock.calls.at(-1)?.[1],
+    ).toMatchObject({
+      mode: "soap_notes",
+      reviewedPlan: {
+        plannerVersion: "soap-notes-v1",
+        dispositions: [],
+        targets: [],
+      },
+    });
+  });
+
+  it("commits malformed medical-history CSV as an explicit zero-write skip", async () => {
+    const { db, insertValues } = createDb([]);
+    const csv = `${HEADER}\n"jane@x.com,Rex`;
+
+    await expect(
+      callerWithDb(db).importSoapNotesCsv({
+        csv,
+        source: "shepherd",
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
+        migrationProtocol: "reviewed-v1",
+      }),
+    ).resolves.toEqual({
+      imported: 0,
+      errors: ["CSV has an unterminated quoted field."],
+    });
+    expect(migrationRunMocks.claimMigrationPreview).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        mode: "soap_notes",
+        reviewedPlan: {
+          plannerVersion: "soap-notes-v1",
+          dispositions: [],
+          targets: [],
+        },
+      }),
+    );
+    expect(migrationRunMocks.completeMigrationRun).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ importedCount: 0 }),
+    );
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("dry run reports matches, duplicates, and missing pets without inserting", async () => {
@@ -171,6 +230,142 @@ describe("medical history (SOAP notes) import", () => {
     expect(
       result.errors.some((e) => /No matching patient was found/.test(e)),
     ).toBe(true);
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("binds each medical-history disposition to the versioned patient selected inside the transaction", async () => {
+    const updatedAt = new Date("2026-08-08T12:00:00.000Z");
+    const { db } = createDb([[{ ...patientRows[0], updatedAt }], []]);
+
+    await callerWithDb(db).importSoapNotesCsv({
+      csv: `${HEADER}\n${REX_ROW}`,
+      dryRun: true,
+      migrationProtocol: "reviewed-v1",
+    });
+
+    expect(migrationRunMocks.lockMigrationPractice).toHaveBeenCalledWith(
+      db,
+      PRACTICE_ID,
+    );
+    expect(
+      migrationRunMocks.createMigrationPreview.mock.calls.at(-1)?.[1],
+    ).toMatchObject({
+      mode: "soap_notes",
+      reviewedPlan: {
+        plannerVersion: "soap-notes-v1",
+        dispositions: [
+          {
+            rowIndex: 0,
+            entityKind: "soap_note",
+            action: "insert",
+          },
+        ],
+        targets: [
+          {
+            rowIndex: 0,
+            kind: "patient",
+            role: "identity_match",
+            targetId: PATIENT_ID,
+            targetVersion: updatedAt.toISOString(),
+          },
+        ],
+      },
+    });
+  });
+
+  it("fails closed when a selected patient's version changes after preview", async () => {
+    const csv = `${HEADER}\n${REX_ROW}`;
+    const previewDb = createDb([
+      [
+        {
+          ...patientRows[0],
+          updatedAt: new Date("2026-08-08T12:00:00.000Z"),
+        },
+      ],
+      [],
+    ]);
+    await callerWithDb(previewDb.db).importSoapNotesCsv({
+      csv,
+      dryRun: true,
+      migrationProtocol: "reviewed-v1",
+    });
+    const reviewed =
+      migrationRunMocks.createMigrationPreview.mock.calls.at(-1)?.[1]
+        ?.reviewedPlan;
+    migrationRunMocks.claimMigrationPreview.mockImplementationOnce(
+      async (_db, input) => {
+        expect(input.summary).toMatchObject({ plannedInsertCount: 1 });
+        expect(input.reviewedPlan).not.toEqual(reviewed);
+        throw new migrationRunMocks.MigrationPreviewError(
+          "The reviewed import plan changed.",
+        );
+      },
+    );
+    const commitDb = createDb([
+      [
+        {
+          ...patientRows[0],
+          updatedAt: new Date("2026-08-08T12:01:00.000Z"),
+        },
+      ],
+      [],
+    ]);
+
+    await expect(
+      callerWithDb(commitDb.db).importSoapNotesCsv({
+        csv,
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
+        migrationProtocol: "reviewed-v1",
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(commitDb.insertValues).not.toHaveBeenCalled();
+  });
+
+  it("returns the saved medical-history result when an exact committed request is retried", async () => {
+    migrationRunMocks.claimMigrationPreview.mockResolvedValueOnce({
+      alreadyCommitted: true,
+      importedCount: 9,
+      reconciledCount: 0,
+      errorCount: 0,
+    });
+    const { db, insertValues } = createDb([[], []]);
+
+    await expect(
+      callerWithDb(db).importSoapNotesCsv({
+        csv: `${HEADER}\n${REX_ROW}`,
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
+        migrationProtocol: "reviewed-v1",
+      }),
+    ).resolves.toEqual({
+      imported: 9,
+      errors: [],
+      alreadyCommitted: true,
+      migrationRunId: PREVIEW_TOKEN,
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(migrationRunMocks.completeMigrationRun).not.toHaveBeenCalled();
+  });
+
+  it("treats patients under seeded demo clients as unavailable migration targets", async () => {
+    const { db, insertValues } = createDb([
+      [{ ...patientRows[0], isDemoClient: true }],
+      [],
+    ]);
+
+    const result = await callerWithDb(db).importSoapNotesCsv({
+      csv: `${HEADER}\n${REX_ROW}`,
+      dryRun: true,
+      migrationProtocol: "reviewed-v1",
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      willInsert: 0,
+      unmatchedPatient: 1,
+    });
+    expect(result.errors[0]).toMatch(/No matching patient/i);
     expect(insertValues).not.toHaveBeenCalled();
   });
 

--- a/apps/web/server/__tests__/data-import-vaccinations.test.ts
+++ b/apps/web/server/__tests__/data-import-vaccinations.test.ts
@@ -1,25 +1,37 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+type MigrationMockInput = {
+  summary: { plannedInsertCount: number };
+  reviewedPlan?: {
+    plannerVersion: string;
+    dispositions: Array<Record<string, unknown>>;
+    targets: Array<Record<string, unknown>>;
+  };
+};
+
 vi.mock("@/lib/audit", () => ({
   recordAuditLog: vi.fn(async () => undefined),
 }));
 
 const migrationRunMocks = vi.hoisted(() => ({
+  MigrationPreviewError: class MigrationPreviewError extends Error {},
   createMigrationPreview: vi.fn(
-    async () => "00000000-0000-0000-0000-0000000000f1",
+    async (_db: unknown, _input: MigrationMockInput) =>
+      "00000000-0000-0000-0000-0000000000f1",
   ),
-  claimMigrationPreview: vi.fn(async () => ({
-    alreadyCommitted: false,
-    importedCount: 0,
-    reconciledCount: 0,
-    errorCount: 0,
-  })),
+  claimMigrationPreview: vi.fn(
+    async (_db: unknown, _input: MigrationMockInput) => ({
+      alreadyCommitted: false,
+      importedCount: 0,
+      reconciledCount: 0,
+      errorCount: 0,
+    }),
+  ),
   completeMigrationRun: vi.fn(async () => undefined),
   lockMigrationPractice: vi.fn(async () => undefined),
 }));
 
 vi.mock("@/lib/import/run-ledger", () => ({
-  MigrationPreviewError: class MigrationPreviewError extends Error {},
   ...migrationRunMocks,
 }));
 
@@ -44,13 +56,16 @@ function callerWithDb(db: Record<string, unknown>, role = "admin") {
 }
 
 function thenableRows(result: unknown[]) {
-  return {
+  const rows = {
     limit: vi.fn(async () => result),
+    orderBy: vi.fn(() => rows),
+    for: vi.fn(async () => result),
     then: (
       resolve: (value: unknown[]) => unknown,
       reject?: (error: unknown) => unknown,
     ) => Promise.resolve(result).then(resolve, reject),
   };
+  return rows;
 }
 
 function createDb(
@@ -137,6 +152,50 @@ describe("vaccination history import", () => {
     });
     expect(select).toHaveBeenCalledTimes(1);
     expect(insertValues).not.toHaveBeenCalled();
+    expect(
+      migrationRunMocks.createMigrationPreview.mock.calls.at(-1)?.[1],
+    ).toMatchObject({
+      mode: "vaccinations",
+      reviewedPlan: {
+        plannerVersion: "vaccinations-v1",
+        dispositions: [],
+        targets: [],
+      },
+    });
+  });
+
+  it("commits malformed vaccination CSV as an explicit zero-write skip", async () => {
+    const { db, insertValues } = createDb([]);
+    const csv = `${HEADER}\n"jane@x.com,Rex`;
+
+    await expect(
+      callerWithDb(db).importVaccinationsCsv({
+        csv,
+        source: "shepherd",
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
+        migrationProtocol: "reviewed-v1",
+      }),
+    ).resolves.toEqual({
+      imported: 0,
+      errors: ["CSV has an unterminated quoted field."],
+    });
+    expect(migrationRunMocks.claimMigrationPreview).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({
+        mode: "vaccinations",
+        reviewedPlan: {
+          plannerVersion: "vaccinations-v1",
+          dispositions: [],
+          targets: [],
+        },
+      }),
+    );
+    expect(migrationRunMocks.completeMigrationRun).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ importedCount: 0 }),
+    );
+    expect(insertValues).not.toHaveBeenCalled();
   });
 
   it("dry run reports matches, duplicates, and missing pets without inserting", async () => {
@@ -168,6 +227,144 @@ describe("vaccination history import", () => {
     expect(
       result.errors.some((e) => /No matching patient was found/.test(e)),
     ).toBe(true);
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("binds each vaccination disposition to the versioned patient selected inside the transaction", async () => {
+    const updatedAt = new Date("2026-08-08T12:00:00.000Z");
+    const { db } = createDb([[{ ...patientRows[0], updatedAt }], []]);
+
+    await callerWithDb(db).importVaccinationsCsv({
+      csv: `${HEADER}\n${REX_ROW}`,
+      dryRun: true,
+      migrationProtocol: "reviewed-v1",
+    });
+
+    expect(migrationRunMocks.lockMigrationPractice).toHaveBeenCalledWith(
+      db,
+      PRACTICE_ID,
+    );
+    expect(
+      migrationRunMocks.createMigrationPreview.mock.calls.at(-1)?.[1],
+    ).toMatchObject({
+      mode: "vaccinations",
+      reviewedPlan: {
+        plannerVersion: "vaccinations-v1",
+        dispositions: [
+          {
+            rowIndex: 0,
+            entityKind: "vaccination",
+            action: "insert",
+          },
+        ],
+        targets: [
+          {
+            rowIndex: 0,
+            kind: "patient",
+            role: "identity_match",
+            targetId: PATIENT_ID,
+            targetVersion: updatedAt.toISOString(),
+          },
+        ],
+      },
+    });
+  });
+
+  it("fails closed when the same-count vaccination target changes after preview", async () => {
+    const csv = `${HEADER}\n${REX_ROW}`;
+    const previewDb = createDb([
+      [
+        {
+          ...patientRows[0],
+          updatedAt: new Date("2026-08-08T12:00:00.000Z"),
+        },
+      ],
+      [],
+    ]);
+    await callerWithDb(previewDb.db).importVaccinationsCsv({
+      csv,
+      dryRun: true,
+      migrationProtocol: "reviewed-v1",
+    });
+    const reviewed =
+      migrationRunMocks.createMigrationPreview.mock.calls.at(-1)?.[1]
+        ?.reviewedPlan;
+    migrationRunMocks.claimMigrationPreview.mockImplementationOnce(
+      async (_db, input) => {
+        expect(input.summary).toMatchObject({ plannedInsertCount: 1 });
+        expect(input.reviewedPlan).not.toEqual(reviewed);
+        throw new migrationRunMocks.MigrationPreviewError(
+          "The reviewed import plan changed.",
+        );
+      },
+    );
+    const commitDb = createDb([
+      [
+        {
+          id: "00000000-0000-0000-0000-0000000000p2",
+          name: "Rex",
+          clientEmail: "jane@x.com",
+          updatedAt: new Date("2026-08-08T12:00:00.000Z"),
+        },
+      ],
+      [],
+    ]);
+
+    await expect(
+      callerWithDb(commitDb.db).importVaccinationsCsv({
+        csv,
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
+        migrationProtocol: "reviewed-v1",
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(commitDb.insertValues).not.toHaveBeenCalled();
+  });
+
+  it("returns the saved vaccination result when an exact committed request is retried", async () => {
+    migrationRunMocks.claimMigrationPreview.mockResolvedValueOnce({
+      alreadyCommitted: true,
+      importedCount: 7,
+      reconciledCount: 0,
+      errorCount: 0,
+    });
+    const { db, insertValues } = createDb([[], []]);
+
+    await expect(
+      callerWithDb(db).importVaccinationsCsv({
+        csv: `${HEADER}\n${REX_ROW}`,
+        dryRun: false,
+        previewToken: PREVIEW_TOKEN,
+        migrationProtocol: "reviewed-v1",
+      }),
+    ).resolves.toEqual({
+      imported: 7,
+      errors: [],
+      alreadyCommitted: true,
+      migrationRunId: PREVIEW_TOKEN,
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(migrationRunMocks.completeMigrationRun).not.toHaveBeenCalled();
+  });
+
+  it("treats seeded demo patients as unavailable migration targets", async () => {
+    const { db, insertValues } = createDb([
+      [{ ...patientRows[0], isDemoPatient: true }],
+      [],
+    ]);
+
+    const result = await callerWithDb(db).importVaccinationsCsv({
+      csv: `${HEADER}\n${REX_ROW}`,
+      dryRun: true,
+      migrationProtocol: "reviewed-v1",
+    });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      willInsert: 0,
+      unmatchedPatient: 1,
+    });
+    expect(result.errors[0]).toMatch(/No matching patient/i);
     expect(insertValues).not.toHaveBeenCalled();
   });
 

--- a/apps/web/server/__tests__/settings-account-deletion.test.ts
+++ b/apps/web/server/__tests__/settings-account-deletion.test.ts
@@ -76,7 +76,7 @@ describe("settings account deletion request", () => {
         reason: " Closing the practice ",
         confirmExportDownloaded: true,
         confirmManualReview: true,
-      })
+      }),
     ).resolves.toMatchObject({
       status: "requested",
       requestedByUserId: USER_ID,
@@ -87,21 +87,13 @@ describe("settings account deletion request", () => {
     });
 
     expect(updateSet).toHaveBeenCalledWith({
-      settings: {
-        brandColor: "#0f766e",
-        accountDeletionRequest: expect.objectContaining({
-          status: "requested",
-          requestedByUserId: USER_ID,
-          requestedByEmail: "admin@example.com",
-          contactEmail: "owner@example.com",
-          reason: "Closing the practice",
-          retentionReviewRequired: true,
-        }),
-      },
+      // The request is merged in SQL against the latest JSON document so a
+      // concurrent migration marker cannot be overwritten.
+      settings: expect.anything(),
     });
     expect(mocks.alertOps).toHaveBeenCalledWith(
       "Account deletion requested",
-      expect.stringContaining("manualRetentionReviewRequired=true")
+      expect.stringContaining("manualRetentionReviewRequired=true"),
     );
   });
 
@@ -125,7 +117,7 @@ describe("settings account deletion request", () => {
         contactEmail: "owner@example.com",
         confirmExportDownloaded: true,
         confirmManualReview: true,
-      })
+      }),
     ).resolves.toEqual(existing);
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -140,7 +132,7 @@ describe("settings account deletion request", () => {
         contactEmail: "owner@example.com",
         confirmExportDownloaded: true,
         confirmManualReview: false,
-      } as never)
+      } as never),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -155,7 +147,7 @@ describe("settings account deletion request", () => {
         contactEmail: `${"a".repeat(244)}@example.com`,
         confirmExportDownloaded: true,
         confirmManualReview: true,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -164,7 +156,7 @@ describe("settings account deletion request", () => {
         reason: "x".repeat(1001),
         confirmExportDownloaded: true,
         confirmManualReview: true,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -179,7 +171,7 @@ describe("settings account deletion request", () => {
         contactEmail: "owner@example.com",
         confirmExportDownloaded: true,
         confirmManualReview: true,
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
     expect(updateSet).not.toHaveBeenCalled();

--- a/apps/web/server/__tests__/settings-onboarding-migrations.test.ts
+++ b/apps/web/server/__tests__/settings-onboarding-migrations.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/billing/subscription-sync", () => ({
+  syncPracticeSubscriptionQuantities: vi.fn(async () => undefined),
+}));
+
+const { settingsRouter } = await import("../routers/settings");
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const USER_ID = "00000000-0000-0000-0000-000000000001";
+
+function callerWithDb(db: Record<string, unknown>) {
+  return settingsRouter.createCaller({
+    db,
+    session: {
+      user: {
+        id: USER_ID,
+        email: "admin@example.com",
+        name: "Admin",
+        role: "admin",
+        practiceId: PRACTICE_ID,
+      },
+    },
+  } as never);
+}
+
+function thenableRows(result: unknown[]) {
+  const rows = {
+    limit: vi.fn(async () => result),
+    orderBy: vi.fn(async () => result),
+    then: (
+      resolveValue: (value: unknown[]) => unknown,
+      rejectValue?: (error: unknown) => unknown,
+    ) => Promise.resolve(result).then(resolveValue, rejectValue),
+  };
+  return rows;
+}
+
+function createDb(selectResults: unknown[][]) {
+  const remaining = [...selectResults];
+  const select = vi.fn(() => {
+    const rows = thenableRows(remaining.shift() ?? []);
+    const builder = {
+      from: vi.fn(() => builder),
+      where: vi.fn(() => rows),
+    };
+    return builder;
+  });
+  const db: Record<string, unknown> = {
+    select,
+    execute: vi.fn(async () => undefined),
+  };
+  db.transaction = async (fn: (tx: unknown) => unknown) => fn(db);
+  return { db, select };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("settings.getOnboardingState migration ledger", () => {
+  it("derives durable progress from committed runs for the latest source", async () => {
+    const latestAt = new Date("2026-08-08T15:00:00.000Z");
+    const { db } = createDb([
+      [
+        {
+          settings: {
+            onboardingState: { migrationHasCommittedChanges: false },
+          },
+        },
+      ],
+      [
+        {
+          mode: "patients",
+          source: "legacy_pims",
+          importedCount: 0,
+          reconciledCount: 0,
+          committedAt: latestAt,
+        },
+        {
+          mode: "soap_notes",
+          source: "legacy_pims",
+          importedCount: 3,
+          reconciledCount: 0,
+          committedAt: new Date("2026-08-08T14:00:00.000Z"),
+        },
+        {
+          mode: "clients",
+          source: "shepherd",
+          importedCount: 8,
+          reconciledCount: 1,
+          committedAt: new Date("2026-08-07T14:00:00.000Z"),
+        },
+      ],
+    ]);
+
+    await expect(callerWithDb(db).getOnboardingState()).resolves.toMatchObject({
+      migrationHasCommittedChanges: true,
+      migrationLastCommittedAt: latestAt.toISOString(),
+      migrationSource: "legacy_pims",
+      migrationSourceHasCommittedChanges: true,
+      migrationCompletedModes: ["patients", "soapNotes"],
+    });
+  });
+
+  it("keeps a latest zero-change source switchable despite older material imports", async () => {
+    const latestAt = new Date("2026-08-08T16:00:00.000Z");
+    const { db } = createDb([
+      [{ settings: { onboardingState: {} } }],
+      [
+        {
+          mode: "clients",
+          source: "legacy_pims",
+          importedCount: 0,
+          reconciledCount: 0,
+          committedAt: latestAt,
+        },
+        {
+          mode: "clients",
+          source: "shepherd",
+          importedCount: 8,
+          reconciledCount: 0,
+          committedAt: new Date("2026-08-07T14:00:00.000Z"),
+        },
+      ],
+    ]);
+
+    await expect(callerWithDb(db).getOnboardingState()).resolves.toMatchObject({
+      migrationHasCommittedChanges: true,
+      migrationLastCommittedAt: latestAt.toISOString(),
+      migrationSource: "legacy_pims",
+      migrationSourceHasCommittedChanges: false,
+      migrationCompletedModes: ["clients"],
+    });
+  });
+
+  it("exposes stable typed defaults and preserves the legacy marker fallback", async () => {
+    const { db } = createDb([
+      [
+        {
+          settings: {
+            onboardingState: { migrationHasCommittedChanges: true },
+          },
+        },
+      ],
+      [],
+    ]);
+
+    await expect(callerWithDb(db).getOnboardingState()).resolves.toMatchObject({
+      migrationHasCommittedChanges: true,
+      migrationLastCommittedAt: null,
+      migrationSource: null,
+      migrationSourceHasCommittedChanges: false,
+      migrationCompletedModes: [],
+    });
+  });
+});

--- a/apps/web/server/routers/data.ts
+++ b/apps/web/server/routers/data.ts
@@ -44,6 +44,7 @@ import {
   IMPORT_MAX_ROWS,
   isImportCsvSizeValid,
 } from "@/lib/import/policy";
+import { MIGRATION_SOURCE_PATTERN } from "@/lib/import/sources";
 import { clinicalDateInput } from "@/lib/records/clinical-inputs";
 import {
   MigrationPreviewError,
@@ -59,6 +60,7 @@ import {
   type MigrationRunMode,
 } from "@/lib/import/run-ledger";
 import { recordActivationAfterAppointmentCreated } from "@/lib/funnel-events-server";
+import { migrationImportFingerprint } from "@/lib/import/fingerprint";
 
 const adminProcedure = protectedProcedure.use(requireRole("admin"));
 export { IMPORT_CSV_MAX_BYTES, IMPORT_MAX_ROWS } from "@/lib/import/policy";
@@ -123,7 +125,7 @@ const importSourceInput = z
   .trim()
   .toLowerCase()
   .regex(
-    /^[a-z0-9][a-z0-9_-]{0,63}$/,
+    MIGRATION_SOURCE_PATTERN,
     "Import source must use letters, numbers, underscores, or hyphens.",
   )
   .default("other");
@@ -273,6 +275,8 @@ type CsvImportIntent = z.infer<typeof importCsvInput>;
 
 const CLIENT_IMPORT_PLANNER_VERSION = "clients-v1";
 const PATIENT_IMPORT_PLANNER_VERSION = "patients-v1";
+const VACCINATION_IMPORT_PLANNER_VERSION = "vaccinations-v1";
+const SOAP_NOTE_IMPORT_PLANNER_VERSION = "soap-notes-v1";
 
 function csvPreviewResult<T extends Record<string, unknown>>(value: T) {
   return value as T & { imported?: never; reconciled?: never };
@@ -376,6 +380,27 @@ async function finishCsvImportRun(
   committedBy: string,
   reconciledCount = 0,
 ): Promise<void> {
+  if (importedCount + reconciledCount > 0) {
+    const committedAt = new Date().toISOString();
+    // This marker must commit atomically with the imported records. The
+    // onboarding shell uses it after a reload to avoid silently treating a
+    // practice with real imported data as sample-only again.
+    await db.execute(sql`
+      update ${practices}
+      set settings = jsonb_set(
+        coalesce(${practices.settings}, '{}'::jsonb),
+        '{onboardingState}',
+        coalesce(${practices.settings} -> 'onboardingState', '{}'::jsonb)
+          || jsonb_build_object(
+            'migrationHasCommittedChanges', true,
+            'migrationLastCommittedAt', ${committedAt}
+          ),
+        true
+      )
+      where ${practices.id} = ${practiceId}
+        and ${practices.deletedAt} is null
+    `);
+  }
   if (!previewToken) return;
   try {
     await completeMigrationRun(db, {
@@ -403,6 +428,27 @@ function activePracticePredicate(practiceId: string) {
     from ${practices}
     where ${practices.id} = ${practiceId}
       and ${practices.deletedAt} is null
+  )`;
+}
+
+function isDemoDataId(
+  practiceId: string,
+  key: "clientIds" | "patientIds",
+  column: typeof clients.id | typeof patients.id,
+) {
+  return sql<boolean>`exists (
+    select 1
+    from practices as demo_practice
+    cross join lateral jsonb_array_elements_text(
+      case
+        when jsonb_typeof(demo_practice.settings -> 'demoData' -> ${key}) = 'array'
+          then demo_practice.settings -> 'demoData' -> ${key}
+        else '[]'::jsonb
+      end
+    ) as demo_id(value)
+    where demo_practice.id = ${practiceId}
+      and demo_practice.deleted_at is null
+      and demo_id.value = ${column}::text
   )`;
 }
 
@@ -445,9 +491,11 @@ type ExistingClientImportIdentity = {
   email: string | null;
   externalSource: string | null;
   externalId: string | null;
+  importFingerprint?: string | null;
   deletedAt: Date | null;
   updatedAt?: Date;
   plannedRowIndex?: number;
+  isDemo?: boolean;
 };
 
 type ExternalIdentityUpdate = {
@@ -495,8 +543,13 @@ function planClientCsvImport(
   const byEmail = new Map<string, ExistingClientImportIdentity>();
   const ambiguousEmails = new Set<string>();
   const byExternalId = new Map<string, ExistingClientImportIdentity>();
+  const importFingerprints = new Set<string>();
 
   for (const client of existingClients) {
+    if (client.isDemo) continue;
+    if (!client.deletedAt && client.importFingerprint) {
+      importFingerprints.add(client.importFingerprint);
+    }
     if (client.externalSource && client.externalId) {
       byExternalId.set(
         externalIdentityKey(client.externalSource, client.externalId),
@@ -634,6 +687,25 @@ function planClientCsvImport(
       zip: client.zip?.trim() || null,
       ...(externalId ? { externalSource: source, externalId } : {}),
     };
+    row.importFingerprint = migrationImportFingerprint("clients", [
+      email ? "email" : externalId ? "external" : "record",
+      email ?? (externalId ? source : normalizeImportText(row.firstName)),
+      email ?? externalId ?? normalizeImportText(row.lastName),
+      email || externalId ? null : normalizeImportText(row.phone),
+      email || externalId ? null : normalizeImportText(row.address),
+      email || externalId ? null : normalizeImportText(row.city),
+      email || externalId ? null : normalizeImportText(row.state),
+      email || externalId ? null : normalizeImportText(row.zip),
+    ]);
+    if (importFingerprints.has(row.importFingerprint)) {
+      duplicates++;
+      reviewedDispositions.push(
+        reviewedDisposition(index, "client", "duplicate"),
+      );
+      errors.push(`Row ${index + 1}: Skipped a duplicate client.`);
+      return;
+    }
+    importFingerprints.add(row.importFingerprint);
     reviewedDispositions.push(reviewedDisposition(index, "client", "insert"));
     rows.push(row);
 
@@ -691,11 +763,13 @@ function patientMicrochipKey(microchipNumber?: string | null): string | null {
 function dedupeClientImport(
   records: ClientImportRecord[],
   existingEmails: Set<string>,
+  existingImportFingerprints: Set<string>,
 ): {
   rows: ClientImportRow[];
   errors: string[];
 } {
   const seen = new Set([...existingEmails].map((email) => email.toLowerCase()));
+  const seenImportFingerprints = new Set(existingImportFingerprints);
   const rows: ClientImportRow[] = [];
   const errors: string[] = [];
 
@@ -711,7 +785,7 @@ function dedupeClientImport(
       seen.add(email);
     }
 
-    rows.push({
+    const row: ClientImportRow = {
       firstName: client.firstName.trim(),
       lastName: client.lastName.trim(),
       email,
@@ -720,7 +794,23 @@ function dedupeClientImport(
       city: client.city?.trim() || null,
       state: client.state?.trim() || null,
       zip: client.zip?.trim() || null,
-    });
+      importFingerprint: migrationImportFingerprint("clients", [
+        email ? "email" : "record",
+        email ?? normalizeImportText(client.firstName),
+        email ?? normalizeImportText(client.lastName),
+        email ? null : normalizeImportText(client.phone),
+        email ? null : normalizeImportText(client.address),
+        email ? null : normalizeImportText(client.city),
+        email ? null : normalizeImportText(client.state),
+        email ? null : normalizeImportText(client.zip),
+      ]),
+    };
+    if (seenImportFingerprints.has(row.importFingerprint!)) {
+      errors.push(`Row ${index + 1}: Skipped a duplicate imported client.`);
+      return;
+    }
+    seenImportFingerprints.add(row.importFingerprint!);
+    rows.push(row);
   });
 
   return { rows, errors };
@@ -795,6 +885,13 @@ function dedupePatientImport(
       dob: patient.dob?.trim() || null,
       color: patient.color?.trim() || null,
       microchipNumber: patient.microchipNumber?.trim() || null,
+      importFingerprint: migrationImportFingerprint("patients", [
+        clientId,
+        normalizeImportText(patient.name),
+        patient.species,
+        patient.dob?.trim() ?? "",
+        patientMicrochipKey(patient.microchipNumber),
+      ]),
     });
   });
 
@@ -810,9 +907,11 @@ type ExistingPatientImportIdentity = {
   microchipNumber: string | null;
   externalSource: string | null;
   externalId: string | null;
+  importFingerprint?: string | null;
   deletedAt: Date | null;
   updatedAt?: Date;
   plannedRowIndex?: number;
+  isDemo?: boolean;
 };
 
 type ClientTargetReference = {
@@ -832,6 +931,7 @@ function createClientReferenceLookup(
   const byExternalId = new Map<string, ClientTargetReference | "archived">();
 
   for (const client of clientsToIndex) {
+    if (client.isDemo) continue;
     const email = normalizeImportEmail(client.email);
     if (email && !client.deletedAt) {
       byEmail.set(
@@ -910,8 +1010,13 @@ function planPatientCsvImport(
     string,
     ExistingPatientImportIdentity | "ambiguous"
   >();
+  const importFingerprints = new Set<string>();
 
   for (const patient of existingPatients) {
+    if (patient.isDemo) continue;
+    if (!patient.deletedAt && patient.importFingerprint) {
+      importFingerprints.add(patient.importFingerprint);
+    }
     if (patient.externalSource && patient.externalId) {
       byExternalId.set(
         externalIdentityKey(patient.externalSource, patient.externalId),
@@ -1144,6 +1249,22 @@ function planPatientCsvImport(
       microchipNumber: patient.microchipNumber?.trim() || null,
       ...(externalId ? { externalSource: source, externalId } : {}),
     };
+    row.importFingerprint = migrationImportFingerprint("patients", [
+      clientId,
+      normalizeImportText(row.name),
+      row.species,
+      row.dob?.trim() ?? "",
+      patientMicrochipKey(row.microchipNumber),
+    ]);
+    if (importFingerprints.has(row.importFingerprint)) {
+      duplicates++;
+      reviewedDispositions.push(
+        reviewedDisposition(index, "patient", "duplicate"),
+      );
+      errors.push(`Row ${index + 1}: Skipped a duplicate patient.`);
+      return;
+    }
+    importFingerprints.add(row.importFingerprint);
     reviewedDispositions.push(reviewedDisposition(index, "patient", "insert"));
     rows.push(row);
 
@@ -1191,6 +1312,8 @@ async function loadClientCsvPlan(
       externalId: clients.externalId,
       deletedAt: clients.deletedAt,
       updatedAt: clients.updatedAt,
+      isDemo: isDemoDataId(practiceId, "clientIds", clients.id),
+      importFingerprint: clients.importFingerprint,
     })
     .from(clients)
     .where(
@@ -1234,6 +1357,7 @@ async function loadPatientCsvPlan(
       externalId: clients.externalId,
       deletedAt: clients.deletedAt,
       updatedAt: clients.updatedAt,
+      isDemo: isDemoDataId(practiceId, "clientIds", clients.id),
     })
     .from(clients)
     .where(
@@ -1258,6 +1382,8 @@ async function loadPatientCsvPlan(
       externalId: patients.externalId,
       deletedAt: patients.deletedAt,
       updatedAt: patients.updatedAt,
+      isDemo: isDemoDataId(practiceId, "patientIds", patients.id),
+      importFingerprint: patients.importFingerprint,
     })
     .from(patients)
     .where(
@@ -1309,17 +1435,30 @@ function externalOwnerPatientKey(
 }
 
 type PatientReferenceLookup = {
-  byExternalPatientId: Record<string, string>;
-  byEmailAndName: Record<string, string | "ambiguous">;
-  byExternalOwnerAndName: Record<string, string | "ambiguous">;
+  byExternalPatientId: Record<string, PatientTargetReference>;
+  byEmailAndName: Record<string, PatientTargetReference | "ambiguous">;
+  byExternalOwnerAndName: Record<string, PatientTargetReference | "ambiguous">;
 };
 
+type PatientTargetReference = {
+  id: string;
+  updatedAt?: Date;
+};
+
+type ResolvedPatientReference =
+  | {
+      target: PatientTargetReference;
+      role: "external_match" | "identity_match";
+    }
+  | "ambiguous"
+  | undefined;
+
 function addUniquePatientReference(
-  target: Record<string, string | "ambiguous">,
+  target: Record<string, PatientTargetReference | "ambiguous">,
   key: string,
-  patientId: string,
+  patient: PatientTargetReference,
 ) {
-  target[key] = target[key] ? "ambiguous" : patientId;
+  target[key] = target[key] ? "ambiguous" : patient;
 }
 
 function createPatientReferenceLookup(
@@ -1331,6 +1470,9 @@ function createPatientReferenceLookup(
     clientEmail: string | null;
     clientExternalSource: string | null;
     clientExternalId: string | null;
+    updatedAt?: Date;
+    isDemoClient?: boolean;
+    isDemoPatient?: boolean;
   }>,
 ): PatientReferenceLookup {
   const lookup: PatientReferenceLookup = {
@@ -1340,16 +1482,18 @@ function createPatientReferenceLookup(
   };
 
   for (const patient of patientRows) {
+    if (patient.isDemoClient || patient.isDemoPatient) continue;
+    const target = { id: patient.id, updatedAt: patient.updatedAt };
     if (patient.externalSource && patient.externalId) {
       lookup.byExternalPatientId[
         externalIdentityKey(patient.externalSource, patient.externalId)
-      ] = patient.id;
+      ] = target;
     }
     if (patient.clientEmail) {
       addUniquePatientReference(
         lookup.byEmailAndName,
         vaccinationPatientKey(patient.clientEmail, patient.name),
-        patient.id,
+        target,
       );
     }
     if (patient.clientExternalSource && patient.clientExternalId) {
@@ -1360,7 +1504,7 @@ function createPatientReferenceLookup(
           patient.clientExternalId,
           patient.name,
         ),
-        patient.id,
+        target,
       );
     }
   }
@@ -1375,9 +1519,9 @@ function resolvePatientReference(
   >,
   source: string,
   lookup: PatientReferenceLookup,
-): string | "ambiguous" | undefined {
+): ResolvedPatientReference {
   const externalPatientId = normalizeExternalId(record.externalPatientId);
-  const matches = new Set<string>();
+  const matches = new Map<string, PatientTargetReference>();
   let ambiguous = false;
   if (externalPatientId) {
     const directMatch =
@@ -1385,7 +1529,7 @@ function resolvePatientReference(
         externalIdentityKey(source, externalPatientId)
       ];
     if (!directMatch) return undefined;
-    matches.add(directMatch);
+    matches.set(directMatch.id, directMatch);
   }
 
   if (record.patientName && record.clientEmail) {
@@ -1394,7 +1538,7 @@ function resolvePatientReference(
         vaccinationPatientKey(record.clientEmail, record.patientName)
       ];
     if (match === "ambiguous") ambiguous = true;
-    else if (match) matches.add(match);
+    else if (match) matches.set(match.id, match);
   }
   const externalClientId = normalizeExternalId(record.externalClientId);
   if (record.patientName && externalClientId) {
@@ -1403,11 +1547,16 @@ function resolvePatientReference(
         externalOwnerPatientKey(source, externalClientId, record.patientName)
       ];
     if (match === "ambiguous") ambiguous = true;
-    else if (match) matches.add(match);
+    else if (match) matches.set(match.id, match);
   }
 
   if (ambiguous || matches.size > 1) return "ambiguous";
-  return matches.values().next().value;
+  const target = matches.values().next().value;
+  if (!target) return undefined;
+  return {
+    target,
+    role: externalPatientId ? "external_match" : "identity_match",
+  };
 }
 
 /** Identity of an administered dose: patient + vaccine + date given. */
@@ -1443,6 +1592,8 @@ function dedupeVaccinationImport(
   }>,
 ): {
   rows: VaccinationImportRow[];
+  reviewedDispositions: MigrationReviewedDisposition[];
+  reviewedTargets: MigrationReviewedTarget[];
   errors: string[];
   duplicates: number;
   unmatchedPatient: number;
@@ -1458,26 +1609,46 @@ function dedupeVaccinationImport(
   );
 
   const rows: VaccinationImportRow[] = [];
+  const reviewedDispositions: MigrationReviewedDisposition[] = [];
+  const reviewedTargets: MigrationReviewedTarget[] = [];
   const errors: string[] = [];
   let duplicates = 0;
   let unmatchedPatient = 0;
 
   records.forEach((record, index) => {
-    const patientId = resolvePatientReference(record, source, patientLookup);
-    if (!patientId) {
+    const patientReference = resolvePatientReference(
+      record,
+      source,
+      patientLookup,
+    );
+    if (!patientReference) {
       unmatchedPatient++;
+      reviewedDispositions.push(
+        reviewedDisposition(index, "vaccination", "unmatched"),
+      );
       errors.push(
         `Row ${index + 1}: No matching patient was found for the supplied reference.`,
       );
       return;
     }
-    if (patientId === "ambiguous") {
+    if (patientReference === "ambiguous") {
       unmatchedPatient++;
+      reviewedDispositions.push(
+        reviewedDisposition(index, "vaccination", "error"),
+      );
       errors.push(
         `Row ${index + 1}: The supplied patient references are ambiguous or conflict. Nothing was changed.`,
       );
       return;
     }
+    const patientId = patientReference.target.id;
+    const target = reviewedTarget(
+      index,
+      "patient",
+      patientReference.role,
+      patientReference.target,
+    );
+    if (target) reviewedTargets.push(target);
 
     const identityKey = vaccinationIdentityKey({
       patientId,
@@ -1486,10 +1657,16 @@ function dedupeVaccinationImport(
     });
     if (seen.has(identityKey)) {
       duplicates++;
+      reviewedDispositions.push(
+        reviewedDisposition(index, "vaccination", "duplicate"),
+      );
       errors.push(`Row ${index + 1}: Skipped a duplicate vaccine dose.`);
       return;
     }
     seen.add(identityKey);
+    reviewedDispositions.push(
+      reviewedDisposition(index, "vaccination", "insert"),
+    );
 
     rows.push({
       patientId,
@@ -1500,10 +1677,102 @@ function dedupeVaccinationImport(
       manufacturer: record.manufacturer?.trim() || null,
       // Historical import: no OpenVPM user administered this dose.
       administeredBy: null,
+      importFingerprint: migrationImportFingerprint("vaccinations", [
+        patientId,
+        normalizeImportText(record.vaccineName),
+        record.administeredAt,
+      ]),
     });
   });
 
-  return { rows, errors, duplicates, unmatchedPatient };
+  return {
+    rows,
+    reviewedDispositions,
+    reviewedTargets,
+    errors,
+    duplicates,
+    unmatchedPatient,
+  };
+}
+
+async function loadMigrationPatientReferences(
+  db: Database,
+  practiceId: string,
+) {
+  return db
+    .select({
+      id: patients.id,
+      name: patients.name,
+      externalSource: patients.externalSource,
+      externalId: patients.externalId,
+      clientEmail: clients.email,
+      clientExternalSource: clients.externalSource,
+      clientExternalId: clients.externalId,
+      updatedAt: patients.updatedAt,
+      isDemoClient: isDemoDataId(practiceId, "clientIds", clients.id),
+      isDemoPatient: isDemoDataId(practiceId, "patientIds", patients.id),
+    })
+    .from(patients)
+    .innerJoin(clients, eq(patients.clientId, clients.id))
+    .where(
+      and(
+        eq(patients.practiceId, practiceId),
+        eq(clients.practiceId, practiceId),
+        activePracticePredicate(practiceId),
+        isNull(patients.deletedAt),
+        isNull(clients.deletedAt),
+      ),
+    )
+    .orderBy(patients.id)
+    .for("update", { of: patients });
+}
+
+async function loadVaccinationCsvPlan(
+  db: Database,
+  practiceId: string,
+  records: VaccinationImportRecord[],
+  source: string,
+  parseErrors: string[],
+) {
+  const patientRows = await loadMigrationPatientReferences(db, practiceId);
+  const patientLookup = createPatientReferenceLookup(patientRows);
+  const existingDoses = await db
+    .select({
+      id: vaccinationRecords.id,
+      patientId: vaccinationRecords.patientId,
+      vaccineName: vaccinationRecords.vaccineName,
+      administeredAt: vaccinationRecords.administeredAt,
+    })
+    .from(vaccinationRecords)
+    .where(
+      and(
+        eq(vaccinationRecords.practiceId, practiceId),
+        activePracticePredicate(practiceId),
+        isNull(vaccinationRecords.deletedAt),
+      ),
+    )
+    .orderBy(vaccinationRecords.id)
+    .for("update");
+  const plan = dedupeVaccinationImport(
+    records,
+    patientLookup,
+    source,
+    existingDoses,
+  );
+  const combinedErrors = [...parseErrors, ...plan.errors];
+  const summary: MigrationPreviewSummary = {
+    sourceRowCount: records.length,
+    plannedInsertCount: plan.rows.length,
+    duplicateCount: plan.duplicates,
+    unmatchedCount: plan.unmatchedPatient,
+    errorCount: combinedErrors.length,
+  };
+  const reviewedPlan: MigrationReviewedPlan = {
+    plannerVersion: VACCINATION_IMPORT_PLANNER_VERSION,
+    dispositions: plan.reviewedDispositions,
+    targets: plan.reviewedTargets,
+  };
+  return { plan, combinedErrors, summary, reviewedPlan };
 }
 
 function parseVaccinationImportRecords(
@@ -1568,6 +1837,8 @@ function dedupeSoapNoteImport(
   }>,
 ): {
   rows: SoapNoteImportRow[];
+  reviewedDispositions: MigrationReviewedDisposition[];
+  reviewedTargets: MigrationReviewedTarget[];
   errors: string[];
   duplicates: number;
   unmatchedPatient: number;
@@ -1583,26 +1854,46 @@ function dedupeSoapNoteImport(
   );
 
   const rows: SoapNoteImportRow[] = [];
+  const reviewedDispositions: MigrationReviewedDisposition[] = [];
+  const reviewedTargets: MigrationReviewedTarget[] = [];
   const errors: string[] = [];
   let duplicates = 0;
   let unmatchedPatient = 0;
 
   records.forEach((record, index) => {
-    const patientId = resolvePatientReference(record, source, patientLookup);
-    if (!patientId) {
+    const patientReference = resolvePatientReference(
+      record,
+      source,
+      patientLookup,
+    );
+    if (!patientReference) {
       unmatchedPatient++;
+      reviewedDispositions.push(
+        reviewedDisposition(index, "soap_note", "unmatched"),
+      );
       errors.push(
         `Row ${index + 1}: No matching patient was found for the supplied reference.`,
       );
       return;
     }
-    if (patientId === "ambiguous") {
+    if (patientReference === "ambiguous") {
       unmatchedPatient++;
+      reviewedDispositions.push(
+        reviewedDisposition(index, "soap_note", "error"),
+      );
       errors.push(
         `Row ${index + 1}: The supplied patient references are ambiguous or conflict. Nothing was changed.`,
       );
       return;
     }
+    const patientId = patientReference.target.id;
+    const target = reviewedTarget(
+      index,
+      "patient",
+      patientReference.role,
+      patientReference.target,
+    );
+    if (target) reviewedTargets.push(target);
 
     const identityKey = soapNoteIdentityKey({
       patientId,
@@ -1611,10 +1902,16 @@ function dedupeSoapNoteImport(
     });
     if (seen.has(identityKey)) {
       duplicates++;
+      reviewedDispositions.push(
+        reviewedDisposition(index, "soap_note", "duplicate"),
+      );
       errors.push(`Row ${index + 1}: Skipped a duplicate medical note.`);
       return;
     }
     seen.add(identityKey);
+    reviewedDispositions.push(
+      reviewedDisposition(index, "soap_note", "insert"),
+    );
 
     rows.push({
       patientId,
@@ -1625,10 +1922,73 @@ function dedupeSoapNoteImport(
       plan: record.plan?.trim() || null,
       // Preserve the visit date so the history reads in chronological order.
       createdAt: soapNoteInstant(record.date),
+      importFingerprint: migrationImportFingerprint("soap_notes", [
+        patientId,
+        record.date,
+        soapNoteContentSignature(record),
+      ]),
     });
   });
 
-  return { rows, errors, duplicates, unmatchedPatient };
+  return {
+    rows,
+    reviewedDispositions,
+    reviewedTargets,
+    errors,
+    duplicates,
+    unmatchedPatient,
+  };
+}
+
+async function loadSoapNoteCsvPlan(
+  db: Database,
+  practiceId: string,
+  records: SoapNoteImportRecord[],
+  source: string,
+  parseErrors: string[],
+) {
+  const patientRows = await loadMigrationPatientReferences(db, practiceId);
+  const patientLookup = createPatientReferenceLookup(patientRows);
+  const existingNotes = await db
+    .select({
+      id: soapNotes.id,
+      patientId: soapNotes.patientId,
+      createdAt: soapNotes.createdAt,
+      subjective: soapNotes.subjective,
+      objective: soapNotes.objective,
+      assessment: soapNotes.assessment,
+      plan: soapNotes.plan,
+    })
+    .from(soapNotes)
+    .where(
+      and(
+        eq(soapNotes.practiceId, practiceId),
+        activePracticePredicate(practiceId),
+        isNull(soapNotes.deletedAt),
+      ),
+    )
+    .orderBy(soapNotes.id)
+    .for("update");
+  const plan = dedupeSoapNoteImport(
+    records,
+    patientLookup,
+    source,
+    existingNotes,
+  );
+  const combinedErrors = [...parseErrors, ...plan.errors];
+  const summary: MigrationPreviewSummary = {
+    sourceRowCount: records.length,
+    plannedInsertCount: plan.rows.length,
+    duplicateCount: plan.duplicates,
+    unmatchedCount: plan.unmatchedPatient,
+    errorCount: combinedErrors.length,
+  };
+  const reviewedPlan: MigrationReviewedPlan = {
+    plannerVersion: SOAP_NOTE_IMPORT_PLANNER_VERSION,
+    dispositions: plan.reviewedDispositions,
+    targets: plan.reviewedTargets,
+  };
+  return { plan, combinedErrors, summary, reviewedPlan };
 }
 
 function parseSoapNoteImportRecords(
@@ -2046,7 +2406,10 @@ export const dataRouter = createRouter({
       }
 
       const existing = await ctx.db
-        .select({ email: clients.email })
+        .select({
+          email: clients.email,
+          importFingerprint: clients.importFingerprint,
+        })
         .from(clients)
         .where(
           and(
@@ -2060,9 +2423,15 @@ export const dataRouter = createRouter({
           .map((client) => normalizeImportEmail(client.email))
           .filter((email): email is string => !!email),
       );
+      const existingImportFingerprints = new Set(
+        existing
+          .map((client) => client.importFingerprint)
+          .filter((fingerprint): fingerprint is string => !!fingerprint),
+      );
       const { rows, errors } = dedupeClientImport(
         input.clients,
         existingEmails,
+        existingImportFingerprints,
       );
 
       if (rows.length > 0) {
@@ -2145,37 +2514,78 @@ export const dataRouter = createRouter({
       const validRecords = parseClientImportRecords(records);
 
       if (validRecords.length === 0 && errors.length > 0) {
-        if (input.dryRun) {
-          await assertActivePractice(ctx);
+        await assertActivePractice(ctx);
+        return ctx.db.transaction(async (tx) => {
+          await tx.execute(sql`set transaction isolation level serializable`);
+          const migrationDb = tx as unknown as Database;
+          await lockMigrationPractice(migrationDb, ctx.practiceId);
           const summary: MigrationPreviewSummary = {
             sourceRowCount: 0,
             plannedInsertCount: 0,
             errorCount: errors.length,
           };
-          const previewToken = await createCsvImportPreview(
-            ctx,
+          const reviewedPlan: MigrationReviewedPlan = {
+            plannerVersion: CLIENT_IMPORT_PLANNER_VERSION,
+            dispositions: [],
+            targets: [],
+          };
+          if (input.dryRun) {
+            const previewToken = await createCsvImportPreview(
+              ctx,
+              input,
+              "clients",
+              summary,
+              reviewedPlan,
+              migrationDb,
+            );
+            return csvPreviewResult({
+              dryRun: true as const,
+              previewToken,
+              total: 0,
+              willInsert: 0,
+              willReconcile: 0,
+              duplicates: 0,
+              errors,
+            });
+          }
+          if (!input.previewToken) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "This CSV has no importable client rows. Check it again.",
+            });
+          }
+          const claim = await claimCsvImportPreview(
+            migrationDb,
+            ctx.practiceId,
             input,
             "clients",
             summary,
+            reviewedPlan,
           );
-          return csvPreviewResult({
-            dryRun: true as const,
-            previewToken,
-            total: 0,
-            willInsert: 0,
-            willReconcile: 0,
-            duplicates: 0,
-            errors,
-          });
-        }
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "This CSV has no importable client rows. Check it again.",
+          if (claim.alreadyCommitted) {
+            return {
+              imported: claim.importedCount,
+              reconciled: claim.reconciledCount,
+              errors,
+              alreadyCommitted: true as const,
+              migrationRunId: input.previewToken,
+            };
+          }
+          await finishCsvImportRun(
+            migrationDb,
+            ctx.practiceId,
+            input.previewToken,
+            0,
+            ctx.user.id,
+          );
+          return { imported: 0, reconciled: 0, errors };
         });
       }
 
       await assertActivePractice(ctx);
       return ctx.db.transaction(async (tx) => {
+        await tx.execute(sql`set transaction isolation level serializable`);
         const migrationDb = tx as unknown as Database;
         await lockMigrationPractice(migrationDb, ctx.practiceId);
         const { plan, combinedErrors, summary, reviewedPlan } =
@@ -2289,38 +2699,79 @@ export const dataRouter = createRouter({
       const validRecords = parsePatientImportRecords(records);
 
       if (validRecords.length === 0 && errors.length > 0) {
-        if (input.dryRun) {
-          await assertActivePractice(ctx);
+        await assertActivePractice(ctx);
+        return ctx.db.transaction(async (tx) => {
+          await tx.execute(sql`set transaction isolation level serializable`);
+          const migrationDb = tx as unknown as Database;
+          await lockMigrationPractice(migrationDb, ctx.practiceId);
           const summary: MigrationPreviewSummary = {
             sourceRowCount: 0,
             plannedInsertCount: 0,
             errorCount: errors.length,
           };
-          const previewToken = await createCsvImportPreview(
-            ctx,
+          const reviewedPlan: MigrationReviewedPlan = {
+            plannerVersion: PATIENT_IMPORT_PLANNER_VERSION,
+            dispositions: [],
+            targets: [],
+          };
+          if (input.dryRun) {
+            const previewToken = await createCsvImportPreview(
+              ctx,
+              input,
+              "patients",
+              summary,
+              reviewedPlan,
+              migrationDb,
+            );
+            return csvPreviewResult({
+              dryRun: true as const,
+              previewToken,
+              total: 0,
+              willInsert: 0,
+              willReconcile: 0,
+              unmatchedClient: 0,
+              duplicates: 0,
+              errors,
+            });
+          }
+          if (!input.previewToken) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "This CSV has no importable patient rows. Check it again.",
+            });
+          }
+          const claim = await claimCsvImportPreview(
+            migrationDb,
+            ctx.practiceId,
             input,
             "patients",
             summary,
+            reviewedPlan,
           );
-          return csvPreviewResult({
-            dryRun: true as const,
-            previewToken,
-            total: 0,
-            willInsert: 0,
-            willReconcile: 0,
-            unmatchedClient: 0,
-            duplicates: 0,
-            errors,
-          });
-        }
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "This CSV has no importable patient rows. Check it again.",
+          if (claim.alreadyCommitted) {
+            return {
+              imported: claim.importedCount,
+              reconciled: claim.reconciledCount,
+              errors,
+              alreadyCommitted: true as const,
+              migrationRunId: input.previewToken,
+            };
+          }
+          await finishCsvImportRun(
+            migrationDb,
+            ctx.practiceId,
+            input.previewToken,
+            0,
+            ctx.user.id,
+          );
+          return { imported: 0, reconciled: 0, errors };
         });
       }
 
       await assertActivePractice(ctx);
       return ctx.db.transaction(async (tx) => {
+        await tx.execute(sql`set transaction isolation level serializable`);
         const migrationDb = tx as unknown as Database;
         await lockMigrationPractice(migrationDb, ctx.practiceId);
         const { plan, combinedErrors, summary, reviewedPlan } =
@@ -2433,153 +2884,143 @@ export const dataRouter = createRouter({
       const validRecords = parseVaccinationImportRecords(records);
 
       if (validRecords.length === 0 && errors.length > 0) {
-        if (input.dryRun) {
-          await assertActivePractice(ctx);
+        await assertActivePractice(ctx);
+        return ctx.db.transaction(async (tx) => {
+          await tx.execute(sql`set transaction isolation level serializable`);
+          const migrationDb = tx as unknown as Database;
+          await lockMigrationPractice(migrationDb, ctx.practiceId);
           const summary: MigrationPreviewSummary = {
             sourceRowCount: 0,
             plannedInsertCount: 0,
             errorCount: errors.length,
           };
+          const reviewedPlan: MigrationReviewedPlan = {
+            plannerVersion: VACCINATION_IMPORT_PLANNER_VERSION,
+            dispositions: [],
+            targets: [],
+          };
+          if (input.dryRun) {
+            const previewToken = await createCsvImportPreview(
+              ctx,
+              input,
+              "vaccinations",
+              summary,
+              reviewedPlan,
+              migrationDb,
+            );
+            return {
+              dryRun: true as const,
+              previewToken,
+              total: 0,
+              willInsert: 0,
+              unmatchedPatient: 0,
+              duplicates: 0,
+              errors,
+            };
+          }
+          if (!input.previewToken) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "This CSV has no importable vaccination rows. Check it again.",
+            });
+          }
+          const claim = await claimCsvImportPreview(
+            migrationDb,
+            ctx.practiceId,
+            input,
+            "vaccinations",
+            summary,
+            reviewedPlan,
+          );
+          if (claim.alreadyCommitted) {
+            return {
+              imported: claim.importedCount,
+              errors,
+              alreadyCommitted: true as const,
+              migrationRunId: input.previewToken,
+            };
+          }
+          await finishCsvImportRun(
+            migrationDb,
+            ctx.practiceId,
+            input.previewToken,
+            0,
+            ctx.user.id,
+          );
+          return { imported: 0, errors };
+        });
+      }
+
+      await assertActivePractice(ctx);
+      return ctx.db.transaction(async (tx) => {
+        await tx.execute(sql`set transaction isolation level serializable`);
+        const migrationDb = tx as unknown as Database;
+        await lockMigrationPractice(migrationDb, ctx.practiceId);
+        const { plan, combinedErrors, summary, reviewedPlan } =
+          await loadVaccinationCsvPlan(
+            migrationDb,
+            ctx.practiceId,
+            validRecords,
+            input.source,
+            errors,
+          );
+
+        if (input.dryRun) {
           const previewToken = await createCsvImportPreview(
             ctx,
             input,
             "vaccinations",
             summary,
+            reviewedPlan,
+            migrationDb,
           );
           return {
             dryRun: true as const,
             previewToken,
-            total: 0,
-            willInsert: 0,
-            unmatchedPatient: 0,
-            duplicates: 0,
-            errors,
+            total: validRecords.length,
+            willInsert: plan.rows.length,
+            unmatchedPatient: plan.unmatchedPatient,
+            duplicates: plan.duplicates,
+            errors: combinedErrors,
           };
         }
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message:
-            "This CSV has no importable vaccination rows. Check it again.",
-        });
-      }
 
-      await assertActivePractice(ctx);
-      await lockMigrationPractice(ctx.db, ctx.practiceId);
-
-      const patientRows = await ctx.db
-        .select({
-          id: patients.id,
-          name: patients.name,
-          externalSource: patients.externalSource,
-          externalId: patients.externalId,
-          clientEmail: clients.email,
-          clientExternalSource: clients.externalSource,
-          clientExternalId: clients.externalId,
-        })
-        .from(patients)
-        .innerJoin(clients, eq(patients.clientId, clients.id))
-        .where(
-          and(
-            eq(patients.practiceId, ctx.practiceId),
-            eq(clients.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(patients.deletedAt),
-            isNull(clients.deletedAt),
-          ),
-        );
-      const patientLookup = createPatientReferenceLookup(patientRows);
-
-      const existingDoses = await ctx.db
-        .select({
-          patientId: vaccinationRecords.patientId,
-          vaccineName: vaccinationRecords.vaccineName,
-          administeredAt: vaccinationRecords.administeredAt,
-        })
-        .from(vaccinationRecords)
-        .where(
-          and(
-            eq(vaccinationRecords.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(vaccinationRecords.deletedAt),
-          ),
-        );
-
-      const deduped = dedupeVaccinationImport(
-        validRecords,
-        patientLookup,
-        input.source,
-        existingDoses,
-      );
-      const combinedErrors = [...errors, ...deduped.errors];
-      const summary: MigrationPreviewSummary = {
-        sourceRowCount: validRecords.length,
-        plannedInsertCount: deduped.rows.length,
-        duplicateCount: deduped.duplicates,
-        unmatchedCount: deduped.unmatchedPatient,
-        errorCount: combinedErrors.length,
-      };
-
-      if (input.dryRun) {
-        const previewToken = await createCsvImportPreview(
-          ctx,
-          input,
-          "vaccinations",
-          summary,
-        );
-        return {
-          dryRun: true as const,
-          previewToken,
-          total: validRecords.length,
-          willInsert: deduped.rows.length,
-          unmatchedPatient: deduped.unmatchedPatient,
-          duplicates: deduped.duplicates,
-          errors: combinedErrors,
-        };
-      }
-
-      let replay:
-        | Extract<MigrationClaimResult, { alreadyCommitted: true }>
-        | undefined;
-      await ctx.db.transaction(async (tx) => {
-        const migrationDb = tx as unknown as Database;
         const claim = await claimCsvImportPreview(
           migrationDb,
           ctx.practiceId,
           input,
           "vaccinations",
           summary,
+          reviewedPlan,
         );
         if (claim.alreadyCommitted) {
-          replay = claim;
-          return;
+          return {
+            imported: claim.importedCount,
+            errors: [] as string[],
+            alreadyCommitted: true as const,
+            migrationRunId: input.previewToken!,
+          };
         }
-        if (deduped.rows.length > 0) {
+        if (plan.rows.length > 0) {
           await tx
             .insert(vaccinationRecords)
             .values(
-              deduped.rows.map((v) => ({ ...v, practiceId: ctx.practiceId })),
+              plan.rows.map((v) => ({ ...v, practiceId: ctx.practiceId })),
             );
         }
         await finishCsvImportRun(
           migrationDb,
           ctx.practiceId,
           input.previewToken!,
-          deduped.rows.length,
+          plan.rows.length,
           ctx.user.id,
         );
-      });
-      if (replay) {
         return {
-          imported: replay.importedCount,
-          errors: [] as string[],
-          alreadyCommitted: true as const,
-          migrationRunId: input.previewToken!,
+          imported: plan.rows.length,
+          errors: combinedErrors,
         };
-      }
-      return {
-        imported: deduped.rows.length,
-        errors: combinedErrors,
-      };
+      });
     }),
 
   /**
@@ -2598,132 +3039,127 @@ export const dataRouter = createRouter({
       const validRecords = parseSoapNoteImportRecords(records);
 
       if (validRecords.length === 0 && errors.length > 0) {
-        if (input.dryRun) {
-          await assertActivePractice(ctx);
+        await assertActivePractice(ctx);
+        return ctx.db.transaction(async (tx) => {
+          await tx.execute(sql`set transaction isolation level serializable`);
+          const migrationDb = tx as unknown as Database;
+          await lockMigrationPractice(migrationDb, ctx.practiceId);
           const summary: MigrationPreviewSummary = {
             sourceRowCount: 0,
             plannedInsertCount: 0,
             errorCount: errors.length,
           };
+          const reviewedPlan: MigrationReviewedPlan = {
+            plannerVersion: SOAP_NOTE_IMPORT_PLANNER_VERSION,
+            dispositions: [],
+            targets: [],
+          };
+          if (input.dryRun) {
+            const previewToken = await createCsvImportPreview(
+              ctx,
+              input,
+              "soap_notes",
+              summary,
+              reviewedPlan,
+              migrationDb,
+            );
+            return {
+              dryRun: true as const,
+              previewToken,
+              total: 0,
+              willInsert: 0,
+              unmatchedPatient: 0,
+              duplicates: 0,
+              errors,
+            };
+          }
+          if (!input.previewToken) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "This CSV has no importable medical history rows. Check it again.",
+            });
+          }
+          const claim = await claimCsvImportPreview(
+            migrationDb,
+            ctx.practiceId,
+            input,
+            "soap_notes",
+            summary,
+            reviewedPlan,
+          );
+          if (claim.alreadyCommitted) {
+            return {
+              imported: claim.importedCount,
+              errors,
+              alreadyCommitted: true as const,
+              migrationRunId: input.previewToken,
+            };
+          }
+          await finishCsvImportRun(
+            migrationDb,
+            ctx.practiceId,
+            input.previewToken,
+            0,
+            ctx.user.id,
+          );
+          return { imported: 0, errors };
+        });
+      }
+
+      await assertActivePractice(ctx);
+      return ctx.db.transaction(async (tx) => {
+        await tx.execute(sql`set transaction isolation level serializable`);
+        const migrationDb = tx as unknown as Database;
+        await lockMigrationPractice(migrationDb, ctx.practiceId);
+        const { plan, combinedErrors, summary, reviewedPlan } =
+          await loadSoapNoteCsvPlan(
+            migrationDb,
+            ctx.practiceId,
+            validRecords,
+            input.source,
+            errors,
+          );
+
+        if (input.dryRun) {
           const previewToken = await createCsvImportPreview(
             ctx,
             input,
             "soap_notes",
             summary,
+            reviewedPlan,
+            migrationDb,
           );
           return {
             dryRun: true as const,
             previewToken,
-            total: 0,
-            willInsert: 0,
-            unmatchedPatient: 0,
-            duplicates: 0,
-            errors,
+            total: validRecords.length,
+            willInsert: plan.rows.length,
+            unmatchedPatient: plan.unmatchedPatient,
+            duplicates: plan.duplicates,
+            errors: combinedErrors,
           };
         }
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message:
-            "This CSV has no importable medical history rows. Check it again.",
-        });
-      }
 
-      await assertActivePractice(ctx);
-      await lockMigrationPractice(ctx.db, ctx.practiceId);
-
-      const patientRows = await ctx.db
-        .select({
-          id: patients.id,
-          name: patients.name,
-          externalSource: patients.externalSource,
-          externalId: patients.externalId,
-          clientEmail: clients.email,
-          clientExternalSource: clients.externalSource,
-          clientExternalId: clients.externalId,
-        })
-        .from(patients)
-        .innerJoin(clients, eq(patients.clientId, clients.id))
-        .where(
-          and(
-            eq(patients.practiceId, ctx.practiceId),
-            eq(clients.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(patients.deletedAt),
-            isNull(clients.deletedAt),
-          ),
-        );
-      const patientLookup = createPatientReferenceLookup(patientRows);
-
-      const existingNotes = await ctx.db
-        .select({
-          patientId: soapNotes.patientId,
-          createdAt: soapNotes.createdAt,
-          subjective: soapNotes.subjective,
-          objective: soapNotes.objective,
-          assessment: soapNotes.assessment,
-          plan: soapNotes.plan,
-        })
-        .from(soapNotes)
-        .where(
-          and(
-            eq(soapNotes.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(soapNotes.deletedAt),
-          ),
-        );
-
-      const deduped = dedupeSoapNoteImport(
-        validRecords,
-        patientLookup,
-        input.source,
-        existingNotes,
-      );
-      const combinedErrors = [...errors, ...deduped.errors];
-      const summary: MigrationPreviewSummary = {
-        sourceRowCount: validRecords.length,
-        plannedInsertCount: deduped.rows.length,
-        duplicateCount: deduped.duplicates,
-        unmatchedCount: deduped.unmatchedPatient,
-        errorCount: combinedErrors.length,
-      };
-
-      if (input.dryRun) {
-        const previewToken = await createCsvImportPreview(
-          ctx,
-          input,
-          "soap_notes",
-          summary,
-        );
-        return {
-          dryRun: true as const,
-          previewToken,
-          total: validRecords.length,
-          willInsert: deduped.rows.length,
-          unmatchedPatient: deduped.unmatchedPatient,
-          duplicates: deduped.duplicates,
-          errors: combinedErrors,
-        };
-      }
-
-      let replay:
-        | Extract<MigrationClaimResult, { alreadyCommitted: true }>
-        | undefined;
-      await ctx.db.transaction(async (tx) => {
-        const migrationDb = tx as unknown as Database;
         const claim = await claimCsvImportPreview(
           migrationDb,
           ctx.practiceId,
           input,
           "soap_notes",
           summary,
+          reviewedPlan,
         );
         if (claim.alreadyCommitted) {
-          replay = claim;
-          return;
+          return {
+            imported: claim.importedCount,
+            errors: [] as string[],
+            alreadyCommitted: true as const,
+            migrationRunId: input.previewToken!,
+          };
         }
-        if (deduped.rows.length > 0) {
+        if (plan.rows.length > 0) {
           await tx.insert(soapNotes).values(
-            deduped.rows.map((n) => ({
+            plan.rows.map((n) => ({
               ...n,
               practiceId: ctx.practiceId,
               authorId: ctx.user.id,
@@ -2737,21 +3173,13 @@ export const dataRouter = createRouter({
           migrationDb,
           ctx.practiceId,
           input.previewToken!,
-          deduped.rows.length,
+          plan.rows.length,
           ctx.user.id,
         );
-      });
-      if (replay) {
         return {
-          imported: replay.importedCount,
-          errors: [] as string[],
-          alreadyCommitted: true as const,
-          migrationRunId: input.previewToken!,
+          imported: plan.rows.length,
+          errors: combinedErrors,
         };
-      }
-      return {
-        imported: deduped.rows.length,
-        errors: combinedErrors,
-      };
+      });
     }),
 });

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
 import { randomUUID } from "crypto";
-import { asc, eq, and, isNull, inArray, ne, notInArray, sql } from "drizzle-orm";
+import {
+  asc,
+  desc,
+  eq,
+  and,
+  isNull,
+  inArray,
+  ne,
+  notInArray,
+  sql,
+} from "drizzle-orm";
 import { hash } from "bcryptjs";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
@@ -23,6 +33,7 @@ import {
   products,
   locations,
   locationMessaging,
+  migrationRuns,
   visitCloseouts,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
@@ -58,6 +69,7 @@ import {
   ONBOARDING_INTENTS,
   type OnboardingIntent,
 } from "@/lib/onboarding/intent";
+import { isValidMigrationSource } from "@/lib/import/sources";
 
 const adminProcedure = protectedProcedure.use(requireRole("admin"));
 
@@ -93,7 +105,7 @@ const currencyInput = z
 const phoneInput = optionalTrimmedString("Phone", SETTINGS_PHONE_MAX_LENGTH);
 const addressInput = optionalTrimmedString(
   "Address",
-  SETTINGS_ADDRESS_MAX_LENGTH
+  SETTINGS_ADDRESS_MAX_LENGTH,
 );
 const timezoneInput = z
   .string()
@@ -101,31 +113,31 @@ const timezoneInput = z
   .min(1, "Timezone is required")
   .max(
     SETTINGS_TIMEZONE_MAX_LENGTH,
-    `Timezone must be at most ${SETTINGS_TIMEZONE_MAX_LENGTH} characters`
+    `Timezone must be at most ${SETTINGS_TIMEZONE_MAX_LENGTH} characters`,
   )
   .refine(
     isSupportedPracticeTimezone,
-    "Timezone must be a valid IANA timezone"
+    "Timezone must be a valid IANA timezone",
   );
 const practiceNameInput = requiredTrimmedString(
   "Practice name",
-  PRACTICE_NAME_MAX_LENGTH
+  PRACTICE_NAME_MAX_LENGTH,
 );
 const locationNameInput = requiredTrimmedString(
   "Location name",
-  LOCATION_NAME_MAX_LENGTH
+  LOCATION_NAME_MAX_LENGTH,
 );
 const staffNameInput = requiredTrimmedString(
   "Staff name",
-  STAFF_NAME_MAX_LENGTH
+  STAFF_NAME_MAX_LENGTH,
 );
 const licenseNumberInput = optionalTrimmedString(
   "License number",
-  STAFF_LICENSE_NUMBER_MAX_LENGTH
+  STAFF_LICENSE_NUMBER_MAX_LENGTH,
 );
 const appointmentTypeNameInput = requiredTrimmedString(
   "Appointment type name",
-  APPOINTMENT_TYPE_NAME_MAX_LENGTH
+  APPOINTMENT_TYPE_NAME_MAX_LENGTH,
 );
 const roomNameInput = requiredTrimmedString("Room name", ROOM_NAME_MAX_LENGTH);
 const activeSchedulingStatuses = [
@@ -214,28 +226,28 @@ async function assertActivePractice(ctx: {
 
 async function syncBillingAfterStaffChange(
   db: Parameters<typeof syncPracticeSubscriptionQuantities>[0]["db"],
-  practiceId: string
+  practiceId: string,
 ): Promise<void> {
   try {
     await syncPracticeSubscriptionQuantities({ db, practiceId });
   } catch (err) {
     await alertOps(
       "Staff billing sync crashed",
-      `practice=${practiceId}: ${err instanceof Error ? err.message : String(err)}`
+      `practice=${practiceId}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }
 
 async function syncBillingAfterLocationChange(
   db: Parameters<typeof syncPracticeSubscriptionQuantities>[0]["db"],
-  practiceId: string
+  practiceId: string,
 ): Promise<void> {
   try {
     await syncPracticeSubscriptionQuantities({ db, practiceId });
   } catch (err) {
     await alertOps(
       "Location billing sync crashed",
-      `practice=${practiceId}: ${err instanceof Error ? err.message : String(err)}`
+      `practice=${practiceId}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }
@@ -277,6 +289,15 @@ interface PracticeSettings {
     journeyStepId?: string | null;
     /** "I'll finish later" — suppresses auto-open without completing onboarding. */
     journeyDismissed?: boolean;
+    /** Sticky marker: a reviewed migration committed real clinic data. */
+    migrationHasCommittedChanges?: boolean;
+    migrationLastCommittedAt?: string;
+    /** Latest source and completed modes are derived from migration_runs. */
+    migrationSource?: string | null;
+    migrationSourceHasCommittedChanges?: boolean;
+    migrationCompletedModes?: Array<
+      "clients" | "patients" | "vaccinations" | "soapNotes"
+    >;
     /** A clinic-admin request for an OpenVPM-assisted first setup session. */
     setupHelpRequestedAt?: string;
     setupHelpRequestedByUserId?: string;
@@ -328,17 +349,20 @@ export const settingsRouter = createRouter({
           .trim()
           .regex(
             SETTINGS_TAX_RATE_PATTERN,
-            "Tax rate must be a number like 20 or 20.00"
+            "Tax rate must be a number like 20 or 20.00",
           )
           .optional(),
         vatNumber: optionalTrimmedString(
           "VAT number",
-          SETTINGS_VAT_NUMBER_MAX_LENGTH
+          SETTINGS_VAT_NUMBER_MAX_LENGTH,
         ),
         // Branding. logoUrl is a real column; brandColor lives in settings.
         logoUrl: optionalTrimmedString("Logo URL", 512),
-        brandColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
-      })
+        brandColor: z
+          .string()
+          .regex(/^#[0-9a-fA-F]{6}$/)
+          .optional(),
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       // brandColor isn't a column — merge it into practices.settings without
@@ -358,16 +382,9 @@ export const settingsRouter = createRouter({
         patch.currency = (patch.currency as string).toLowerCase();
       }
       if (brandColor !== undefined) {
-        const [practice] = await ctx.db
-          .select({ settings: practices.settings })
-          .from(practices)
-          .where(activePracticeWhere(ctx.practiceId))
-          .limit(1);
-        if (!practice) {
-          throw practiceNotFound();
-        }
-        const settings = (practice.settings ?? {}) as PracticeSettings;
-        patch.settings = { ...settings, brandColor: brandColor.toLowerCase() };
+        patch.settings = settingsMergePatch({
+          brandColor: brandColor.toLowerCase(),
+        });
       }
       const [updated] = await ctx.db
         .update(practices)
@@ -401,11 +418,11 @@ export const settingsRouter = createRouter({
         contactEmail: emailInput,
         reason: optionalTrimmedString(
           "Deletion reason",
-          ACCOUNT_DELETION_REASON_MAX_LENGTH
+          ACCOUNT_DELETION_REASON_MAX_LENGTH,
         ),
         confirmExportDownloaded: z.literal(true),
         confirmManualReview: z.literal(true),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const [practice] = await ctx.db
@@ -437,7 +454,7 @@ export const settingsRouter = createRouter({
       await ctx.db
         .update(practices)
         .set({
-          settings: { ...settings, accountDeletionRequest: request },
+          settings: settingsMergePatch({ accountDeletionRequest: request }),
         })
         .where(activePracticeWhere(ctx.practiceId));
 
@@ -449,7 +466,7 @@ export const settingsRouter = createRouter({
           `requestedBy=${ctx.user.email}`,
           `contact=${request.contactEmail}`,
           "manualRetentionReviewRequired=true",
-        ].join(" ")
+        ].join(" "),
       );
 
       return request;
@@ -497,8 +514,8 @@ export const settingsRouter = createRouter({
         and(
           eq(locations.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(locations.deletedAt)
-        )
+          isNull(locations.deletedAt),
+        ),
       );
   }),
 
@@ -509,7 +526,7 @@ export const settingsRouter = createRouter({
         address: addressInput,
         phone: phoneInput,
         isPrimary: z.boolean().optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -521,8 +538,8 @@ export const settingsRouter = createRouter({
             and(
               eq(locations.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(locations.deletedAt)
-            )
+              isNull(locations.deletedAt),
+            ),
           );
       }
 
@@ -548,7 +565,7 @@ export const settingsRouter = createRouter({
         name: locationNameInput.optional(),
         address: addressInput,
         phone: phoneInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
@@ -560,8 +577,8 @@ export const settingsRouter = createRouter({
             eq(locations.id, id),
             eq(locations.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(locations.deletedAt)
-          )
+            isNull(locations.deletedAt),
+          ),
         )
         .returning();
 
@@ -587,8 +604,8 @@ export const settingsRouter = createRouter({
               eq(locations.id, input.id),
               eq(locations.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(locations.deletedAt)
-            )
+              isNull(locations.deletedAt),
+            ),
           )
           .returning();
 
@@ -607,8 +624,8 @@ export const settingsRouter = createRouter({
               eq(locations.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               isNull(locations.deletedAt),
-              ne(locations.id, input.id)
-            )
+              ne(locations.id, input.id),
+            ),
           );
 
         return target;
@@ -627,8 +644,8 @@ export const settingsRouter = createRouter({
           and(
             eq(locations.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(locations.deletedAt)
-          )
+            isNull(locations.deletedAt),
+          ),
         );
       const target = activeLocations.find((loc) => loc.id === input.id);
 
@@ -654,8 +671,8 @@ export const settingsRouter = createRouter({
             eq(rooms.locationId, input.id),
             eq(rooms.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(rooms.deletedAt)
-          )
+            isNull(rooms.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -674,8 +691,8 @@ export const settingsRouter = createRouter({
             eq(users.locationId, input.id),
             eq(users.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(users.deletedAt)
-          )
+            isNull(users.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -694,8 +711,8 @@ export const settingsRouter = createRouter({
             eq(products.locationId, input.id),
             eq(products.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(products.deletedAt)
-          )
+            isNull(products.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -714,8 +731,8 @@ export const settingsRouter = createRouter({
             eq(staffSchedules.locationId, input.id),
             eq(staffSchedules.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(staffSchedules.deletedAt)
-          )
+            isNull(staffSchedules.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -735,8 +752,8 @@ export const settingsRouter = createRouter({
               eq(locations.id, input.id),
               eq(locations.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(locations.deletedAt)
-            )
+              isNull(locations.deletedAt),
+            ),
           )
           .returning({ id: locations.id });
 
@@ -754,12 +771,14 @@ export const settingsRouter = createRouter({
             and(
               eq(locationMessaging.locationId, input.id),
               eq(locationMessaging.practiceId, ctx.practiceId),
-              activePracticePredicate(ctx.practiceId)
-            )
+              activePracticePredicate(ctx.practiceId),
+            ),
           );
 
         if (target.isPrimary) {
-          const replacement = activeLocations.find((loc) => loc.id !== input.id);
+          const replacement = activeLocations.find(
+            (loc) => loc.id !== input.id,
+          );
           if (replacement) {
             const [promoted] = await tx
               .update(locations)
@@ -769,8 +788,8 @@ export const settingsRouter = createRouter({
                   eq(locations.id, replacement.id),
                   eq(locations.practiceId, ctx.practiceId),
                   activePracticePredicate(ctx.practiceId),
-                  isNull(locations.deletedAt)
-                )
+                  isNull(locations.deletedAt),
+                ),
               )
               .returning({ id: locations.id });
 
@@ -816,83 +835,83 @@ export const settingsRouter = createRouter({
       completedRealVisit,
       nextRealAppointment,
     ] = await Promise.all([
-        ctx.db
-          .select({ id: patients.id })
-          .from(patients)
-          .where(
-            and(
-              eq(patients.practiceId, ctx.practiceId),
-              isNull(patients.deletedAt)
-            )
-          )
-          .limit(ESTABLISHED_PRACTICE_PATIENT_THRESHOLD),
-        ctx.db
-          .select({ id: appointments.id })
-          .from(appointments)
-          .where(
-            and(
-              eq(appointments.practiceId, ctx.practiceId),
-              isNull(appointments.deletedAt),
-              realAppointmentFilter
-            )
-          )
-          .limit(1),
-        ctx.db
-          .select({ id: appointments.id })
-          .from(appointments)
-          .where(
-            and(
-              eq(appointments.practiceId, ctx.practiceId),
-              eq(appointments.status, "checked_out"),
-              isNull(appointments.deletedAt),
-              realAppointmentFilter
-            )
-          )
-          .limit(1),
-        ctx.db
-          .select({ id: visitCloseouts.id })
-          .from(visitCloseouts)
-          .innerJoin(
-            appointments,
-            and(
-              eq(appointments.id, visitCloseouts.appointmentId),
-              eq(appointments.practiceId, ctx.practiceId),
-              isNull(appointments.deletedAt),
-              realAppointmentFilter
-            )
-          )
-          .where(
-            and(
-              eq(visitCloseouts.practiceId, ctx.practiceId),
-              eq(visitCloseouts.status, "completed"),
-              isNull(visitCloseouts.deletedAt)
-            )
-          )
-          .limit(1),
-        ctx.db
-          .select({ id: appointments.id })
-          .from(appointments)
-          .where(
-            and(
-              eq(appointments.practiceId, ctx.practiceId),
-              inArray(appointments.status, activeSchedulingStatuses),
-              isNull(appointments.deletedAt),
-              realAppointmentFilter
-            )
-          )
-          .orderBy(
-            sql`case ${appointments.status}
+      ctx.db
+        .select({ id: patients.id })
+        .from(patients)
+        .where(
+          and(
+            eq(patients.practiceId, ctx.practiceId),
+            isNull(patients.deletedAt),
+          ),
+        )
+        .limit(ESTABLISHED_PRACTICE_PATIENT_THRESHOLD),
+      ctx.db
+        .select({ id: appointments.id })
+        .from(appointments)
+        .where(
+          and(
+            eq(appointments.practiceId, ctx.practiceId),
+            isNull(appointments.deletedAt),
+            realAppointmentFilter,
+          ),
+        )
+        .limit(1),
+      ctx.db
+        .select({ id: appointments.id })
+        .from(appointments)
+        .where(
+          and(
+            eq(appointments.practiceId, ctx.practiceId),
+            eq(appointments.status, "checked_out"),
+            isNull(appointments.deletedAt),
+            realAppointmentFilter,
+          ),
+        )
+        .limit(1),
+      ctx.db
+        .select({ id: visitCloseouts.id })
+        .from(visitCloseouts)
+        .innerJoin(
+          appointments,
+          and(
+            eq(appointments.id, visitCloseouts.appointmentId),
+            eq(appointments.practiceId, ctx.practiceId),
+            isNull(appointments.deletedAt),
+            realAppointmentFilter,
+          ),
+        )
+        .where(
+          and(
+            eq(visitCloseouts.practiceId, ctx.practiceId),
+            eq(visitCloseouts.status, "completed"),
+            isNull(visitCloseouts.deletedAt),
+          ),
+        )
+        .limit(1),
+      ctx.db
+        .select({ id: appointments.id })
+        .from(appointments)
+        .where(
+          and(
+            eq(appointments.practiceId, ctx.practiceId),
+            inArray(appointments.status, activeSchedulingStatuses),
+            isNull(appointments.deletedAt),
+            realAppointmentFilter,
+          ),
+        )
+        .orderBy(
+          sql`case ${appointments.status}
               when 'in_exam' then 0
               when 'checked_in' then 1
               when 'confirmed' then 2
               when 'scheduled' then 3
               else 4
             end`,
-            asc(appointments.startTime),
-            asc(appointments.id)
-          )
-          .limit(1),
-      ]);
+          asc(appointments.startTime),
+          asc(appointments.id),
+        )
+        .limit(1),
+    ]);
     const demoPatientIds = new Set(settings.demoData?.patientIds ?? []);
     return {
       completedAt: settings.onboardingCompletedAt ?? null,
@@ -901,7 +920,7 @@ export const settingsRouter = createRouter({
       // delete the sample clinic first. This also keeps the checklist honest
       // when real and demo patients intentionally coexist during evaluation.
       hasRealData: existingPatients.some(
-        (patient) => !demoPatientIds.has(patient.id)
+        (patient) => !demoPatientIds.has(patient.id),
       ),
       // Scheduling a real appointment is the first operational commitment in
       // the clinic-ready path. Demo appointments must never complete it.
@@ -959,8 +978,8 @@ export const settingsRouter = createRouter({
           and(
             eq(clients.id, demoClientId),
             eq(clients.practiceId, ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .limit(1);
       portalClient = row ?? null;
@@ -976,8 +995,8 @@ export const settingsRouter = createRouter({
         .where(
           and(
             eq(clients.practiceId, ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .limit(1);
       portalClient = row ?? null;
@@ -994,8 +1013,8 @@ export const settingsRouter = createRouter({
           and(
             eq(patients.id, candidatePatientId),
             eq(patients.practiceId, ctx.practiceId),
-            isNull(patients.deletedAt)
-          )
+            isNull(patients.deletedAt),
+          ),
         )
         .limit(1);
       demoPatientName = row?.name ?? null;
@@ -1013,8 +1032,8 @@ export const settingsRouter = createRouter({
           and(
             eq(invoices.id, candidateInvoiceId),
             eq(invoices.practiceId, ctx.practiceId),
-            isNull(invoices.deletedAt)
-          )
+            isNull(invoices.deletedAt),
+          ),
         )
         .limit(1);
       demoInvoiceId = row?.id ?? null;
@@ -1049,16 +1068,60 @@ export const settingsRouter = createRouter({
 
   /** Read the in-app value-tour + finish-setup progress. */
   getOnboardingState: adminProcedure.query(async ({ ctx }) => {
-    const [practice] = await ctx.db
-      .select({ settings: practices.settings })
-      .from(practices)
-      .where(activePracticeWhere(ctx.practiceId))
-      .limit(1);
+    const [practiceRows, committedRuns] = await Promise.all([
+      ctx.db
+        .select({ settings: practices.settings })
+        .from(practices)
+        .where(activePracticeWhere(ctx.practiceId))
+        .limit(1),
+      ctx.db
+        .select({
+          mode: migrationRuns.mode,
+          source: migrationRuns.source,
+          importedCount: migrationRuns.importedCount,
+          reconciledCount: migrationRuns.reconciledCount,
+          committedAt: migrationRuns.committedAt,
+        })
+        .from(migrationRuns)
+        .where(
+          and(
+            eq(migrationRuns.practiceId, ctx.practiceId),
+            eq(migrationRuns.status, "committed"),
+            isNull(migrationRuns.deletedAt),
+          ),
+        )
+        .orderBy(desc(migrationRuns.committedAt), desc(migrationRuns.id)),
+    ]);
+    const practice = practiceRows[0];
     if (!practice) {
       throw practiceNotFound();
     }
     const settings = (practice.settings ?? {}) as PracticeSettings;
-    return {
+    const savedState = settings.onboardingState ?? {};
+    const latestCommittedRun = committedRuns[0];
+    const latestMigrationSource = isValidMigrationSource(
+      latestCommittedRun?.source,
+    )
+      ? latestCommittedRun.source
+      : null;
+    const completedModes = Array.from(
+      new Set(
+        committedRuns
+          .filter((run) => run.source === latestMigrationSource)
+          .map((run) =>
+            run.mode === "soap_notes" ? ("soapNotes" as const) : run.mode,
+          ),
+      ),
+    );
+    const ledgerHasCommittedChanges = committedRuns.some(
+      (run) => run.importedCount + run.reconciledCount > 0,
+    );
+    const latestSourceHasCommittedChanges = committedRuns.some(
+      (run) =>
+        run.source === latestMigrationSource &&
+        run.importedCount + run.reconciledCount > 0,
+    );
+    const defaults = {
       tourStatus: "not_started" as const,
       lastStepId: null,
       setupDismissed: false,
@@ -1066,7 +1129,30 @@ export const settingsRouter = createRouter({
       onboardingIntentSelectedAt: null,
       journeyStepId: null,
       journeyDismissed: false,
-      ...(settings.onboardingState ?? {}),
+      migrationHasCommittedChanges: false,
+      migrationLastCommittedAt: null,
+      migrationSource: null as string | null,
+      migrationSourceHasCommittedChanges: false,
+      migrationCompletedModes: [] as Array<
+        "clients" | "patients" | "vaccinations" | "soapNotes"
+      >,
+    };
+    return {
+      ...defaults,
+      ...savedState,
+      // migration_runs is authoritative for reviewed imports. The settings
+      // marker remains only as a fallback for compatibility-window commits
+      // that predate the run ledger.
+      migrationHasCommittedChanges:
+        ledgerHasCommittedChanges ||
+        savedState.migrationHasCommittedChanges === true,
+      migrationLastCommittedAt:
+        latestCommittedRun?.committedAt?.toISOString() ??
+        savedState.migrationLastCommittedAt ??
+        null,
+      migrationSource: latestMigrationSource,
+      migrationSourceHasCommittedChanges: latestSourceHasCommittedChanges,
+      migrationCompletedModes: completedModes,
     };
   }),
 
@@ -1076,7 +1162,7 @@ export const settingsRouter = createRouter({
       z.object({
         status: z.enum(["not_started", "in_progress", "completed", "skipped"]),
         lastStepId: tourStepIdInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const patch: Record<string, unknown> = { tourStatus: input.status };
@@ -1124,12 +1210,13 @@ export const settingsRouter = createRouter({
       z.object({
         stepId: journeyStepIdInput,
         dismissed: z.boolean().optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const patch: Record<string, unknown> = {};
       if (input.stepId != null) patch.journeyStepId = input.stepId;
-      if (input.dismissed !== undefined) patch.journeyDismissed = input.dismissed;
+      if (input.dismissed !== undefined)
+        patch.journeyDismissed = input.dismissed;
       if (Object.keys(patch).length === 0) return { ok: true };
 
       const [updated] = await ctx.db
@@ -1159,8 +1246,7 @@ export const settingsRouter = createRouter({
     }
 
     const settings = (practice.settings ?? {}) as PracticeSettings;
-    const existingRequestedAt =
-      settings.onboardingState?.setupHelpRequestedAt;
+    const existingRequestedAt = settings.onboardingState?.setupHelpRequestedAt;
     if (existingRequestedAt) {
       return { requestedAt: existingRequestedAt };
     }
@@ -1188,7 +1274,7 @@ export const settingsRouter = createRouter({
         `practiceName=${practice.name}`,
         `requestedBy=${ctx.user.email}`,
         `requestedAt=${requestedAt}`,
-      ].join(" ")
+      ].join(" "),
     );
 
     return { requestedAt };
@@ -1230,8 +1316,8 @@ export const settingsRouter = createRouter({
           .where(
             and(
               eq(products.practiceId, ctx.practiceId),
-              inArray(products.id, demo.productIds)
-            )
+              inArray(products.id, demo.productIds),
+            ),
           );
       }
       if (demo.communicationIds?.length) {
@@ -1241,8 +1327,8 @@ export const settingsRouter = createRouter({
           .where(
             and(
               eq(communications.practiceId, ctx.practiceId),
-              inArray(communications.id, demo.communicationIds)
-            )
+              inArray(communications.id, demo.communicationIds),
+            ),
           );
       }
       if (demo.invoiceItemIds?.length) {
@@ -1257,8 +1343,8 @@ export const settingsRouter = createRouter({
                 from ${invoices}
                 where ${invoices.id} = ${invoiceItems.invoiceId}
                   and ${invoices.practiceId} = ${ctx.practiceId}
-              )`
-            )
+              )`,
+            ),
           );
       }
       if (demo.invoiceIds?.length) {
@@ -1268,8 +1354,8 @@ export const settingsRouter = createRouter({
           .where(
             and(
               eq(invoices.practiceId, ctx.practiceId),
-              inArray(invoices.id, demo.invoiceIds)
-            )
+              inArray(invoices.id, demo.invoiceIds),
+            ),
           );
       }
       if (demo.problemIds?.length) {
@@ -1279,8 +1365,8 @@ export const settingsRouter = createRouter({
           .where(
             and(
               eq(problemList.practiceId, ctx.practiceId),
-              inArray(problemList.id, demo.problemIds)
-            )
+              inArray(problemList.id, demo.problemIds),
+            ),
           );
       }
       if (demo.vaccinationIds?.length) {
@@ -1290,8 +1376,8 @@ export const settingsRouter = createRouter({
           .where(
             and(
               eq(vaccinationRecords.practiceId, ctx.practiceId),
-              inArray(vaccinationRecords.id, demo.vaccinationIds)
-            )
+              inArray(vaccinationRecords.id, demo.vaccinationIds),
+            ),
           );
       }
       if (demo.soapNoteIds?.length) {
@@ -1301,8 +1387,8 @@ export const settingsRouter = createRouter({
           .where(
             and(
               eq(soapNotes.practiceId, ctx.practiceId),
-              inArray(soapNotes.id, demo.soapNoteIds)
-            )
+              inArray(soapNotes.id, demo.soapNoteIds),
+            ),
           );
       }
       if (demo.appointmentIds?.length) {
@@ -1312,8 +1398,8 @@ export const settingsRouter = createRouter({
           .where(
             and(
               eq(appointments.practiceId, ctx.practiceId),
-              inArray(appointments.id, demo.appointmentIds)
-            )
+              inArray(appointments.id, demo.appointmentIds),
+            ),
           );
       }
       if (demo.patientIds?.length) {
@@ -1323,8 +1409,8 @@ export const settingsRouter = createRouter({
           .where(
             and(
               eq(patients.practiceId, ctx.practiceId),
-              inArray(patients.id, demo.patientIds)
-            )
+              inArray(patients.id, demo.patientIds),
+            ),
           );
       }
       if (demo.clientIds?.length) {
@@ -1334,8 +1420,8 @@ export const settingsRouter = createRouter({
           .where(
             and(
               eq(clients.practiceId, ctx.practiceId),
-              inArray(clients.id, demo.clientIds)
-            )
+              inArray(clients.id, demo.clientIds),
+            ),
           );
       }
     }
@@ -1386,8 +1472,8 @@ export const settingsRouter = createRouter({
         and(
           eq(users.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(users.deletedAt)
-        )
+          isNull(users.deletedAt),
+        ),
       );
   }),
 
@@ -1397,10 +1483,16 @@ export const settingsRouter = createRouter({
         name: staffNameInput,
         email: emailInput,
         password: authPasswordInput,
-        role: z.enum(["admin", "veterinarian", "technician", "front_desk", "viewer"]),
+        role: z.enum([
+          "admin",
+          "veterinarian",
+          "technician",
+          "front_desk",
+          "viewer",
+        ]),
         phone: phoneInput,
         licenseNumber: licenseNumberInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -1452,7 +1544,7 @@ export const settingsRouter = createRouter({
           "front_desk",
           "viewer",
         ]),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const email = input.email.trim().toLowerCase();
@@ -1494,7 +1586,7 @@ export const settingsRouter = createRouter({
       // Unguessable placeholder — replaced when the invite is accepted.
       const passwordHash = await hash(
         `invite:${randomUUID()}:${randomUUID()}`,
-        PASSWORD_HASH_COST
+        PASSWORD_HASH_COST,
       );
 
       const [user] = await ctx.db
@@ -1551,7 +1643,7 @@ export const settingsRouter = createRouter({
           .optional(),
         phone: phoneInput,
         licenseNumber: licenseNumberInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
@@ -1559,8 +1651,8 @@ export const settingsRouter = createRouter({
         return ctx.db.transaction(async (tx) => {
           await tx.execute(
             sql`select pg_advisory_xact_lock(hashtext(${staffAdminRosterLockKey(
-              ctx.practiceId
-            )}::text))`
+              ctx.practiceId,
+            )}::text))`,
           );
 
           const [targetUser] = await tx
@@ -1571,13 +1663,16 @@ export const settingsRouter = createRouter({
                 eq(users.id, id),
                 eq(users.practiceId, ctx.practiceId),
                 activePracticePredicate(ctx.practiceId),
-                isNull(users.deletedAt)
-              )
+                isNull(users.deletedAt),
+              ),
             )
             .limit(1);
 
           if (!targetUser) {
-            throw new TRPCError({ code: "NOT_FOUND", message: "User not found" });
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "User not found",
+            });
           }
 
           if (targetUser.role === "admin") {
@@ -1590,8 +1685,8 @@ export const settingsRouter = createRouter({
                   eq(users.role, "admin"),
                   ne(users.id, id),
                   activePracticePredicate(ctx.practiceId),
-                  isNull(users.deletedAt)
-                )
+                  isNull(users.deletedAt),
+                ),
               )
               .limit(1);
 
@@ -1612,8 +1707,8 @@ export const settingsRouter = createRouter({
                 eq(users.practiceId, ctx.practiceId),
                 eq(users.role, targetUser.role),
                 activePracticePredicate(ctx.practiceId),
-                isNull(users.deletedAt)
-              )
+                isNull(users.deletedAt),
+              ),
             )
             .returning();
 
@@ -1636,8 +1731,8 @@ export const settingsRouter = createRouter({
             eq(users.id, id),
             eq(users.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(users.deletedAt)
-          )
+            isNull(users.deletedAt),
+          ),
         )
         .returning();
       if (!updated) {
@@ -1659,8 +1754,8 @@ export const settingsRouter = createRouter({
       await ctx.db.transaction(async (tx) => {
         await tx.execute(
           sql`select pg_advisory_xact_lock(hashtext(${staffAdminRosterLockKey(
-            ctx.practiceId
-          )}::text))`
+            ctx.practiceId,
+          )}::text))`,
         );
 
         const [targetUser] = await tx
@@ -1671,8 +1766,8 @@ export const settingsRouter = createRouter({
               eq(users.id, input.id),
               eq(users.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(users.deletedAt)
-            )
+              isNull(users.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -1690,8 +1785,8 @@ export const settingsRouter = createRouter({
                 eq(users.role, "admin"),
                 ne(users.id, input.id),
                 activePracticePredicate(ctx.practiceId),
-                isNull(users.deletedAt)
-              )
+                isNull(users.deletedAt),
+              ),
             )
             .limit(1);
 
@@ -1712,8 +1807,8 @@ export const settingsRouter = createRouter({
               eq(appointments.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               isNull(appointments.deletedAt),
-              inArray(appointments.status, activeSchedulingStatuses)
-            )
+              inArray(appointments.status, activeSchedulingStatuses),
+            ),
           )
           .limit(1);
 
@@ -1733,8 +1828,8 @@ export const settingsRouter = createRouter({
               eq(staffSchedules.userId, input.id),
               eq(staffSchedules.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(staffSchedules.deletedAt)
-            )
+              isNull(staffSchedules.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -1755,8 +1850,8 @@ export const settingsRouter = createRouter({
               eq(users.practiceId, ctx.practiceId),
               eq(users.role, targetUser.role),
               activePracticePredicate(ctx.practiceId),
-              isNull(users.deletedAt)
-            )
+              isNull(users.deletedAt),
+            ),
           )
           .returning({ id: users.id });
         if (!updated) {
@@ -1780,8 +1875,8 @@ export const settingsRouter = createRouter({
           and(
             eq(users.id, input.id),
             eq(users.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId)
-          )
+            activePracticePredicate(ctx.practiceId),
+          ),
         )
         .returning({ id: users.id });
       if (!updated) {
@@ -1802,8 +1897,8 @@ export const settingsRouter = createRouter({
         and(
           eq(appointmentTypes.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(appointmentTypes.deletedAt)
-        )
+          isNull(appointmentTypes.deletedAt),
+        ),
       );
   }),
 
@@ -1821,7 +1916,7 @@ export const settingsRouter = createRouter({
         defaultRoomType: z
           .enum(["exam", "surgery", "treatment", "boarding"])
           .default("exam"),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -1843,12 +1938,15 @@ export const settingsRouter = createRouter({
           .min(APPOINTMENT_TYPE_DURATION_MIN_MINUTES)
           .max(APPOINTMENT_TYPE_DURATION_MAX_MINUTES)
           .optional(),
-        color: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
+        color: z
+          .string()
+          .regex(/^#[0-9a-fA-F]{6}$/)
+          .optional(),
         requiresDoctor: z.number().int().min(0).max(1).optional(),
         defaultRoomType: z
           .enum(["exam", "surgery", "treatment", "boarding"])
           .optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const { id, ...data } = input;
@@ -1860,8 +1958,8 @@ export const settingsRouter = createRouter({
             eq(appointmentTypes.id, id),
             eq(appointmentTypes.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(appointmentTypes.deletedAt)
-          )
+            isNull(appointmentTypes.deletedAt),
+          ),
         )
         .returning();
       if (!updated) {
@@ -1885,8 +1983,8 @@ export const settingsRouter = createRouter({
               eq(appointmentTypes.id, input.id),
               eq(appointmentTypes.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(appointmentTypes.deletedAt)
-            )
+              isNull(appointmentTypes.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -1906,8 +2004,8 @@ export const settingsRouter = createRouter({
               eq(appointments.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               isNull(appointments.deletedAt),
-              inArray(appointments.status, activeSchedulingStatuses)
-            )
+              inArray(appointments.status, activeSchedulingStatuses),
+            ),
           )
           .limit(1);
 
@@ -1928,8 +2026,8 @@ export const settingsRouter = createRouter({
               eq(appointmentWaitlist.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               eq(appointmentWaitlist.status, "waiting"),
-              isNull(appointmentWaitlist.deletedAt)
-            )
+              isNull(appointmentWaitlist.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -1949,8 +2047,8 @@ export const settingsRouter = createRouter({
               eq(appointmentTypes.id, input.id),
               eq(appointmentTypes.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(appointmentTypes.deletedAt)
-            )
+              isNull(appointmentTypes.deletedAt),
+            ),
           )
           .returning({ id: appointmentTypes.id });
         if (!deleted) {
@@ -1974,8 +2072,8 @@ export const settingsRouter = createRouter({
         and(
           eq(rooms.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(rooms.deletedAt)
-        )
+          isNull(rooms.deletedAt),
+        ),
       );
   }),
 
@@ -1984,7 +2082,7 @@ export const settingsRouter = createRouter({
       z.object({
         name: roomNameInput,
         type: z.enum(["exam", "surgery", "treatment", "boarding"]),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -2007,8 +2105,8 @@ export const settingsRouter = createRouter({
               eq(rooms.id, input.id),
               eq(rooms.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(rooms.deletedAt)
-            )
+              isNull(rooms.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -2025,8 +2123,8 @@ export const settingsRouter = createRouter({
               eq(appointments.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               isNull(appointments.deletedAt),
-              inArray(appointments.status, activeSchedulingStatuses)
-            )
+              inArray(appointments.status, activeSchedulingStatuses),
+            ),
           )
           .limit(1);
 
@@ -2045,8 +2143,8 @@ export const settingsRouter = createRouter({
               eq(rooms.id, input.id),
               eq(rooms.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(rooms.deletedAt)
-            )
+              isNull(rooms.deletedAt),
+            ),
           )
           .returning({ id: rooms.id });
         if (!deleted) {

--- a/packages/db/drizzle/0051_wide_maximus.sql
+++ b/packages/db/drizzle/0051_wide_maximus.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "clients" ADD COLUMN "import_fingerprint" varchar(64);--> statement-breakpoint
+ALTER TABLE "patients" ADD COLUMN "import_fingerprint" varchar(64);--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD COLUMN "import_fingerprint" varchar(64);--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD COLUMN "import_fingerprint" varchar(64);--> statement-breakpoint
+CREATE UNIQUE INDEX "clients_import_fingerprint_uq" ON "clients" USING btree ("practice_id","import_fingerprint") WHERE "clients"."import_fingerprint" is not null and "clients"."deleted_at" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX "patients_import_fingerprint_uq" ON "patients" USING btree ("practice_id","import_fingerprint") WHERE "patients"."import_fingerprint" is not null and "patients"."deleted_at" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX "soap_notes_import_fingerprint_uq" ON "soap_notes" USING btree ("practice_id","import_fingerprint") WHERE "soap_notes"."import_fingerprint" is not null and "soap_notes"."deleted_at" is null;--> statement-breakpoint
+CREATE UNIQUE INDEX "vaccination_records_import_fingerprint_uq" ON "vaccination_records" USING btree ("practice_id","import_fingerprint") WHERE "vaccination_records"."import_fingerprint" is not null and "vaccination_records"."deleted_at" is null;--> statement-breakpoint
+ALTER TABLE "clients" ADD CONSTRAINT "clients_import_fingerprint_check" CHECK ("clients"."import_fingerprint" is null or "clients"."import_fingerprint" ~ '^[0-9a-f]{64}$');--> statement-breakpoint
+ALTER TABLE "patients" ADD CONSTRAINT "patients_import_fingerprint_check" CHECK ("patients"."import_fingerprint" is null or "patients"."import_fingerprint" ~ '^[0-9a-f]{64}$');--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD CONSTRAINT "soap_notes_import_fingerprint_check" CHECK ("soap_notes"."import_fingerprint" is null or "soap_notes"."import_fingerprint" ~ '^[0-9a-f]{64}$');--> statement-breakpoint
+ALTER TABLE "vaccination_records" ADD CONSTRAINT "vaccination_records_import_fingerprint_check" CHECK ("vaccination_records"."import_fingerprint" is null or "vaccination_records"."import_fingerprint" ~ '^[0-9a-f]{64}$');

--- a/packages/db/drizzle/meta/0051_snapshot.json
+++ b/packages/db/drizzle/meta/0051_snapshot.json
@@ -1,0 +1,15187 @@
+{
+  "id": "5ce94262-8964-452c-8bb2-05bb9403df1d",
+  "prevId": "cba327f0-9842-4ec7-bff7-e2557540f344",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "performed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "practice_id",
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n      )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": [
+        "entered_in_error"
+      ]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invoiced",
+        "waived"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": [
+        "unresolved",
+        "charged",
+        "no_charge",
+        "voided"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1786231827955,
       "tag": "0050_patient_identity_merge_ledger",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1786237311529,
+      "tag": "0051_wide_maximus",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schema/clients.ts
+++ b/packages/db/schema/clients.ts
@@ -32,6 +32,9 @@ export const clients = pgTable(
     lastName: varchar("last_name", { length: 128 }).notNull(),
     externalSource: varchar("external_source", { length: 64 }),
     externalId: varchar("external_id", { length: 160 }),
+    // Set only by supervised migrations. Normal clinic-created clients leave
+    // this null, so legitimate shared contact details remain possible.
+    importFingerprint: varchar("import_fingerprint", { length: 64 }),
     email: varchar("email", { length: 255 }),
     phone: varchar("phone", { length: 32 }),
     address: text("address"),
@@ -72,6 +75,15 @@ export const clients = pgTable(
       .where(
         sql`${table.externalSource} is not null and ${table.externalId} is not null`,
       ),
+    importFingerprintUq: uniqueIndex("clients_import_fingerprint_uq")
+      .on(table.practiceId, table.importFingerprint)
+      .where(
+        sql`${table.importFingerprint} is not null and ${table.deletedAt} is null`,
+      ),
+    importFingerprintCheck: check(
+      "clients_import_fingerprint_check",
+      sql`${table.importFingerprint} is null or ${table.importFingerprint} ~ '^[0-9a-f]{64}$'`,
+    ),
     externalIdentityPairCheck: check(
       "clients_external_identity_pair_check",
       sql`(${table.externalSource} is null) = (${table.externalId} is null)`,

--- a/packages/db/schema/clinical.ts
+++ b/packages/db/schema/clinical.ts
@@ -9,11 +9,12 @@ import {
   numeric,
   date,
   boolean,
+  check,
   foreignKey,
   index,
   uniqueIndex,
 } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import { baseColumns } from "./common";
 import { practices } from "./practices";
 import { users } from "./users";
@@ -46,12 +47,10 @@ export const treatmentPlanStatusEnum = pgEnum("treatment_plan_status", [
   "discontinued",
 ]);
 
-export const treatmentPlanItemStatusEnum = pgEnum("treatment_plan_item_status", [
-  "pending",
-  "in_progress",
-  "done",
-  "skipped",
-]);
+export const treatmentPlanItemStatusEnum = pgEnum(
+  "treatment_plan_item_status",
+  ["pending", "in_progress", "done", "skipped"],
+);
 
 export const soapNotes = pgTable(
   "soap_notes",
@@ -75,18 +74,33 @@ export const soapNotes = pgTable(
     // no OpenVPM author, so authorId holds the importing admin; this flag lets
     // the record show "Imported" instead of implying that admin wrote the note.
     imported: boolean("imported").notNull().default(false),
+    // Import-only content identity. Clinic-authored notes keep this null so
+    // clinically legitimate repeated notes remain representable.
+    importFingerprint: varchar("import_fingerprint", { length: 64 }),
   },
   (table) => ({
     patientIdx: index("soap_notes_patient_idx").on(table.patientId),
     practiceRecordUq: uniqueIndex("soap_notes_practice_record_uq").on(
       table.practiceId,
-      table.id
+      table.id,
     ),
-    practiceIdx: index("soap_notes_practice_idx").on(table.practiceId, table.deletedAt),
+    importFingerprintUq: uniqueIndex("soap_notes_import_fingerprint_uq")
+      .on(table.practiceId, table.importFingerprint)
+      .where(
+        sql`${table.importFingerprint} is not null and ${table.deletedAt} is null`,
+      ),
+    importFingerprintCheck: check(
+      "soap_notes_import_fingerprint_check",
+      sql`${table.importFingerprint} is null or ${table.importFingerprint} ~ '^[0-9a-f]{64}$'`,
+    ),
+    practiceIdx: index("soap_notes_practice_idx").on(
+      table.practiceId,
+      table.deletedAt,
+    ),
     appointmentIdx: index("soap_notes_appointment_idx").on(
       table.practiceId,
       table.appointmentId,
-      table.deletedAt
+      table.deletedAt,
     ),
     patientPracticeFk: foreignKey({
       columns: [table.practiceId, table.patientId],
@@ -102,7 +116,7 @@ export const soapNotes = pgTable(
       ],
       name: "soap_notes_practice_appointment_fk",
     }),
-  })
+  }),
 );
 
 export const vaccinationRecords = pgTable(
@@ -117,6 +131,8 @@ export const vaccinationRecords = pgTable(
       .references(() => patients.id),
     appointmentId: uuid("appointment_id").references(() => appointments.id),
     vaccineName: varchar("vaccine_name", { length: 255 }).notNull(),
+    // Import-only dose identity. Normal administered doses keep this null.
+    importFingerprint: varchar("import_fingerprint", { length: 64 }),
     lotNumber: varchar("lot_number", { length: 64 }),
     manufacturer: varchar("manufacturer", { length: 128 }),
     administeredBy: uuid("administered_by").references(() => users.id),
@@ -129,29 +145,40 @@ export const vaccinationRecords = pgTable(
   (table) => ({
     patientIdx: index("vaccination_records_patient_idx").on(
       table.patientId,
-      table.nextDueDate
+      table.nextDueDate,
     ),
     practiceDueIdx: index("vaccination_records_practice_due_idx").on(
       table.practiceId,
       table.nextDueDate,
-      table.deletedAt
+      table.deletedAt,
     ),
     appointmentIdx: index("vaccination_records_appointment_idx").on(
       table.practiceId,
       table.appointmentId,
-      table.deletedAt
+      table.deletedAt,
     ),
     visitSourceUq: uniqueIndex("vaccination_records_visit_source_uq").on(
       table.practiceId,
       table.appointmentId,
-      table.id
+      table.id,
+    ),
+    importFingerprintUq: uniqueIndex(
+      "vaccination_records_import_fingerprint_uq",
+    )
+      .on(table.practiceId, table.importFingerprint)
+      .where(
+        sql`${table.importFingerprint} is not null and ${table.deletedAt} is null`,
+      ),
+    importFingerprintCheck: check(
+      "vaccination_records_import_fingerprint_check",
+      sql`${table.importFingerprint} is null or ${table.importFingerprint} ~ '^[0-9a-f]{64}$'`,
     ),
     appointmentPracticeFk: foreignKey({
       columns: [table.practiceId, table.appointmentId],
       foreignColumns: [appointments.practiceId, appointments.id],
       name: "vaccination_records_practice_appointment_fk",
     }),
-  })
+  }),
 );
 
 export const labResults = pgTable(
@@ -181,28 +208,31 @@ export const labResults = pgTable(
     reviewedBy: uuid("reviewed_by").references(() => users.id),
   },
   (table) => ({
-    patientIdx: index("lab_results_patient_idx").on(table.patientId, table.status),
+    patientIdx: index("lab_results_patient_idx").on(
+      table.patientId,
+      table.status,
+    ),
     practiceStatusIdx: index("lab_results_practice_status_idx").on(
       table.practiceId,
       table.status,
-      table.deletedAt
+      table.deletedAt,
     ),
     appointmentIdx: index("lab_results_appointment_idx").on(
       table.practiceId,
       table.appointmentId,
-      table.deletedAt
+      table.deletedAt,
     ),
     visitSourceUq: uniqueIndex("lab_results_visit_source_uq").on(
       table.practiceId,
       table.appointmentId,
-      table.id
+      table.id,
     ),
     appointmentPracticeFk: foreignKey({
       columns: [table.practiceId, table.appointmentId],
       foreignColumns: [appointments.practiceId, appointments.id],
       name: "lab_results_practice_appointment_fk",
     }),
-  })
+  }),
 );
 
 export const procedures = pgTable(
@@ -227,24 +257,24 @@ export const procedures = pgTable(
     patientIdx: index("procedures_patient_idx").on(table.patientId),
     practiceIdx: index("procedures_practice_idx").on(
       table.practiceId,
-      table.deletedAt
+      table.deletedAt,
     ),
     appointmentIdx: index("procedures_appointment_idx").on(
       table.practiceId,
       table.appointmentId,
-      table.deletedAt
+      table.deletedAt,
     ),
     visitSourceUq: uniqueIndex("procedures_visit_source_uq").on(
       table.practiceId,
       table.appointmentId,
-      table.id
+      table.id,
     ),
     appointmentPracticeFk: foreignKey({
       columns: [table.practiceId, table.appointmentId],
       foreignColumns: [appointments.practiceId, appointments.id],
       name: "procedures_practice_appointment_fk",
     }),
-  })
+  }),
 );
 
 export const clinicalNotes = pgTable(
@@ -266,13 +296,13 @@ export const clinicalNotes = pgTable(
   (table) => ({
     patientIdx: index("clinical_notes_patient_idx").on(
       table.patientId,
-      table.noteType
+      table.noteType,
     ),
     practiceIdx: index("clinical_notes_practice_idx").on(
       table.practiceId,
-      table.deletedAt
+      table.deletedAt,
     ),
-  })
+  }),
 );
 
 export const problemList = pgTable(
@@ -293,14 +323,14 @@ export const problemList = pgTable(
   (table) => ({
     patientStatusIdx: index("problem_list_patient_status_idx").on(
       table.patientId,
-      table.status
+      table.status,
     ),
     practiceStatusIdx: index("problem_list_practice_status_idx").on(
       table.practiceId,
       table.status,
-      table.deletedAt
+      table.deletedAt,
     ),
-  })
+  }),
 );
 
 export const vitalSigns = pgTable(
@@ -327,21 +357,30 @@ export const vitalSigns = pgTable(
     /** Pain score, 0-10 scale. */
     painScore: integer("pain_score"),
     mucousMembrane: varchar("mucous_membrane", { length: 64 }),
-    capillaryRefillSec: numeric("capillary_refill_sec", { precision: 3, scale: 1 }),
+    capillaryRefillSec: numeric("capillary_refill_sec", {
+      precision: 3,
+      scale: 1,
+    }),
     notes: text("notes"),
   },
   (table) => ({
-    patientIdx: index("vital_signs_patient_idx").on(table.patientId, table.recordedAt),
+    patientIdx: index("vital_signs_patient_idx").on(
+      table.patientId,
+      table.recordedAt,
+    ),
     practiceRecordUq: uniqueIndex("vital_signs_practice_record_uq").on(
       table.practiceId,
-      table.id
+      table.id,
     ),
-    practiceIdx: index("vital_signs_practice_idx").on(table.practiceId, table.deletedAt),
+    practiceIdx: index("vital_signs_practice_idx").on(
+      table.practiceId,
+      table.deletedAt,
+    ),
     appointmentIdx: index("vital_signs_appointment_idx").on(
       table.practiceId,
       table.appointmentId,
       table.deletedAt,
-      table.recordedAt
+      table.recordedAt,
     ),
     patientPracticeFk: foreignKey({
       columns: [table.practiceId, table.patientId],
@@ -357,7 +396,7 @@ export const vitalSigns = pgTable(
       ],
       name: "vital_signs_practice_appointment_fk",
     }),
-  })
+  }),
 );
 
 export const cases = pgTable(
@@ -382,14 +421,14 @@ export const cases = pgTable(
   (table) => ({
     patientStatusIdx: index("cases_patient_status_idx").on(
       table.patientId,
-      table.status
+      table.status,
     ),
     practiceStatusIdx: index("cases_practice_status_idx").on(
       table.practiceId,
       table.status,
-      table.deletedAt
+      table.deletedAt,
     ),
-  })
+  }),
 );
 
 export const caseEntries = pgTable(
@@ -405,11 +444,8 @@ export const caseEntries = pgTable(
     notes: text("notes"),
   },
   (table) => ({
-    caseIdx: index("case_entries_case_idx").on(
-      table.caseId,
-      table.deletedAt
-    ),
-  })
+    caseIdx: index("case_entries_case_idx").on(table.caseId, table.deletedAt),
+  }),
 );
 
 export const treatmentPlans = pgTable(
@@ -432,8 +468,11 @@ export const treatmentPlans = pgTable(
   },
   (table) => ({
     patientIdx: index("treatment_plans_patient_idx").on(table.patientId),
-    practiceIdx: index("treatment_plans_practice_idx").on(table.practiceId, table.deletedAt),
-  })
+    practiceIdx: index("treatment_plans_practice_idx").on(
+      table.practiceId,
+      table.deletedAt,
+    ),
+  }),
 );
 
 export const treatmentPlanItems = pgTable(
@@ -452,9 +491,9 @@ export const treatmentPlanItems = pgTable(
     planOrderIdx: index("treatment_plan_items_plan_order_idx").on(
       table.planId,
       table.deletedAt,
-      table.sortOrder
+      table.sortOrder,
     ),
-  })
+  }),
 );
 
 // Relations
@@ -492,7 +531,7 @@ export const vaccinationRecordsRelations = relations(
       fields: [vaccinationRecords.administeredBy],
       references: [users.id],
     }),
-  })
+  }),
 );
 
 export const labResultsRelations = relations(labResults, ({ one }) => ({
@@ -629,7 +668,7 @@ export const treatmentPlansRelations = relations(
       references: [users.id],
     }),
     items: many(treatmentPlanItems),
-  })
+  }),
 );
 
 export const treatmentPlanItemsRelations = relations(
@@ -639,5 +678,5 @@ export const treatmentPlanItemsRelations = relations(
       fields: [treatmentPlanItems.planId],
       references: [treatmentPlans.id],
     }),
-  })
+  }),
 );

--- a/packages/db/schema/patients.ts
+++ b/packages/db/schema/patients.ts
@@ -58,6 +58,8 @@ export const patients = pgTable(
       .references(() => clients.id),
     externalSource: varchar("external_source", { length: 64 }),
     externalId: varchar("external_id", { length: 160 }),
+    // Import-only identity. Ordinary clinic-created charts keep this null.
+    importFingerprint: varchar("import_fingerprint", { length: 64 }),
     name: varchar("name", { length: 128 }).notNull(),
     species: speciesEnum("species").notNull(),
     breed: varchar("breed", { length: 128 }),
@@ -84,6 +86,15 @@ export const patients = pgTable(
       .where(
         sql`${table.externalSource} is not null and ${table.externalId} is not null`,
       ),
+    importFingerprintUq: uniqueIndex("patients_import_fingerprint_uq")
+      .on(table.practiceId, table.importFingerprint)
+      .where(
+        sql`${table.importFingerprint} is not null and ${table.deletedAt} is null`,
+      ),
+    importFingerprintCheck: check(
+      "patients_import_fingerprint_check",
+      sql`${table.importFingerprint} is null or ${table.importFingerprint} ~ '^[0-9a-f]{64}$'`,
+    ),
     externalIdentityPairCheck: check(
       "patients_external_identity_pair_check",
       sql`(${table.externalSource} is null) = (${table.externalId} is null)`,


### PR DESCRIPTION
## Summary
- expose reviewed clients, patients, vaccination history, and SOAP history imports in guided onboarding and Settings
- preserve exact migration sources and durable completed-stage state across resume, with accessible mobile-safe review and recovery UX
- bind all four preview/commit paths to practice-locked serializable plans, exclude sample charts, and record explicit zero-write reviews
- add import-only fingerprints and migration 0051 for database-enforced idempotency without restricting legitimate clinic-created duplicates
- make onboarding/settings JSON updates concurrency-safe

## Safety and verification
- `pnpm type-check`
- `pnpm test` — 293 files / 2,716 tests
- `pnpm build`
- `pnpm db:generate` — no additional schema changes
- `git diff --check`
- public-repo secret/participant scan

## Release order
Migration 0051 is additive and backward-compatible. After PR CI passes against PostgreSQL 16, run the Apply migrations workflow on this branch and verify production + demo migration/RLS/drift jobs before merging the application commit. The post-merge migration run is then an idempotent verification, preventing an app-before-schema deployment window.