### PR TITLE
Make online booking request-only

### DIFF
--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -96,6 +96,8 @@ type AppointmentStatus =
   | "no_show"
   | "cancelled";
 
+type ConfirmationContactMethod = "phone" | "email";
+
 type RecurrenceFrequency = "weekly" | "monthly" | "annual";
 
 const STATUS_COLORS: Record<AppointmentStatus, string> = {
@@ -341,13 +343,17 @@ type Appointment = {
   patientId: string | null;
   clientFirstName: string | null;
   clientLastName: string | null;
+  clientEmail: string | null;
+  clientPhone: string | null;
   clientId: string | null;
   doctorName: string | null;
   doctorId: string | null;
   typeName: string | null;
   typeColor: string | null;
   typeDuration: number | null;
+  typeRequiresDoctor: number | null;
   roomName: string | null;
+  roomId: string | null;
 };
 
 // --- Components ---
@@ -881,11 +887,17 @@ function AppointmentDetailPopover({
   appointment: Appointment;
   timeZone?: string | null;
   onClose: () => void;
-  onStatusChange: (id: string, status: AppointmentStatus) => void;
+  onStatusChange: (
+    id: string,
+    status: AppointmentStatus,
+    confirmationContactMethod?: ConfirmationContactMethod
+  ) => void;
   onReschedule: (input: {
     id: string;
     startTime: string;
     endTime: string;
+    doctorId: string | null;
+    roomId: string | null;
   }) => void;
   onCancelRecurringSeries: (seriesId: string) => void;
   canUpdateStatus: boolean;
@@ -899,9 +911,19 @@ function AppointmentDetailPopover({
   const onCloseRef = useRef(onClose);
   const restoreFocusRef = useRef(true);
   const dialogTitleId = useId();
+  const rescheduleDateId = `${dialogTitleId}-date`;
+  const rescheduleTimeId = `${dialogTitleId}-time`;
+  const rescheduleDurationId = `${dialogTitleId}-duration`;
+  const rescheduleDoctorFieldId = `${dialogTitleId}-doctor`;
+  const rescheduleRoomFieldId = `${dialogTitleId}-room`;
+  const confirmationPhoneFieldId = `${dialogTitleId}-confirmation-phone`;
+  const confirmationEmailFieldId = `${dialogTitleId}-confirmation-email`;
   const start = new Date(appointment.startTime);
   const end = new Date(appointment.endTime);
   const [showRescheduleForm, setShowRescheduleForm] = useState(false);
+  const [showConfirmationForm, setShowConfirmationForm] = useState(false);
+  const [confirmationContactMethod, setConfirmationContactMethod] =
+    useState<ConfirmationContactMethod | "">("");
   const [rescheduleDate, setRescheduleDate] = useState(() =>
     toISODate(start, timeZone)
   );
@@ -911,6 +933,18 @@ function AppointmentDetailPopover({
   const [rescheduleDuration, setRescheduleDuration] = useState(() =>
     appointmentDurationMinutes(start, end)
   );
+  const [rescheduleDoctorId, setRescheduleDoctorId] = useState(
+    appointment.doctorId ?? ""
+  );
+  const [rescheduleRoomId, setRescheduleRoomId] = useState(
+    appointment.roomId ?? ""
+  );
+  const doctorsQuery = trpc.appointments.listDoctors.useQuery(undefined, {
+    enabled: canManageSchedule && showRescheduleForm,
+  });
+  const roomsQuery = trpc.appointments.listRooms.useQuery(undefined, {
+    enabled: canManageSchedule && showRescheduleForm,
+  });
 
   useEffect(() => {
     onCloseRef.current = onClose;
@@ -985,20 +1019,66 @@ function AppointmentDetailPopover({
 
   useEffect(() => {
     setShowRescheduleForm(false);
+    setShowConfirmationForm(false);
+    setConfirmationContactMethod("");
     setRescheduleDate(toISODate(start, timeZone));
     setRescheduleTime(formatTimeInput(start, timeZone));
     setRescheduleDuration(appointmentDurationMinutes(start, end));
-  }, [appointment.id, appointment.startTime, appointment.endTime, timeZone]);
+    setRescheduleDoctorId(appointment.doctorId ?? "");
+    setRescheduleRoomId(appointment.roomId ?? "");
+  }, [
+    appointment.id,
+    appointment.startTime,
+    appointment.endTime,
+    appointment.doctorId,
+    appointment.roomId,
+    timeZone,
+  ]);
 
   const clientName = [appointment.clientFirstName, appointment.clientLastName]
     .filter(Boolean)
     .join(" ") || "Unknown Client";
 
-  const statusActions: { label: string; status: AppointmentStatus; variant: "default" | "outline" | "destructive" }[] = [];
+  const statusActions: {
+    label: string;
+    status: AppointmentStatus;
+    variant: "default" | "outline" | "destructive";
+    disabled?: boolean;
+    disabledReason?: string;
+  }[] = [];
   const current = appointment.status as AppointmentStatus;
   const canMoveAppointment = current === "scheduled" || current === "confirmed";
+  const doctorRequiredForAdvance =
+    current === "scheduled" &&
+    appointment.typeRequiresDoctor === 1 &&
+    !appointment.doctorId;
+  const resourceOptionsUnavailable =
+    doctorsQuery.isLoading ||
+    roomsQuery.isLoading ||
+    Boolean(doctorsQuery.error || roomsQuery.error);
 
-  if (current === "scheduled" || current === "confirmed") {
+  if (current === "scheduled") {
+    statusActions.push({
+      label: "Confirm",
+      status: "confirmed",
+      variant: "default",
+      disabled: doctorRequiredForAdvance,
+      disabledReason: doctorRequiredForAdvance
+        ? "Assign a doctor before confirming this appointment."
+        : undefined,
+    });
+    statusActions.push({
+      label: "Check In",
+      status: "checked_in",
+      variant: "outline",
+      disabled: doctorRequiredForAdvance,
+      disabledReason: doctorRequiredForAdvance
+        ? "Assign a doctor before checking in this appointment."
+        : undefined,
+    });
+    statusActions.push({ label: "No Show", status: "no_show", variant: "outline" });
+    statusActions.push({ label: "Cancel", status: "cancelled", variant: "destructive" });
+  } else if (current === "confirmed") {
     statusActions.push({ label: "Check In", status: "checked_in", variant: "default" });
     statusActions.push({ label: "No Show", status: "no_show", variant: "outline" });
     statusActions.push({ label: "Cancel", status: "cancelled", variant: "destructive" });
@@ -1012,6 +1092,7 @@ function AppointmentDetailPopover({
   const canSubmitReschedule =
     isAppointmentDateInputValid(rescheduleDate) &&
     isAppointmentDurationInputValid(rescheduleDuration) &&
+    !resourceOptionsUnavailable &&
     !isRescheduling;
 
   const handleReschedule = () => {
@@ -1026,18 +1107,20 @@ function AppointmentDetailPopover({
       id: appointment.id,
       startTime: startDt.toISOString(),
       endTime: endDt.toISOString(),
+      doctorId: rescheduleDoctorId || null,
+      roomId: rescheduleRoomId || null,
     });
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-3 sm:p-4">
       <div
         ref={popoverRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={dialogTitleId}
         tabIndex={-1}
-        className="w-full max-w-sm rounded-lg border border-border bg-card shadow-lg"
+        className="max-h-[calc(100dvh-1.5rem)] w-full max-w-sm overflow-y-auto rounded-lg border border-border bg-card shadow-lg sm:max-h-[calc(100dvh-2rem)]"
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-4 py-3">
@@ -1108,6 +1191,12 @@ function AppointmentDetailPopover({
                 {appointment.notes}
               </p>
             )}
+            {doctorRequiredForAdvance && (
+              <p className="rounded-md bg-amber-50 px-2.5 py-2 text-xs text-amber-900">
+                Assign a doctor before confirming or checking in this appointment
+                request.
+              </p>
+            )}
           </div>
         </div>
 
@@ -1115,10 +1204,14 @@ function AppointmentDetailPopover({
           <div className="border-t border-border px-4 py-3">
             <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
               <div>
-                <label className="text-xs font-medium text-muted-foreground">
+                <label
+                  htmlFor={rescheduleDateId}
+                  className="text-xs font-medium text-muted-foreground"
+                >
                   Date
                 </label>
                 <Input
+                  id={rescheduleDateId}
                   type="date"
                   value={rescheduleDate}
                   aria-invalid={!isAppointmentDateInputValid(rescheduleDate)}
@@ -1127,10 +1220,14 @@ function AppointmentDetailPopover({
                 />
               </div>
               <div>
-                <label className="text-xs font-medium text-muted-foreground">
+                <label
+                  htmlFor={rescheduleTimeId}
+                  className="text-xs font-medium text-muted-foreground"
+                >
                   Time
                 </label>
                 <select
+                  id={rescheduleTimeId}
                   value={rescheduleTime}
                   onChange={(e) => setRescheduleTime(e.target.value)}
                   className="mt-1 h-9 w-full rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
@@ -1143,10 +1240,14 @@ function AppointmentDetailPopover({
                 </select>
               </div>
               <div>
-                <label className="text-xs font-medium text-muted-foreground">
+                <label
+                  htmlFor={rescheduleDurationId}
+                  className="text-xs font-medium text-muted-foreground"
+                >
                   Duration
                 </label>
                 <Input
+                  id={rescheduleDurationId}
                   type="number"
                   min={APPOINTMENT_DURATION_MIN_MINUTES}
                   max={APPOINTMENT_DURATION_MAX_MINUTES}
@@ -1158,6 +1259,80 @@ function AppointmentDetailPopover({
                 />
               </div>
             </div>
+            {current === "confirmed" ? (
+              <p className="mt-2 rounded-md bg-amber-50 px-2.5 py-2 text-xs text-amber-900">
+                Changing the date, time, or duration returns this appointment to
+                requested status. Contact the client and record confirmation
+                again before reminders can be sent.
+              </p>
+            ) : null}
+            <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <div>
+                <label
+                  htmlFor={rescheduleDoctorFieldId}
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Doctor
+                </label>
+                <select
+                  id={rescheduleDoctorFieldId}
+                  value={rescheduleDoctorId}
+                  onChange={(e) => setRescheduleDoctorId(e.target.value)}
+                  disabled={resourceOptionsUnavailable}
+                  className="mt-1 h-9 w-full rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+                >
+                  <option value="">Unassigned</option>
+                  {(doctorsQuery.data ?? []).map((doctor) => (
+                    <option key={doctor.id} value={doctor.id}>
+                      Dr. {doctor.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label
+                  htmlFor={rescheduleRoomFieldId}
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  Room
+                </label>
+                <select
+                  id={rescheduleRoomFieldId}
+                  value={rescheduleRoomId}
+                  onChange={(e) => setRescheduleRoomId(e.target.value)}
+                  disabled={resourceOptionsUnavailable}
+                  className="mt-1 h-9 w-full rounded-md border border-input bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+                >
+                  <option value="">Unassigned</option>
+                  {(roomsQuery.data ?? []).map((room) => (
+                    <option key={room.id} value={room.id}>
+                      {room.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            {(doctorsQuery.error || roomsQuery.error) && (
+              <div className="mt-2 flex items-center justify-between gap-2 rounded-md bg-destructive/10 px-2.5 py-2">
+                <p className="text-xs text-destructive">
+                  Doctor or room options could not be loaded. Retry before
+                  changing this appointment.
+                </p>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    void Promise.all([
+                      doctorsQuery.refetch(),
+                      roomsQuery.refetch(),
+                    ]);
+                  }}
+                >
+                  Retry options
+                </Button>
+              </div>
+            )}
             <div className="mt-3 flex justify-end gap-2">
               <Button
                 size="sm"
@@ -1174,7 +1349,100 @@ function AppointmentDetailPopover({
                 {isRescheduling && (
                   <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
                 )}
-                Move Appointment
+                Save changes
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {showConfirmationForm && (
+          <div className="border-t border-border px-4 py-3">
+            <fieldset>
+              <legend className="text-sm font-semibold">
+                Record client confirmation
+              </legend>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Contact the client first. This records how they agreed to the
+                appointment; it does not send a message.
+              </p>
+              <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <label
+                  htmlFor={confirmationPhoneFieldId}
+                  className="flex items-start gap-2 rounded-md border border-border p-2.5 text-sm has-[:checked]:border-teal-500 has-[:checked]:bg-teal-50"
+                >
+                  <input
+                    id={confirmationPhoneFieldId}
+                    type="radio"
+                    name={`${dialogTitleId}-confirmation-method`}
+                    value="phone"
+                    checked={confirmationContactMethod === "phone"}
+                    disabled={!appointment.clientPhone}
+                    onChange={() => setConfirmationContactMethod("phone")}
+                    className="mt-0.5 h-4 w-4"
+                  />
+                  <span>
+                    Phone
+                    {!appointment.clientPhone ? (
+                      <span className="block text-xs text-muted-foreground">
+                        No phone on file
+                      </span>
+                    ) : null}
+                  </span>
+                </label>
+                <label
+                  htmlFor={confirmationEmailFieldId}
+                  className="flex items-start gap-2 rounded-md border border-border p-2.5 text-sm has-[:checked]:border-teal-500 has-[:checked]:bg-teal-50"
+                >
+                  <input
+                    id={confirmationEmailFieldId}
+                    type="radio"
+                    name={`${dialogTitleId}-confirmation-method`}
+                    value="email"
+                    checked={confirmationContactMethod === "email"}
+                    disabled={!appointment.clientEmail}
+                    onChange={() => setConfirmationContactMethod("email")}
+                    className="mt-0.5 h-4 w-4"
+                  />
+                  <span>
+                    Email
+                    {!appointment.clientEmail ? (
+                      <span className="block text-xs text-muted-foreground">
+                        No email on file
+                      </span>
+                    ) : null}
+                  </span>
+                </label>
+              </div>
+            </fieldset>
+            <div className="mt-3 flex justify-end gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setShowConfirmationForm(false);
+                  setConfirmationContactMethod("");
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                disabled={!confirmationContactMethod || isUpdating}
+                onClick={() => {
+                  if (!confirmationContactMethod) return;
+                  onStatusChange(
+                    appointment.id,
+                    "confirmed",
+                    confirmationContactMethod
+                  );
+                }}
+              >
+                {isUpdating ? (
+                  <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+                ) : null}
+                Record confirmation
               </Button>
             </div>
           </div>
@@ -1229,11 +1497,10 @@ function AppointmentDetailPopover({
                 onClick={() => setShowRescheduleForm((show) => !show)}
               >
                 <Clock className="mr-1.5 h-3 w-3" />
-                Reschedule
+                Edit appointment
               </Button>
             )}
-            {canSendReminders &&
-              (current === "scheduled" || current === "confirmed") && (
+            {canSendReminders && current === "confirmed" && (
               <SendReminderButton appointmentId={appointment.id} />
             )}
             {canManageSchedule && appointment.recurringSeriesId && (
@@ -1256,8 +1523,16 @@ function AppointmentDetailPopover({
                 key={action.status}
                 size="sm"
                 variant={action.variant}
-                disabled={isUpdating}
-                onClick={() => onStatusChange(appointment.id, action.status)}
+                disabled={isUpdating || action.disabled}
+                title={action.disabledReason}
+                onClick={() => {
+                  if (action.status === "confirmed") {
+                    setShowRescheduleForm(false);
+                    setShowConfirmationForm(true);
+                    return;
+                  }
+                  onStatusChange(appointment.id, action.status);
+                }}
               >
                 {isUpdating ? (
                   <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
@@ -1989,8 +2264,12 @@ export default function SchedulePage() {
   const utils = trpc.useUtils();
 
   const rescheduleAppointment = trpc.appointments.reschedule.useMutation({
-    onSuccess: () => {
-      toast.success("Appointment rescheduled");
+    onSuccess: (result) => {
+      toast.success(
+        result.confirmationRequired
+          ? "Appointment moved; contact the client and confirm the new time"
+          : "Appointment updated"
+      );
       setSelectedAppointment(null);
       utils.appointments.list.invalidate();
     },
@@ -2016,9 +2295,13 @@ export default function SchedulePage() {
     },
   });
 
-  const handleStatusChange = (id: string, status: AppointmentStatus) => {
+  const handleStatusChange = (
+    id: string,
+    status: AppointmentStatus,
+    confirmationContactMethod?: ConfirmationContactMethod
+  ) => {
     updateStatus.mutate(
-      { id, status },
+      { id, status, confirmationContactMethod },
       {
         onSuccess: () => {
           utils.appointments.list.invalidate();
@@ -2031,6 +2314,8 @@ export default function SchedulePage() {
     id: string;
     startTime: string;
     endTime: string;
+    doctorId: string | null;
+    roomId: string | null;
   }) => {
     rescheduleAppointment.mutate(input);
   };

--- a/apps/web/app/api/cron/reminders/route.test.ts
+++ b/apps/web/app/api/cron/reminders/route.test.ts
@@ -639,6 +639,10 @@ describe("appointment reminder cron query scoping", () => {
     expect(source).toMatch(
       /innerJoin\(\s*practices,\s*and\(\s*eq\(appointments\.practiceId, practices\.id\),\s*isNull\(practices\.deletedAt\)\s*\)\s*\)/s
     );
+    expect(source).toContain('eq(appointments.status, "confirmed")');
+    expect(source).not.toContain(
+      'inArray(appointments.status, ["scheduled", "confirmed"])'
+    );
   });
 
   it("matches provider suppressions against trimmed normalized client emails", () => {

--- a/apps/web/app/api/cron/reminders/route.ts
+++ b/apps/web/app/api/cron/reminders/route.ts
@@ -5,7 +5,6 @@ import {
   isNull,
   gte,
   lte,
-  inArray,
   sql,
 } from "drizzle-orm";
 import { db } from "@openpims/db/client";
@@ -294,7 +293,7 @@ export async function GET(request: Request) {
             isNull(clients.deletedAt),
             gte(appointments.startTime, now),
             lte(appointments.startTime, in24h),
-            inArray(appointments.status, ["scheduled", "confirmed"]),
+            eq(appointments.status, "confirmed"),
           ),
         )
         .orderBy(appointments.startTime),

--- a/apps/web/app/book/[slug]/page.tsx
+++ b/apps/web/app/book/[slug]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { AlertCircle, CalendarX2 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
@@ -26,6 +26,17 @@ function dateInputValue(d: Date): string {
 export default function PublicBookingPage() {
   const params = useParams();
   const slug = (params.slug as string) ?? "";
+  const formId = useId();
+  const typeFieldId = `${formId}-type`;
+  const dateFieldId = `${formId}-date`;
+  const firstNameFieldId = `${formId}-first-name`;
+  const lastNameFieldId = `${formId}-last-name`;
+  const emailFieldId = `${formId}-email`;
+  const phoneFieldId = `${formId}-phone`;
+  const websiteFieldId = `${formId}-website`;
+  const petNameFieldId = `${formId}-pet-name`;
+  const speciesFieldId = `${formId}-species`;
+  const reasonFieldId = `${formId}-reason`;
 
   const page = trpc.booking.getPage.useQuery({ slug }, { enabled: !!slug });
   const book = trpc.booking.book.useMutation();
@@ -44,8 +55,8 @@ export default function PublicBookingPage() {
   const [website, setWebsite] = useState("");
 
   const slots = trpc.booking.availableSlots.useQuery(
-    { slug, date, typeId: typeId || undefined },
-    { enabled: !!slug && !!date }
+    { slug, date, typeId },
+    { enabled: !!slug && !!date && !!typeId }
   );
 
   const dateBounds = useMemo(() => {
@@ -70,8 +81,8 @@ export default function PublicBookingPage() {
       <EmptyState
         className="py-16"
         icon={AlertCircle}
-        title="This booking page isn't available"
-        description="The link may be incorrect, or online booking may be turned off. Please contact the clinic directly."
+        title="This appointment request page isn't available"
+        description="The link may be incorrect, or online appointment requests may be turned off. Please contact the clinic directly."
       />
     );
   }
@@ -82,6 +93,7 @@ export default function PublicBookingPage() {
   const canSubmit = Boolean(
     date &&
       time &&
+      typeId &&
       firstName.trim() &&
       lastName.trim() &&
       email.trim() &&
@@ -95,7 +107,7 @@ export default function PublicBookingPage() {
     if (!canSubmit) return;
     book.mutate({
       slug,
-      typeId: typeId || undefined,
+      typeId,
       date,
       time,
       contact: {
@@ -127,9 +139,7 @@ export default function PublicBookingPage() {
             <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
           </svg>
         </div>
-        <h1 className="text-xl font-bold text-gray-900 mb-2">
-          {book.data.requiresConfirmation ? "Request sent!" : "You're booked!"}
-        </h1>
+        <h1 className="text-xl font-bold text-gray-900 mb-2">Request sent!</h1>
         <p className="text-gray-600 max-w-sm mx-auto">{book.data.message}</p>
         <p className="text-gray-500 text-sm mt-4">
           We sent the details to the clinic. Questions?{" "}
@@ -173,36 +183,53 @@ export default function PublicBookingPage() {
       </header>
 
       <form onSubmit={submit} className="rounded-2xl bg-white p-6 shadow-sm space-y-5">
-        <h2 className="text-base font-semibold text-gray-900">Book an appointment</h2>
-
-        {data.types.length > 0 && (
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
-              What do you need?
-            </label>
-            <select
-              value={typeId}
-              onChange={(e) => {
-                setTypeId(e.target.value);
-                setTime("");
-              }}
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
-            >
-              <option value="">General visit (30 min)</option>
-              {data.types.map((t) => (
-                <option key={t.id} value={t.id}>
-                  {t.name} ({t.durationMinutes} min)
-                </option>
-              ))}
-            </select>
-          </div>
-        )}
+        <div>
+          <h2 className="text-base font-semibold text-gray-900">
+            Request an appointment
+          </h2>
+          <p className="mt-1 text-sm text-gray-500">
+            Choose a preferred time. The clinic will review your request and
+            confirm the appointment with you.
+          </p>
+        </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">
+          <label
+            htmlFor={typeFieldId}
+            className="block text-sm font-medium text-gray-700 mb-1.5"
+          >
+            What do you need?
+          </label>
+          <select
+            id={typeFieldId}
+            value={typeId}
+            onChange={(e) => {
+              setTypeId(e.target.value);
+              setTime("");
+            }}
+            required
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
+          >
+            <option value="" disabled>
+              Choose a visit type
+            </option>
+            {data.types.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.name} ({t.durationMinutes} min)
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label
+            htmlFor={dateFieldId}
+            className="block text-sm font-medium text-gray-700 mb-1.5"
+          >
             Pick a day
           </label>
           <input
+            id={dateFieldId}
             type="date"
             value={date}
             onChange={(e) => {
@@ -216,9 +243,11 @@ export default function PublicBookingPage() {
           />
         </div>
 
-        {date && (
-          <div>
-            <p className="text-sm font-medium text-gray-700 mb-2">Pick a time</p>
+        {date && typeId && (
+          <fieldset>
+            <legend className="text-sm font-medium text-gray-700 mb-2">
+              Pick a time
+            </legend>
             {slots.isLoading && (
               <p className="text-xs text-gray-500">Checking open times…</p>
             )}
@@ -238,38 +267,50 @@ export default function PublicBookingPage() {
                 {slots.data.map((s) => {
                   const selected = time === s.time;
                   return (
-                    <button
-                      key={s.iso}
-                      type="button"
-                      onClick={() => setTime(s.time)}
-                      className={`rounded-md border px-3 py-1.5 text-sm transition-colors ${
-                        selected
-                          ? "text-white"
-                          : "border-gray-200 text-gray-600 hover:border-gray-400"
-                      }`}
-                      style={
-                        selected
-                          ? { backgroundColor: accent, borderColor: accent }
-                          : undefined
-                      }
-                    >
-                      {s.time}
-                    </button>
+                    <label key={s.iso} className="cursor-pointer">
+                      <input
+                        type="radio"
+                        name={`${formId}-time`}
+                        value={s.time}
+                        checked={selected}
+                        onChange={() => setTime(s.time)}
+                        required
+                        className="peer sr-only"
+                      />
+                      <span
+                        className={`block rounded-md border px-3 py-1.5 text-sm transition-colors peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-teal-500 peer-focus-visible:ring-offset-2 ${
+                          selected
+                            ? "text-white"
+                            : "border-gray-200 text-gray-600 hover:border-gray-400"
+                        }`}
+                        style={
+                          selected
+                            ? { backgroundColor: accent, borderColor: accent }
+                            : undefined
+                        }
+                      >
+                        {s.time}
+                      </span>
+                    </label>
                   );
                 })}
               </div>
             )}
-          </div>
+          </fieldset>
         )}
 
         <div className="border-t border-gray-100 pt-5 space-y-4">
           <p className="text-sm font-semibold text-gray-900">About you</p>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              <label
+                htmlFor={firstNameFieldId}
+                className="block text-sm font-medium text-gray-700 mb-1.5"
+              >
                 First name
               </label>
               <input
+                id={firstNameFieldId}
                 value={firstName}
                 onChange={(e) => setFirstName(e.target.value)}
                 required
@@ -279,10 +320,14 @@ export default function PublicBookingPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              <label
+                htmlFor={lastNameFieldId}
+                className="block text-sm font-medium text-gray-700 mb-1.5"
+              >
                 Last name
               </label>
               <input
+                id={lastNameFieldId}
                 value={lastName}
                 onChange={(e) => setLastName(e.target.value)}
                 required
@@ -294,10 +339,14 @@ export default function PublicBookingPage() {
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              <label
+                htmlFor={emailFieldId}
+                className="block text-sm font-medium text-gray-700 mb-1.5"
+              >
                 Email
               </label>
               <input
+                id={emailFieldId}
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -308,10 +357,14 @@ export default function PublicBookingPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              <label
+                htmlFor={phoneFieldId}
+                className="block text-sm font-medium text-gray-700 mb-1.5"
+              >
                 Phone <span className="text-gray-400 font-normal">(optional)</span>
               </label>
               <input
+                id={phoneFieldId}
                 type="tel"
                 value={phone}
                 onChange={(e) => setPhone(e.target.value)}
@@ -324,9 +377,10 @@ export default function PublicBookingPage() {
 
           {/* Honeypot: invisible to humans, present for bots. */}
           <div className="absolute -left-[9999px] top-auto" aria-hidden="true">
-            <label>
+            <label htmlFor={websiteFieldId}>
               Website
               <input
+                id={websiteFieldId}
                 tabIndex={-1}
                 autoComplete="off"
                 value={website}
@@ -337,10 +391,14 @@ export default function PublicBookingPage() {
 
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              <label
+                htmlFor={petNameFieldId}
+                className="block text-sm font-medium text-gray-700 mb-1.5"
+              >
                 Pet's name
               </label>
               <input
+                id={petNameFieldId}
                 value={petName}
                 onChange={(e) => setPetName(e.target.value)}
                 required
@@ -349,10 +407,14 @@ export default function PublicBookingPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              <label
+                htmlFor={speciesFieldId}
+                className="block text-sm font-medium text-gray-700 mb-1.5"
+              >
                 Pet type
               </label>
               <select
+                id={speciesFieldId}
                 value={species}
                 onChange={(e) => setSpecies(e.target.value as SpeciesValue)}
                 className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
@@ -367,10 +429,14 @@ export default function PublicBookingPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+            <label
+              htmlFor={reasonFieldId}
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
               What's this visit about?
             </label>
             <textarea
+              id={reasonFieldId}
               value={reason}
               onChange={(e) => setReason(e.target.value)}
               required
@@ -391,10 +457,10 @@ export default function PublicBookingPage() {
           style={{ backgroundColor: accent }}
         >
           {book.isPending
-            ? "Booking…"
+            ? "Sending request…"
             : selectedType
-              ? `Book ${selectedType.name}`
-              : "Book appointment"}
+              ? `Request ${selectedType.name}`
+              : "Request appointment"}
         </button>
         <p className="text-center text-xs text-gray-400">
           Prefer to talk to a person?

--- a/apps/web/app/portal/[token]/appointments/page.tsx
+++ b/apps/web/app/portal/[token]/appointments/page.tsx
@@ -38,6 +38,9 @@ function formatDateTime(d: string | Date, timeZone?: string | null): string {
 }
 
 function formatStatusLabel(status: string): string {
+  // `scheduled` is the internal state for a request that clinic staff have
+  // not yet confirmed with the owner. Never present it as a firm appointment.
+  if (status === "scheduled") return "Requested — awaiting confirmation";
   // Pet-owner wording: "checked out" is clinic jargon.
   if (status === "checked_out") return "Completed";
   return status.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
@@ -102,13 +105,13 @@ export default function AppointmentsPage() {
       <section className="mb-10">
         <h2 className="text-lg font-semibold text-gray-800 mb-4 flex items-center gap-2">
           <span className="h-2 w-2 rounded-full bg-teal-500" />
-          Upcoming
+          Upcoming and requests
         </h2>
         {upcoming.length === 0 ? (
           <EmptyState
             className="py-10"
             icon={CalendarClock}
-            title="No upcoming appointments"
+            title="No upcoming appointments or requests"
             action={{
               label: "Request appointment",
               onClick: () => router.push(`/portal/${token}/book`),

--- a/apps/web/app/portal/[token]/book/page.tsx
+++ b/apps/web/app/portal/[token]/book/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useId, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { AlertCircle, PawPrint } from "lucide-react";
@@ -17,6 +17,13 @@ import { formatPortalDateInput } from "@/lib/portal/date";
 export default function BookAppointmentPage() {
   const params = useParams();
   const token = params.token as string;
+  const formId = useId();
+  const patientFieldId = `${formId}-patient`;
+  const typeFieldId = `${formId}-type`;
+  const dateFieldId = `${formId}-date`;
+  const timeFieldId = `${formId}-time`;
+  const timeHelpId = `${formId}-time-help`;
+  const reasonFieldId = `${formId}-reason`;
 
   const client = trpc.portal.getClient.useQuery({ token });
   const types = trpc.portal.getAppointmentTypes.useQuery({ token });
@@ -43,21 +50,15 @@ export default function BookAppointmentPage() {
     preferredTime,
     selectedDurationMinutes
   );
-  const hasValidAppointmentType = !typeId || Boolean(selectedType);
+  const hasValidAppointmentType = Boolean(typeId && selectedType);
   const hasValidReason = isPortalBookingReasonValid(reason);
   const showTimeBoundsError =
     preferredTime !== "" && hasValidBookingWindow && !hasValidPreferredTime;
 
-  useEffect(() => {
-    if (!appointmentTypesUnavailable || !typeId) return;
-    setTypeId("");
-    setPreferredTime("");
-  }, [appointmentTypesUnavailable, typeId]);
-
   // Suggested open times for the chosen date.
   const slots = trpc.portal.availableSlots.useQuery(
     { token, date: preferredDate, durationMinutes: selectedDurationMinutes },
-    { enabled: !!preferredDate }
+    { enabled: !!preferredDate && hasValidAppointmentType }
   );
   const slotsUnavailable = Boolean(
     preferredDate &&
@@ -86,6 +87,27 @@ export default function BookAppointmentPage() {
     );
   }
 
+  if (types.isLoading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-teal-600 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (appointmentTypesUnavailable || appointmentTypes.length === 0) {
+    return (
+      <div className="max-w-xl">
+        <EmptyState
+          className="py-12"
+          icon={AlertCircle}
+          title="Appointment requests are unavailable"
+          description="The clinic has not made any active visit types available. Please contact the clinic directly."
+        />
+      </div>
+    );
+  }
+
   const clientData = client.data;
   const today = formatPortalDateInput(new Date(), clientData.timezone);
   const pets = clientData.patients;
@@ -104,7 +126,7 @@ export default function BookAppointmentPage() {
     request.mutate({
       token,
       patientId,
-      typeId: hasValidAppointmentType && typeId ? typeId : undefined,
+      typeId,
       preferredDate,
       preferredTime,
       reason: reason.trim(),
@@ -158,10 +180,14 @@ export default function BookAppointmentPage() {
       ) : (
         <form onSubmit={submit} className="space-y-5">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+            <label
+              htmlFor={patientFieldId}
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
               Pet
             </label>
             <select
+              id={patientFieldId}
               value={patientId}
               onChange={(e) => setPatientId(e.target.value)}
               required
@@ -177,37 +203,43 @@ export default function BookAppointmentPage() {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+            <label
+              htmlFor={typeFieldId}
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
               Reason for visit
             </label>
             <select
+              id={typeFieldId}
               value={typeId}
               onChange={(e) => {
                 setTypeId(e.target.value);
                 setPreferredTime("");
               }}
+              required
               className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
             >
-              <option value="">General visit</option>
+              <option value="" disabled>
+                Select a visit type…
+              </option>
               {appointmentTypes.map((t) => (
                 <option key={t.id} value={t.id}>
                   {t.name}
                 </option>
               ))}
             </select>
-            {appointmentTypesUnavailable && (
-              <p className="mt-1.5 text-xs text-red-600">
-                Appointment types could not be verified. You can still request a general visit.
-              </p>
-            )}
           </div>
 
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              <label
+                htmlFor={dateFieldId}
+                className="block text-sm font-medium text-gray-700 mb-1.5"
+              >
                 Preferred date
               </label>
               <input
+                id={dateFieldId}
                 type="date"
                 value={preferredDate}
                 onChange={(e) => {
@@ -220,10 +252,14 @@ export default function BookAppointmentPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1.5">
+              <label
+                htmlFor={timeFieldId}
+                className="block text-sm font-medium text-gray-700 mb-1.5"
+              >
                 Preferred time
               </label>
               <input
+                id={timeFieldId}
                 type="time"
                 value={preferredTime}
                 onChange={(e) => setPreferredTime(e.target.value)}
@@ -231,12 +267,12 @@ export default function BookAppointmentPage() {
                 max={timeBounds.maxTime ?? timeBounds.minTime}
                 disabled={!hasValidBookingWindow}
                 aria-invalid={showTimeBoundsError}
-                aria-describedby="preferred-time-help"
+                aria-describedby={timeHelpId}
                 required
                 className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500"
               />
               <p
-                id="preferred-time-help"
+                id={timeHelpId}
                 className={`mt-1.5 text-xs ${
                   showTimeBoundsError ? "text-red-600" : "text-gray-500"
                 }`}
@@ -299,10 +335,14 @@ export default function BookAppointmentPage() {
             )}
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+            <label
+              htmlFor={reasonFieldId}
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
               Anything we should know?
             </label>
             <textarea
+              id={reasonFieldId}
               value={reason}
               onChange={(e) => setReason(e.target.value)}
               required

--- a/apps/web/components/dashboard/activation-checklist.tsx
+++ b/apps/web/components/dashboard/activation-checklist.tsx
@@ -223,16 +223,18 @@ export function ActivationChecklist() {
     },
     {
       key: "booking",
-      label: "Publish online booking",
-      hint: "Put one appointment type live and test the client booking path.",
-      done: bookingData.page?.published === true,
+      label: "Configure appointment requests",
+      hint: "Choose which visit types and times clients can request, then publish the page.",
+      done:
+        bookingData.page?.published === true &&
+        bookingData.page.config.bookableTypeIds.length > 0,
       href: "/settings?tab=booking",
     },
     {
       key: "texting",
-      label: "Start texting registration",
-      hint: "Choose a number and submit carrier registration. Approval can take 1–2 weeks.",
-      done: textingData.hasAnyNumber,
+      label: "Finish texting activation",
+      hint: "Submit carrier registration and wait for approval. Texting is not live until an active number is enabled.",
+      done: textingData.hasActiveNumber,
       href: "/settings?tab=messaging&setup=texting",
     },
     ...(clientPaymentData.stripeConfigured
@@ -251,7 +253,7 @@ export function ActivationChecklist() {
           {
             key: "billing",
             label: "Confirm billing is connected",
-            hint: "Stripe keeps the trial ready to convert. Cancel anytime.",
+            hint: "A saved card lets the trial convert without interrupting access. Cancel anytime.",
             done: !!subscriptionData.hasBillingAccount,
             href: "/settings?tab=billing",
           } as Milestone,
@@ -322,10 +324,11 @@ export function ActivationChecklist() {
           </span>
           <div className="min-w-0 flex-1">
             <p className="font-heading text-sm font-semibold">
-              You&apos;re all set 🎉
+              Guided setup checks complete
             </p>
             <p className="text-xs text-zinc-400">
-              {practiceName} is ready to run.
+              Keep validating real clinic workflows with your team before
+              switching systems.
             </p>
           </div>
           <button
@@ -361,7 +364,7 @@ export function ActivationChecklist() {
           </span>
           <div className="min-w-0">
             <p className="truncate font-heading text-sm font-semibold">
-              Get {practiceName} running
+              Finish {practiceName}&apos;s setup checks
             </p>
             <p className="text-xs text-zinc-400">
               {pathway.shortLabel} · {doneCount} of {total} done

--- a/apps/web/components/onboarding/journey-overlay.tsx
+++ b/apps/web/components/onboarding/journey-overlay.tsx
@@ -51,8 +51,8 @@ interface StepDef {
 
 /**
  * The effective step list. Billing ("add a card") only appears on the hosted
- * service; self-host has nothing to charge. The closing "all set" step always
- * comes last and offers the quick product tour.
+ * service; self-host has nothing to charge. The closing guided-setup step
+ * always comes last and offers the quick product tour.
  */
 function buildSteps(billingEnforced: boolean): StepDef[] {
   return [
@@ -66,7 +66,7 @@ function buildSteps(billingEnforced: boolean): StepDef[] {
     ...(billingEnforced
       ? [{ id: "billing" as const, title: "Add a card." }]
       : []),
-    { id: "allSet", title: "You're all set." },
+    { id: "allSet", title: "Guided setup complete." },
   ];
 }
 

--- a/apps/web/components/onboarding/steps/all-set.tsx
+++ b/apps/web/components/onboarding/steps/all-set.tsx
@@ -30,9 +30,10 @@ export function AllSetStep({
           <PartyPopper className="h-5 w-5" />
         </span>
         <p className="text-sm leading-6 text-slate-600">
-          Your workspace is ready. Everything here is yours, and the AI helper is
-          built in whenever you need it. Want a quick look around before you dive
-          in?
+          You finished the guided setup. Before switching clinic workflows,
+          use the launch checklist on your dashboard to validate a real visit,
+          appointment requests, payments, and communications with your team.
+          Want a quick look around first?
         </p>
       </div>
 

--- a/apps/web/components/settings/booking-tab.tsx
+++ b/apps/web/components/settings/booking-tab.tsx
@@ -48,14 +48,21 @@ export function BookingTab() {
   const utils = trpc.useUtils();
   const myPage = trpc.booking.getMyPage.useQuery();
   const types = trpc.settings.listAppointmentTypes.useQuery();
+  const [publishError, setPublishError] = useState<string | null>(null);
   const save = trpc.booking.savePage.useMutation({
     onSuccess: (saved) => {
+      setPublishError(null);
       toast.success(
-        saved.published ? "Booking page published" : "Booking page saved"
+        saved.published
+          ? "Appointment request page published"
+          : "Appointment request page saved"
       );
       utils.booking.getMyPage.invalidate();
     },
-    onError: (err) => toast.error(err.message),
+    onError: (err) => {
+      setPublishError(err.message);
+      toast.error(err.message);
+    },
   });
 
   const [slug, setSlug] = useState("");
@@ -88,15 +95,20 @@ export function BookingTab() {
   const origin =
     typeof window !== "undefined" ? window.location.origin : "";
   const pageUrl = `${origin}/book/${slug}`;
-  const embedSnippet = `<a href="${pageUrl}">Book an appointment</a>`;
+  const embedSnippet = `<a href="${pageUrl}">Request an appointment</a>`;
   const isLive = Boolean(myPage.data?.page?.published);
   const liveUrl = myPage.data?.page
     ? `${origin}/book/${myPage.data.page.slug}`
     : pageUrl;
 
   const allTypes = types.data ?? [];
+  const pageSettingsUnavailable = Boolean(myPage.error) || !myPage.data;
+  const appointmentTypesMissing =
+    !types.isLoading && !types.error && !types.data;
+  const appointmentTypesUnavailable =
+    Boolean(types.error) || appointmentTypesMissing;
   const bookableSet = useMemo(
-    () => (config.bookableTypeIds === null ? null : new Set(config.bookableTypeIds)),
+    () => new Set(config.bookableTypeIds),
     [config.bookableTypeIds]
   );
 
@@ -109,22 +121,14 @@ export function BookingTab() {
   }
 
   function toggleType(id: string) {
+    setPublishError(null);
     setConfig((c) => {
-      if (c.bookableTypeIds === null) {
-        // "All types" → uncheck one: keep every other type.
-        return {
-          ...c,
-          bookableTypeIds: allTypes.map((t) => t.id).filter((t) => t !== id),
-        };
-      }
       const set = new Set(c.bookableTypeIds);
       if (set.has(id)) set.delete(id);
       else set.add(id);
-      // Back to "all" when everything is selected again.
-      const nextIds = allTypes.filter((t) => set.has(t.id)).map((t) => t.id);
       return {
         ...c,
-        bookableTypeIds: nextIds.length === allTypes.length ? null : nextIds,
+        bookableTypeIds: allTypes.filter((t) => set.has(t.id)).map((t) => t.id),
       };
     });
   }
@@ -142,14 +146,82 @@ export function BookingTab() {
 
   function handleSave(nextPublished: boolean) {
     if (!slugValid || slugTaken) return;
+    if (nextPublished && bookableSet.size === 0) {
+      const message =
+        "Select at least one active visit type before publishing the appointment request page.";
+      setPublishError(message);
+      toast.error(message);
+      return;
+    }
+    setPublishError(null);
     setPublished(nextPublished);
     save.mutate({ slug, published: nextPublished, config });
   }
 
-  if (myPage.isLoading) {
+  if (myPage.isLoading || types.isLoading) {
     return (
       <div className="flex items-center justify-center py-16">
         <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  if (pageSettingsUnavailable || appointmentTypesUnavailable) {
+    return (
+      <div className="space-y-3">
+        {pageSettingsUnavailable ? (
+          <div
+            role="alert"
+            className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-900"
+          >
+            <p className="text-sm font-semibold">
+              Appointment request settings could not be loaded
+            </p>
+            <p className="mt-1 text-sm text-red-800">
+              Nothing can be changed until the saved settings are available.
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              disabled={myPage.isFetching}
+              onClick={() => void myPage.refetch()}
+            >
+              {myPage.isFetching ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : null}
+              Retry loading settings
+            </Button>
+          </div>
+        ) : null}
+        {appointmentTypesUnavailable ? (
+          <div
+            role="alert"
+            className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-900"
+          >
+            <p className="text-sm font-semibold">
+              Active visit types could not be loaded
+            </p>
+            <p className="mt-1 text-sm text-red-800">
+              Publishing and editing are unavailable so saved selections are
+              not accidentally erased.
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              disabled={types.isFetching}
+              onClick={() => void types.refetch()}
+            >
+              {types.isFetching ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : null}
+              Retry loading visit types
+            </Button>
+          </div>
+        ) : null}
       </div>
     );
   }
@@ -159,23 +231,28 @@ export function BookingTab() {
       <div>
         <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
           <Globe className="h-5 w-5 text-teal-600" />
-          Online booking page
+          Online appointment requests
         </h2>
         <p className="text-sm text-gray-500 mt-1">
-          A public page where clients (new and existing) book appointments
-          straight into your calendar. Share the link, print the QR code, or
+          Give new and existing clients a simple way to request a preferred
+          appointment time. Every request lands on your schedule for your team
+          to review, assign, and confirm. Share the link, print the QR code, or
           add the button to your website.
         </p>
       </div>
 
       {/* Link + publish state */}
       <div className="rounded-xl border border-gray-200 p-4 space-y-3">
-        <label className="block text-sm font-medium text-gray-700">
-          Your booking link
+        <label
+          htmlFor="booking-page-slug"
+          className="block text-sm font-medium text-gray-700"
+        >
+          Your appointment request link
         </label>
         <div className="flex items-center gap-2">
           <span className="text-sm text-gray-500 shrink-0">{origin}/book/</span>
           <Input
+            id="booking-page-slug"
             value={slug}
             onChange={(e) =>
               setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))
@@ -243,9 +320,9 @@ export function BookingTab() {
       {/* Hours */}
       <div className="rounded-xl border border-gray-200 p-4 space-y-3">
         <div>
-          <h3 className="text-sm font-semibold text-gray-900">Booking hours</h3>
+          <h3 className="text-sm font-semibold text-gray-900">Request hours</h3>
           <p className="text-xs text-gray-500 mt-0.5">
-            When clients can book online. Uses your practice timezone.
+            When clients can request times online. Uses your practice timezone.
           </p>
         </div>
         <div className="space-y-2">
@@ -298,14 +375,15 @@ export function BookingTab() {
         </div>
       </div>
 
-      {/* What can be booked */}
+      {/* What can be requested */}
       <div className="rounded-xl border border-gray-200 p-4 space-y-3">
         <div>
           <h3 className="text-sm font-semibold text-gray-900">
-            Bookable visit types
+            Requestable visit types
           </h3>
           <p className="text-xs text-gray-500 mt-0.5">
-            Uncheck anything you don't want offered online.
+            Select each active visit type clients may request online. The public
+            page stays unavailable until at least one type is selected.
           </p>
         </div>
         {allTypes.length === 0 ? (
@@ -318,7 +396,7 @@ export function BookingTab() {
               <label key={t.id} className="flex items-center gap-2 text-sm text-gray-700">
                 <input
                   type="checkbox"
-                  checked={bookableSet === null || bookableSet.has(t.id)}
+                  checked={bookableSet.has(t.id)}
                   onChange={() => toggleType(t.id)}
                   className="h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
                 />
@@ -330,15 +408,19 @@ export function BookingTab() {
         )}
       </div>
 
-      {/* Rules */}
+      {/* Request rules */}
       <div className="rounded-xl border border-gray-200 p-4 space-y-4">
-        <h3 className="text-sm font-semibold text-gray-900">Booking rules</h3>
+        <h3 className="text-sm font-semibold text-gray-900">Request rules</h3>
         <div className="grid gap-4 sm:grid-cols-2">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+            <label
+              htmlFor="booking-minimum-notice"
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
               Minimum notice
             </label>
             <select
+              id="booking-minimum-notice"
               value={config.leadTimeMinutes}
               onChange={(e) =>
                 setConfig((c) => ({
@@ -356,10 +438,14 @@ export function BookingTab() {
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1.5">
+            <label
+              htmlFor="booking-window"
+              className="block text-sm font-medium text-gray-700 mb-1.5"
+            >
               How far ahead
             </label>
             <select
+              id="booking-window"
               value={config.bookingWindowDays}
               onChange={(e) =>
                 setConfig((c) => ({
@@ -387,38 +473,31 @@ export function BookingTab() {
             className="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
           />
           <span>
-            Let new clients book
+            Let new clients request appointments
             <span className="block text-xs text-gray-500">
               New clients and their pets are added to your records automatically.
             </span>
           </span>
         </label>
-        <label className="flex items-start gap-2 text-sm text-gray-700">
-          <input
-            type="checkbox"
-            checked={config.autoConfirm}
-            onChange={(e) =>
-              setConfig((c) => ({ ...c, autoConfirm: e.target.checked }))
-            }
-            className="mt-0.5 h-4 w-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-          />
-          <span>
-            Confirm bookings automatically
-            <span className="block text-xs text-gray-500">
-              Off means bookings arrive as requests your team confirms.
-            </span>
-          </span>
-        </label>
+        <p className="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-900">
+          Requests are never confirmed automatically. Your team reviews the
+          requested time, assigns a doctor and room as needed, and confirms it
+          from the schedule.
+        </p>
       </div>
 
       {/* Look and feel */}
       <div className="rounded-xl border border-gray-200 p-4 space-y-4">
         <h3 className="text-sm font-semibold text-gray-900">Look and feel</h3>
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1.5">
+          <label
+            htmlFor="booking-welcome-message"
+            className="block text-sm font-medium text-gray-700 mb-1.5"
+          >
             Welcome message <span className="text-gray-400 font-normal">(optional)</span>
           </label>
           <textarea
+            id="booking-welcome-message"
             value={config.welcomeText}
             onChange={(e) =>
               setConfig((c) => ({ ...c, welcomeText: e.target.value }))
@@ -430,8 +509,14 @@ export function BookingTab() {
           />
         </div>
         <div className="flex items-center gap-3">
-          <label className="text-sm font-medium text-gray-700">Accent color</label>
+          <label
+            htmlFor="booking-accent-color"
+            className="text-sm font-medium text-gray-700"
+          >
+            Accent color
+          </label>
           <input
+            id="booking-accent-color"
             type="color"
             value={config.accentColor}
             onChange={(e) =>
@@ -447,7 +532,7 @@ export function BookingTab() {
         <div className="rounded-xl border border-gray-200 p-4">
           <h3 className="text-sm font-semibold text-gray-900 mb-1">QR code</h3>
           <p className="text-xs text-gray-500 mb-3">
-            Print it for your front desk. Clients scan it to book.
+            Print it for your front desk. Clients scan it to request a visit.
           </p>
           <div className="inline-block rounded-lg bg-white p-3 border border-gray-100">
             <QRCodeSVG value={liveUrl} size={144} />
@@ -456,6 +541,11 @@ export function BookingTab() {
       )}
 
       {/* Actions */}
+      {publishError ? (
+        <p role="alert" className="text-sm text-red-700">
+          {publishError}
+        </p>
+      ) : null}
       <div className="flex items-center gap-3">
         <Button
           type="button"

--- a/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
+++ b/apps/web/lib/__tests__/dashboard-onboarding-ui.test.ts
@@ -54,12 +54,15 @@ describe("dashboard onboarding UI states", () => {
     expect(activationSource).toContain(
       "done: onboardingData.hasRealData"
     );
-    expect(activationSource).toContain('label: "Publish online booking"');
+    expect(activationSource).toContain('label: "Configure appointment requests"');
     expect(activationSource).toContain(
-      "done: bookingData.page?.published === true"
+      "bookingData.page?.published === true &&"
     );
-    expect(activationSource).toContain('label: "Start texting registration"');
-    expect(activationSource).toContain("done: textingData.hasAnyNumber");
+    expect(activationSource).toContain(
+      "bookingData.page.config.bookableTypeIds.length > 0"
+    );
+    expect(activationSource).toContain('label: "Finish texting activation"');
+    expect(activationSource).toContain("done: textingData.hasActiveNumber");
     expect(activationSource).toContain('label: "Add one real client and pet"');
     expect(activationSource).toContain('href: "/clients/new"');
     expect(activationSource).toContain(

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -735,4 +735,22 @@ describe("committed Drizzle migrations", () => {
       "REVOKE ALL ON dispense_charge_queue FROM authenticated",
     );
   });
+
+  it("backfills explicit requestable types for legacy booking pages", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries?: Array<{ tag?: string }> };
+    expect(journal.entries?.map((entry) => entry.tag)).toContain(
+      "0052_booking_page_request_types",
+    );
+
+    const sql = readRepoFile(
+      "packages/db/drizzle/0052_booking_page_request_types.sql",
+    );
+    expect(sql).toContain("at.practice_id = bp.practice_id");
+    expect(sql).toContain("at.deleted_at IS NULL");
+    expect(sql).toContain("'{bookableTypeIds}'");
+    expect(sql).toContain("jsonb_array_length(legacy.active_type_ids) = 0");
+    expect(sql).toContain("THEN false");
+  });
 });

--- a/apps/web/lib/__tests__/portal-booking-ui.test.ts
+++ b/apps/web/lib/__tests__/portal-booking-ui.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from "vitest";
 
 describe("portal booking UI", () => {
   const source = readFileSync("app/portal/[token]/book/page.tsx", "utf8");
+  const appointmentsSource = readFileSync(
+    "app/portal/[token]/appointments/page.tsx",
+    "utf8"
+  );
 
   it("fails closed while portal client data is loading or invalid", () => {
     expect(source).toContain('import { EmptyState } from "@/components/common/empty-state"');
@@ -80,13 +84,16 @@ describe("portal booking UI", () => {
     expect(source).toContain("const appointmentTypesMissing =");
     expect(source).toContain("const appointmentTypesUnavailable =");
     expect(source).toContain("Boolean(types.error) || appointmentTypesMissing");
-    expect(source).toContain("Appointment types could not be verified");
-    expect(source).toContain("const hasValidAppointmentType = !typeId || Boolean(selectedType)");
-    expect(source).toContain("hasValidAppointmentType &&");
-    expect(source).toContain("if (!appointmentTypesUnavailable || !typeId) return;");
-    expect(source).toContain("setTypeId(\"\")");
+    expect(source).toContain("appointmentTypes.length === 0");
+    expect(source).toContain('title="Appointment requests are unavailable"');
     expect(source).toContain(
-      "typeId: hasValidAppointmentType && typeId ? typeId : undefined"
+      "const hasValidAppointmentType = Boolean(typeId && selectedType)"
+    );
+    expect(source).toContain(
+      "{ enabled: !!preferredDate && hasValidAppointmentType }"
+    );
+    expect(source).toContain(
+      "patientId,\n      typeId,\n      preferredDate,"
     );
     expect(source).toContain("slots.isLoading");
     expect(source).toContain("Checking open times");
@@ -108,5 +115,12 @@ describe("portal booking UI", () => {
     expect(source).toContain("maxLength={PORTAL_BOOKING_REASON_MAX_LENGTH}");
     expect(source).toContain("aria-invalid={reason.length > 0 && !hasValidReason}");
     expect(source).not.toContain("reason.trim() &&");
+  });
+
+  it("does not present an unconfirmed request as a scheduled appointment", () => {
+    expect(appointmentsSource).toContain(
+      'if (status === "scheduled") return "Requested — awaiting confirmation"'
+    );
+    expect(appointmentsSource).toContain("Upcoming and requests");
   });
 });

--- a/apps/web/lib/__tests__/portal-empty-states.test.ts
+++ b/apps/web/lib/__tests__/portal-empty-states.test.ts
@@ -89,7 +89,9 @@ describe("portal empty states", () => {
     );
     expect(appointments).not.toContain("Upcoming & Active");
     expect(appointments).toContain("Upcoming");
-    expect(appointments).toContain('title="No upcoming appointments"');
+    expect(appointments).toContain(
+      'title="No upcoming appointments or requests"'
+    );
     expect(appointments).toContain('title="No past appointments"');
     expect(appointments).toContain('label: "Request appointment"');
     expect(appointments).not.toContain("data.filter((a)");

--- a/apps/web/lib/__tests__/request-only-booking-ui.test.ts
+++ b/apps/web/lib/__tests__/request-only-booking-ui.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("request-only booking UI", () => {
+  const publicPage = readFileSync("app/book/[slug]/page.tsx", "utf8");
+  const settingsTab = readFileSync(
+    "components/settings/booking-tab.tsx",
+    "utf8"
+  );
+  const portalPage = readFileSync("app/portal/[token]/book/page.tsx", "utf8");
+  const activationChecklist = readFileSync(
+    "components/dashboard/activation-checklist.tsx",
+    "utf8"
+  );
+  const allSetStep = readFileSync(
+    "components/onboarding/steps/all-set.tsx",
+    "utf8"
+  );
+
+  it("describes every public submission as a request that the clinic confirms", () => {
+    expect(publicPage).toContain("Request an appointment");
+    expect(publicPage).toContain("Request sent!");
+    expect(publicPage).toContain("Request appointment");
+    expect(publicPage).toContain("The clinic will review your request");
+    expect(publicPage).not.toContain("You're booked!");
+    expect(publicPage).not.toContain('"Book appointment"');
+    expect(publicPage).not.toContain("`Book ${selectedType.name}`");
+  });
+
+  it("removes auto-confirm from settings and explains the staff handoff", () => {
+    expect(settingsTab).toContain("Online appointment requests");
+    expect(settingsTab).toContain("Requests are never confirmed automatically.");
+    expect(settingsTab).toContain("assigns a doctor and room as needed");
+    expect(settingsTab).not.toContain("Confirm bookings automatically");
+    expect(settingsTab).not.toContain("config.autoConfirm");
+  });
+
+  it("requires an explicitly selected requestable type on both public forms", () => {
+    expect(publicPage).toContain("typeId &&");
+    expect(publicPage).toContain("{ enabled: !!slug && !!date && !!typeId }");
+    expect(publicPage).toContain("Choose a visit type");
+    expect(publicPage).not.toContain("General visit");
+
+    expect(portalPage).toContain("hasValidAppointmentType");
+    expect(portalPage).toContain("appointmentTypes.length === 0");
+    expect(portalPage).toContain("Appointment requests are unavailable");
+    expect(portalPage).toContain("typeId,");
+    expect(portalPage).not.toContain("General visit");
+  });
+
+  it("associates public form labels and exposes time choices as radios", () => {
+    for (const field of [
+      "typeFieldId",
+      "dateFieldId",
+      "firstNameFieldId",
+      "lastNameFieldId",
+      "emailFieldId",
+      "phoneFieldId",
+      "websiteFieldId",
+      "petNameFieldId",
+      "speciesFieldId",
+      "reasonFieldId",
+    ]) {
+      expect(publicPage).toContain(`htmlFor={${field}}`);
+      expect(publicPage).toContain(`id={${field}}`);
+    }
+    expect(publicPage).toContain("<fieldset>");
+    expect(publicPage).toContain("<legend");
+    expect(publicPage).toContain('type="radio"');
+
+    for (const field of [
+      "patientFieldId",
+      "typeFieldId",
+      "dateFieldId",
+      "timeFieldId",
+      "reasonFieldId",
+    ]) {
+      expect(portalPage).toContain(`htmlFor={${field}}`);
+      expect(portalPage).toContain(`id={${field}}`);
+    }
+  });
+
+  it("associates booking settings labels with their controls", () => {
+    for (const id of [
+      "booking-page-slug",
+      "booking-minimum-notice",
+      "booking-window",
+      "booking-welcome-message",
+      "booking-accent-color",
+    ]) {
+      expect(settingsTab).toContain(`htmlFor="${id}"`);
+      expect(settingsTab).toContain(`id="${id}"`);
+    }
+  });
+
+  it("blocks misleading publication and explains how to resolve it", () => {
+    expect(settingsTab).toContain("nextPublished && bookableSet.size === 0");
+    expect(settingsTab).toContain(
+      "Select at least one active visit type before publishing"
+    );
+    expect(settingsTab).toContain('role="alert"');
+  });
+
+  it("fails closed until saved booking settings are available", () => {
+    expect(settingsTab).toContain("pageSettingsUnavailable");
+    expect(settingsTab).toContain(
+      "Appointment request settings could not be loaded"
+    );
+    expect(settingsTab).toContain(
+      "Nothing can be changed until the saved settings are available."
+    );
+    expect(settingsTab).toContain("onClick={() => void myPage.refetch()}");
+    expect(settingsTab).toContain("Retry loading settings");
+    expect(settingsTab).toContain("appointmentTypesUnavailable");
+    expect(settingsTab).toContain("Active visit types could not be loaded");
+    expect(settingsTab).toContain(
+      "Publishing and editing are unavailable so saved selections are"
+    );
+    expect(settingsTab).toContain("onClick={() => void types.refetch()}");
+    expect(settingsTab).toContain("Retry loading visit types");
+  });
+
+  it("calls guided setup complete without claiming the clinic is ready to switch", () => {
+    expect(activationChecklist).toContain("Guided setup checks complete");
+    expect(activationChecklist).toContain("Configure appointment requests");
+    expect(activationChecklist).toContain(
+      "Choose which visit types and times clients can request, then publish the page."
+    );
+    expect(activationChecklist).toContain(
+      "Keep validating real clinic workflows with your team before"
+    );
+    expect(activationChecklist).not.toContain("is ready to run");
+    expect(allSetStep).toContain("You finished the guided setup.");
+    expect(allSetStep).toContain("Before switching clinic workflows");
+    expect(allSetStep).not.toContain("Your workspace is ready");
+  });
+});

--- a/apps/web/lib/__tests__/schedule-ui.test.ts
+++ b/apps/web/lib/__tests__/schedule-ui.test.ts
@@ -284,7 +284,38 @@ describe("schedule appointment form UX", () => {
     expect(source).toContain("rescheduleDate,");
     expect(source).toContain("rescheduleTime,");
     expect(source).toContain("timeZone");
-    expect(source).toContain("Move Appointment");
+    expect(source).toContain("Save changes");
+    expect(source).toContain('label: "Confirm",');
+    expect(source).toContain("Record client confirmation");
+    expect(source).toContain(
+      "Contact the client first. This records how they agreed to the"
+    );
+    expect(source).toContain("it does not send a message.");
+    expect(source).toContain('type="radio"');
+    expect(source).toContain("confirmationContactMethod");
+    expect(source).toContain("Record confirmation");
+    expect(source).toContain("doctorRequiredForAdvance");
+    expect(source).toContain("setRescheduleDoctorId");
+    expect(source).toContain("setRescheduleRoomId");
+    expect(source).toContain(
+      "Assign a doctor before confirming or checking in this appointment"
+    );
+    expect(source).toContain('disabled: doctorRequiredForAdvance');
+    expect(source).toContain('current === "confirmed" && (');
+    expect(source).toContain(
+      "Changing the date, time, or duration returns this appointment to"
+    );
+    expect(source).toContain(
+      "Appointment moved; contact the client and confirm the new time"
+    );
+    expect(source).toContain("resourceOptionsUnavailable");
+    expect(source).toContain("Retry options");
+    expect(source).toContain("max-h-[calc(100dvh-1.5rem)]");
+    expect(source).toContain("overflow-y-auto");
+    expect(source).toContain("htmlFor={rescheduleDoctorFieldId}");
+    expect(source).toContain("id={rescheduleDoctorFieldId}");
+    expect(source).toContain("htmlFor={rescheduleRoomFieldId}");
+    expect(source).toContain("id={rescheduleRoomFieldId}");
     expect(source).toContain('label: "Reopen", status: "scheduled"');
     expect(source).not.toContain('label: "Reschedule", status: "scheduled"');
   });

--- a/apps/web/lib/booking/__tests__/page-config.test.ts
+++ b/apps/web/lib/booking/__tests__/page-config.test.ts
@@ -31,8 +31,8 @@ describe("parseBookingPageConfig", () => {
       accentColor: "teal",
     });
     expect(parsed.hours).toEqual(DEFAULT_WEEKLY_HOURS);
-    expect(parsed.bookableTypeIds).toBeNull();
-    expect(parsed.autoConfirm).toBe(true);
+    expect(parsed.bookableTypeIds).toEqual([]);
+    expect(parsed.autoConfirm).toBe(false);
     expect(parsed.leadTimeMinutes).toBe(
       DEFAULT_BOOKING_PAGE_CONFIG.leadTimeMinutes
     );
@@ -41,6 +41,17 @@ describe("parseBookingPageConfig", () => {
     );
     expect(parsed.welcomeText).toBe("Hi there");
     expect(parsed.accentColor).toBe(DEFAULT_BOOKING_PAGE_CONFIG.accentColor);
+  });
+
+  it("makes legacy auto-confirm settings inert", () => {
+    expect(parseBookingPageConfig({ autoConfirm: true }).autoConfirm).toBe(false);
+    expect(parseBookingPageConfig({ autoConfirm: false }).autoConfirm).toBe(false);
+  });
+
+  it("normalizes the legacy null requestable-type setting to fail closed", () => {
+    expect(parseBookingPageConfig({ bookableTypeIds: null }).bookableTypeIds).toEqual(
+      []
+    );
   });
 
   it("rejects hours where open is not before close", () => {

--- a/apps/web/lib/booking/page-config.ts
+++ b/apps/web/lib/booking/page-config.ts
@@ -2,9 +2,9 @@
  * Pure config + hours logic for public booking pages. No I/O.
  *
  * A booking page's `config` jsonb is never trusted raw: everything read from
- * the database goes through `parseBookingPageConfig`, which fills defaults
- * and drops invalid values instead of throwing, so a bad config can never
- * take a published page down.
+ * the database goes through `parseBookingPageConfig`, which fills safe
+ * defaults and drops invalid values instead of throwing. Requestable visit
+ * types deliberately fail closed when missing or malformed.
  */
 
 import { z } from "zod";
@@ -116,10 +116,20 @@ export const BOOKING_WINDOW_MAX_DAYS = 365;
 
 const configSchema = z.object({
   hours: weeklyHoursSchema.catch(() => DEFAULT_WEEKLY_HOURS),
-  /** null = every non-deleted appointment type is bookable. */
-  bookableTypeIds: z.array(z.string().uuid()).nullable().catch(null),
-  /** false = bookings land as "scheduled" requests the team confirms. */
-  autoConfirm: z.boolean().catch(false),
+  /** Explicitly selected active appointment types; empty fails public booking closed. */
+  bookableTypeIds: z
+    .array(z.string().uuid())
+    .nullable()
+    .catch([])
+    .transform((ids) => ids ?? []),
+  /**
+   * Legacy compatibility only. Public booking is request-only, so old saved
+   * `true` values and stale clients are normalized to false on every read/write.
+   */
+  autoConfirm: z
+    .boolean()
+    .catch(false)
+    .transform(() => false),
   allowNewClients: z.boolean().catch(true),
   leadTimeMinutes: z
     .number()
@@ -150,7 +160,7 @@ export type BookingPageConfig = z.infer<typeof configSchema>;
 
 export const DEFAULT_BOOKING_PAGE_CONFIG: BookingPageConfig = {
   hours: DEFAULT_WEEKLY_HOURS,
-  bookableTypeIds: null,
+  bookableTypeIds: [],
   autoConfirm: false,
   allowNewClients: true,
   leadTimeMinutes: BOOKING_LEAD_TIME_DEFAULT_MINUTES,

--- a/apps/web/server/__tests__/appointments-safety.test.ts
+++ b/apps/web/server/__tests__/appointments-safety.test.ts
@@ -484,6 +484,174 @@ describe("appointments target safety", () => {
     expect(updateSet).not.toHaveBeenCalled();
   });
 
+  it("blocks confirmation when the appointment type requires an unassigned doctor", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "scheduled",
+            doctorId: null,
+            typeRequiresDoctor: 1,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).updateStatus({
+        id: APPOINTMENT_ID,
+        status: "confirmed",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Assign a doctor before confirming this appointment.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("blocks direct check-in when the appointment type requires an unassigned doctor", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "scheduled",
+            doctorId: null,
+            typeRequiresDoctor: 1,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).updateStatus({
+        id: APPOINTMENT_ID,
+        status: "checked_in",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Assign a doctor before checking in this appointment.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("confirms a doctor-required appointment after a doctor is assigned", async () => {
+    const scheduledStateUpdatedAt = new Date("2026-06-30T18:00:00.000Z");
+    const { db, updateSet, insertValues } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "scheduled",
+            doctorId: DOCTOR_ID,
+            clientId: CLIENT_ID,
+            startTime: new Date(startTime),
+            updatedAt: scheduledStateUpdatedAt,
+            typeRequiresDoctor: 1,
+          },
+        ],
+        [{ id: CLIENT_ID, phone: "555-0100", email: "client@example.com" }],
+        [],
+      ],
+      updatedRows: [
+        {
+          id: APPOINTMENT_ID,
+          status: "confirmed",
+          doctorId: DOCTOR_ID,
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).updateStatus({
+        id: APPOINTMENT_ID,
+        status: "confirmed",
+        confirmationContactMethod: "phone",
+      })
+    ).resolves.toMatchObject({
+      id: APPOINTMENT_ID,
+      status: "confirmed",
+      doctorId: DOCTOR_ID,
+    });
+    expect(updateSet).toHaveBeenCalledWith({ status: "confirmed" });
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        clientId: CLIENT_ID,
+        channel: "phone",
+        direction: "outbound",
+        subject: "Appointment confirmation recorded",
+        status: "sent",
+        assignedTo: USER_ID,
+        dedupeKey: `appointment-confirmation:v1:${PRACTICE_ID}:${APPOINTMENT_ID}:${scheduledStateUpdatedAt.getTime()}`,
+      })
+    );
+  });
+
+  it("requires an explicit client contact record before confirming", async () => {
+    const { db, updateSet, insertValues } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "scheduled",
+            doctorId: DOCTOR_ID,
+            clientId: CLIENT_ID,
+            startTime: new Date(startTime),
+            updatedAt: new Date("2026-06-30T18:00:00.000Z"),
+            typeRequiresDoctor: 0,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).updateStatus({
+        id: APPOINTMENT_ID,
+        status: "confirmed",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Contact the client and record phone or email confirmation before confirming this appointment.",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("requires the selected confirmation channel to exist on the active client", async () => {
+    const { db, updateSet, insertValues } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "scheduled",
+            doctorId: DOCTOR_ID,
+            clientId: CLIENT_ID,
+            startTime: new Date(startTime),
+            updatedAt: new Date("2026-06-30T18:00:00.000Z"),
+            typeRequiresDoctor: 0,
+          },
+        ],
+        [{ id: CLIENT_ID, phone: null, email: "client@example.com" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).updateStatus({
+        id: APPOINTMENT_ID,
+        status: "confirmed",
+        confirmationContactMethod: "phone",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Add a client phone number or record email confirmation instead.",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
   it("does not cancel or reopen a clinically finalized visit", async () => {
     const { db, updateSet } = createDb({
       selectResults: [
@@ -765,6 +933,7 @@ describe("appointments target safety", () => {
       endTime: expect.any(Date),
       doctorId: null,
       roomId: null,
+      status: "scheduled",
     });
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
       PRACTICE_ID,
@@ -792,6 +961,8 @@ describe("appointments target safety", () => {
           {
             id: APPOINTMENT_ID,
             status: "scheduled",
+            startTime: new Date(startTime),
+            endTime: new Date(endTime),
             doctorId: null,
             roomId: null,
           },
@@ -810,6 +981,196 @@ describe("appointments target safety", () => {
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("assigns a practice doctor and room while reviewing a scheduled request", async () => {
+    const previousStartTime = new Date("2026-07-01T13:00:00.000Z");
+    const previousEndTime = new Date("2026-07-01T13:30:00.000Z");
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "scheduled",
+            startTime: previousStartTime,
+            endTime: previousEndTime,
+            patientId: PATIENT_ID,
+            clientId: CLIENT_ID,
+            doctorId: null,
+            roomId: null,
+            typeId: TYPE_ID,
+          },
+        ],
+        [{ id: DOCTOR_ID }],
+        [{ id: ROOM_ID }],
+        [],
+      ],
+      updatedRows: [
+        {
+          id: APPOINTMENT_ID,
+          status: "scheduled",
+          startTime: new Date(startTime),
+          endTime: new Date(endTime),
+          patientId: PATIENT_ID,
+          clientId: CLIENT_ID,
+          doctorId: DOCTOR_ID,
+          roomId: ROOM_ID,
+          typeId: TYPE_ID,
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).reschedule({
+        id: APPOINTMENT_ID,
+        doctorId: DOCTOR_ID,
+        roomId: ROOM_ID,
+        startTime,
+        endTime,
+      })
+    ).resolves.toMatchObject({
+      id: APPOINTMENT_ID,
+      doctorId: DOCTOR_ID,
+      roomId: ROOM_ID,
+    });
+    expect(updateSet).toHaveBeenCalledWith({
+      startTime: expect.any(Date),
+      endTime: expect.any(Date),
+      doctorId: DOCTOR_ID,
+      roomId: ROOM_ID,
+      status: "scheduled",
+    });
+  });
+
+  it("does not unassign the doctor from a confirmed doctor-required appointment", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "confirmed",
+            startTime: new Date(startTime),
+            endTime: new Date(endTime),
+            doctorId: DOCTOR_ID,
+            roomId: ROOM_ID,
+            typeId: TYPE_ID,
+            typeRequiresDoctor: 1,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).reschedule({
+        id: APPOINTMENT_ID,
+        doctorId: null,
+        startTime,
+        endTime,
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Assign a doctor before saving a confirmed appointment.",
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("returns a moved confirmed appointment to requested status", async () => {
+    const previousStartTime = new Date("2026-07-01T13:00:00.000Z");
+    const previousEndTime = new Date("2026-07-01T13:30:00.000Z");
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "confirmed",
+            startTime: previousStartTime,
+            endTime: previousEndTime,
+            patientId: PATIENT_ID,
+            clientId: CLIENT_ID,
+            doctorId: DOCTOR_ID,
+            roomId: ROOM_ID,
+            typeId: TYPE_ID,
+            typeRequiresDoctor: 1,
+          },
+        ],
+        [],
+      ],
+      updatedRows: [
+        {
+          id: APPOINTMENT_ID,
+          status: "scheduled",
+          startTime: new Date(startTime),
+          endTime: new Date(endTime),
+          patientId: PATIENT_ID,
+          clientId: CLIENT_ID,
+          doctorId: DOCTOR_ID,
+          roomId: ROOM_ID,
+          typeId: TYPE_ID,
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).reschedule({ id: APPOINTMENT_ID, startTime, endTime })
+    ).resolves.toMatchObject({
+      id: APPOINTMENT_ID,
+      status: "scheduled",
+      confirmationRequired: true,
+    });
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "scheduled" })
+    );
+  });
+
+  it("keeps confirmation for a resource-only edit", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "confirmed",
+            startTime: new Date(startTime),
+            endTime: new Date(endTime),
+            patientId: PATIENT_ID,
+            clientId: CLIENT_ID,
+            doctorId: DOCTOR_ID,
+            roomId: null,
+            typeId: TYPE_ID,
+            typeRequiresDoctor: 1,
+          },
+        ],
+        [{ id: ROOM_ID }],
+        [],
+      ],
+      updatedRows: [
+        {
+          id: APPOINTMENT_ID,
+          status: "confirmed",
+          startTime: new Date(startTime),
+          endTime: new Date(endTime),
+          patientId: PATIENT_ID,
+          clientId: CLIENT_ID,
+          doctorId: DOCTOR_ID,
+          roomId: ROOM_ID,
+          typeId: TYPE_ID,
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).reschedule({
+        id: APPOINTMENT_ID,
+        roomId: ROOM_ID,
+        startTime,
+        endTime,
+      })
+    ).resolves.toMatchObject({
+      status: "confirmed",
+      confirmationRequired: false,
+    });
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "confirmed", roomId: ROOM_ID })
+    );
   });
 
   it.each(["checked_in", "in_exam", "checked_out", "no_show", "cancelled"] as const)(
@@ -843,6 +1204,8 @@ describe("appointments target safety", () => {
           {
             id: APPOINTMENT_ID,
             status: "scheduled",
+            startTime: new Date(startTime),
+            endTime: new Date(endTime),
             doctorId: null,
             roomId: null,
           },
@@ -866,6 +1229,7 @@ describe("appointments target safety", () => {
       endTime: expect.any(Date),
       doctorId: null,
       roomId: null,
+      status: "scheduled",
     });
   });
 

--- a/apps/web/server/__tests__/booking-router.test.ts
+++ b/apps/web/server/__tests__/booking-router.test.ts
@@ -73,6 +73,7 @@ function pageRow(config?: Record<string, unknown>) {
       config: {
         hours: ALL_DAYS_OPEN,
         leadTimeMinutes: 0,
+        bookableTypeIds: [TYPE_A],
         ...config,
       },
     },
@@ -110,12 +111,17 @@ function createDb(opts?: {
   const selectResults = [...(opts?.selectResults ?? [])];
   const insertResults = [...(opts?.insertResults ?? [])];
   const insertedValues: unknown[] = [];
+  const operations: string[] = [];
 
   const select = vi.fn(() => {
     const result = selectResults.shift() ?? [];
     const afterWhere = {
       limit: vi.fn(async () => result),
       orderBy: vi.fn(async () => result),
+      for: vi.fn(async () => {
+        operations.push("type-lock");
+        return result;
+      }),
       then: (
         resolve: (value: unknown[]) => unknown,
         reject?: (error: unknown) => unknown
@@ -133,6 +139,7 @@ function createDb(opts?: {
 
   const insert = vi.fn(() => ({
     values: vi.fn((vals: unknown) => {
+      operations.push("insert");
       insertedValues.push(vals);
       const result = insertResults.shift() ?? [];
       return {
@@ -154,7 +161,10 @@ function createDb(opts?: {
   });
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
-  const update = vi.fn(() => ({ set: updateSet }));
+  const update = vi.fn(() => {
+    operations.push("update");
+    return { set: updateSet };
+  });
 
   const db: Record<string, unknown> = {
     transaction: async (fn: (tx: unknown) => unknown) => fn(db),
@@ -171,6 +181,7 @@ function createDb(opts?: {
     insertedValues,
     updateSet,
     execute: db.execute as ReturnType<typeof vi.fn>,
+    operations,
   };
 }
 
@@ -210,6 +221,22 @@ describe("public booking page", () => {
     expect(result.practice.name).toBe("Test Clinic");
     expect(result.types).toEqual([types[0]]);
   });
+
+  it("hides a published page with no configured active requestable type", async () => {
+    const emptyConfig = createDb({
+      selectResults: [[pageRow({ bookableTypeIds: [] })]],
+    });
+    await expect(
+      publicCaller(emptyConfig.db).getPage({ slug: "test-clinic" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    const staleConfig = createDb({
+      selectResults: [[pageRow({ bookableTypeIds: [TYPE_A] })], []],
+    });
+    await expect(
+      publicCaller(staleConfig.db).getPage({ slug: "test-clinic" })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
 });
 
 describe("public availability", () => {
@@ -222,6 +249,7 @@ describe("public availability", () => {
     const result = await publicCaller(db).availableSlots({
       slug: "test-clinic",
       date: "2026-07-20",
+      typeId: TYPE_A,
     });
     expect(result).toEqual([]);
     // Page lookup only; the busy-appointments query is never made.
@@ -238,13 +266,37 @@ describe("public availability", () => {
       },
     ];
     const { db } = createDb({
-      selectResults: [[pageRow()], busy],
+      selectResults: [
+        [pageRow()],
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+        busy,
+      ],
     });
     const result = await publicCaller(db).availableSlots({
       slug: "test-clinic",
       date: "2026-07-20",
+      typeId: TYPE_A,
     });
     expect(result).toEqual([{ time: "17:30", iso: "2026-07-20T17:30:00.000Z" }]);
+  });
+
+  it("rejects a stale or unrequestable type before reading appointments", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-19T12:00:00Z"));
+    const { db, select } = createDb({
+      selectResults: [
+        [pageRow({ bookableTypeIds: [TYPE_A] })],
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+      ],
+    });
+    await expect(
+      publicCaller(db).availableSlots({
+        slug: "test-clinic",
+        date: "2026-07-20",
+        typeId: TYPE_B,
+      })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(select).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -252,6 +304,7 @@ describe("public booking", () => {
   function bookInput(overrides?: Record<string, unknown>) {
     return {
       slug: "test-clinic",
+      typeId: TYPE_A,
       date: "2026-07-20",
       time: "09:00",
       contact: {
@@ -286,10 +339,16 @@ describe("public booking", () => {
       status: "scheduled",
       patientId: PATIENT_ID,
       clientId: CLIENT_ID,
-      typeId: null,
+      typeId: TYPE_A,
     };
     const { db, insertedValues, execute } = createDb({
-      selectResults: [[pageRow()], [], [], []],
+      selectResults: [
+        [pageRow()],
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+        [],
+        [],
+        [],
+      ],
       insertResults: [
         [{ id: CLIENT_ID }],
         [{ id: PATIENT_ID, name: "Milo" }],
@@ -327,14 +386,16 @@ describe("public booking", () => {
       practiceId: PRACTICE_ID,
       clientId: CLIENT_ID,
       patientId: PATIENT_ID,
+      typeId: TYPE_A,
       status: "scheduled",
     });
-    expect(apptValues!.notes).toContain("[Online booking]");
+    expect(apptValues!.notes).toContain("[Online request]");
     expect(commValues).toMatchObject({
       practiceId: PRACTICE_ID,
       clientId: CLIENT_ID,
       channel: "portal",
       direction: "inbound",
+      subject: "New appointment request for Milo",
       status: "pending",
     });
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
@@ -349,12 +410,13 @@ describe("public booking", () => {
     );
   });
 
-  it("books as confirmed when the page auto-confirms", async () => {
+  it("keeps legacy auto-confirm pages request-only", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-19T12:00:00Z"));
     const { db, insertedValues } = createDb({
       selectResults: [
         [pageRow({ autoConfirm: true })],
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
         [],
         [{ id: CLIENT_ID }],
         [{ id: PATIENT_ID, name: "Milo" }],
@@ -362,16 +424,21 @@ describe("public booking", () => {
       insertResults: [[{ id: APPOINTMENT_ID, startTime: new Date(), endTime: new Date() }], []],
     });
     const result = await publicCaller(db).book(bookInput());
-    expect(result.requiresConfirmation).toBe(false);
+    expect(result.requiresConfirmation).toBe(true);
+    expect(result.message).toContain("request has been sent");
     const apptValues = insertedValues[0] as Record<string, unknown>;
-    expect(apptValues.status).toBe("confirmed");
+    expect(apptValues.status).toBe("scheduled");
   });
 
   it("rejects times that clash with an existing appointment", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-19T12:00:00Z"));
     const { db, insert } = createDb({
-      selectResults: [[pageRow()], [{ id: APPOINTMENT_ID }]],
+      selectResults: [
+        [pageRow()],
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+        [{ id: APPOINTMENT_ID }],
+      ],
     });
     await expect(publicCaller(db).book(bookInput())).rejects.toMatchObject({
       code: "CONFLICT",
@@ -383,7 +450,12 @@ describe("public booking", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-19T12:00:00Z"));
     const { db, insert } = createDb({
-      selectResults: [[pageRow({ allowNewClients: false })], [], []],
+      selectResults: [
+        [pageRow({ allowNewClients: false })],
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+        [],
+        [],
+      ],
     });
     await expect(publicCaller(db).book(bookInput())).rejects.toMatchObject({
       code: "FORBIDDEN",
@@ -414,7 +486,10 @@ describe("public booking", () => {
     vi.setSystemTime(new Date("2026-07-19T12:00:00Z"));
     const closedMonday = [null, null, ...ALL_DAYS_OPEN.slice(2)];
     const { db } = createDb({
-      selectResults: [[pageRow({ hours: closedMonday })]],
+      selectResults: [
+        [pageRow({ hours: closedMonday })],
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+      ],
     });
     await expect(publicCaller(db).book(bookInput())).rejects.toMatchObject({
       code: "BAD_REQUEST",
@@ -425,7 +500,10 @@ describe("public booking", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-20T08:30:00Z"));
     const { db } = createDb({
-      selectResults: [[pageRow({ leadTimeMinutes: 120 })]],
+      selectResults: [
+        [pageRow({ leadTimeMinutes: 120 })],
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+      ],
     });
     await expect(publicCaller(db).book(bookInput())).rejects.toMatchObject({
       code: "BAD_REQUEST",
@@ -502,20 +580,70 @@ describe("booking page admin", () => {
   });
 
   it("creates the page on first save", async () => {
-    const { db, insertedValues } = createDb({
-      selectResults: [[]],
+    const { db, insertedValues, operations } = createDb({
+      selectResults: [
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+        [],
+      ],
       insertResults: [[{ slug: "test-clinic", published: true }]],
     });
     const result = await adminCaller(db).savePage({
       slug: "test-clinic",
       published: true,
-      config: {},
+      config: { autoConfirm: true, bookableTypeIds: [TYPE_A] },
     } as never);
     expect(result).toEqual({ slug: "test-clinic", published: true });
     expect(insertedValues[0]).toMatchObject({
       practiceId: PRACTICE_ID,
       slug: "test-clinic",
       published: true,
+      config: expect.objectContaining({ autoConfirm: false }),
+    });
+    expect(operations.indexOf("type-lock")).toBeGreaterThanOrEqual(0);
+    expect(operations.indexOf("type-lock")).toBeLessThan(
+      operations.indexOf("insert")
+    );
+  });
+
+  it("rejects publication unless a selected type is active in this practice", async () => {
+    const noSelection = createDb();
+    await expect(
+      adminCaller(noSelection.db).savePage({
+        slug: "test-clinic",
+        published: true,
+        config: {},
+      } as never)
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Select at least one active visit type before publishing the appointment request page.",
+    });
+
+    const staleSelection = createDb({ selectResults: [[]] });
+    await expect(
+      adminCaller(staleSelection.db).savePage({
+        slug: "test-clinic",
+        published: true,
+        config: { bookableTypeIds: [TYPE_A] },
+      } as never)
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+  });
+
+  it("drops stale selected type IDs when saving a draft", async () => {
+    const { db, insertedValues } = createDb({
+      selectResults: [
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+        [],
+      ],
+      insertResults: [[{ slug: "test-clinic", published: false }]],
+    });
+    await adminCaller(db).savePage({
+      slug: "test-clinic",
+      published: false,
+      config: { bookableTypeIds: [TYPE_A, TYPE_B] },
+    } as never);
+    expect(insertedValues[0]).toMatchObject({
+      config: expect.objectContaining({ bookableTypeIds: [TYPE_A] }),
     });
   });
 
@@ -532,7 +660,11 @@ describe("booking page admin", () => {
     expect(result).toEqual({ slug: "new-slug", published: false });
     expect(insertedValues).toHaveLength(0);
     expect(updateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ slug: "new-slug", published: false })
+      expect.objectContaining({
+        slug: "new-slug",
+        published: false,
+        config: expect.objectContaining({ autoConfirm: false }),
+      })
     );
   });
 
@@ -541,7 +673,10 @@ describe("booking page admin", () => {
       code: "23505",
     });
     const { db } = createDb({
-      selectResults: [[]],
+      selectResults: [
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+        [],
+      ],
       insertError: duplicate,
     });
 
@@ -549,7 +684,7 @@ describe("booking page admin", () => {
       adminCaller(db).savePage({
         slug: "race-winner",
         published: true,
-        config: {},
+        config: { bookableTypeIds: [TYPE_A] },
       } as never)
     ).rejects.toMatchObject({
       code: "CONFLICT",
@@ -562,7 +697,10 @@ describe("booking page admin", () => {
       code: "23505",
     });
     const { db } = createDb({
-      selectResults: [[{ id: "existing-page" }]],
+      selectResults: [
+        [{ id: TYPE_A, name: "Wellness Exam", durationMinutes: 30 }],
+        [{ id: "existing-page" }],
+      ],
       updateError: duplicate,
     });
 
@@ -570,7 +708,7 @@ describe("booking page admin", () => {
       adminCaller(db).savePage({
         slug: "race-winner",
         published: true,
-        config: {},
+        config: { bookableTypeIds: [TYPE_A] },
       } as never)
     ).rejects.toMatchObject({
       code: "CONFLICT",

--- a/apps/web/server/__tests__/notifications-safety.test.ts
+++ b/apps/web/server/__tests__/notifications-safety.test.ts
@@ -196,6 +196,38 @@ describe("notification target safety", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
+  it("rejects manual reminders for an unconfirmed appointment request", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [
+          {
+            id: APPOINTMENT_ID,
+            status: "scheduled",
+            startTime: new Date("2026-07-01T14:00:00Z"),
+            patientName: "Miso",
+            clientId: CLIENT_ID,
+            clientFirstName: "Ada",
+            clientLastName: "Lovelace",
+            clientEmail: "ada@example.com",
+            preferredContactMethod: "email",
+            smsConsent: false,
+            practiceName: "Neighborhood Veterinary",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Confirm the appointment before sending a reminder.",
+    });
+    expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
+    expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("omits upcoming reminders filtered out by inactive recipient joins", async () => {
     const { db } = createDb({ selectResults: [[]] });
 
@@ -213,6 +245,7 @@ describe("notification target safety", () => {
         [
           {
             id: APPOINTMENT_ID,
+            status: "confirmed",
             startTime: new Date("2026-07-01T04:30:00Z"),
             patientName: "Miso",
             clientId: CLIENT_ID,
@@ -266,6 +299,7 @@ describe("notification target safety", () => {
         [
           {
             id: APPOINTMENT_ID,
+            status: "confirmed",
             startTime: new Date("2026-07-03T19:00:00Z"),
             patientName: "Miso",
             clientId: CLIENT_ID,
@@ -303,6 +337,7 @@ describe("notification target safety", () => {
         [
           {
             id: APPOINTMENT_ID,
+            status: "confirmed",
             startTime: new Date("2026-07-03T19:00:00Z"),
             patientName: "Miso",
             clientId: CLIENT_ID,
@@ -342,6 +377,7 @@ describe("notification target safety", () => {
         [
           {
             id: APPOINTMENT_ID,
+            status: "confirmed",
             startTime: new Date("2026-07-01T14:00:00Z"),
             patientName: "Miso",
             clientId: CLIENT_ID,
@@ -382,6 +418,7 @@ describe("notification target safety", () => {
         [
           {
             id: APPOINTMENT_ID,
+            status: "confirmed",
             startTime: new Date("2026-07-01T14:00:00Z"),
             patientName: "Miso",
             clientId: CLIENT_ID,
@@ -417,6 +454,7 @@ describe("notification target safety", () => {
         [
           {
             id: APPOINTMENT_ID,
+            status: "confirmed",
             startTime: new Date("2026-07-01T14:00:00Z"),
             patientName: "Miso",
             clientId: CLIENT_ID,
@@ -1420,6 +1458,13 @@ describe("notification query scoping", () => {
       "appointments.doctorId",
       "ctx.practiceId"
     );
+    expect(source).not.toContain(
+      'inArray(appointments.status, ["scheduled", "confirmed"])'
+    );
+    expect(source).toContain('if (appt.status !== "confirmed")');
+    expect(
+      source.match(/eq\(appointments\.status, "confirmed"\)/g)?.length
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it("keeps active reminder SMS sender lookup tenant scoped and active", () => {

--- a/apps/web/server/__tests__/portal-booking-inputs.test.ts
+++ b/apps/web/server/__tests__/portal-booking-inputs.test.ts
@@ -45,6 +45,7 @@ const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const CLIENT_ID = "00000000-0000-0000-0000-0000000000bb";
 const PATIENT_ID = "00000000-0000-0000-0000-000000000001";
 const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000002";
+const TYPE_ID = "00000000-0000-0000-0000-000000000003";
 const ACTIVE_PRACTICE = [{ id: PRACTICE_ID }];
 
 function callerWithDb(db: Record<string, unknown>, ip?: string) {
@@ -56,10 +57,15 @@ function createDb(opts?: {
   insertedRows?: unknown[];
 }) {
   const selectResults = [...(opts?.selectResults ?? [])];
+  const operations: string[] = [];
   const select = vi.fn(() => {
     const result = selectResults.shift() ?? [];
     const afterWhere = {
       limit: vi.fn(async () => result),
+      for: vi.fn(async () => {
+        operations.push("type-lock");
+        return result;
+      }),
       then: (
         resolve: (value: unknown[]) => unknown,
         reject?: (error: unknown) => unknown
@@ -73,18 +79,28 @@ function createDb(opts?: {
     };
     return builder;
   });
-  const insertValues = vi.fn(() => ({
-    returning: vi.fn(async () => opts?.insertedRows ?? []),
-  }));
+  const insertValues = vi.fn(() => {
+    operations.push("insert");
+    return {
+      returning: vi.fn(async () => opts?.insertedRows ?? []),
+    };
+  });
   const insert = vi.fn(() => ({ values: insertValues }));
+  const execute = vi.fn(async (statement: unknown) => {
+    operations.push(
+      JSON.stringify(statement).includes("pg_advisory_xact_lock")
+        ? "booking-lock"
+        : "execute"
+    );
+  });
   const db: Record<string, unknown> = {
     transaction: vi.fn(async (fn: (tx: unknown) => unknown) => fn(db)),
-    execute: vi.fn(async () => undefined),
+    execute,
     select,
     insert,
     update: vi.fn(),
   };
-  return { db, select, insert, insertValues };
+  return { db, select, insert, insertValues, execute, operations };
 }
 
 function sqlIncludesColumnName(
@@ -163,6 +179,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: oversizedToken,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "09:00",
         reason: "Wellness visit",
@@ -328,6 +345,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-02-30",
         preferredTime: "09:00",
         reason: "Wellness visit",
@@ -338,6 +356,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "25:00",
         reason: "Wellness visit",
@@ -355,6 +374,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "09:00",
         reason: "   ",
@@ -365,6 +385,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "09:00",
         reason: "A".repeat(PORTAL_BOOKING_REASON_MAX_LENGTH + 1),
@@ -387,6 +408,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "09:00",
         reason: "Wellness visit",
@@ -418,6 +440,7 @@ describe("portal booking input validation", () => {
         callerWithDb(db).requestAppointment({
           token: TOKEN,
           patientId: PATIENT_ID,
+          typeId: TYPE_ID,
           preferredDate: "2026-07-01",
           preferredTime: "09:00",
           reason: "Wellness visit",
@@ -462,6 +485,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "09:00",
         reason: "Wellness visit",
@@ -501,6 +525,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db, IP).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "09:00",
         reason: "Wellness visit",
@@ -576,6 +601,7 @@ describe("portal booking input validation", () => {
         ACTIVE_PRACTICE,
         [{ timezone: "America/Los_Angeles" }],
         [{ id: PATIENT_ID, name: "Juniper" }],
+        [{ id: TYPE_ID, durationMinutes: 30 }],
         [{ id: APPOINTMENT_ID }],
       ],
     });
@@ -584,6 +610,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "09:00",
         reason: "Wellness visit",
@@ -613,6 +640,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "09:00",
         reason: "Wellness visit",
@@ -641,6 +669,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "09:00",
         reason: "Wellness visit",
@@ -670,6 +699,7 @@ describe("portal booking input validation", () => {
         ACTIVE_PRACTICE,
         [{ timezone: "America/Los_Angeles" }],
         [{ id: PATIENT_ID, name: "Juniper" }],
+        [{ id: TYPE_ID, durationMinutes: 30 }],
       ],
     });
 
@@ -677,6 +707,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "07:30",
         reason: "Wellness visit",
@@ -696,13 +727,14 @@ describe("portal booking input validation", () => {
   it("stores portal appointment requests in the practice timezone", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-01T14:00:00.000Z"));
-    const { db, insertValues } = createDb({
+    const { db, insertValues, execute, operations } = createDb({
       selectResults: [
         [{ id: CLIENT_ID, practiceId: PRACTICE_ID }],
         ACTIVE_PRACTICE,
         ACTIVE_PRACTICE,
         [{ timezone: "America/Los_Angeles" }],
         [{ id: PATIENT_ID, name: "Juniper" }],
+        [{ id: TYPE_ID, durationMinutes: 30 }],
         [],
       ],
       insertedRows: [
@@ -719,6 +751,7 @@ describe("portal booking input validation", () => {
       callerWithDb(db).requestAppointment({
         token: TOKEN,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         preferredDate: "2026-07-01",
         preferredTime: "09:00",
         reason: "Wellness visit",
@@ -734,9 +767,20 @@ describe("portal booking input validation", () => {
         practiceId: PRACTICE_ID,
         clientId: CLIENT_ID,
         patientId: PATIENT_ID,
+        typeId: TYPE_ID,
         startTime: new Date("2026-07-01T16:00:00.000Z"),
         endTime: new Date("2026-07-01T16:30:00.000Z"),
       })
+    );
+    expect(execute).toHaveBeenCalled();
+    expect(JSON.stringify(execute.mock.calls.at(-1)?.[0])).toContain(
+      "pg_advisory_xact_lock"
+    );
+    expect(operations.indexOf("booking-lock")).toBeLessThan(
+      operations.indexOf("type-lock")
+    );
+    expect(operations.indexOf("type-lock")).toBeLessThan(
+      operations.indexOf("insert")
     );
     expect(insertValues).toHaveBeenNthCalledWith(
       2,
@@ -783,5 +827,35 @@ describe("portal booking input validation", () => {
         source: "portal",
       })
     );
+  });
+
+  it("rejects stale or cross-practice appointment types before creating a request", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T14:00:00.000Z"));
+    const { db, insert } = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID, practiceId: PRACTICE_ID }],
+        ACTIVE_PRACTICE,
+        ACTIVE_PRACTICE,
+        [{ timezone: "America/Los_Angeles" }],
+        [{ id: PATIENT_ID, name: "Juniper" }],
+        [],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).requestAppointment({
+        token: TOKEN,
+        patientId: PATIENT_ID,
+        typeId: TYPE_ID,
+        preferredDate: "2026-07-01",
+        preferredTime: "09:00",
+        reason: "Wellness visit",
+      })
+    ).rejects.toMatchObject({
+      code: "NOT_FOUND",
+      message: "Appointment type not found",
+    });
+    expect(insert).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -59,13 +59,16 @@ function createDb(opts?: {
   const selectResults = [...(opts?.selectResults ?? [])];
   const select = vi.fn(() => ({
     from: vi.fn(() => ({
-      where: vi.fn(() => ({
-        limit: vi.fn(async () =>
+      where: vi.fn(() => {
+        const result =
           selectResults.length > 0
             ? selectResults.shift()
-            : (opts?.selectRows ?? [])
-        ),
-      })),
+            : (opts?.selectRows ?? []);
+        return {
+          limit: vi.fn(async () => result),
+          for: vi.fn(async () => result),
+        };
+      }),
     })),
   }));
   const updateReturning = vi.fn(async () => opts?.updatedRows ?? []);
@@ -604,6 +607,26 @@ describe("settings admin stale target safety", () => {
     expect(updateSet).toHaveBeenCalledWith({ deletedAt: expect.any(Date) });
   });
 
+  it("rejects appointment type deletes while a published request page offers the type", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [{ id: TYPE_ID }],
+        [],
+        [],
+        [{ config: { bookableTypeIds: [TYPE_ID] } }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).deleteAppointmentType({ id: TYPE_ID })
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("appointment request page"),
+    });
+
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
   it("rejects stale room deletes", async () => {
     const { db, updateSet } = createDb({ selectResults: [[]] });
 
@@ -722,6 +745,10 @@ describe("settings scheduling metadata delete safety", () => {
     );
     expect(appointmentTypeDeleteBlock).toContain(
       'eq(appointmentWaitlist.status, "waiting")'
+    );
+    expect(appointmentTypeDeleteBlock).toContain('.for("update")');
+    expect(appointmentTypeDeleteBlock).toContain(
+      "parseBookingPageConfig(publishedPage.config)"
     );
 
     expect(roomDeleteBlock).toContain("eq(appointments.roomId, input.id)");

--- a/apps/web/server/routers/appointments.ts
+++ b/apps/web/server/routers/appointments.ts
@@ -13,6 +13,7 @@ import {
   rooms,
   recurringSeries,
   visitCloseouts,
+  communications,
 } from "@openpims/db";
 import {
   detectConflicts,
@@ -67,6 +68,7 @@ const appointmentNotesInput = z
   .optional()
   .transform((value) => value || undefined);
 const appointmentStatusInput = z.enum(appointmentStatusValues);
+const confirmationContactMethodInput = z.enum(["phone", "email"]);
 const appointmentRangeInput = z.string().refine(
   (value) =>
     isValidClinicalDateInput(value) ||
@@ -214,6 +216,14 @@ function activePracticePredicate(practiceId: string) {
     where ${practices.id} = ${practiceId}
       and ${practices.deletedAt} is null
   )`;
+}
+
+function appointmentConfirmationDedupeKey(input: {
+  practiceId: string;
+  appointmentId: string;
+  scheduledStateUpdatedAt: Date;
+}): string {
+  return `appointment-confirmation:v1:${input.practiceId}:${input.appointmentId}:${input.scheduledStateUpdatedAt.getTime()}`;
 }
 
 async function assertActivePractice(ctx: AppointmentsContext) {
@@ -487,13 +497,17 @@ export const appointmentsRouter = createRouter({
           patientId: appointments.patientId,
           clientFirstName: clients.firstName,
           clientLastName: clients.lastName,
+          clientEmail: clients.email,
+          clientPhone: clients.phone,
           clientId: appointments.clientId,
           doctorName: users.name,
           doctorId: appointments.doctorId,
           typeName: appointmentTypes.name,
           typeColor: appointmentTypes.color,
           typeDuration: appointmentTypes.durationMinutes,
+          typeRequiresDoctor: appointmentTypes.requiresDoctor,
           roomName: rooms.name,
+          roomId: appointments.roomId,
         })
         .from(appointments)
         .leftJoin(
@@ -744,13 +758,30 @@ export const appointmentsRouter = createRouter({
       z.object({
         id: z.string().uuid(),
         status: appointmentStatusInput,
+        confirmationContactMethod: confirmationContactMethodInput.optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       const { current, appt } = await ctx.db.transaction(async (tx) => {
         const [current] = await tx
-          .select({ id: appointments.id, status: appointments.status })
+          .select({
+            id: appointments.id,
+            status: appointments.status,
+            doctorId: appointments.doctorId,
+            clientId: appointments.clientId,
+            startTime: appointments.startTime,
+            updatedAt: appointments.updatedAt,
+            typeRequiresDoctor: appointmentTypes.requiresDoctor,
+          })
           .from(appointments)
+          .leftJoin(
+            appointmentTypes,
+            and(
+              eq(appointments.typeId, appointmentTypes.id),
+              eq(appointmentTypes.practiceId, ctx.practiceId),
+              isNull(appointmentTypes.deletedAt)
+            )
+          )
           .where(
             and(
               eq(appointments.id, input.id),
@@ -779,6 +810,89 @@ export const appointmentsRouter = createRouter({
             message: `Cannot change appointment status from ${current.status} to ${input.status}.`,
           });
         }
+        if (
+          (input.status === "confirmed" || input.status === "checked_in") &&
+          current.typeRequiresDoctor === 1 &&
+          !current.doctorId
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              input.status === "confirmed"
+                ? "Assign a doctor before confirming this appointment."
+                : "Assign a doctor before checking in this appointment.",
+          });
+        }
+        const isNewConfirmation =
+          current.status !== "confirmed" && input.status === "confirmed";
+        let confirmationRecord:
+          | {
+              clientId: string;
+              channel: "phone" | "email";
+              content: string;
+              dedupeKey: string;
+            }
+          | undefined;
+        if (isNewConfirmation) {
+          if (!input.confirmationContactMethod) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message:
+                "Contact the client and record phone or email confirmation before confirming this appointment.",
+            });
+          }
+          if (!current.clientId) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message: "Assign an active client before confirming this appointment.",
+            });
+          }
+          const [client] = await tx
+            .select({
+              id: clients.id,
+              email: clients.email,
+              phone: clients.phone,
+            })
+            .from(clients)
+            .where(
+              and(
+                eq(clients.id, current.clientId),
+                eq(clients.practiceId, ctx.practiceId),
+                activePracticePredicate(ctx.practiceId),
+                isNull(clients.deletedAt)
+              )
+            )
+            .limit(1);
+          if (!client) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Client not found",
+            });
+          }
+          const contactAddress =
+            input.confirmationContactMethod === "phone"
+              ? client.phone?.trim()
+              : client.email?.trim();
+          if (!contactAddress) {
+            throw new TRPCError({
+              code: "PRECONDITION_FAILED",
+              message:
+                input.confirmationContactMethod === "phone"
+                  ? "Add a client phone number or record email confirmation instead."
+                  : "Add a client email address or record phone confirmation instead.",
+            });
+          }
+          confirmationRecord = {
+            clientId: client.id,
+            channel: input.confirmationContactMethod,
+            content: `Staff recorded that the client agreed by ${input.confirmationContactMethod} to the appointment scheduled for ${current.startTime.toISOString()}.`,
+            dedupeKey: appointmentConfirmationDedupeKey({
+              practiceId: ctx.practiceId,
+              appointmentId: current.id,
+              scheduledStateUpdatedAt: current.updatedAt,
+            }),
+          };
+        }
 
         const [closeout] = await tx
           .select({ id: visitCloseouts.id, status: visitCloseouts.status })
@@ -799,6 +913,20 @@ export const appointmentsRouter = createRouter({
             code: "PRECONDITION_FAILED",
             message:
               "Clinical handoff is finalized. Complete the visit through closeout instead of changing its status.",
+          });
+        }
+
+        if (confirmationRecord) {
+          await tx.insert(communications).values({
+            practiceId: ctx.practiceId,
+            clientId: confirmationRecord.clientId,
+            channel: confirmationRecord.channel,
+            direction: "outbound",
+            subject: "Appointment confirmation recorded",
+            content: confirmationRecord.content,
+            status: "sent",
+            assignedTo: ctx.user.id,
+            dedupeKey: confirmationRecord.dedupeKey,
           });
         }
 
@@ -976,8 +1104,17 @@ export const appointmentsRouter = createRouter({
           doctorId: appointments.doctorId,
           roomId: appointments.roomId,
           typeId: appointments.typeId,
+          typeRequiresDoctor: appointmentTypes.requiresDoctor,
         })
         .from(appointments)
+        .leftJoin(
+          appointmentTypes,
+          and(
+            eq(appointments.typeId, appointmentTypes.id),
+            eq(appointmentTypes.practiceId, ctx.practiceId),
+            isNull(appointmentTypes.deletedAt)
+          )
+        )
         .where(
           and(
             eq(appointments.id, input.id),
@@ -1004,10 +1141,26 @@ export const appointmentsRouter = createRouter({
       const doctorId =
         input.doctorId === undefined ? current.doctorId : input.doctorId;
       const roomId = input.roomId === undefined ? current.roomId : input.roomId;
+      const timeChanged =
+        current.startTime.getTime() !== startTime.getTime() ||
+        current.endTime.getTime() !== endTime.getTime();
+      const confirmationRequired =
+        current.status === "confirmed" && timeChanged;
       await assertAppointmentTargets(ctx, {
         doctorId: input.doctorId,
         roomId: input.roomId,
       });
+      if (
+        current.status === "confirmed" &&
+        !confirmationRequired &&
+        current.typeRequiresDoctor === 1 &&
+        !doctorId
+      ) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "Assign a doctor before saving a confirmed appointment.",
+        });
+      }
 
       if (doctorId || roomId) {
         const existing = await fetchOverlapping(
@@ -1032,6 +1185,7 @@ export const appointmentsRouter = createRouter({
           endTime,
           doctorId: doctorId ?? null,
           roomId: roomId ?? null,
+          status: confirmationRequired ? "scheduled" : current.status,
         })
         .where(
           and(
@@ -1064,7 +1218,7 @@ export const appointmentsRouter = createRouter({
         typeId: updated.typeId,
         source: "dashboard",
       });
-      return updated;
+      return { ...updated, confirmationRequired };
     }),
 
   /** Open slots on a given date for a doctor and/or room. */

--- a/apps/web/server/routers/booking.ts
+++ b/apps/web/server/routers/booking.ts
@@ -39,9 +39,9 @@ const bookingSlugInput = z
   .toLowerCase()
   .min(1)
   .max(BOOKING_SLUG_MAX_LENGTH);
-const bookingDateInput = clinicalDateInput("Booking date");
+const bookingDateInput = clinicalDateInput("Appointment request date");
 const bookingTimeInput = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, {
-  message: "Booking time must be in 24-hour HH:MM format.",
+  message: "Appointment request time must be in 24-hour HH:MM format.",
 });
 
 const PAGE_READ_IP_RATE_LIMIT = { limit: 300, windowMs: 15 * 60 * 1000 };
@@ -83,7 +83,7 @@ async function assertBookingIpRateLimit(
 function pageNotFound(): TRPCError {
   return new TRPCError({
     code: "NOT_FOUND",
-    message: "This booking page is not available.",
+    message: "This appointment request page is not available.",
   });
 }
 
@@ -180,8 +180,9 @@ function assertBookingBillingAccess(practice: {
 async function bookableTypesForPage(
   db: any,
   practiceId: string,
-  bookableTypeIds: string[] | null
+  bookableTypeIds: string[]
 ): Promise<Array<{ id: string; name: string; durationMinutes: number }>> {
+  if (bookableTypeIds.length === 0) return [];
   const rows = await db
     .select({
       id: appointmentTypes.id,
@@ -197,9 +198,58 @@ async function bookableTypesForPage(
     )
     .orderBy(asc(appointmentTypes.name));
 
-  if (!bookableTypeIds) return rows;
   const allowed = new Set(bookableTypeIds);
   return rows.filter((t: { id: string }) => allowed.has(t.id));
+}
+
+/**
+ * Lock the exact active type used by a request until the surrounding
+ * transaction commits. This prevents an appointment type from being archived
+ * after validation but before the appointment row is created.
+ */
+async function lockBookableTypeForRequest(
+  db: any,
+  practiceId: string,
+  bookableTypeIds: string[],
+  requestedTypeId: string
+): Promise<{ id: string; durationMinutes: number } | null> {
+  if (!bookableTypeIds.includes(requestedTypeId)) return null;
+  const [type] = await db
+    .select({
+      id: appointmentTypes.id,
+      durationMinutes: appointmentTypes.durationMinutes,
+    })
+    .from(appointmentTypes)
+    .where(
+      and(
+        eq(appointmentTypes.id, requestedTypeId),
+        eq(appointmentTypes.practiceId, practiceId),
+        isNull(appointmentTypes.deletedAt)
+      )
+    )
+    .for("share");
+  return type ?? null;
+}
+
+async function lockActiveSelectedTypeIds(
+  db: any,
+  practiceId: string,
+  selectedTypeIds: string[]
+): Promise<string[]> {
+  if (selectedTypeIds.length === 0) return [];
+  const rows = await db
+    .select({ id: appointmentTypes.id })
+    .from(appointmentTypes)
+    .where(
+      and(
+        eq(appointmentTypes.practiceId, practiceId),
+        inArray(appointmentTypes.id, selectedTypeIds),
+        isNull(appointmentTypes.deletedAt)
+      )
+    )
+    .for("share");
+  const active = new Set(rows.map((row: { id: string }) => row.id));
+  return [...new Set(selectedTypeIds)].filter((id) => active.has(id));
 }
 
 const contactInput = z.object({
@@ -238,6 +288,7 @@ export const bookingRouter = createRouter({
         practice.id,
         config.bookableTypeIds
       );
+      if (types.length === 0) throw pageNotFound();
 
       return {
         practice: {
@@ -262,7 +313,7 @@ export const bookingRouter = createRouter({
       z.object({
         slug: bookingSlugInput,
         date: bookingDateInput,
-        typeId: z.string().uuid().optional(),
+        typeId: z.string().uuid(),
       })
     )
     .query(async ({ ctx, input }) => {
@@ -279,22 +330,19 @@ export const bookingRouter = createRouter({
       const window = bookingWindowForDate(config, input.date, practice.timezone);
       if (!window) return [];
 
-      let durationMinutes = 30;
-      if (input.typeId) {
-        const types = await bookableTypesForPage(
-          ctx.db,
-          practice.id,
-          config.bookableTypeIds
-        );
-        const type = types.find((t: { id: string }) => t.id === input.typeId);
-        if (!type) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Appointment type not found",
-          });
-        }
-        durationMinutes = type.durationMinutes;
+      const types = await bookableTypesForPage(
+        ctx.db,
+        practice.id,
+        config.bookableTypeIds
+      );
+      const type = types.find((candidate) => candidate.id === input.typeId);
+      if (!type) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Appointment type not found",
+        });
       }
+      const durationMinutes = type.durationMinutes;
 
       const busy = await ctx.db
         .select({
@@ -335,7 +383,7 @@ export const bookingRouter = createRouter({
     .input(
       z.object({
         slug: bookingSlugInput,
-        typeId: z.string().uuid().optional(),
+        typeId: z.string().uuid(),
         date: bookingDateInput,
         time: bookingTimeInput,
         contact: contactInput,
@@ -366,39 +414,43 @@ export const bookingRouter = createRouter({
       const { practice, config } = await getLivePage(ctx.db, input.slug);
       assertBookingBillingAccess(practice);
 
-      // Resolve the type for duration; only publicly bookable types count.
-      let durationMinutes = 30;
-      let typeId: string | null = null;
-      if (input.typeId) {
-        const types = await bookableTypesForPage(
-          ctx.db,
-          practice.id,
-          config.bookableTypeIds
-        );
-        const type = types.find((t: { id: string }) => t.id === input.typeId);
-        if (!type) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Appointment type not found",
-          });
-        }
-        typeId = type.id;
-        durationMinutes = type.durationMinutes;
+      // Public and portal requests for one practice share a transaction lock,
+      // so neither path can pass the conflict check concurrently. Take it
+      // before the type row lock to keep request lock ordering consistent.
+      await ctx.db.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`public-booking:${practice.id}`}::text))`
+      );
+
+      // Resolve and hold the type through appointment creation; only types
+      // explicitly offered on this page count.
+      const type = await lockBookableTypeForRequest(
+        ctx.db,
+        practice.id,
+        config.bookableTypeIds,
+        input.typeId
+      );
+      if (!type) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Appointment type not found",
+        });
       }
+      const typeId = type.id;
+      const durationMinutes = type.durationMinutes;
 
       // The requested slot must sit inside the page's hours, lead time, and
       // booking window for that calendar date.
       if (!isDateWithinBookingWindow(config, input.date)) {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "That date is outside the online booking window.",
+          message: "That date is outside the online appointment request window.",
         });
       }
       const window = bookingWindowForDate(config, input.date, practice.timezone);
       if (!window) {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Online booking is not available on that day.",
+          message: "Online appointment requests are not available on that day.",
         });
       }
       const [hour, minute] = input.time.split(":").map(Number);
@@ -412,7 +464,7 @@ export const bookingRouter = createRouter({
       if (slotStart < window.dayStart || slotEnd > window.dayEnd) {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Please choose a time within the clinic's booking hours.",
+          message: "Please choose a time within the clinic's request hours.",
         });
       }
       if (slotStart.getTime() < minimumBookableInstant(config).getTime()) {
@@ -421,13 +473,6 @@ export const bookingRouter = createRouter({
           message: "That time is too soon. Please choose a later time.",
         });
       }
-
-      // Public booking requests for one practice must not both pass the
-      // conflict check before either appointment commits. publicProcedure
-      // already supplies a transaction, so this lock is held through commit.
-      await ctx.db.execute(
-        sql`select pg_advisory_xact_lock(hashtext(${`public-booking:${practice.id}`}::text))`
-      );
 
       const [conflict] = await ctx.db
         .select({ id: appointments.id })
@@ -472,7 +517,7 @@ export const bookingRouter = createRouter({
           throw new TRPCError({
             code: "FORBIDDEN",
             message:
-              "Online booking is limited to existing clients. Please call the clinic to get set up.",
+              "Online appointment requests are limited to existing clients. Please call the clinic to get set up.",
           });
         }
         const [created] = await ctx.db
@@ -525,7 +570,6 @@ export const bookingRouter = createRouter({
         petName = created!.name;
       }
 
-      const status = config.autoConfirm ? "confirmed" : "scheduled";
       const [appt] = await ctx.db
         .insert(appointments)
         .values({
@@ -535,8 +579,10 @@ export const bookingRouter = createRouter({
           typeId,
           startTime: slotStart,
           endTime: slotEnd,
-          status,
-          notes: `[Online booking] ${input.reason}`,
+          // Public booking is deliberately request-only. Keep this invariant
+          // independent of legacy booking-page config stored in jsonb.
+          status: "scheduled",
+          notes: `[Online request] ${input.reason}`,
         })
         .returning();
       await recordActivationAfterAppointmentCreated(
@@ -545,14 +591,14 @@ export const bookingRouter = createRouter({
         "booking.book"
       );
 
-      // Surface the booking in the communications inbox so the front desk
-      // sees new online bookings alongside portal requests and messages.
+      // Surface the request in the communications inbox so the front desk
+      // sees it alongside portal requests and messages.
       await ctx.db.insert(communications).values({
         practiceId: practice.id,
         clientId,
         channel: "portal",
         direction: "inbound",
-        subject: `New online booking for ${petName}`,
+        subject: `New appointment request for ${petName}`,
         content: [
           `Client: ${input.contact.firstName} ${input.contact.lastName}${isNewClient ? " (new client)" : ""}`,
           `Pet: ${petName}`,
@@ -571,10 +617,9 @@ export const bookingRouter = createRouter({
 
       return {
         success: true as const,
-        requiresConfirmation: !config.autoConfirm,
-        message: config.autoConfirm
-          ? "You're booked! We'll see you then."
-          : "Your appointment request has been sent! The clinic will confirm your appointment.",
+        requiresConfirmation: true,
+        message:
+          "Your appointment request has been sent! The clinic will confirm your appointment.",
       };
     }),
 
@@ -650,55 +695,77 @@ export const bookingRouter = createRouter({
         });
       }
 
-      const [existing] = await ctx.db
-        .select({ id: bookingPages.id })
-        .from(bookingPages)
-        .where(
-          and(
-            eq(bookingPages.practiceId, ctx.practiceId),
-            isNull(bookingPages.deletedAt)
-          )
-        )
-        .limit(1);
+      return ctx.db.transaction(async (tx) => {
+        // Publication must be truthful. The shared locks are held until the
+        // page write commits, so a selected type cannot be archived between
+        // validation and publication.
+        const activeSelectedTypeIds = await lockActiveSelectedTypeIds(
+          tx,
+          ctx.practiceId,
+          input.config.bookableTypeIds
+        );
+        if (input.published && activeSelectedTypeIds.length === 0) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Select at least one active visit type before publishing the appointment request page.",
+          });
+        }
+        const config = {
+          ...input.config,
+          bookableTypeIds: activeSelectedTypeIds,
+        };
 
-      if (existing) {
+        const [existing] = await tx
+          .select({ id: bookingPages.id })
+          .from(bookingPages)
+          .where(
+            and(
+              eq(bookingPages.practiceId, ctx.practiceId),
+              isNull(bookingPages.deletedAt)
+            )
+          )
+          .limit(1);
+
+        if (existing) {
+          try {
+            const [updated] = await tx
+              .update(bookingPages)
+              .set({
+                slug: input.slug,
+                published: input.published,
+                config,
+              })
+              .where(eq(bookingPages.id, existing.id))
+              .returning({
+                slug: bookingPages.slug,
+                published: bookingPages.published,
+              });
+            return updated!;
+          } catch (error) {
+            if (isPostgresUniqueViolation(error)) throw bookingSlugConflict();
+            throw error;
+          }
+        }
+
         try {
-          const [updated] = await ctx.db
-            .update(bookingPages)
-            .set({
+          const [created] = await tx
+            .insert(bookingPages)
+            .values({
+              practiceId: ctx.practiceId,
               slug: input.slug,
               published: input.published,
-              config: input.config,
+              config,
             })
-            .where(eq(bookingPages.id, existing.id))
             .returning({
               slug: bookingPages.slug,
               published: bookingPages.published,
             });
-          return updated!;
+          return created!;
         } catch (error) {
           if (isPostgresUniqueViolation(error)) throw bookingSlugConflict();
           throw error;
         }
-      }
-
-      try {
-        const [created] = await ctx.db
-          .insert(bookingPages)
-          .values({
-            practiceId: ctx.practiceId,
-            slug: input.slug,
-            published: input.published,
-            config: input.config,
-          })
-          .returning({
-            slug: bookingPages.slug,
-            published: bookingPages.published,
-          });
-        return created!;
-      } catch (error) {
-        if (isPostgresUniqueViolation(error)) throw bookingSlugConflict();
-        throw error;
-      }
+      });
     }),
 });

--- a/apps/web/server/routers/notifications.ts
+++ b/apps/web/server/routers/notifications.ts
@@ -209,6 +209,7 @@ export const notificationsRouter = createRouter({
         .select({
           id: appointments.id,
           startTime: appointments.startTime,
+          status: appointments.status,
           patientName: patients.name,
           clientId: appointments.clientId,
           clientFirstName: clients.firstName,
@@ -274,6 +275,12 @@ export const notificationsRouter = createRouter({
 
       if (!appt) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" });
+      }
+      if (appt.status !== "confirmed") {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "Confirm the appointment before sending a reminder.",
+        });
       }
 
       // Manual send: respect the client's preferred channel + SMS consent.
@@ -548,7 +555,7 @@ export const notificationsRouter = createRouter({
           isNull(appointments.deletedAt),
           gte(appointments.startTime, now),
           lte(appointments.startTime, in24h),
-          inArray(appointments.status, ["scheduled", "confirmed"])
+          eq(appointments.status, "confirmed")
         )
       )
       .orderBy(appointments.startTime);
@@ -633,7 +640,8 @@ export const notificationsRouter = createRouter({
             isNull(patients.deletedAt),
             eq(clients.practiceId, ctx.practiceId),
             isNull(clients.deletedAt),
-            isNull(appointments.deletedAt)
+            isNull(appointments.deletedAt),
+            eq(appointments.status, "confirmed")
           )
         );
 

--- a/apps/web/server/routers/portal.ts
+++ b/apps/web/server/routers/portal.ts
@@ -902,7 +902,7 @@ export const portalRouter = createRouter({
       z.object({
         token: portalTokenInput,
         patientId: z.string().uuid(),
-        typeId: z.string().uuid().optional(),
+        typeId: z.string().uuid(),
         preferredDate: portalBookingDateInput,
         preferredTime: portalBookingTimeInput,
         reason: z.string().trim().min(1).max(PORTAL_BOOKING_REASON_MAX_LENGTH),
@@ -944,27 +944,36 @@ export const portalRouter = createRouter({
         throw new TRPCError({ code: "NOT_FOUND", message: "Pet not found" });
       }
 
-      // Resolve the requested type (must belong to this practice) for duration.
-      let durationMinutes = 30;
-      let typeId: string | null = null;
-      if (input.typeId) {
-        const [type] = await ctx.db
-          .select({ id: appointmentTypes.id, durationMinutes: appointmentTypes.durationMinutes })
-          .from(appointmentTypes)
-          .where(
-            and(
-              eq(appointmentTypes.id, input.typeId),
-              eq(appointmentTypes.practiceId, client.practiceId),
-              isNull(appointmentTypes.deletedAt)
-            )
+      // Serialize portal and public requests for this practice before taking
+      // the type row lock. The public procedure transaction holds both locks
+      // through the conflict check and appointment insert.
+      await ctx.db.execute(
+        sql`select pg_advisory_xact_lock(hashtext(${`public-booking:${client.practiceId}`}::text))`
+      );
+
+      // Every request must reference a verified active type in this practice.
+      const [type] = await ctx.db
+        .select({
+          id: appointmentTypes.id,
+          durationMinutes: appointmentTypes.durationMinutes,
+        })
+        .from(appointmentTypes)
+        .where(
+          and(
+            eq(appointmentTypes.id, input.typeId),
+            eq(appointmentTypes.practiceId, client.practiceId),
+            isNull(appointmentTypes.deletedAt)
           )
-          .limit(1);
-        if (!type) {
-          throw new TRPCError({ code: "NOT_FOUND", message: "Appointment type not found" });
-        }
-        typeId = type.id;
-        durationMinutes = type.durationMinutes;
+        )
+        .for("share");
+      if (!type) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Appointment type not found",
+        });
       }
+      const typeId = type.id;
+      const durationMinutes = type.durationMinutes;
 
       let slot;
       try {

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -35,6 +35,7 @@ import {
   locationMessaging,
   migrationRuns,
   visitCloseouts,
+  bookingPages,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import { regionDefaults } from "@/lib/locale/format";
@@ -70,6 +71,7 @@ import {
   type OnboardingIntent,
 } from "@/lib/onboarding/intent";
 import { isValidMigrationSource } from "@/lib/import/sources";
+import { parseBookingPageConfig } from "@/lib/booking/page-config";
 
 const adminProcedure = protectedProcedure.use(requireRole("admin"));
 
@@ -1986,7 +1988,7 @@ export const settingsRouter = createRouter({
               isNull(appointmentTypes.deletedAt),
             ),
           )
-          .limit(1);
+          .for("update");
 
         if (!type) {
           throw new TRPCError({
@@ -2036,6 +2038,31 @@ export const settingsRouter = createRouter({
             code: "BAD_REQUEST",
             message:
               "Cannot delete an appointment type used by waiting appointment requests.",
+          });
+        }
+
+        const [publishedPage] = await tx
+          .select({ config: bookingPages.config })
+          .from(bookingPages)
+          .where(
+            and(
+              eq(bookingPages.practiceId, ctx.practiceId),
+              eq(bookingPages.published, true),
+              isNull(bookingPages.deletedAt),
+            ),
+          )
+          .limit(1);
+
+        if (
+          publishedPage &&
+          parseBookingPageConfig(publishedPage.config).bookableTypeIds.includes(
+            input.id,
+          )
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Unpublish the appointment request page or remove this visit type from it before deleting the type.",
           });
         }
 

--- a/packages/db/drizzle/0052_booking_page_request_types.sql
+++ b/packages/db/drizzle/0052_booking_page_request_types.sql
@@ -1,0 +1,38 @@
+-- Preserve legacy published booking pages while moving from implicit "all
+-- active types" behavior to explicit requestable type selections. Pages with
+-- no active types are unpublished instead of remaining visibly live but
+-- returning a closed public route.
+WITH legacy_pages AS (
+  SELECT
+    bp.id,
+    COALESCE(
+      (
+        SELECT jsonb_agg(to_jsonb(at.id::text) ORDER BY at.id)
+        FROM appointment_types at
+        WHERE at.practice_id = bp.practice_id
+          AND at.deleted_at IS NULL
+      ),
+      '[]'::jsonb
+    ) AS active_type_ids
+  FROM booking_pages bp
+  WHERE bp.deleted_at IS NULL
+    AND (
+      NOT (bp.config ? 'bookableTypeIds')
+      OR bp.config -> 'bookableTypeIds' = 'null'::jsonb
+    )
+)
+UPDATE booking_pages bp
+SET
+  config = jsonb_set(
+    CASE WHEN jsonb_typeof(bp.config) = 'object' THEN bp.config ELSE '{}'::jsonb END,
+    '{bookableTypeIds}',
+    legacy.active_type_ids,
+    true
+  ),
+  published = CASE
+    WHEN jsonb_array_length(legacy.active_type_ids) = 0 THEN false
+    ELSE bp.published
+  END,
+  updated_at = now()
+FROM legacy_pages legacy
+WHERE bp.id = legacy.id;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1786237311529,
       "tag": "0051_wide_maximus",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1786240800000,
+      "tag": "0052_booking_page_request_types",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- make public and portal booking request-only until staff confirms contact
- require explicit active visit types and safe doctor/room assignment
- prevent request double-booking and type archival races with transaction locks
- backfill legacy published pages with explicit requestable types
- suppress reminders until requests are confirmed

## Validation
- independent release review: SHIP
- 294 test files / 2,745 tests passed
- web type-check passed
- production build passed (42 pages)
- diff and secret checks passed