### PR TITLE
Require inventory links in treatment templates

### DIFF
--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -4623,6 +4623,7 @@ const CATEGORY_BADGE: Record<string, string> = {
 
 interface TemplateItem {
   itemType: "service" | "product";
+  itemId?: string | null;
   description: string;
   defaultQuantity: number;
   defaultUnitPrice: string;
@@ -4632,12 +4633,19 @@ interface TemplateItem {
 function TemplatesTab() {
   const formatCurrency = useCurrencyFormatter();
   const utils = trpc.useUtils();
+  const [showAdd, setShowAdd] = useState(false);
   const {
     data: templateList,
     isLoading,
     error: templatesError,
     refetch: refetchTemplates,
   } = trpc.templates.list.useQuery();
+  const {
+    data: templateProducts,
+    isLoading: templateProductsLoading,
+    error: templateProductsError,
+    refetch: refetchTemplateProducts,
+  } = trpc.templates.listProducts.useQuery(undefined, { enabled: showAdd });
   const createMutation = trpc.templates.create.useMutation({
     onSuccess: () => {
       utils.templates.list.invalidate();
@@ -4659,7 +4667,6 @@ function TemplatesTab() {
     },
   });
 
-  const [showAdd, setShowAdd] = useState(false);
   const [addForm, setAddForm] = useState({
     name: "",
     description: "",
@@ -4668,6 +4675,7 @@ function TemplatesTab() {
   const [addItems, setAddItems] = useState<TemplateItem[]>([
     {
       itemType: "service",
+      itemId: null,
       description: "",
       defaultQuantity: 1,
       defaultUnitPrice: "0",
@@ -4683,6 +4691,7 @@ function TemplatesTab() {
     setAddItems([
       {
         itemType: "service",
+        itemId: null,
         description: "",
         defaultQuantity: 1,
         defaultUnitPrice: "0",
@@ -4692,42 +4701,92 @@ function TemplatesTab() {
   };
 
   const addItemRow = () => {
-    setAddItems([
-      ...addItems,
+    setAddItems((currentItems) => [
+      ...currentItems,
       {
         itemType: "service",
+        itemId: null,
         description: "",
         defaultQuantity: 1,
         defaultUnitPrice: "0",
-        sortOrder: addItems.length,
+        sortOrder: currentItems.length,
       },
     ]);
   };
 
   const removeItemRow = (index: number) => {
-    setAddItems(addItems.filter((_, i) => i !== index));
+    setAddItems((currentItems) =>
+      currentItems.filter((_, itemIndex) => itemIndex !== index),
+    );
   };
 
   const updateItem = (
     index: number,
     field: keyof TemplateItem,
-    value: string | number,
+    value: string | number | null,
   ) => {
-    setAddItems(
-      addItems.map((item, i) =>
-        i === index ? { ...item, [field]: value } : item,
+    setAddItems((currentItems) =>
+      currentItems.map((item, itemIndex) =>
+        itemIndex === index ? { ...item, [field]: value } : item,
       ),
     );
   };
+
+  const changeItemType = (
+    index: number,
+    itemType: TemplateItem["itemType"],
+  ) => {
+    setAddItems((currentItems) =>
+      currentItems.map((item, itemIndex) =>
+        itemIndex === index
+          ? {
+              ...item,
+              itemType,
+              itemId: null,
+              description: "",
+              defaultUnitPrice: "0",
+            }
+          : item,
+      ),
+    );
+  };
+
+  const selectTemplateProduct = (index: number, productId: string) => {
+    const product = templateProducts?.find(
+      (candidate) => candidate.id === productId,
+    );
+    setAddItems((currentItems) =>
+      currentItems.map((item, itemIndex) =>
+        itemIndex === index
+          ? {
+              ...item,
+              itemId: product?.id ?? null,
+              description: product?.name ?? "",
+              defaultUnitPrice: product?.unitPrice ?? "0",
+            }
+          : item,
+      ),
+    );
+  };
+
   const templateItemsToCreate = addItems
     .map((item, index) => ({
-      ...item,
+      itemType: item.itemType,
+      itemId: item.itemId || undefined,
       description: item.description.trim(),
+      defaultQuantity: item.defaultQuantity,
       defaultUnitPrice: item.defaultUnitPrice.trim(),
       sortOrder: index,
     }))
     .filter((item) => item.description.length > 0);
+  const activeTemplateProductIds = new Set(
+    templateProducts?.map((product) => product.id) ?? [],
+  );
+  const hasActiveTemplateProductLink = (itemId?: string | null) =>
+    Boolean(itemId && activeTemplateProductIds.has(itemId));
   const isTemplateItemFormValid = (item: TemplateItem) =>
+    (item.itemType !== "product" ||
+      hasActiveTemplateProductLink(item.itemId)) &&
     item.description.trim().length > 0 &&
     item.description.trim().length <=
       TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH &&
@@ -4737,6 +4796,25 @@ function TemplatesTab() {
       item.defaultUnitPrice,
       item.defaultQuantity,
     );
+  const templateProductsMissing =
+    !templateProductsLoading && !templateProductsError && !templateProducts;
+  const templateProductCatalogUnavailable =
+    templateProductsLoading ||
+    Boolean(templateProductsError) ||
+    templateProductsMissing;
+  const hasProductRows = addItems.some((item) => item.itemType === "product");
+  const hasUnlinkedProductRows = addItems.some(
+    (item) =>
+      item.itemType === "product" &&
+      !hasActiveTemplateProductLink(item.itemId),
+  );
+  const hasStaleProductRows = addItems.some(
+    (item) =>
+      item.itemType === "product" &&
+      Boolean(item.itemId) &&
+      !templateProductCatalogUnavailable &&
+      !hasActiveTemplateProductLink(item.itemId),
+  );
   const canCreateTemplate =
     addForm.name.trim().length > 0 &&
     addForm.name.trim().length <= TREATMENT_TEMPLATE_NAME_MAX_LENGTH &&
@@ -4745,6 +4823,8 @@ function TemplatesTab() {
     templateItemsToCreate.length > 0 &&
     templateItemsToCreate.length <= TREATMENT_TEMPLATE_MAX_ITEMS &&
     templateItemsToCreate.every(isTemplateItemFormValid) &&
+    !hasUnlinkedProductRows &&
+    (!hasProductRows || !templateProductCatalogUnavailable) &&
     !createMutation.isPending;
 
   const selectedTemplate = templateList?.find(
@@ -4879,8 +4959,15 @@ function TemplatesTab() {
                     <td className="px-4 py-3 font-medium">
                       {item.description}
                     </td>
-                    <td className="px-4 py-3 text-muted-foreground capitalize">
-                      {item.itemType}
+                    <td className="px-4 py-3 text-muted-foreground">
+                      <span className="capitalize">{item.itemType}</span>
+                      {item.itemType === "product" &&
+                      item.hasActiveProductLink !== true ? (
+                        <p className="mt-1 max-w-xs text-xs text-amber-700 dark:text-amber-400">
+                          Missing or archived inventory product — recreate this
+                          template before use.
+                        </p>
+                      ) : null}
                     </td>
                     <td className="px-4 py-3 text-muted-foreground">
                       {item.defaultQuantity}
@@ -4968,19 +5055,60 @@ function TemplatesTab() {
                 key={index}
                 className="grid grid-cols-[1fr_auto_auto_auto_auto] items-center gap-2"
               >
-                <Input
-                  placeholder="Item description"
-                  maxLength={TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH}
-                  value={item.description}
-                  onChange={(e) =>
-                    updateItem(index, "description", e.target.value)
-                  }
-                />
+                {item.itemType === "product" ? (
+                  <select
+                    aria-label={`Inventory product ${index + 1}`}
+                    className="h-10 min-w-0 rounded-md border border-input bg-background px-2 text-sm"
+                    value={item.itemId ?? ""}
+                    aria-invalid={
+                      Boolean(item.itemId) &&
+                      !templateProductCatalogUnavailable &&
+                      !hasActiveTemplateProductLink(item.itemId)
+                    }
+                    disabled={
+                      templateProductCatalogUnavailable ||
+                      templateProducts?.length === 0
+                    }
+                    onChange={(e) =>
+                      selectTemplateProduct(index, e.target.value)
+                    }
+                  >
+                    <option value="">
+                      {templateProductsLoading
+                        ? "Loading inventory products..."
+                        : templateProductsError || templateProductsMissing
+                          ? "Inventory products unavailable"
+                          : templateProducts?.length === 0
+                            ? "No inventory products found"
+                            : "Choose an inventory product"}
+                    </option>
+                    {templateProducts?.map((product) => (
+                      <option key={product.id} value={product.id}>
+                        {product.name}
+                        {product.sku ? ` (${product.sku})` : ""} —{" "}
+                        {formatCurrency(product.unitPrice)}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <Input
+                    placeholder="Item description"
+                    maxLength={TREATMENT_TEMPLATE_ITEM_DESCRIPTION_MAX_LENGTH}
+                    value={item.description}
+                    onChange={(e) =>
+                      updateItem(index, "description", e.target.value)
+                    }
+                  />
+                )}
                 <select
+                  aria-label={`Item type ${index + 1}`}
                   className="h-10 rounded-md border border-input bg-background px-2 text-sm"
                   value={item.itemType}
                   onChange={(e) =>
-                    updateItem(index, "itemType", e.target.value)
+                    changeItemType(
+                      index,
+                      e.target.value as TemplateItem["itemType"],
+                    )
                   }
                 >
                   <option value="service">Service</option>
@@ -5024,6 +5152,37 @@ function TemplatesTab() {
                 </Button>
               </div>
             ))}
+            {hasProductRows &&
+            (templateProductsError || templateProductsMissing) ? (
+              <div className="flex flex-wrap items-center gap-2 text-sm text-destructive">
+                <span>
+                  Inventory products could not load. Product template items are
+                  disabled until the catalog is available.
+                </span>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void refetchTemplateProducts()}
+                >
+                  Retry
+                </Button>
+              </div>
+            ) : null}
+            {hasProductRows &&
+            !templateProductCatalogUnavailable &&
+            templateProducts?.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                Add an inventory product before creating a product template
+                item.
+              </p>
+            ) : null}
+            {hasStaleProductRows ? (
+              <p role="alert" className="text-sm text-destructive">
+                A selected inventory product is no longer active. Choose an
+                active product before creating this template.
+              </p>
+            ) : null}
             <Button
               size="sm"
               variant="outline"

--- a/apps/web/lib/__tests__/templates-settings-ui.test.ts
+++ b/apps/web/lib/__tests__/templates-settings-ui.test.ts
@@ -21,6 +21,7 @@ describe("treatment template settings UI", () => {
     expect(source).toContain("Templates");
     expect(source).toContain("trpc.templates.create.useMutation");
     expect(source).toContain("trpc.templates.getById.useQuery");
+    expect(source).toContain("trpc.templates.listProducts.useQuery");
   });
 
   it("keeps template create controls aligned to shared policy", () => {
@@ -58,5 +59,31 @@ describe("treatment template settings UI", () => {
     );
     expect(source).toContain("disabled={!canCreateTemplate}");
     expect(source).toContain("items: templateItemsToCreate");
+  });
+
+  it("links product template rows to inventory and fails closed without the catalog", () => {
+    expect(source).toContain("itemId?: string | null");
+    expect(source).toContain("const selectTemplateProduct =");
+    expect(source).toContain("itemId: product?.id ?? null");
+    expect(source).toContain("description: product?.name ?? \"\"");
+    expect(source).toContain("defaultUnitPrice: product?.unitPrice ?? \"0\"");
+    expect(source).toContain("itemId: item.itemId || undefined");
+    expect(source).toContain(
+      'item.itemType !== "product" ||\n      hasActiveTemplateProductLink(item.itemId)',
+    );
+    expect(source).toContain("const hasUnlinkedProductRows = addItems.some(");
+    expect(source).toContain("const activeTemplateProductIds = new Set(");
+    expect(source).toContain("const hasActiveTemplateProductLink =");
+    expect(source).toContain("const hasStaleProductRows = addItems.some(");
+    expect(source).toContain("!hasActiveTemplateProductLink(item.itemId)");
+    expect(source).toContain("!hasUnlinkedProductRows");
+    expect(source).toContain("!templateProductCatalogUnavailable");
+    expect(source).toContain("Inventory products could not load");
+    expect(source).toContain("onClick={() => void refetchTemplateProducts()}");
+    expect(source).toContain('aria-invalid={');
+    expect(source).toContain('role="alert"');
+    expect(source).toContain("selected inventory product is no longer active");
+    expect(source).toContain("item.hasActiveProductLink !== true");
+    expect(source).toContain("Missing or archived inventory product");
   });
 });

--- a/apps/web/server/__tests__/templates-safety.test.ts
+++ b/apps/web/server/__tests__/templates-safety.test.ts
@@ -21,13 +21,13 @@ const INVOICE_ID = "00000000-0000-0000-0000-000000000006";
 const SECOND_SERVICE_ID = "00000000-0000-0000-0000-000000000007";
 const SECOND_PRODUCT_ID = "00000000-0000-0000-0000-000000000008";
 
-function callerWithDb(db: Record<string, unknown>) {
+function callerWithDb(db: Record<string, unknown>, role = "admin") {
   const session = {
     user: {
       id: USER_ID,
       email: "admin@example.com",
       name: "Admin",
-      role: "admin",
+      role,
       practiceId: PRACTICE_ID,
     },
   };
@@ -144,6 +144,40 @@ describe("treatment template safety", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
+  it("requires every product template item to link to inventory before DB work", async () => {
+    const { db, select, insertValues } = createDb();
+    const unlinkedProduct = {
+      itemType: "product" as const,
+      description: "Dental chews",
+      defaultQuantity: 1,
+      defaultUnitPrice: "12.00",
+      sortOrder: 0,
+    };
+
+    await expect(
+      callerWithDb(db).create({
+        name: "Dental package",
+        items: [unlinkedProduct],
+      })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("active inventory product"),
+    });
+
+    await expect(
+      callerWithDb(db).addItem({
+        templateId: TEMPLATE_ID,
+        ...unlinkedProduct,
+      })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("active inventory product"),
+    });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("rejects invalid template text, quantities, totals, and item counts before DB work", async () => {
     const { db, select, insertValues, updateSet } = createDb();
 
@@ -244,8 +278,112 @@ describe("treatment template safety", () => {
     }
   );
 
+  it("lists active tenant inventory products for template setup", async () => {
+    const productOptions = [
+      {
+        id: PRODUCT_ID,
+        name: "Dental chews",
+        sku: "DENTAL-1",
+        unitPrice: "12.00",
+      },
+    ];
+    const { db, select } = createDb({
+      selectResults: [[{ id: PRACTICE_ID }], productOptions],
+    });
+
+    await expect(callerWithDb(db).listProducts()).resolves.toEqual(productOptions);
+    expect(select).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the template product catalog admin-only and tenant-scoped", async () => {
+    const { db, select } = createDb();
+
+    await expect(
+      callerWithDb(db, "veterinarian").listProducts()
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(select).not.toHaveBeenCalled();
+
+    const source = readFileSync("server/routers/templates.ts", "utf8");
+    const listProductsBlock = source.slice(
+      source.indexOf("listProducts:"),
+      source.indexOf("getById:")
+    );
+    expect(listProductsBlock).toContain('requireRole("admin")');
+    expect(listProductsBlock).toContain(
+      "eq(products.practiceId, ctx.practiceId)"
+    );
+    expect(listProductsBlock).toContain("activePracticePredicate(ctx.practiceId)");
+    expect(listProductsBlock).toContain("isNull(products.deletedAt)");
+  });
+
+  it("reports missing and archived product links without exposing catalog data", async () => {
+    const { db } = createDb({
+      selectResults: [
+        [{ id: PRACTICE_ID }],
+        [{ id: TEMPLATE_ID, practiceId: PRACTICE_ID }],
+        [
+          {
+            id: ITEM_ID,
+            itemType: "product",
+            itemId: PRODUCT_ID,
+            description: "Active product",
+          },
+          {
+            id: "00000000-0000-0000-0000-000000000009",
+            itemType: "product",
+            itemId: SECOND_PRODUCT_ID,
+            description: "Archived product",
+          },
+          {
+            id: "00000000-0000-0000-0000-000000000010",
+            itemType: "product",
+            itemId: null,
+            description: "Legacy product",
+          },
+          {
+            id: "00000000-0000-0000-0000-000000000011",
+            itemType: "service",
+            itemId: SERVICE_ID,
+            description: "Exam",
+          },
+        ],
+        [{ id: PRODUCT_ID }],
+      ],
+    });
+
+    const result = await callerWithDb(db).getById({ id: TEMPLATE_ID });
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        itemId: PRODUCT_ID,
+        hasActiveProductLink: true,
+      }),
+      expect.objectContaining({
+        itemId: SECOND_PRODUCT_ID,
+        hasActiveProductLink: false,
+      }),
+      expect.objectContaining({
+        itemId: null,
+        hasActiveProductLink: false,
+      }),
+      expect.objectContaining({
+        itemType: "service",
+        hasActiveProductLink: null,
+      }),
+    ]);
+
+    const source = readFileSync("server/routers/templates.ts", "utf8");
+    const detailBlock = source.slice(
+      source.indexOf("getById:"),
+      source.indexOf("create: protectedProcedure")
+    );
+    expect(detailBlock).toContain("inArray(products.id, linkedProductIds)");
+    expect(detailBlock).toContain("eq(products.practiceId, ctx.practiceId)");
+    expect(detailBlock).toContain("isNull(products.deletedAt)");
+  });
+
   it("creates a template after validating referenced catalog items", async () => {
-    const { db, insertValues, transaction } = createDb({
+    const { db, insertValues, transaction, lockFor } = createDb({
       selectResults: [[{ id: PRACTICE_ID }], [{ id: PRODUCT_ID }]],
       insertedRows: [{ id: TEMPLATE_ID, name: "Dental package" }],
     });
@@ -269,6 +407,10 @@ describe("treatment template safety", () => {
     ).resolves.toMatchObject({ id: TEMPLATE_ID });
 
     expect(transaction).toHaveBeenCalled();
+    expect(lockFor).toHaveBeenCalledWith("share");
+    expect(lockFor.mock.invocationCallOrder[0]).toBeLessThan(
+      insertValues.mock.invocationCallOrder[0]!
+    );
     expect(insertValues).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -290,7 +432,7 @@ describe("treatment template safety", () => {
   });
 
   it("trims added template item text and money before writing", async () => {
-    const { db, insertValues } = createDb({
+    const { db, insertValues, transaction, lockFor } = createDb({
       selectResults: [
         [{ id: PRACTICE_ID }],
         [{ id: TEMPLATE_ID }],
@@ -311,6 +453,11 @@ describe("treatment template safety", () => {
       })
     ).resolves.toMatchObject({ id: ITEM_ID });
 
+    expect(transaction).toHaveBeenCalled();
+    expect(lockFor).toHaveBeenCalledWith("share");
+    expect(lockFor.mock.invocationCallOrder[0]).toBeLessThan(
+      insertValues.mock.invocationCallOrder[0]!
+    );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         templateId: TEMPLATE_ID,
@@ -431,6 +578,46 @@ describe("treatment template safety", () => {
     expect(lockFor).toHaveBeenCalledTimes(1);
     expect(lockFor).toHaveBeenCalledWith("share");
     expect(execute).toHaveBeenCalled();
+  });
+
+  it("rejects legacy unlinked products before invoice or inventory writes", async () => {
+    const { db, insertValues, updateSet, select } = createDb({
+      selectResults: [
+        [{ id: PRACTICE_ID }],
+        [{ id: TEMPLATE_ID }],
+        [
+          {
+            id: INVOICE_ID,
+            status: "draft",
+            paidAmount: "0.00",
+            isEstimate: false,
+          },
+        ],
+        [
+          {
+            description: "Legacy dental chews",
+            defaultQuantity: 1,
+            defaultUnitPrice: "12.00",
+            itemType: "product",
+            itemId: null,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).applyToInvoice({
+        templateId: TEMPLATE_ID,
+        invoiceId: INVOICE_ID,
+      })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("active inventory product"),
+    });
+
+    expect(select).toHaveBeenCalledTimes(4);
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
   });
 
   it("batch-locks unique service and product references before inserting", async () => {
@@ -872,11 +1059,16 @@ describe("treatment template safety", () => {
 
   it("rejects template reads and writes when the practice is missing or deleted", async () => {
     const { db, insertValues, updateSet } = createDb({
-      selectResults: [[], [], [], [], [], [], [], []],
+      selectResults: [[], [], [], [], [], [], [], [], []],
     });
     const caller = callerWithDb(db);
 
     await expect(caller.list()).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Practice not found",
+    });
+
+    await expect(caller.listProducts()).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
     });

--- a/apps/web/server/routers/templates.ts
+++ b/apps/web/server/routers/templates.ts
@@ -49,6 +49,9 @@ const moneyInput = z.string().trim().refine((value) => {
   return TREATMENT_TEMPLATE_UNIT_PRICE_PATTERN.test(value);
 }, "Amount must be a valid currency amount.");
 
+const PRODUCT_LINK_REQUIRED_MESSAGE =
+  "Every product template item must be linked to an active inventory product.";
+
 const templateItemBaseInput = z.object({
   itemType: z.enum(["service", "product"]),
   itemId: z.string().uuid().optional(),
@@ -75,6 +78,14 @@ function refineTemplateItemTotal(
   item: z.infer<typeof templateItemBaseInput>,
   ctx: z.RefinementCtx
 ) {
+  if (item.itemType === "product" && !item.itemId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["itemId"],
+      message: PRODUCT_LINK_REQUIRED_MESSAGE,
+    });
+  }
+
   const totalCents = moneyToCents(item.defaultUnitPrice) * item.defaultQuantity;
   if (totalCents > TREATMENT_TEMPLATE_MAX_MONEY_CENTS) {
     ctx.addIssue({
@@ -144,50 +155,18 @@ async function assertActivePractice(ctx: TemplatesContext) {
   }
 }
 
-async function assertCatalogItemBelongsToPractice(
-  ctx: TemplatesContext,
-  itemType: "service" | "product",
-  itemId: string | undefined
-) {
-  if (!itemId) return;
-
-  const table = itemType === "service" ? services : products;
-  const [item] = await ctx.db
-    .select({ id: table.id })
-    .from(table)
-    .where(
-      and(
-        eq(table.id, itemId),
-        eq(table.practiceId, ctx.practiceId),
-        activePracticePredicate(ctx.practiceId),
-        isNull(table.deletedAt)
-      )
-    )
-    .limit(1);
-
-  if (!item) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message:
-        itemType === "service" ? "Service not found" : "Product not found",
-    });
-  }
-}
-
-async function assertTemplateItemsBelongToPractice(
-  ctx: TemplatesContext,
-  items: Array<{ itemType: "service" | "product"; itemId?: string }>
-) {
-  for (const item of items) {
-    await assertCatalogItemBelongsToPractice(ctx, item.itemType, item.itemId);
-  }
-}
-
 async function lockActiveTemplateCatalogItems(
   ctx: TemplatesContext,
   items: Array<{ itemType: "service" | "product"; itemId?: string }>,
   options: { lockProductsForStock?: boolean } = {}
 ) {
+  if (items.some((item) => item.itemType === "product" && !item.itemId)) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: PRODUCT_LINK_REQUIRED_MESSAGE,
+    });
+  }
+
   const serviceIds = [
     ...new Set(
       items
@@ -296,6 +275,28 @@ export const templatesRouter = createRouter({
       .orderBy(asc(treatmentTemplates.name));
   }),
 
+  listProducts: protectedProcedure
+    .use(requireRole("admin"))
+    .query(async ({ ctx }) => {
+      await assertActivePractice(ctx);
+      return ctx.db
+        .select({
+          id: products.id,
+          name: products.name,
+          sku: products.sku,
+          unitPrice: products.unitPrice,
+        })
+        .from(products)
+        .where(
+          and(
+            eq(products.practiceId, ctx.practiceId),
+            activePracticePredicate(ctx.practiceId),
+            isNull(products.deletedAt)
+          )
+        )
+        .orderBy(asc(products.name), asc(products.id));
+    }),
+
   getById: protectedProcedure
     .input(z.object({ id: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
@@ -331,7 +332,43 @@ export const templatesRouter = createRouter({
         )
         .orderBy(asc(treatmentTemplateItems.sortOrder));
 
-      return { ...template, items };
+      const linkedProductIds = [
+        ...new Set(
+          items
+            .filter((item) => item.itemType === "product" && item.itemId)
+            .map((item) => item.itemId!)
+        ),
+      ];
+      const activeLinkedProducts =
+        linkedProductIds.length === 0
+          ? []
+          : await ctx.db
+              .select({ id: products.id })
+              .from(products)
+              .where(
+                and(
+                  inArray(products.id, linkedProductIds),
+                  eq(products.practiceId, ctx.practiceId),
+                  activePracticePredicate(ctx.practiceId),
+                  isNull(products.deletedAt)
+                )
+              );
+      const activeLinkedProductIds = new Set(
+        activeLinkedProducts.map((product) => product.id)
+      );
+
+      return {
+        ...template,
+        items: items.map((item) => ({
+          ...item,
+          hasActiveProductLink:
+            item.itemType === "product"
+              ? Boolean(
+                  item.itemId && activeLinkedProductIds.has(item.itemId)
+                )
+              : null,
+        })),
+      };
     }),
 
   create: protectedProcedure
@@ -339,9 +376,16 @@ export const templatesRouter = createRouter({
     .input(createTemplateInput)
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
-      await assertTemplateItemsBelongToPractice(ctx, input.items);
 
       return ctx.db.transaction(async (tx) => {
+        // Keep catalog validation and insertion in the same transaction. The
+        // share locks prevent an item from being archived after validation but
+        // before the template persists its reference.
+        await lockActiveTemplateCatalogItems(
+          { db: tx, practiceId: ctx.practiceId },
+          input.items
+        );
+
         const [template] = await tx
           .insert(treatmentTemplates)
           .values({
@@ -440,47 +484,50 @@ export const templatesRouter = createRouter({
     .input(addTemplateItemInput)
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
-      // Verify the template belongs to this practice
-      const [template] = await ctx.db
-        .select({ id: treatmentTemplates.id })
-        .from(treatmentTemplates)
-        .where(
-          and(
-            eq(treatmentTemplates.id, input.templateId),
-            eq(treatmentTemplates.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(treatmentTemplates.deletedAt)
+
+      return ctx.db.transaction(async (tx) => {
+        // Verify the template belongs to this practice inside the same
+        // transaction that locks the catalog reference and inserts the row.
+        const [template] = await tx
+          .select({ id: treatmentTemplates.id })
+          .from(treatmentTemplates)
+          .where(
+            and(
+              eq(treatmentTemplates.id, input.templateId),
+              eq(treatmentTemplates.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(treatmentTemplates.deletedAt)
+            )
           )
-        )
-        .limit(1);
+          .limit(1);
 
-      if (!template) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Treatment template not found",
-        });
-      }
+        if (!template) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Treatment template not found",
+          });
+        }
 
-      await assertCatalogItemBelongsToPractice(
-        ctx,
-        input.itemType,
-        input.itemId
-      );
+        await lockActiveTemplateCatalogItems(
+          { db: tx, practiceId: ctx.practiceId },
+          [input]
+        );
 
-      const [item] = await ctx.db
-        .insert(treatmentTemplateItems)
-        .values({
-          templateId: input.templateId,
-          itemType: input.itemType as "service" | "product",
-          itemId: input.itemId ?? null,
-          description: input.description,
-          defaultQuantity: input.defaultQuantity,
-          defaultUnitPrice: input.defaultUnitPrice,
-          sortOrder: input.sortOrder,
-        })
-        .returning();
+        const [item] = await tx
+          .insert(treatmentTemplateItems)
+          .values({
+            templateId: input.templateId,
+            itemType: input.itemType as "service" | "product",
+            itemId: input.itemId ?? null,
+            description: input.description,
+            defaultQuantity: input.defaultQuantity,
+            defaultUnitPrice: input.defaultUnitPrice,
+            sortOrder: input.sortOrder,
+          })
+          .returning();
 
-      return item!;
+        return item!;
+      });
     }),
 
   removeItem: protectedProcedure


### PR DESCRIPTION
## Outcome

Treatment-template product lines now point to active clinic inventory before they can be saved or applied, so invoice creation and stock deduction cannot silently diverge.

## Changes

- Require product template items to reference an active tenant-owned inventory product.
- Select products from the active catalog and snapshot their current name and price.
- Validate and share-lock catalog references inside the same transaction as template creation or item insertion.
- Reject legacy missing/archived product links before invoice or stock writes.
- Fail closed when the product catalog is unavailable or a selected product becomes stale.
- Surface missing or archived links without exposing product details across tenants.

## Safety

- No database migration.
- No historical template rewrite.
- No inventory mutation occurs until a template is applied to a real invoice.
- Existing estimate behavior remains non-deducting.

## Validation

- Full repository: 293 test files / 2,723 tests passed.
- Web type-check passed.
- Production build passed (42 static pages).
- Independent review findings resolved.
- git diff --check and secret scan passed.
