### PR TITLE
Keep texting registration available without a website

### DIFF
--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -257,6 +257,37 @@ describe("messaging location target safety", () => {
     });
   });
 
+  it("keeps carrier registration available when the clinic website is blank", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    const { db } = createDb({
+      selectResults: [
+        [
+          {
+            name: "Healthy Pets",
+            email: "clinic@example.com",
+            phone: "+15555550100",
+            website: "",
+            primaryLocationPhone: null,
+          },
+        ],
+      ],
+    });
+
+    await expect(callerWithDb(db).getRegistrationDefaults()).resolves.toEqual({
+      displayName: "Healthy Pets",
+      contactFirstName: "Admin",
+      contactLastName: "",
+      contactEmail: "clinic@example.com",
+      businessPhone: "+15555550100",
+      website: "",
+      programUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}`,
+      privacyPolicyUrl:
+        `https://app.openvpm.com/sms/${PRACTICE_ID}/privacy`,
+      termsUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/terms`,
+      optInUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/opt-in`,
+    });
+  });
+
   it("encrypts clinic tax IDs and upserts registration details tenant-scoped", async () => {
     vi.stubEnv(
       "MESSAGING_REGISTRATION_ENCRYPTION_KEY",

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -65,12 +65,22 @@ const messagingPhoneInput = z
     return e164;
   });
 
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 const httpsUrlInput = z
   .string()
   .trim()
   .url()
   .max(500)
-  .refine((value) => new URL(value).protocol === "https:", {
+  // Refinements still run after an earlier Zod string issue. Keep this check
+  // total so an empty clinic default becomes "no prefill" instead of a 500.
+  .refine(isHttpsUrl, {
     message: "Use a public HTTPS URL.",
   });
 


### PR DESCRIPTION
## Outcome

Clinics without a saved website can load the US carrier-registration form instead of seeing an unhandled Invalid URL error.

## Why

Production smoke testing showed Settings > Messaging failing in messaging.getRegistrationDefaults when the practice website was blank. Zod continues through refinements after an earlier URL validation issue, and the protocol refinement called new URL("") turning an optional blank prefill into a 500.

## Changes

- Make the HTTPS refinement total for malformed and empty input.
- Preserve strict HTTPS validation when clinics submit registration details.
- Add the exact blank-website regression case.

## Safety

- No database changes.
- No provider calls or provisioning changes.
- No carrier fees or number purchases.
- Provisioning kill switch and pilot allowlist remain unchanged.

## Validation

- 293 test files / 2,717 tests passed.
- Web type-check passed.
- Production build passed (42 static pages).
- git diff --check and secret scan passed.
