### PR TITLE
Harden visit billing and payment integrity

### DIFF
--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -1369,7 +1369,9 @@ function InvoiceRow({
                         <Download className="mr-1 h-3.5 w-3.5" />
                         Download PDF
                       </Button>
-                      {canManageBilling && (
+                      {canManageBilling &&
+                        (invoice.status === "sent" ||
+                          invoice.status === "overdue") && (
                         <EmailInvoiceButton invoiceId={invoice.id} />
                       )}
                     </div>
@@ -1383,6 +1385,7 @@ function InvoiceRow({
                     invoicePaidAmount={detail.data.paidAmount}
                     invoiceAdjustedAmount={detail.data.adjustedAmount}
                     invoiceBalanceDue={detail.data.balanceDue}
+                    invoiceDueDate={detail.data.dueDate}
                     invoiceStatus={invoice.status}
                     billingTimeZone={billingTimeZone}
                     canManageBilling={canManageBilling}
@@ -1436,6 +1439,7 @@ function PaymentSection({
   invoicePaidAmount,
   invoiceAdjustedAmount,
   invoiceBalanceDue,
+  invoiceDueDate,
   invoiceStatus,
   billingTimeZone,
   canManageBilling,
@@ -1444,6 +1448,7 @@ function PaymentSection({
   invoicePaidAmount: string | null;
   invoiceAdjustedAmount: string | null;
   invoiceBalanceDue: string | null;
+  invoiceDueDate: string | null;
   invoiceStatus: string;
   billingTimeZone?: string | null;
   canManageBilling: boolean;
@@ -1463,6 +1468,8 @@ function PaymentSection({
     paymentId: string;
     amount: string;
   } | null>(null);
+  const [refundReason, setRefundReason] = useState("");
+  const [refundDueDate, setRefundDueDate] = useState("");
   const paymentOperationId = useRef<string | null>(null);
   const adjustmentOperationId = useRef<string | null>(null);
 
@@ -1526,6 +1533,8 @@ function PaymentSection({
     onSuccess: () => {
       toast.success("Payment refunded");
       setRefundTarget(null);
+      setRefundReason("");
+      setRefundDueDate("");
       utils.billing.listPayments.invalidate({ invoiceId });
       utils.billing.listInvoices.invalidate();
       utils.billing.getInvoice.invalidate({ id: invoiceId });
@@ -1613,11 +1622,22 @@ function PaymentSection({
   const closeRefundDialog = () => {
     if (refundPayment.isPending) return;
     setRefundTarget(null);
+    setRefundReason("");
+    setRefundDueDate("");
   };
 
   const confirmRefund = () => {
-    if (!refundTarget) return;
-    refundPayment.mutate({ paymentId: refundTarget.paymentId });
+    if (
+      !refundTarget ||
+      refundReason.trim().length < BILLING_ACTION_REASON_MIN_LENGTH
+    ) {
+      return;
+    }
+    refundPayment.mutate({
+      paymentId: refundTarget.paymentId,
+      reason: refundReason.trim(),
+      dueDate: refundDueDate || undefined,
+    });
   };
 
   return (
@@ -1886,12 +1906,14 @@ function PaymentSection({
                         size="sm"
                         className="h-7 px-2 text-xs text-muted-foreground hover:text-destructive"
                         disabled={refundPayment.isPending}
-                        onClick={() =>
+                        onClick={() => {
+                          setRefundReason("");
+                          setRefundDueDate(invoiceDueDate ?? "");
                           setRefundTarget({
                             paymentId: payment.id,
                             amount: payment.amount,
-                          })
-                        }
+                          });
+                        }}
                       >
                         Refund
                       </Button>
@@ -1974,9 +1996,35 @@ function PaymentSection({
         confirmLabel="Refund payment"
         confirmVariant="destructive"
         isPending={refundPayment.isPending}
+        reason={{
+          label: "Reason for refund",
+          value: refundReason,
+          onChange: setRefundReason,
+          placeholder: "Explain the refund for the audit trail",
+          minLength: BILLING_ACTION_REASON_MIN_LENGTH,
+          maxLength: BILLING_ACTION_REASON_MAX_LENGTH,
+        }}
         onCancel={closeRefundDialog}
         onConfirm={confirmRefund}
-      />
+      >
+        <label
+          htmlFor={`refund-due-date-${invoiceId}`}
+          className="text-sm font-medium"
+        >
+          Due date if this refund reopens the visit balance
+        </label>
+        <Input
+          id={`refund-due-date-${invoiceId}`}
+          type="date"
+          className="mt-2"
+          value={refundDueDate}
+          disabled={refundPayment.isPending || Boolean(invoiceDueDate)}
+          onChange={(event) => setRefundDueDate(event.target.value)}
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          Required when a completed, paid visit becomes accounts receivable.
+        </p>
+      </ActionConfirmationDialog>
     </div>
   );
 }

--- a/apps/web/app/api/portal/checkout/route.test.ts
+++ b/apps/web/app/api/portal/checkout/route.test.ts
@@ -8,17 +8,20 @@ const ROUTE_SOURCE = readFileSync(
 );
 
 const mocks = vi.hoisted(() => {
-  const selectResults: unknown[][] = [];
+  const selectResults: Array<unknown[] | Error> = [];
   const select = vi.fn(() => {
     const result = selectResults.shift() ?? [];
+    const resultPromise = () =>
+      result instanceof Error ? Promise.reject(result) : Promise.resolve(result);
     const builder = {
       from: vi.fn(() => builder),
       where: vi.fn(() => builder),
-      limit: vi.fn(async () => result),
+      limit: vi.fn(() => resultPromise()),
+      for: vi.fn(() => resultPromise()),
       then: (
         resolve: (value: unknown[]) => unknown,
         reject?: (error: unknown) => unknown
-      ) => Promise.resolve(result).then(resolve, reject),
+      ) => resultPromise().then(resolve, reject),
     };
     return builder;
   });
@@ -95,6 +98,7 @@ const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const CLIENT_ID = "00000000-0000-0000-0000-0000000000bb";
 const INVOICE_ID = "00000000-0000-0000-0000-0000000000cc";
 const PATIENT_ID = "00000000-0000-0000-0000-0000000000dd";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-0000000000ee";
 const IP = "203.0.113.10";
 const TOKEN_BUCKET =
   "portal-checkout:token:0ba11c8c03cc892e40cac090ac14c4db6e655ecfaff2490257fbe4c10fba19f9";
@@ -484,6 +488,55 @@ describe("portal checkout route", () => {
     );
     // Self-host: the platform Stripe key IS the practice's account.
     expect(mocks.getChargeableStripeConnectAccountId).not.toHaveBeenCalled();
+  });
+
+  it("returns a controlled conflict when a linked visit is not ready", async () => {
+    mocks.selectResults.push(
+      [client()],
+      [invoice({ appointmentId: APPOINTMENT_ID })],
+      [{ id: APPOINTMENT_ID }],
+      [{ status: "draft" }]
+    );
+
+    const response = await POST(
+      portalRequest({ token: "portal-token", invoiceId: INVOICE_ID })
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Finalize the clinical handoff before sending or collecting this visit invoice.",
+    });
+    expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("does not expose database failures as visit-readiness conflicts", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mocks.selectResults.push(
+      [client()],
+      [invoice({ appointmentId: APPOINTMENT_ID })],
+      [{ id: APPOINTMENT_ID }],
+      new Error("database unavailable: secret detail")
+    );
+
+    try {
+      const response = await POST(
+        portalRequest({ token: "portal-token", invoiceId: INVOICE_ID })
+      );
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: "Internal server error",
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[Portal Checkout] Error:",
+        expect.any(Error)
+      );
+      expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("hosted: routes portal checkout through the practice's Connect account", async () => {

--- a/apps/web/app/api/portal/checkout/route.ts
+++ b/apps/web/app/api/portal/checkout/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { eq, and, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
+import { TRPCError } from "@trpc/server";
 import { db } from "@openpims/db/client";
 import {
+  appointments,
   clients,
   invoiceAdjustments,
   invoices,
@@ -31,6 +33,7 @@ import {
 import { rateLimit, rateLimitResponseHeaders } from "@/lib/rate-limit";
 import { clientIpFromRequest } from "@/lib/request-ip";
 import { readJsonRequestBody } from "@/lib/request-json";
+import { assertVisitInvoiceReadyForFinancialAction } from "@/server/visit-billing-integrity";
 
 const portalCheckoutInput = z.object({
   token: z.string().trim().min(1).max(PORTAL_ACCESS_TOKEN_MAX_LENGTH),
@@ -147,6 +150,7 @@ export async function POST(req: NextRequest) {
           clientId: invoices.clientId,
           patientId: invoices.patientId,
           practiceId: invoices.practiceId,
+          appointmentId: invoices.appointmentId,
         })
         .from(invoices)
         .where(
@@ -195,6 +199,43 @@ export async function POST(req: NextRequest) {
           { error: "Invoice is not ready for online payment" },
           { status: 400 },
         );
+      }
+
+      if (invoice.appointmentId) {
+        const [appointment] = await tx
+          .select({ id: appointments.id })
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.id, invoice.appointmentId),
+              eq(appointments.practiceId, invoice.practiceId),
+              isNull(appointments.deletedAt)
+            )
+          )
+          .for("update");
+        if (!appointment) {
+          return NextResponse.json(
+            { error: "The linked appointment is no longer available" },
+            { status: 409 }
+          );
+        }
+        try {
+          await assertVisitInvoiceReadyForFinancialAction(
+            { db: tx, practiceId: invoice.practiceId },
+            invoice.appointmentId
+          );
+        } catch (err) {
+          if (
+            err instanceof TRPCError &&
+            err.code === "PRECONDITION_FAILED"
+          ) {
+            return NextResponse.json(
+              { error: err.message },
+              { status: 409 }
+            );
+          }
+          throw err;
+        }
       }
 
       const adjustmentRows = await tx

--- a/apps/web/app/api/webhooks/stripe-connect/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe-connect/route.test.ts
@@ -1,16 +1,62 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+
+const ROUTE_SOURCE = readFileSync(
+  new URL("./route.ts", import.meta.url),
+  "utf8"
+);
 
 const mocks = vi.hoisted(() => {
-  const updateWhere = vi.fn(async () => []);
+  const selectResults: unknown[][] = [];
+  const select = vi.fn(() => {
+    const result = selectResults.shift() ?? [];
+    const builder = {
+      from: vi.fn(() => builder),
+      innerJoin: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      limit: vi.fn(() => builder),
+      for: vi.fn(async () => result),
+      then: (
+        resolve: (value: unknown[]) => unknown,
+        reject?: (error: unknown) => unknown
+      ) => Promise.resolve(result).then(resolve, reject),
+    };
+    return builder;
+  });
+
+  const insertConflict = vi.fn(async () => undefined);
+  const insertValues = vi.fn((_values: unknown) => ({
+    onConflictDoNothing: insertConflict,
+  }));
+  const insert = vi.fn(() => ({ values: insertValues }));
+
+  const updateReturning = vi.fn(async () => [{ id: "invoice_updated" }]);
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const execute = vi.fn(async () => []);
   return {
     db: {
+      execute,
+      insert,
+      select,
       update: vi.fn(() => ({ set: updateSet })),
     },
+    selectResults,
+    execute,
+    insertValues,
+    insertConflict,
     updateSet,
     updateWhere,
+    captureStripeCheckoutAuthorization: vi.fn(
+      async (input: { amountCents: number }) => ({
+        amountCapturedCents: input.amountCents,
+      })
+    ),
     constructConnectWebhookEvent: vi.fn(),
     claimStripeEvent: vi.fn(async () => true),
+    refundInvalidStripeCheckoutPayment: vi.fn(async () => ({
+      outcome: "authorization_canceled" as const,
+    })),
   };
 });
 
@@ -23,7 +69,10 @@ vi.mock("@/lib/tenant-db", () => ({
 }));
 
 vi.mock("@/lib/stripe", () => ({
+  captureStripeCheckoutAuthorization: mocks.captureStripeCheckoutAuthorization,
   constructConnectWebhookEvent: mocks.constructConnectWebhookEvent,
+  INVOICE_CHECKOUT_CAPTURE_MODE: "manual_v1",
+  refundInvalidStripeCheckoutPayment: mocks.refundInvalidStripeCheckoutPayment,
 }));
 
 vi.mock("@/lib/billing/stripe-events", () => ({
@@ -40,6 +89,10 @@ vi.mock("@/lib/billing/client-receipts", () => ({
 }));
 
 const { POST } = await import("./route");
+const { auditLog } = await import("@openpims/db");
+vi.spyOn(console, "error").mockImplementation(() => {});
+const APPOINTMENT_ID = "00000000-0000-0000-0000-0000000000ab";
+const CLOSEOUT_ID = "00000000-0000-0000-0000-0000000000ac";
 
 function stripeRequest() {
   return new Request("https://openvpm.test/api/webhooks/stripe-connect", {
@@ -51,7 +104,17 @@ function stripeRequest() {
 
 afterEach(() => {
   vi.clearAllMocks();
+  mocks.selectResults.length = 0;
   mocks.claimStripeEvent.mockResolvedValue(true);
+  mocks.captureStripeCheckoutAuthorization.mockImplementation(
+    async (input: { amountCents: number }) => ({
+      amountCapturedCents: input.amountCents,
+    })
+  );
+  mocks.execute.mockResolvedValue([]);
+  mocks.refundInvalidStripeCheckoutPayment.mockResolvedValue({
+    outcome: "authorization_canceled",
+  });
 });
 
 describe("Stripe Connect webhook", () => {
@@ -117,5 +180,392 @@ describe("Stripe Connect webhook", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.db.update).not.toHaveBeenCalled();
+  });
+
+  it("ignores unrelated connected-account Checkout sessions before claiming", async () => {
+    mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
+      id: "evt_unrelated_checkout",
+      account: "acct_123",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_unrelated",
+          metadata: { source: "another_product", invoiceId: "invoice_123" },
+        },
+      },
+    });
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.claimStripeEvent).not.toHaveBeenCalled();
+    expect(mocks.refundInvalidStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
+  it("ignores invoice Checkout with inconsistent connected-account metadata", async () => {
+    mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
+      id: "evt_mismatched_account",
+      account: "acct_authoritative",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_mismatched_account",
+          metadata: {
+            source: "client_invoice_connect",
+            invoiceId: "invoice_123",
+            stripeConnectAccountId: "acct_untrusted",
+          },
+        },
+      },
+    });
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.claimStripeEvent).not.toHaveBeenCalled();
+    expect(mocks.refundInvalidStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
+  it("resolves a recognized Checkout when its payment account was deleted", async () => {
+    mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
+      id: "evt_deleted_account",
+      account: "acct_deleted",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_deleted_account",
+          amount_total: 12500,
+          metadata: {
+            source: "client_invoice_connect",
+            invoiceId: "invoice_123",
+            stripeConnectAccountId: "acct_deleted",
+          },
+        },
+      },
+    });
+    mocks.selectResults.push([]);
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.refundInvalidStripeCheckoutPayment).toHaveBeenCalledWith({
+      externalId:
+        "stripe:connect:acct_deleted:checkout:cs_deleted_account",
+      amountCents: 12500,
+      idempotencyKey:
+        "invalid:stripe:connect:acct_deleted:checkout:cs_deleted_account",
+    });
+  });
+
+  it("resolves a recognized Checkout with missing invoice metadata", async () => {
+    mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
+      id: "evt_missing_invoice",
+      account: "acct_123",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_missing_invoice",
+          amount_total: 12500,
+          metadata: {
+            source: "client_invoice_connect",
+            stripeConnectAccountId: "acct_123",
+          },
+        },
+      },
+    });
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.refundInvalidStripeCheckoutPayment).toHaveBeenCalledWith({
+      externalId: "stripe:connect:acct_123:checkout:cs_missing_invoice",
+      amountCents: 12500,
+      idempotencyKey:
+        "invalid:stripe:connect:acct_123:checkout:cs_missing_invoice",
+    });
+  });
+
+  it("partially captures a stale manual Connect Checkout at the live balance", async () => {
+    mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
+      id: "evt_connect_checkout",
+      account: "acct_123",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_connect_123",
+          payment_intent: "pi_connect_123",
+          amount_total: 12500,
+          metadata: {
+            invoiceId: "invoice_123",
+            captureMode: "manual_v1",
+            source: "client_invoice_connect",
+            stripeConnectAccountId: "acct_123",
+          },
+        },
+      },
+    });
+    mocks.selectResults.push(
+      [{ practiceId: "practice_123", stripeAccountId: "acct_123" }],
+      [{
+        id: "invoice_123",
+        practiceId: "practice_123",
+      }],
+      [{
+        id: "invoice_123",
+        practiceId: "practice_123",
+        total: "125.00",
+        paidAmount: "75.00",
+        status: "sent",
+        isEstimate: false,
+      }],
+      [],
+      [],
+      [{ total: "125.00" }]
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.captureStripeCheckoutAuthorization).toHaveBeenCalledWith({
+      paymentIntentId: "pi_connect_123",
+      amountCents: 5000,
+      checkoutSessionId: "cs_connect_123",
+      connectedAccountId: "acct_123",
+    });
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: "50.00",
+        externalId: "stripe:connect:acct_123:checkout:cs_connect_123",
+      })
+    );
+    expect(mocks.refundInvalidStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
+  it("settles a completed accounts-receivable closeout with a Connect payment", async () => {
+    mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
+      id: "evt_connect_closeout",
+      account: "acct_123",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_connect_closeout",
+          payment_intent: "pi_connect_closeout",
+          amount_total: 12500,
+          metadata: {
+            source: "client_invoice_connect",
+            invoiceId: "invoice_123",
+            captureMode: "manual_v1",
+            stripeConnectAccountId: "acct_123",
+          },
+        },
+      },
+    });
+    const linkedInvoice = {
+      id: "invoice_123",
+      practiceId: "practice_123",
+      appointmentId: APPOINTMENT_ID,
+      total: "125.00",
+      paidAmount: "0.00",
+      status: "sent",
+      isEstimate: false,
+    };
+    mocks.selectResults.push(
+      [{ practiceId: "practice_123", stripeAccountId: "acct_123" }],
+      [linkedInvoice],
+      [{ id: APPOINTMENT_ID }],
+      [{ status: "completed" }],
+      [linkedInvoice],
+      [],
+      [],
+      [{ total: "125.00" }],
+      [{
+        id: CLOSEOUT_ID,
+        chargeDisposition: "accounts_receivable",
+        revision: 8,
+      }]
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ chargeDisposition: "paid", revision: 9 })
+    );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: "practice_123",
+        userId: null,
+        action: "visit_closeout_settled",
+        entityId: CLOSEOUT_ID,
+        changes: expect.objectContaining({
+          source: "stripe_connect",
+          paymentExternalId:
+            "stripe:connect:acct_123:checkout:cs_connect_closeout",
+          priorRevision: 8,
+          nextRevision: 9,
+        }),
+      })
+    );
+  });
+
+  it("refunds a legacy Connect Checkout when its linked visit is not ready", async () => {
+    mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
+      id: "evt_connect_unready",
+      account: "acct_123",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_connect_unready",
+          amount_total: 12500,
+          metadata: {
+            source: "client_invoice_connect",
+            invoiceId: "invoice_123",
+            stripeConnectAccountId: "acct_123",
+          },
+        },
+      },
+    });
+    mocks.selectResults.push(
+      [{ practiceId: "practice_123", stripeAccountId: "acct_123" }],
+      [{
+        id: "invoice_123",
+        practiceId: "practice_123",
+        appointmentId: APPOINTMENT_ID,
+      }],
+      [{ id: APPOINTMENT_ID }],
+      [{ status: "draft" }]
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.refundInvalidStripeCheckoutPayment).toHaveBeenCalledWith({
+      externalId: "stripe:connect:acct_123:checkout:cs_connect_unready",
+      amountCents: 12500,
+      idempotencyKey:
+        "invalid:stripe:connect:acct_123:checkout:cs_connect_unready",
+    });
+  });
+
+  it("retries Connect Checkout when readiness infrastructure fails", async () => {
+    mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
+      id: "evt_connect_db_error",
+      account: "acct_123",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_connect_db_error",
+          amount_total: 12500,
+          metadata: {
+            source: "client_invoice_connect",
+            invoiceId: "invoice_123",
+            stripeConnectAccountId: "acct_123",
+          },
+        },
+      },
+    });
+    mocks.selectResults.push(
+      [{ practiceId: "practice_123", stripeAccountId: "acct_123" }],
+      [{
+        id: "invoice_123",
+        practiceId: "practice_123",
+        appointmentId: APPOINTMENT_ID,
+      }],
+      [{ id: APPOINTMENT_ID }],
+      [{ status: "clinical_finalized" }]
+    );
+    mocks.execute.mockRejectedValueOnce(new Error("database unavailable"));
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(500);
+    expect(mocks.refundInvalidStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
+  it("does not capture a manual Connect Checkout after the invoice is voided", async () => {
+    mocks.constructConnectWebhookEvent.mockResolvedValueOnce({
+      id: "evt_connect_void",
+      account: "acct_123",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_connect_void",
+          payment_intent: "pi_connect_void",
+          amount_total: 12500,
+          metadata: {
+            invoiceId: "invoice_123",
+            captureMode: "manual_v1",
+            source: "client_invoice_connect",
+            stripeConnectAccountId: "acct_123",
+          },
+        },
+      },
+    });
+    mocks.selectResults.push(
+      [{ practiceId: "practice_123", stripeAccountId: "acct_123" }],
+      [{
+        id: "invoice_123",
+        practiceId: "practice_123",
+      }],
+      [{
+        id: "invoice_123",
+        practiceId: "practice_123",
+        total: "125.00",
+        paidAmount: "0.00",
+        status: "void",
+        isEstimate: false,
+      }],
+      []
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.captureStripeCheckoutAuthorization).not.toHaveBeenCalled();
+    expect(mocks.refundInvalidStripeCheckoutPayment).toHaveBeenCalledWith({
+      externalId: "stripe:connect:acct_123:checkout:cs_connect_void",
+      amountCents: 12500,
+      idempotencyKey:
+        "invalid:stripe:connect:acct_123:checkout:cs_connect_void",
+    });
+    const auditWrite = mocks.insertValues.mock.calls
+      .map(([value]) => value)
+      .find(
+        (value) =>
+          (value as { action?: string }).action ===
+          "stripe_checkout_invalid_resolved"
+      ) as Record<string, any>;
+    expect(auditWrite).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        practiceId: "practice_123",
+        action: "stripe_checkout_invalid_resolved",
+        entityType: "stripe_checkout_resolution",
+        changes: expect.objectContaining({
+          eventId: "evt_connect_void",
+          endpoint: "client-invoice-connect",
+          sessionId: "cs_connect_void",
+          externalId:
+            "stripe:connect:acct_123:checkout:cs_connect_void",
+          invoiceId: "invoice_123",
+          practiceId: "practice_123",
+          connectedAccountId: "acct_123",
+          reason: "invoice_void",
+          outcome: "authorization_canceled",
+          refundId: null,
+          refundAmountCents: null,
+          checkoutAmountCents: 12500,
+        }),
+      })
+    );
+    expect(auditWrite.entityId).toBe(auditWrite.id);
+    expect(mocks.insertConflict).toHaveBeenCalledWith({ target: auditLog.id });
+  });
+
+  it("locks a linked appointment before the invoice row", () => {
+    expect(ROUTE_SOURCE.indexOf(".from(appointments)")).toBeGreaterThan(-1);
+    expect(ROUTE_SOURCE.indexOf(".from(appointments)")).toBeLessThan(
+      ROUTE_SOURCE.indexOf('.for("update", { of: invoices })')
+    );
   });
 });

--- a/apps/web/app/api/webhooks/stripe-connect/route.ts
+++ b/apps/web/app/api/webhooks/stripe-connect/route.ts
@@ -1,14 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
+import { TRPCError } from "@trpc/server";
 import { and, eq, isNull, sum } from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import {
   invoiceAdjustments,
   invoices,
   payments,
+  appointments,
   practicePaymentAccounts,
   practices,
 } from "@openpims/db";
-import { constructConnectWebhookEvent } from "@/lib/stripe";
+import {
+  captureStripeCheckoutAuthorization,
+  constructConnectWebhookEvent,
+  INVOICE_CHECKOUT_CAPTURE_MODE,
+} from "@/lib/stripe";
 import { withSystem } from "@/lib/tenant-db";
 import { claimStripeEvent } from "@/lib/billing/stripe-events";
 import {
@@ -30,6 +36,11 @@ import {
   STRIPE_WEBHOOK_BODY_MAX_BYTES,
   stripeWebhookContentLengthTooLarge,
 } from "@/lib/stripe-webhook-limits";
+import {
+  assertVisitInvoiceReadyForFinancialAction,
+  markCompletedVisitCloseoutPaid,
+} from "@/server/visit-billing-integrity";
+import { resolveInvalidInvoiceCheckout } from "@/server/stripe-checkout-resolution";
 
 function payloadTooLargeResponse() {
   return NextResponse.json(
@@ -73,6 +84,28 @@ export async function POST(req: NextRequest) {
         { error: "Webhook verification failed or Stripe not configured" },
         { status: 400 },
       );
+    }
+
+    if (event.type === "checkout.session.completed") {
+      const candidate = event.data.object as {
+        metadata?: {
+          source?: string;
+          stripeConnectAccountId?: string;
+        };
+      };
+      if (candidate.metadata?.source !== "client_invoice_connect") {
+        return NextResponse.json({ received: true });
+      }
+      if (
+        !event.account ||
+        (candidate.metadata.stripeConnectAccountId &&
+          candidate.metadata.stripeConnectAccountId !== event.account)
+      ) {
+        console.error(
+          "[Stripe Connect Webhook] Invoice Checkout account identity is missing or inconsistent"
+        );
+        return NextResponse.json({ received: true });
+      }
     }
 
     const paidInvoiceEvents: {
@@ -134,17 +167,60 @@ export async function POST(req: NextRequest) {
       const session = event.data.object as {
         id?: string;
         metadata?: {
+          captureMode?: string;
           invoiceId?: string;
+          source?: string;
           stripeConnectAccountId?: string;
         };
         amount_total?: number | null;
+        payment_intent?: string | { id?: string } | null;
       };
 
-      const connectedAccountId =
-        event.account ?? session.metadata?.stripeConnectAccountId;
+      const connectedAccountId = event.account!;
       const invoiceId = session.metadata?.invoiceId;
-      if (!connectedAccountId || !invoiceId) {
-        console.error("[Stripe Connect Webhook] Missing account or invoice metadata");
+      if (!connectedAccountId || !session.id) {
+        console.error(
+          "[Stripe Connect Webhook] Invoice Checkout is missing account or session identity"
+        );
+        return;
+      }
+
+      const amountCents = session.amount_total ?? 0;
+      const checkoutSessionId = session.id;
+      const externalId = `stripe:connect:${connectedAccountId}:checkout:${checkoutSessionId}`;
+      const manualCapture =
+        session.metadata?.captureMode === INVOICE_CHECKOUT_CAPTURE_MODE;
+      const paymentIntentId =
+        typeof session.payment_intent === "string"
+          ? session.payment_intent
+          : session.payment_intent?.id;
+      let resolutionPracticeId: string | null = null;
+
+      const resolveInvalidCheckout = async (reason: string) => {
+        const resolution = await resolveInvalidInvoiceCheckout(tx, {
+          eventId: event.id,
+          endpoint: "client-invoice-connect",
+          externalId,
+          sessionId: checkoutSessionId,
+          invoiceId,
+          practiceId: resolutionPracticeId,
+          connectedAccountId,
+          amountCents,
+          reason,
+        });
+        console.error(
+          "[Stripe Connect Webhook] Checkout could not be attributed",
+          {
+            invoiceId,
+            sessionId: session.id,
+            reason,
+            resolution: resolution.outcome,
+          }
+        );
+      };
+
+      if (!invoiceId) {
+        await resolveInvalidCheckout("missing_invoice_metadata");
         return;
       }
 
@@ -171,23 +247,70 @@ export async function POST(req: NextRequest) {
         .limit(1);
 
       if (!paymentAccount) {
-        console.error("[Stripe Connect Webhook] Account not found", {
-          connectedAccountId,
-          sessionId: session.id,
-        });
+        await resolveInvalidCheckout("payment_account_not_found");
+        return;
+      }
+      resolutionPracticeId = paymentAccount.practiceId;
+
+      const [invoiceIdentity] = await tx
+        .select({
+          id: invoices.id,
+          practiceId: invoices.practiceId,
+          appointmentId: invoices.appointmentId,
+        })
+        .from(invoices)
+        .where(
+          and(
+            eq(invoices.id, invoiceId),
+            eq(invoices.practiceId, paymentAccount.practiceId),
+            isNull(invoices.deletedAt)
+          )
+        )
+        .limit(1);
+
+      if (!invoiceIdentity) {
+        await resolveInvalidCheckout("invoice_not_found");
         return;
       }
 
-      const amountCents = session.amount_total ?? 0;
-      const amountDollars = (amountCents / 100).toFixed(2);
-      const externalId = `stripe:connect:${connectedAccountId}:checkout:${
-        session.id ?? event.id
-      }`;
+      if (invoiceIdentity.appointmentId) {
+        const [appointment] = await tx
+          .select({ id: appointments.id })
+          .from(appointments)
+          .where(
+            and(
+              eq(appointments.id, invoiceIdentity.appointmentId),
+              eq(appointments.practiceId, paymentAccount.practiceId),
+              isNull(appointments.deletedAt)
+            )
+          )
+          .for("update", { of: appointments });
+        if (!appointment) {
+          await resolveInvalidCheckout("appointment_not_found");
+          return;
+        }
+        try {
+          await assertVisitInvoiceReadyForFinancialAction(
+            { db: tx, practiceId: paymentAccount.practiceId },
+            invoiceIdentity.appointmentId
+          );
+        } catch (err) {
+          if (
+            err instanceof TRPCError &&
+            err.code === "PRECONDITION_FAILED"
+          ) {
+            await resolveInvalidCheckout("visit_not_ready");
+            return;
+          }
+          throw err;
+        }
+      }
 
       const [invoice] = await tx
         .select({
           id: invoices.id,
           practiceId: invoices.practiceId,
+          appointmentId: invoices.appointmentId,
           total: invoices.total,
           paidAmount: invoices.paidAmount,
           status: invoices.status,
@@ -201,28 +324,11 @@ export async function POST(req: NextRequest) {
             isNull(invoices.deletedAt)
           )
         )
-        .limit(1);
+        .limit(1)
+        .for("update", { of: invoices });
 
       if (!invoice) {
-        console.error("[Stripe Connect Webhook] Invoice not found for Checkout", {
-          invoiceId,
-          sessionId: session.id,
-        });
-        return;
-      }
-
-      if (
-        invoice.isEstimate ||
-        invoice.status === "draft" ||
-        invoice.status === "paid" ||
-        invoice.status === "void"
-      ) {
-        console.error("[Stripe Connect Webhook] Checkout for non-payable invoice", {
-          invoiceId,
-          status: invoice.status,
-          isEstimate: invoice.isEstimate,
-          sessionId: session.id,
-        });
+        await resolveInvalidCheckout("invoice_not_found");
         return;
       }
 
@@ -240,6 +346,20 @@ export async function POST(req: NextRequest) {
         );
       }
 
+      if (
+        invoice.isEstimate ||
+        invoice.status === "draft" ||
+        invoice.status === "paid" ||
+        invoice.status === "void"
+      ) {
+        if (!existingPayment) {
+          await resolveInvalidCheckout(
+            invoice.isEstimate ? "estimate" : `invoice_${invoice.status}`
+          );
+        }
+        return;
+      }
+
       const adjustmentRows = await tx
         .select({ amount: invoiceAdjustments.amount })
         .from(invoiceAdjustments)
@@ -254,13 +374,42 @@ export async function POST(req: NextRequest) {
         0,
       );
 
+      let recordedPaymentAmountCents: number | null = null;
       if (!existingPayment) {
         const balanceCents = invoiceBalanceCents(invoice, adjustedCents);
-        if (amountCents <= 0 || amountCents > balanceCents) {
-          throw new Error(
-            `Stripe Connect Checkout amount no longer matches invoice balance: ${invoiceId}`,
-          );
+        if (amountCents <= 0 || balanceCents <= 0) {
+          await resolveInvalidCheckout("no_live_balance");
+          return;
         }
+
+        let paymentAmountCents = amountCents;
+        if (manualCapture) {
+          if (!paymentIntentId) {
+            throw new Error(
+              `Manual Stripe Connect Checkout is missing its PaymentIntent: ${checkoutSessionId}`
+            );
+          }
+          const captured = await captureStripeCheckoutAuthorization({
+            paymentIntentId,
+            amountCents: Math.min(amountCents, balanceCents),
+            checkoutSessionId,
+            connectedAccountId,
+          });
+          paymentAmountCents = captured.amountCapturedCents;
+          if (
+            paymentAmountCents <= 0 ||
+            paymentAmountCents > balanceCents
+          ) {
+            await resolveInvalidCheckout("captured_amount_exceeds_balance");
+            return;
+          }
+        } else if (amountCents > balanceCents) {
+          await resolveInvalidCheckout("legacy_amount_exceeds_balance");
+          return;
+        }
+
+        const amountDollars = (paymentAmountCents / 100).toFixed(2);
+        recordedPaymentAmountCents = paymentAmountCents;
 
         await tx
           .insert(payments)
@@ -313,6 +462,16 @@ export async function POST(req: NextRequest) {
       }
 
       if (updates.status === "paid") {
+        await markCompletedVisitCloseoutPaid(
+          { db: tx, practiceId: invoice.practiceId },
+          {
+            appointmentId: invoice.appointmentId,
+            invoiceId,
+            source: "stripe_connect",
+            paymentId: existingPayment?.id ?? null,
+            paymentExternalId: externalId,
+          }
+        );
         paidInvoiceEvents.push({
           practiceId: invoice.practiceId,
           payload: {
@@ -328,7 +487,7 @@ export async function POST(req: NextRequest) {
       // Receipt only for a newly recorded payment, never on redelivery.
       if (!existingPayment) {
         const receipt = await loadClientReceipt(tx, invoiceId, {
-          amountPaidCents: amountCents,
+          amountPaidCents: recordedPaymentAmountCents!,
           balanceRemainingCents: totalCents - paidCents - adjustedCents,
         });
         if (receipt) clientReceipts.push(receipt);

--- a/apps/web/app/api/webhooks/stripe/route.test.ts
+++ b/apps/web/app/api/webhooks/stripe/route.test.ts
@@ -15,7 +15,8 @@ const mocks = vi.hoisted(() => {
       from: vi.fn(() => builder),
       innerJoin: vi.fn(() => builder),
       where: vi.fn(() => builder),
-      limit: vi.fn(async () => result),
+      limit: vi.fn(() => builder),
+      for: vi.fn(async () => result),
       then: (
         resolve: (value: unknown[]) => unknown,
         reject?: (error: unknown) => unknown
@@ -37,7 +38,8 @@ const mocks = vi.hoisted(() => {
   const updateSet = vi.fn((_values: unknown) => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
 
-  const db = { insert, select, update };
+  const execute = vi.fn(async () => []);
+  const db = { execute, insert, select, update };
 
   return {
     db,
@@ -46,10 +48,17 @@ const mocks = vi.hoisted(() => {
     insertValues,
     updateSet,
     claimStripeEvent: vi.fn(async () => true),
+    captureStripeCheckoutAuthorization: vi.fn(async (input: { amountCents: number }) => ({
+      amountCapturedCents: input.amountCents,
+    })),
     constructWebhookEvent: vi.fn(),
     dispatchWebhookEvent: vi.fn(async () => undefined),
     loadClientReceipt: vi.fn(async (): Promise<unknown> => null),
     deliverClientReceipt: vi.fn(async () => undefined),
+    execute,
+    refundInvalidStripeCheckoutPayment: vi.fn(async () => ({
+      outcome: "authorization_canceled" as const,
+    })),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
       fn(db)
     ),
@@ -65,7 +74,10 @@ vi.mock("@/lib/tenant-db", () => ({
 }));
 
 vi.mock("@/lib/stripe", () => ({
+  captureStripeCheckoutAuthorization: mocks.captureStripeCheckoutAuthorization,
   constructWebhookEvent: mocks.constructWebhookEvent,
+  INVOICE_CHECKOUT_CAPTURE_MODE: "manual_v1",
+  refundInvalidStripeCheckoutPayment: mocks.refundInvalidStripeCheckoutPayment,
 }));
 
 vi.mock("@/lib/billing/stripe-events", () => ({
@@ -82,13 +94,15 @@ vi.mock("@/lib/billing/client-receipts", () => ({
 }));
 
 const { POST } = await import("./route");
-const { payments } = await import("@openpims/db");
+const { auditLog, payments } = await import("@openpims/db");
 const { STRIPE_WEBHOOK_BODY_MAX_BYTES } = await import(
   "@/lib/stripe-webhook-limits"
 );
 
 const INVOICE_ID = "00000000-0000-0000-0000-000000000001";
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-0000000000ab";
+const CLOSEOUT_ID = "00000000-0000-0000-0000-0000000000ac";
 vi.spyOn(console, "error").mockImplementation(() => {});
 
 const activeInvoice = {
@@ -107,7 +121,7 @@ function checkoutEvent(overrides: Record<string, unknown> = {}) {
     data: {
       object: {
         id: "cs_test_123",
-        metadata: { invoiceId: INVOICE_ID },
+        metadata: { invoiceId: INVOICE_ID, source: "client_invoice" },
         amount_total: 12500,
         ...overrides,
       },
@@ -146,7 +160,16 @@ afterEach(() => {
   vi.clearAllMocks();
   mocks.selectResults.length = 0;
   mocks.claimStripeEvent.mockResolvedValue(true);
+  mocks.captureStripeCheckoutAuthorization.mockImplementation(
+    async (input: { amountCents: number }) => ({
+      amountCapturedCents: input.amountCents,
+    })
+  );
   mocks.loadClientReceipt.mockResolvedValue(null);
+  mocks.execute.mockResolvedValue([]);
+  mocks.refundInvalidStripeCheckoutPayment.mockResolvedValue({
+    outcome: "authorization_canceled",
+  });
 });
 
 describe("Stripe client invoice webhook", () => {
@@ -199,6 +222,7 @@ describe("Stripe client invoice webhook", () => {
     mocks.constructWebhookEvent.mockResolvedValue(checkoutEvent());
     mocks.selectResults.push(
       [activeInvoice],
+      [activeInvoice],
       [],
       [],
       [{ total: "125.00" }]
@@ -244,11 +268,124 @@ describe("Stripe client invoice webhook", () => {
     });
   });
 
+  it("settles a completed accounts-receivable closeout with the Stripe payment", async () => {
+    const linkedInvoice = { ...activeInvoice, appointmentId: APPOINTMENT_ID };
+    mocks.constructWebhookEvent.mockResolvedValue(checkoutEvent());
+    mocks.selectResults.push(
+      [linkedInvoice],
+      [{ id: APPOINTMENT_ID }],
+      [{ status: "completed" }],
+      [linkedInvoice],
+      [],
+      [],
+      [{ total: "125.00" }],
+      [{
+        id: CLOSEOUT_ID,
+        chargeDisposition: "accounts_receivable",
+        revision: 2,
+      }]
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ chargeDisposition: "paid", revision: 3 })
+    );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        userId: null,
+        action: "visit_closeout_settled",
+        entityId: CLOSEOUT_ID,
+        changes: expect.objectContaining({
+          source: "stripe",
+          paymentExternalId: "stripe:checkout:cs_test_123",
+          priorRevision: 2,
+          nextRevision: 3,
+        }),
+      })
+    );
+  });
+
+  it("refunds a recognized legacy Checkout when its linked visit is not ready", async () => {
+    const linkedInvoice = { ...activeInvoice, appointmentId: APPOINTMENT_ID };
+    mocks.constructWebhookEvent.mockResolvedValue(checkoutEvent());
+    mocks.selectResults.push(
+      [linkedInvoice],
+      [{ id: APPOINTMENT_ID }],
+      [{ status: "draft" }]
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.refundInvalidStripeCheckoutPayment).toHaveBeenCalledWith({
+      externalId: "stripe:checkout:cs_test_123",
+      amountCents: 12500,
+      idempotencyKey: "invalid:stripe:checkout:cs_test_123",
+    });
+    const auditWrite = mocks.insertValues.mock.calls
+      .map(([value]) => value)
+      .find(
+        (value) =>
+          (value as { action?: string }).action ===
+          "stripe_checkout_invalid_resolved"
+      ) as Record<string, any>;
+    expect(auditWrite).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        practiceId: PRACTICE_ID,
+        action: "stripe_checkout_invalid_resolved",
+        entityType: "stripe_checkout_resolution",
+        changes: expect.objectContaining({
+          eventId: "evt_123",
+          endpoint: "client-invoice",
+          sessionId: "cs_test_123",
+          externalId: "stripe:checkout:cs_test_123",
+          invoiceId: INVOICE_ID,
+          practiceId: PRACTICE_ID,
+          connectedAccountId: null,
+          reason: "visit_not_ready",
+          outcome: "authorization_canceled",
+          refundId: null,
+          refundAmountCents: null,
+          checkoutAmountCents: 12500,
+        }),
+      })
+    );
+    expect(auditWrite.entityId).toBe(auditWrite.id);
+    expect(mocks.insertConflict).toHaveBeenCalledWith({ target: auditLog.id });
+    expect(mocks.captureStripeCheckoutAuthorization).not.toHaveBeenCalled();
+  });
+
+  it("retries rather than resolving Checkout when readiness infrastructure fails", async () => {
+    const linkedInvoice = { ...activeInvoice, appointmentId: APPOINTMENT_ID };
+    mocks.constructWebhookEvent.mockResolvedValue(checkoutEvent());
+    mocks.selectResults.push(
+      [linkedInvoice],
+      [{ id: APPOINTMENT_ID }],
+      [{ status: "clinical_finalized" }]
+    );
+    mocks.execute.mockRejectedValueOnce(new Error("database unavailable"));
+
+    const response = await POST(stripeRequest());
+
+    expect(response.status).toBe(500);
+    expect(mocks.refundInvalidStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
   it("emails a receipt only when the client has an email on file", async () => {
     mocks.constructWebhookEvent.mockResolvedValue(checkoutEvent());
     const receipt = { to: "jane@example.com" };
     mocks.loadClientReceipt.mockResolvedValue(receipt);
-    mocks.selectResults.push([activeInvoice], [], [], [{ total: "125.00" }]);
+    mocks.selectResults.push(
+      [activeInvoice],
+      [activeInvoice],
+      [],
+      [],
+      [{ total: "125.00" }]
+    );
 
     const response = await POST(stripeRequest());
 
@@ -268,11 +405,53 @@ describe("Stripe client invoice webhook", () => {
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
   });
 
+  it("ignores unrelated Checkout sessions before claiming money events", async () => {
+    mocks.constructWebhookEvent.mockResolvedValue(
+      checkoutEvent({
+        metadata: { source: "subscription", invoiceId: INVOICE_ID },
+      })
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.claimStripeEvent).not.toHaveBeenCalled();
+    expect(mocks.refundInvalidStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
+  it("ignores Checkout carrying only arbitrary invoice metadata without our source", async () => {
+    mocks.constructWebhookEvent.mockResolvedValue(
+      checkoutEvent({ metadata: { invoiceId: INVOICE_ID } })
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.claimStripeEvent).not.toHaveBeenCalled();
+    expect(mocks.refundInvalidStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
+  it("resolves a recognized invoice Checkout with missing invoice metadata", async () => {
+    mocks.constructWebhookEvent.mockResolvedValue(
+      checkoutEvent({ metadata: { source: "client_invoice" } })
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.refundInvalidStripeCheckoutPayment).toHaveBeenCalledWith({
+      externalId: "stripe:checkout:cs_test_123",
+      amountCents: 12500,
+      idempotencyKey: "invalid:stripe:checkout:cs_test_123",
+    });
+  });
+
   it("recalculates invoice totals for an already-recorded checkout-session payment", async () => {
     mocks.constructWebhookEvent.mockResolvedValue(
       checkoutEvent({ amount_total: 7500 })
     );
     mocks.selectResults.push(
+      [{ ...activeInvoice, total: "100.00", paidAmount: "75.00" }],
       [{ ...activeInvoice, total: "100.00", paidAmount: "75.00" }],
       [{ id: "pay_existing", invoiceId: INVOICE_ID }],
       [],
@@ -303,11 +482,12 @@ describe("Stripe client invoice webhook", () => {
     expect(mocks.updateSet).not.toHaveBeenCalled();
   });
 
-  it("fails before money side effects when Checkout exceeds the live invoice balance", async () => {
+  it("refunds a legacy automatic-capture Checkout that exceeds the live balance", async () => {
     mocks.constructWebhookEvent.mockResolvedValue(
       checkoutEvent({ amount_total: 7500 })
     );
     mocks.selectResults.push(
+      [{ ...activeInvoice, paidAmount: "75.00" }],
       [{ ...activeInvoice, paidAmount: "75.00" }],
       [],
       []
@@ -315,9 +495,11 @@ describe("Stripe client invoice webhook", () => {
 
     const response = await POST(stripeRequest());
 
-    expect(response.status).toBe(500);
-    await expect(response.json()).resolves.toEqual({
-      error: "Webhook handler failed",
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.refundInvalidStripeCheckoutPayment).toHaveBeenCalledWith({
+      externalId: "stripe:checkout:cs_test_123",
+      amountCents: 7500,
+      idempotencyKey: "invalid:stripe:checkout:cs_test_123",
     });
     expect(mocks.insertValues).not.toHaveBeenCalledWith(
       expect.objectContaining({ invoiceId: INVOICE_ID })
@@ -326,11 +508,83 @@ describe("Stripe client invoice webhook", () => {
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
   });
 
+  it("partially captures a stale manual Checkout at the live remaining balance", async () => {
+    mocks.constructWebhookEvent.mockResolvedValue(
+      checkoutEvent({
+        amount_total: 12500,
+        payment_intent: "pi_manual_123",
+        metadata: {
+          invoiceId: INVOICE_ID,
+          captureMode: "manual_v1",
+          source: "client_invoice",
+        },
+      })
+    );
+    mocks.selectResults.push(
+      [{ ...activeInvoice, paidAmount: "75.00" }],
+      [{ ...activeInvoice, paidAmount: "75.00" }],
+      [],
+      [],
+      [{ total: "125.00" }]
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.captureStripeCheckoutAuthorization).toHaveBeenCalledWith({
+      paymentIntentId: "pi_manual_123",
+      amountCents: 5000,
+      checkoutSessionId: "cs_test_123",
+    });
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: "50.00" })
+    );
+    expect(mocks.refundInvalidStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
+  it("does not capture a manual Checkout after the invoice is voided", async () => {
+    mocks.constructWebhookEvent.mockResolvedValue(
+      checkoutEvent({
+        payment_intent: "pi_manual_void",
+        metadata: {
+          invoiceId: INVOICE_ID,
+          captureMode: "manual_v1",
+          source: "client_invoice",
+        },
+      })
+    );
+    mocks.selectResults.push(
+      [{ ...activeInvoice, status: "void" }],
+      [{ ...activeInvoice, status: "void" }],
+      []
+    );
+
+    const response = await POST(stripeRequest());
+
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(mocks.captureStripeCheckoutAuthorization).not.toHaveBeenCalled();
+    expect(mocks.refundInvalidStripeCheckoutPayment).toHaveBeenCalledWith({
+      externalId: "stripe:checkout:cs_test_123",
+      amountCents: 12500,
+      idempotencyKey: "invalid:stripe:checkout:cs_test_123",
+    });
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "stripe_checkout_invalid_resolved",
+        changes: expect.objectContaining({ reason: "invoice_void" }),
+      })
+    );
+  });
+
   it.each(["draft", "paid", "void"])(
     "skips payment side effects when Checkout completes for a %s invoice",
     async (status) => {
       mocks.constructWebhookEvent.mockResolvedValue(checkoutEvent());
-      mocks.selectResults.push([{ ...activeInvoice, status }]);
+      mocks.selectResults.push(
+        [{ ...activeInvoice, status }],
+        [{ ...activeInvoice, status }],
+        []
+      );
 
       const response = await POST(stripeRequest());
 
@@ -340,16 +594,28 @@ describe("Stripe client invoice webhook", () => {
       );
       expect(mocks.updateSet).not.toHaveBeenCalled();
       expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
+      expect(mocks.refundInvalidStripeCheckoutPayment).toHaveBeenCalledWith({
+        externalId: "stripe:checkout:cs_test_123",
+        amountCents: 12500,
+        idempotencyKey: "invalid:stripe:checkout:cs_test_123",
+      });
     }
   );
 
   it("matches checkout invoices only for active practices", () => {
     const invoiceLookup = ROUTE_SOURCE.match(
-      /const \[invoice\] = await tx[\s\S]+?\.limit\(1\);/
+      /const \[invoice\] = await tx[\s\S]+?\.for\("update", \{ of: invoices \}\);/
     )?.[0];
 
     expect(invoiceLookup).toContain("innerJoin(");
     expect(invoiceLookup).toContain("practices");
     expect(invoiceLookup).toContain("isNull(practices.deletedAt)");
+  });
+
+  it("locks a linked appointment before the invoice row", () => {
+    expect(ROUTE_SOURCE.indexOf(".from(appointments)")).toBeGreaterThan(-1);
+    expect(ROUTE_SOURCE.indexOf(".from(appointments)")).toBeLessThan(
+      ROUTE_SOURCE.indexOf('.for("update", { of: invoices })')
+    );
   });
 });

--- a/apps/web/app/api/webhooks/stripe/route.ts
+++ b/apps/web/app/api/webhooks/stripe/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { TRPCError } from "@trpc/server";
 import { eq, and, isNull, sum } from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import {
@@ -6,8 +7,13 @@ import {
   invoices,
   payments,
   practices,
+  appointments,
 } from "@openpims/db";
-import { constructWebhookEvent } from "@/lib/stripe";
+import {
+  captureStripeCheckoutAuthorization,
+  constructWebhookEvent,
+  INVOICE_CHECKOUT_CAPTURE_MODE,
+} from "@/lib/stripe";
 import { withSystem } from "@/lib/tenant-db";
 import { claimStripeEvent } from "@/lib/billing/stripe-events";
 import {
@@ -25,6 +31,11 @@ import {
   STRIPE_WEBHOOK_BODY_MAX_BYTES,
   stripeWebhookContentLengthTooLarge,
 } from "@/lib/stripe-webhook-limits";
+import {
+  assertVisitInvoiceReadyForFinancialAction,
+  markCompletedVisitCloseoutPaid,
+} from "@/server/visit-billing-integrity";
+import { resolveInvalidInvoiceCheckout } from "@/server/stripe-checkout-resolution";
 
 function payloadTooLargeResponse() {
   return NextResponse.json(
@@ -71,6 +82,15 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    if (event.type === "checkout.session.completed") {
+      const candidate = event.data.object as {
+        metadata?: { invoiceId?: string; source?: string };
+      };
+      if (candidate.metadata?.source !== "client_invoice") {
+        return NextResponse.json({ received: true });
+      }
+    }
+
     // Webhook has no tenant session, so claim/process in system context. The
     // event claim lives in the same transaction as side effects; if processing
     // throws, the claim rolls back and Stripe can retry.
@@ -91,25 +111,118 @@ export async function POST(req: NextRequest) {
       if (event.type === "checkout.session.completed") {
         const session = event.data.object as {
           id?: string;
-          metadata?: { invoiceId?: string };
+          metadata?: {
+            invoiceId?: string;
+            captureMode?: string;
+            source?: string;
+          };
           amount_total?: number | null;
+          payment_intent?: string | { id?: string } | null;
         };
 
         const invoiceId = session.metadata?.invoiceId;
-        if (!invoiceId) {
-          console.error("[Stripe Webhook] No invoiceId in session metadata");
+        if (!session.id) {
+          console.error("[Stripe Webhook] Invoice Checkout is missing session id");
           return;
         }
 
         // Calculate payment amount from Stripe (convert cents to dollars)
         const amountCents = session.amount_total ?? 0;
-        const amountDollars = (amountCents / 100).toFixed(2);
-        const externalId = `stripe:checkout:${session.id ?? event.id}`;
+        const checkoutSessionId = session.id;
+        const externalId = `stripe:checkout:${checkoutSessionId}`;
+        const manualCapture =
+          session.metadata?.captureMode === INVOICE_CHECKOUT_CAPTURE_MODE;
+        const paymentIntentId =
+          typeof session.payment_intent === "string"
+            ? session.payment_intent
+            : session.payment_intent?.id;
+        let resolutionPracticeId: string | null = null;
+
+        const resolveInvalidCheckout = async (reason: string) => {
+          const resolution = await resolveInvalidInvoiceCheckout(tx, {
+            eventId: event.id,
+            endpoint: "client-invoice",
+            externalId,
+            sessionId: checkoutSessionId,
+            invoiceId,
+            practiceId: resolutionPracticeId,
+            amountCents,
+            reason,
+          });
+          console.error("[Stripe Webhook] Checkout could not be attributed", {
+            invoiceId,
+            sessionId: session.id,
+            reason,
+            resolution: resolution.outcome,
+          });
+        };
+
+        if (!invoiceId) {
+          await resolveInvalidCheckout("missing_invoice_metadata");
+          return;
+        }
+
+        const [invoiceIdentity] = await tx
+          .select({
+            id: invoices.id,
+            practiceId: invoices.practiceId,
+            appointmentId: invoices.appointmentId,
+          })
+          .from(invoices)
+          .innerJoin(
+            practices,
+            and(
+              eq(practices.id, invoices.practiceId),
+              isNull(practices.deletedAt),
+            ),
+          )
+          .where(and(eq(invoices.id, invoiceId), isNull(invoices.deletedAt)))
+          .limit(1);
+
+        if (!invoiceIdentity) {
+          await resolveInvalidCheckout("invoice_not_found");
+          return;
+        }
+        resolutionPracticeId = invoiceIdentity.practiceId;
+
+        if (invoiceIdentity.appointmentId) {
+          const [appointment] = await tx
+            .select({ id: appointments.id })
+            .from(appointments)
+            .where(
+              and(
+                eq(appointments.id, invoiceIdentity.appointmentId),
+                eq(appointments.practiceId, invoiceIdentity.practiceId),
+                isNull(appointments.deletedAt)
+              )
+            )
+            .for("update", { of: appointments });
+          if (!appointment) {
+            await resolveInvalidCheckout("appointment_not_found");
+            return;
+          }
+          try {
+            await assertVisitInvoiceReadyForFinancialAction(
+              { db: tx, practiceId: invoiceIdentity.practiceId },
+              invoiceIdentity.appointmentId
+            );
+          } catch (err) {
+            if (
+              err instanceof TRPCError &&
+              err.code === "PRECONDITION_FAILED"
+            ) {
+              await resolveInvalidCheckout("visit_not_ready");
+              return;
+            }
+            throw err;
+          }
+        }
 
         const [invoice] = await tx
           .select({
             id: invoices.id,
             practiceId: invoices.practiceId,
+            appointmentId: invoices.appointmentId,
             total: invoices.total,
             paidAmount: invoices.paidAmount,
             status: invoices.status,
@@ -124,28 +237,11 @@ export async function POST(req: NextRequest) {
             ),
           )
           .where(and(eq(invoices.id, invoiceId), isNull(invoices.deletedAt)))
-          .limit(1);
+          .limit(1)
+          .for("update", { of: invoices });
 
         if (!invoice) {
-          console.error("[Stripe Webhook] Invoice not found for Checkout", {
-            invoiceId,
-            sessionId: session.id,
-          });
-          return;
-        }
-
-        if (
-          invoice.isEstimate ||
-          invoice.status === "draft" ||
-          invoice.status === "paid" ||
-          invoice.status === "void"
-        ) {
-          console.error("[Stripe Webhook] Checkout for non-payable invoice", {
-            invoiceId,
-            status: invoice.status,
-            isEstimate: invoice.isEstimate,
-            sessionId: session.id,
-          });
+          await resolveInvalidCheckout("invoice_not_found");
           return;
         }
 
@@ -163,6 +259,20 @@ export async function POST(req: NextRequest) {
           );
         }
 
+        if (
+          invoice.isEstimate ||
+          invoice.status === "draft" ||
+          invoice.status === "paid" ||
+          invoice.status === "void"
+        ) {
+          if (!existingPayment) {
+            await resolveInvalidCheckout(
+              invoice.isEstimate ? "estimate" : `invoice_${invoice.status}`
+            );
+          }
+          return;
+        }
+
         const adjustmentRows = await tx
           .select({ amount: invoiceAdjustments.amount })
           .from(invoiceAdjustments)
@@ -177,13 +287,46 @@ export async function POST(req: NextRequest) {
           0,
         );
 
+        let recordedPaymentAmountCents: number | null = null;
         if (!existingPayment) {
           const balanceCents = invoiceBalanceCents(invoice, adjustedCents);
-          if (amountCents <= 0 || amountCents > balanceCents) {
-            throw new Error(
-              `Stripe Checkout amount no longer matches invoice balance: ${invoiceId}`,
-            );
+          if (amountCents <= 0 || balanceCents <= 0) {
+            await resolveInvalidCheckout("no_live_balance");
+            return;
           }
+
+          let paymentAmountCents = amountCents;
+          if (manualCapture) {
+            if (!paymentIntentId) {
+              throw new Error(
+                `Manual Stripe Checkout is missing its PaymentIntent: ${checkoutSessionId}`
+              );
+            }
+            const captured = await captureStripeCheckoutAuthorization({
+              paymentIntentId,
+              amountCents: Math.min(amountCents, balanceCents),
+              checkoutSessionId,
+            });
+            paymentAmountCents = captured.amountCapturedCents;
+            // A previous webhook attempt may have captured successfully before
+            // its DB transaction rolled back. Never attribute that capture over
+            // a balance that changed before Stripe retried the event.
+            if (
+              paymentAmountCents <= 0 ||
+              paymentAmountCents > balanceCents
+            ) {
+              await resolveInvalidCheckout("captured_amount_exceeds_balance");
+              return;
+            }
+          } else if (amountCents > balanceCents) {
+            // Sessions created before manual capture was deployed have already
+            // moved money. Refund the full stale payment instead of orphaning it.
+            await resolveInvalidCheckout("legacy_amount_exceeds_balance");
+            return;
+          }
+
+          const amountDollars = (paymentAmountCents / 100).toFixed(2);
+          recordedPaymentAmountCents = paymentAmountCents;
 
           // Record the payment once per Checkout Session. The Stripe event ledger
           // handles normal redelivery; this protects money state if Stripe ever
@@ -245,6 +388,16 @@ export async function POST(req: NextRequest) {
         }
 
         if (updates.status === "paid") {
+          await markCompletedVisitCloseoutPaid(
+            { db: tx, practiceId: invoice.practiceId },
+            {
+              appointmentId: invoice.appointmentId,
+              invoiceId,
+              source: "stripe",
+              paymentId: existingPayment?.id ?? null,
+              paymentExternalId: externalId,
+            }
+          );
           paidInvoiceEvents.push({
             practiceId: invoice.practiceId,
             payload: {
@@ -260,7 +413,7 @@ export async function POST(req: NextRequest) {
         // Receipt only for a newly recorded payment, never on redelivery.
         if (!existingPayment) {
           const receipt = await loadClientReceipt(tx, invoiceId, {
-            amountPaidCents: amountCents,
+            amountPaidCents: recordedPaymentAmountCents!,
             balanceRemainingCents: totalCents - paidCents - adjustedCents,
           });
           if (receipt) clientReceipts.push(receipt);

--- a/apps/web/components/common/action-confirmation-dialog.tsx
+++ b/apps/web/components/common/action-confirmation-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useRef } from "react";
+import { useEffect, useId, useRef, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -23,6 +23,7 @@ export function ActionConfirmationDialog({
   confirmVariant = "default",
   isPending = false,
   reason,
+  children,
   onCancel,
   onConfirm,
 }: {
@@ -33,6 +34,7 @@ export function ActionConfirmationDialog({
   confirmVariant?: "default" | "destructive";
   isPending?: boolean;
   reason?: ReasonInput;
+  children?: ReactNode;
   onCancel: () => void;
   onConfirm: () => void;
 }) {
@@ -143,6 +145,8 @@ export function ActionConfirmationDialog({
             </p>
           </div>
         ) : null}
+
+        {children ? <div className="mt-4">{children}</div> : null}
 
         <div className="mt-5 flex justify-end gap-2">
           <Button variant="outline" disabled={isPending} onClick={onCancel}>

--- a/apps/web/lib/__tests__/billing-ui.test.ts
+++ b/apps/web/lib/__tests__/billing-ui.test.ts
@@ -203,6 +203,15 @@ describe("billing invoice payment actions", () => {
     expect(source).toContain("Take Card");
   });
 
+  it("offers invoice email only while a balance-bearing invoice is sent or overdue", () => {
+    expect(source).toContain(
+      '(invoice.status === "sent" ||\n                          invoice.status === "overdue")'
+    );
+    expect(source).not.toContain(
+      'invoice.status === "overdue" ||\n                          invoice.status === "paid"'
+    );
+  });
+
   it("uses accessible in-app dialogs for irreversible billing actions", () => {
     expect(source).toContain("<ActionConfirmationDialog");
     expect(source).toContain('title="Void invoice?"');

--- a/apps/web/lib/__tests__/stripe.test.ts
+++ b/apps/web/lib/__tests__/stripe.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildInvoiceCheckoutSessionParams,
   buildSubscriptionCheckoutSessionParams,
+  INVOICE_CHECKOUT_CAPTURE_MODE,
   STRIPE_TAX_ENABLED_ENV,
 } from "../stripe";
 import { TRIAL_DAYS } from "../billing/plans";
@@ -17,6 +18,9 @@ async function importStripeWithMock() {
   const checkoutCreate = vi.fn();
   const checkoutRetrieve = vi.fn();
   const refundCreate = vi.fn();
+  const paymentIntentCapture = vi.fn();
+  const paymentIntentCancel = vi.fn();
+  const paymentIntentRetrieve = vi.fn();
   const billingPortalCreate = vi.fn();
   const accountCreate = vi.fn();
   const accountRetrieve = vi.fn();
@@ -31,6 +35,11 @@ async function importStripeWithMock() {
         sessions: { create: checkoutCreate, retrieve: checkoutRetrieve },
       };
       refunds = { create: refundCreate };
+      paymentIntents = {
+        cancel: paymentIntentCancel,
+        capture: paymentIntentCapture,
+        retrieve: paymentIntentRetrieve,
+      };
       billingPortal = { sessions: { create: billingPortalCreate } };
       accounts = {
         create: accountCreate,
@@ -49,6 +58,9 @@ async function importStripeWithMock() {
     checkoutCreate,
     checkoutRetrieve,
     refundCreate,
+    paymentIntentCapture,
+    paymentIntentCancel,
+    paymentIntentRetrieve,
     billingPortalCreate,
     accountCreate,
     accountRetrieve,
@@ -216,9 +228,18 @@ describe("buildInvoiceCheckoutSessionParams", () => {
       mode: "payment",
       customer_email: "client@example.com",
       client_reference_id: "invoice_123",
-      metadata: { invoiceId: "invoice_123", source: "client_invoice" },
+      metadata: {
+        invoiceId: "invoice_123",
+        captureMode: INVOICE_CHECKOUT_CAPTURE_MODE,
+        source: "client_invoice",
+      },
       payment_intent_data: {
-        metadata: { invoiceId: "invoice_123", source: "client_invoice" },
+        capture_method: "manual",
+        metadata: {
+          invoiceId: "invoice_123",
+          captureMode: INVOICE_CHECKOUT_CAPTURE_MODE,
+          source: "client_invoice",
+        },
       },
       success_url: "https://app.example.com/billing?payment=success",
       cancel_url: "https://app.example.com/billing?payment=cancelled",
@@ -307,15 +328,18 @@ describe("buildInvoiceCheckoutSessionParams", () => {
 
     expect(params.metadata).toEqual({
       invoiceId: "invoice_123",
+      captureMode: INVOICE_CHECKOUT_CAPTURE_MODE,
       source: "client_invoice_connect",
       stripeConnectAccountId: "acct_123",
     });
     expect(params.payment_intent_data).toEqual({
       metadata: {
         invoiceId: "invoice_123",
+        captureMode: INVOICE_CHECKOUT_CAPTURE_MODE,
         source: "client_invoice_connect",
         stripeConnectAccountId: "acct_123",
       },
+      capture_method: "manual",
       application_fee_amount: 125,
     });
   });
@@ -345,7 +369,11 @@ describe("create Stripe hosted sessions", () => {
     expect(checkoutCreate).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        metadata: { invoiceId: "invoice_123", source: "client_invoice" },
+        metadata: {
+          invoiceId: "invoice_123",
+          captureMode: INVOICE_CHECKOUT_CAPTURE_MODE,
+          source: "client_invoice",
+        },
       }),
       expect.objectContaining({
         idempotencyKey: expect.stringMatching(
@@ -469,6 +497,208 @@ describe("create Stripe hosted sessions", () => {
       expect.objectContaining({
         idempotencyKey: expect.stringMatching(
           /^openvpm:refund:refund:payment:payment_123:/
+        ),
+        stripeAccount: "acct_9",
+      })
+    );
+  });
+
+  it("captures only the live invoice balance from a manual authorization", async () => {
+    const {
+      stripeModule,
+      paymentIntentCapture,
+      paymentIntentRetrieve,
+    } = await importStripeWithMock();
+    paymentIntentRetrieve.mockResolvedValue({
+      status: "requires_capture",
+      amount: 12550,
+      amount_capturable: 12550,
+      application_fee_amount: 125,
+    });
+    paymentIntentCapture.mockResolvedValue({ amount_received: 5000 });
+
+    await expect(
+      stripeModule.captureStripeCheckoutAuthorization({
+        paymentIntentId: "pi_123",
+        amountCents: 5000,
+        checkoutSessionId: "cs_123",
+        connectedAccountId: "acct_123",
+      })
+    ).resolves.toEqual({ amountCapturedCents: 5000 });
+
+    expect(paymentIntentRetrieve).toHaveBeenCalledWith("pi_123", {
+      stripeAccount: "acct_123",
+    });
+    expect(paymentIntentCapture).toHaveBeenCalledWith(
+      "pi_123",
+      { amount_to_capture: 5000, application_fee_amount: 49 },
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^openvpm:invoice-capture:cs_123:/
+        ),
+        stripeAccount: "acct_123",
+      })
+    );
+  });
+
+  it("overrides a partial Connect capture fee to zero for a one-cent balance", async () => {
+    const {
+      stripeModule,
+      paymentIntentCapture,
+      paymentIntentRetrieve,
+    } = await importStripeWithMock();
+    paymentIntentRetrieve.mockResolvedValue({
+      status: "requires_capture",
+      amount: 10000,
+      amount_capturable: 10000,
+      application_fee_amount: 250,
+    });
+    paymentIntentCapture.mockResolvedValue({ amount_received: 1 });
+
+    await stripeModule.captureStripeCheckoutAuthorization({
+      paymentIntentId: "pi_one_cent",
+      amountCents: 1,
+      checkoutSessionId: "cs_one_cent",
+      connectedAccountId: "acct_123",
+    });
+
+    expect(paymentIntentCapture).toHaveBeenCalledWith(
+      "pi_one_cent",
+      { amount_to_capture: 1, application_fee_amount: 0 },
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^openvpm:invoice-capture:cs_one_cent:/
+        ),
+        stripeAccount: "acct_123",
+      })
+    );
+  });
+
+  it("cancels an invalid manual Checkout authorization immediately", async () => {
+    const {
+      stripeModule,
+      checkoutRetrieve,
+      paymentIntentCancel,
+      paymentIntentRetrieve,
+      refundCreate,
+    } = await importStripeWithMock();
+    checkoutRetrieve.mockResolvedValue({ payment_intent: "pi_123" });
+    paymentIntentRetrieve.mockResolvedValue({
+      status: "requires_capture",
+      amount_received: 0,
+    });
+
+    await expect(
+      stripeModule.refundInvalidStripeCheckoutPayment({
+        externalId: "stripe:checkout:cs_123",
+        amountCents: 12550,
+        idempotencyKey: "invalid:cs_123",
+      })
+    ).resolves.toEqual({ outcome: "authorization_canceled" });
+    expect(paymentIntentCancel).toHaveBeenCalledWith(
+      "pi_123",
+      { cancellation_reason: "abandoned" },
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^openvpm:invalid-checkout-cancel:invalid:cs_123:/
+        ),
+      })
+    );
+    expect(refundCreate).not.toHaveBeenCalled();
+  });
+
+  it("treats an already-canceled invalid authorization as a safe replay", async () => {
+    const {
+      stripeModule,
+      checkoutRetrieve,
+      paymentIntentCancel,
+      paymentIntentRetrieve,
+    } = await importStripeWithMock();
+    checkoutRetrieve.mockResolvedValue({ payment_intent: "pi_canceled" });
+    paymentIntentRetrieve.mockResolvedValue({
+      status: "canceled",
+      amount_received: 0,
+    });
+
+    await expect(
+      stripeModule.refundInvalidStripeCheckoutPayment({
+        externalId: "stripe:checkout:cs_canceled",
+        amountCents: 12550,
+        idempotencyKey: "invalid:cs_canceled",
+      })
+    ).resolves.toEqual({ outcome: "no_funds" });
+    expect(paymentIntentCancel).not.toHaveBeenCalled();
+  });
+
+  it("cancels invalid Connect authorization on the event account", async () => {
+    const {
+      stripeModule,
+      checkoutRetrieve,
+      paymentIntentCancel,
+      paymentIntentRetrieve,
+    } = await importStripeWithMock();
+    checkoutRetrieve.mockResolvedValue({ payment_intent: "pi_connect_cancel" });
+    paymentIntentRetrieve.mockResolvedValue({
+      status: "requires_capture",
+      amount_received: 0,
+    });
+    paymentIntentCancel.mockResolvedValue({ status: "canceled" });
+
+    await expect(
+      stripeModule.refundInvalidStripeCheckoutPayment({
+        externalId: "stripe:connect:acct_9:checkout:cs_connect_cancel",
+        amountCents: 12550,
+        idempotencyKey: "invalid:cs_connect_cancel",
+      })
+    ).resolves.toEqual({ outcome: "authorization_canceled" });
+    expect(paymentIntentCancel).toHaveBeenCalledWith(
+      "pi_connect_cancel",
+      { cancellation_reason: "abandoned" },
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^openvpm:invalid-checkout-cancel:invalid:cs_connect_cancel:/
+        ),
+        stripeAccount: "acct_9",
+      })
+    );
+  });
+
+  it("refunds the full captured legacy payment from Stripe's authoritative amount", async () => {
+    const {
+      stripeModule,
+      checkoutRetrieve,
+      paymentIntentRetrieve,
+      refundCreate,
+    } = await importStripeWithMock();
+    checkoutRetrieve.mockResolvedValue({ payment_intent: "pi_legacy" });
+    paymentIntentRetrieve.mockResolvedValue({
+      status: "succeeded",
+      amount_received: 12550,
+    });
+    refundCreate.mockResolvedValue({ id: "re_legacy" });
+
+    await expect(
+      stripeModule.refundInvalidStripeCheckoutPayment({
+        externalId: "stripe:connect:acct_9:checkout:cs_legacy",
+        // Checkout Session amount_total is nullable/stale; it must not cap the
+        // reversal of funds Stripe says were captured.
+        amountCents: 0,
+        idempotencyKey: "invalid:cs_legacy",
+      })
+    ).resolves.toEqual({
+      outcome: "refunded",
+      refundId: "re_legacy",
+      amountCents: 12550,
+    });
+    expect(refundCreate).toHaveBeenCalledWith(
+      {
+        payment_intent: "pi_legacy",
+        amount: 12550,
+        refund_application_fee: true,
+      },
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(
+          /^openvpm:invalid-checkout-refund:invalid:cs_legacy:/
         ),
         stripeAccount: "acct_9",
       })

--- a/apps/web/lib/billing/__tests__/payment-accounts.test.ts
+++ b/apps/web/lib/billing/__tests__/payment-accounts.test.ts
@@ -63,5 +63,9 @@ describe("Stripe Connect payment accounts", () => {
 
     vi.stubEnv("STRIPE_CONNECT_APPLICATION_FEE_BPS", "250");
     expect(stripeConnectApplicationFeeAmount(10_000)).toBe(250);
+
+    vi.stubEnv("STRIPE_CONNECT_APPLICATION_FEE_BPS", "10000");
+    expect(stripeConnectApplicationFeeAmount(1)).toBeUndefined();
+    expect(stripeConnectApplicationFeeAmount(2)).toBe(1);
   });
 });

--- a/apps/web/lib/billing/payment-accounts.ts
+++ b/apps/web/lib/billing/payment-accounts.ts
@@ -81,8 +81,11 @@ export function stripeConnectApplicationFeeAmount(
   paymentAmountCents: number
 ): number | undefined {
   const bps = stripeConnectApplicationFeeBps();
-  if (bps <= 0 || paymentAmountCents <= 0) return undefined;
-  return Math.floor((paymentAmountCents * bps) / 10_000);
+  if (bps <= 0 || paymentAmountCents <= 1) return undefined;
+  const fee = Math.floor((paymentAmountCents * bps) / 10_000);
+  if (fee <= 0) return undefined;
+  // Always leave at least one cent of a client payment with the clinic.
+  return Math.min(fee, paymentAmountCents - 1);
 }
 
 export function stripeConnectAccountState(

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -10,6 +10,7 @@ import {
 import { envFlagEnabled } from "@/lib/env-bool";
 
 export const STRIPE_TAX_ENABLED_ENV = "STRIPE_TAX_ENABLED";
+export const INVOICE_CHECKOUT_CAPTURE_MODE = "manual_v1";
 
 function stripeIdempotencyKey(
   scope: string,
@@ -56,6 +57,187 @@ export async function createCheckoutSession(data: {
       : {}),
   });
   return { url: stripeCheckoutRedirectUrl(session.url) };
+}
+
+function checkoutAccountOptions(connectedAccountId?: string) {
+  return connectedAccountId
+    ? { stripeAccount: connectedAccountId }
+    : undefined;
+}
+
+/**
+ * Capture a Checkout authorization only after the webhook has locked and
+ * revalidated the invoice's live balance. Partial capture releases the unused
+ * authorization, so a stale Checkout session can never overpay the invoice.
+ */
+export async function captureStripeCheckoutAuthorization(data: {
+  paymentIntentId: string;
+  amountCents: number;
+  checkoutSessionId: string;
+  connectedAccountId?: string;
+}): Promise<{ amountCapturedCents: number }> {
+  if (!stripe) {
+    throw new Error("Stripe is not configured; cannot capture card payment.");
+  }
+  if (!Number.isInteger(data.amountCents) || data.amountCents <= 0) {
+    throw new Error("Stripe capture amount must be a positive integer.");
+  }
+
+  const accountOptions = checkoutAccountOptions(data.connectedAccountId);
+  const current = accountOptions
+    ? await stripe.paymentIntents.retrieve(data.paymentIntentId, accountOptions)
+    : await stripe.paymentIntents.retrieve(data.paymentIntentId);
+
+  // A transaction may fail after Stripe accepted the capture. On retry, use
+  // Stripe's authoritative captured amount instead of attempting a new charge.
+  if (current.status === "succeeded") {
+    return { amountCapturedCents: current.amount_received };
+  }
+  if (current.status !== "requires_capture") {
+    throw new Error(
+      `Stripe Checkout authorization is not capturable: ${current.status}`
+    );
+  }
+
+  const amountToCapture = Math.min(
+    data.amountCents,
+    current.amount_capturable
+  );
+  if (amountToCapture <= 0) {
+    throw new Error("Stripe Checkout authorization has no capturable amount.");
+  }
+  const originalApplicationFee = current.application_fee_amount ?? 0;
+  const proportionalApplicationFee =
+    data.connectedAccountId &&
+    originalApplicationFee > 0 &&
+    current.amount > 0 &&
+    amountToCapture > 1
+      ? Math.min(
+          Math.floor(
+            (originalApplicationFee * amountToCapture) / current.amount
+          ),
+          amountToCapture - 1
+        )
+      : 0;
+  const overrideApplicationFee =
+    Boolean(data.connectedAccountId) && originalApplicationFee > 0;
+  const captureParams: Stripe.PaymentIntentCaptureParams = {
+    amount_to_capture: amountToCapture,
+    ...(overrideApplicationFee
+      ? { application_fee_amount: proportionalApplicationFee }
+      : {}),
+  };
+  const captured = await stripe.paymentIntents.capture(
+    data.paymentIntentId,
+    captureParams,
+    {
+      idempotencyKey: stripeIdempotencyKey(
+        "invoice-capture",
+        data.checkoutSessionId,
+        captureParams
+      ),
+      ...(accountOptions ?? {}),
+    }
+  );
+  return { amountCapturedCents: captured.amount_received };
+}
+
+/**
+ * Resolve a Checkout payment that can no longer be attributed safely. Manual
+ * authorizations are canceled immediately; legacy automatic-capture sessions
+ * are refunded with stable idempotency.
+ */
+export async function refundInvalidStripeCheckoutPayment(data: {
+  externalId: string;
+  amountCents: number;
+  idempotencyKey: string;
+}): Promise<
+  | { outcome: "authorization_canceled" }
+  | { outcome: "no_funds" }
+  | { outcome: "refunded"; refundId: string; amountCents: number }
+> {
+  const parsed = parseStripeCheckoutExternalId(data.externalId);
+  if (!parsed) {
+    throw new Error("Invalid Stripe Checkout payment identity.");
+  }
+  if (!stripe) {
+    throw new Error("Stripe is not configured; cannot resolve card payment.");
+  }
+
+  const accountOptions = checkoutAccountOptions(parsed.connectedAccountId);
+  const session = accountOptions
+    ? await stripe.checkout.sessions.retrieve(parsed.sessionId, accountOptions)
+    : await stripe.checkout.sessions.retrieve(parsed.sessionId);
+  const paymentIntentId =
+    typeof session.payment_intent === "string"
+      ? session.payment_intent
+      : session.payment_intent?.id;
+  if (!paymentIntentId) {
+    throw new Error(
+      `Stripe Checkout session has no payment intent: ${parsed.sessionId}`
+    );
+  }
+  const paymentIntent =
+    typeof session.payment_intent === "object" && session.payment_intent
+      ? session.payment_intent
+      : accountOptions
+        ? await stripe.paymentIntents.retrieve(paymentIntentId, accountOptions)
+        : await stripe.paymentIntents.retrieve(paymentIntentId);
+
+  if (paymentIntent.status === "requires_capture") {
+    await stripe.paymentIntents.cancel(
+      paymentIntentId,
+      { cancellation_reason: "abandoned" },
+      {
+        idempotencyKey: stripeIdempotencyKey(
+          "invalid-checkout-cancel",
+          data.idempotencyKey
+        ),
+        ...(accountOptions ?? {}),
+      }
+    );
+    return { outcome: "authorization_canceled" };
+  }
+  if (
+    paymentIntent.status === "canceled" ||
+    paymentIntent.status === "requires_payment_method"
+  ) {
+    return { outcome: "no_funds" };
+  }
+  if (paymentIntent.status !== "succeeded") {
+    throw new Error(
+      `Stripe Checkout payment is not ready to resolve: ${paymentIntent.status}`
+    );
+  }
+
+  // An invalid Checkout must be reversed in full. Session.amount_total is
+  // nullable and webhook payloads can be stale, while the PaymentIntent is
+  // Stripe's authoritative record of money actually captured.
+  const refundableCents = paymentIntent.amount_received;
+  if (refundableCents <= 0) {
+    return { outcome: "no_funds" };
+  }
+  const refund = await stripe.refunds.create(
+    {
+      payment_intent: paymentIntentId,
+      amount: refundableCents,
+      ...(parsed.connectedAccountId
+        ? { refund_application_fee: true }
+        : {}),
+    },
+    {
+      idempotencyKey: stripeIdempotencyKey(
+        "invalid-checkout-refund",
+        data.idempotencyKey
+      ),
+      ...(accountOptions ?? {}),
+    }
+  );
+  return {
+    outcome: "refunded",
+    refundId: refund.id,
+    amountCents: refundableCents,
+  };
 }
 
 /**
@@ -146,6 +328,7 @@ export function buildInvoiceCheckoutSessionParams(data: {
 }): Stripe.Checkout.SessionCreateParams {
   const metadata: Record<string, string> = {
     invoiceId: data.invoiceId,
+    captureMode: INVOICE_CHECKOUT_CAPTURE_MODE,
     source: data.connectedAccountId
       ? "client_invoice_connect"
       : "client_invoice",
@@ -155,6 +338,7 @@ export function buildInvoiceCheckoutSessionParams(data: {
   }
   const paymentIntentData: Stripe.Checkout.SessionCreateParams.PaymentIntentData = {
     metadata,
+    capture_method: "manual",
   };
   if (data.applicationFeeAmount && data.applicationFeeAmount > 0) {
     paymentIntentData.application_fee_amount = data.applicationFeeAmount;

--- a/apps/web/server/__tests__/billing-adjustments.test.ts
+++ b/apps/web/server/__tests__/billing-adjustments.test.ts
@@ -19,6 +19,8 @@ const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const INVOICE_ID = "00000000-0000-0000-0000-000000000002";
 const OPERATION_ID = "00000000-0000-0000-0000-000000000009";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-00000000000a";
+const CLOSEOUT_ID = "00000000-0000-0000-0000-00000000000b";
 
 const baseInvoice = {
   id: INVOICE_ID,
@@ -58,14 +60,16 @@ function callerWithDb(
 }
 
 function thenableRows(result: unknown[]) {
-  return {
-    limit: vi.fn(async () => result),
-    orderBy: vi.fn(async () => result),
+  const builder = {
+    limit: vi.fn(() => builder),
+    orderBy: vi.fn(() => builder),
+    for: vi.fn(async () => result),
     then: (
       resolve: (value: unknown[]) => unknown,
       reject?: (e: unknown) => unknown
     ) => Promise.resolve(result).then(resolve, reject),
   };
+  return builder;
 }
 
 function createDb(opts: {
@@ -278,6 +282,52 @@ describe("billing invoice adjustments", () => {
     );
   });
 
+  it("settles the completed visit when an adjustment closes accounts receivable", async () => {
+    const linkedInvoice = { ...baseInvoice, appointmentId: APPOINTMENT_ID };
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [linkedInvoice],
+        [{ id: APPOINTMENT_ID }],
+        [linkedInvoice],
+        [{ status: "completed" }],
+        [],
+        [{
+          id: CLOSEOUT_ID,
+          chargeDisposition: "accounts_receivable",
+          revision: 6,
+        }],
+      ],
+      updateReturns: [[{ id: INVOICE_ID }], [{ id: CLOSEOUT_ID }]],
+    });
+
+    await callerWithDb(db).applyInvoiceAdjustment({
+      invoiceId: INVOICE_ID,
+      type: "write_off",
+      amount: "80.00",
+      reason: "Bad debt",
+    });
+
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chargeDisposition: "paid",
+        revision: 7,
+      })
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        userId: USER_ID,
+        action: "visit_closeout_settled",
+        entityId: CLOSEOUT_ID,
+        changes: expect.objectContaining({
+          source: "dashboard_adjustment",
+          priorRevision: 6,
+          nextRevision: 7,
+        }),
+      })
+    );
+  });
+
   it("returns the original adjustment for an exact operation retry", async () => {
     const replayAdjustment = {
       id: "00000000-0000-0000-0000-000000000003",
@@ -413,7 +463,10 @@ describe("billing invoice adjustments", () => {
     });
 
     await expect(
-      callerWithDb(db).voidInvoice({ id: INVOICE_ID })
+      callerWithDb(db).voidInvoice({
+        id: INVOICE_ID,
+        reason: "Duplicate invoice",
+      })
     ).resolves.toMatchObject({ status: "void" });
 
     expect(updateSet).toHaveBeenCalledWith({ status: "void" });
@@ -427,7 +480,10 @@ describe("billing invoice adjustments", () => {
     });
 
     await expect(
-      callerWithDb(db).voidInvoice({ id: INVOICE_ID })
+      callerWithDb(db).voidInvoice({
+        id: INVOICE_ID,
+        reason: "Duplicate invoice",
+      })
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Invoice changed while voiding. Refresh and try again.",
@@ -443,7 +499,10 @@ describe("billing invoice adjustments", () => {
     });
 
     await expect(
-      callerWithDb(db).voidInvoice({ id: INVOICE_ID })
+      callerWithDb(db).voidInvoice({
+        id: INVOICE_ID,
+        reason: "Duplicate invoice",
+      })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();

--- a/apps/web/server/__tests__/billing-card-checkout.test.ts
+++ b/apps/web/server/__tests__/billing-card-checkout.test.ts
@@ -22,6 +22,7 @@ const { billingRouter } = await import("../routers/billing");
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const INVOICE_ID = "00000000-0000-0000-0000-000000000002";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000003";
 
 const baseInvoice = {
   id: INVOICE_ID,
@@ -73,13 +74,15 @@ function callerWithDb(db: Record<string, unknown>) {
 }
 
 function thenableRows(result: unknown[]) {
-  return {
-    limit: vi.fn(async () => result),
+  const rows = {
+    limit: vi.fn(() => rows),
+    for: vi.fn(async () => result),
     then: (
       resolve: (value: unknown[]) => unknown,
       reject?: (e: unknown) => unknown
     ) => Promise.resolve(result).then(resolve, reject),
   };
+  return rows;
 }
 
 function createDb(selectResults: unknown[][]) {
@@ -187,6 +190,25 @@ describe("billing card checkout", () => {
       message: "Mark the invoice as sent before recording payment.",
     });
 
+    expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects checkout until an appointment-linked visit is finalized", async () => {
+    const visitInvoice = { ...baseInvoice, appointmentId: APPOINTMENT_ID };
+    const { db } = createDb([
+      [visitInvoice],
+      [{ id: APPOINTMENT_ID }],
+      [visitInvoice],
+      [{ status: "draft" }],
+    ]);
+
+    await expect(
+      callerWithDb(db).createCardPaymentCheckout({ invoiceId: INVOICE_ID })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Finalize the clinical handoff before sending or collecting this visit invoice.",
+    });
     expect(mocks.createCheckoutSession).not.toHaveBeenCalled();
   });
 

--- a/apps/web/server/__tests__/billing-invoice-integrity.test.ts
+++ b/apps/web/server/__tests__/billing-invoice-integrity.test.ts
@@ -1193,6 +1193,7 @@ describe("billing invoice integrity", () => {
             resolutionReason: waiverReason,
           },
         ],
+        [],
         [
           {
             id: "00000000-0000-0000-0000-00000000000a",
@@ -1492,83 +1493,80 @@ describe("billing invoice integrity", () => {
     expect(updateSet).toHaveBeenCalledTimes(2);
   });
 
-  it("restores product stock when voiding a real invoice through status updates", async () => {
-    const { db, updateSet } = createDb({
-      selectResults: [
-        [
-          {
-            id: INVOICE_ID,
-            total: "30.00",
-            paidAmount: "0.00",
-            status: "sent",
-            isEstimate: false,
-          },
-        ],
-        [],
-        [],
-        [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
-      ],
-      updateReturns: [
-        [{ id: INVOICE_ID, status: "void", isEstimate: false }],
-        [{ id: PRODUCT_ID, stockQuantity: 12 }],
-      ],
-    });
+  it("rejects voiding through the generic status endpoint", async () => {
+    const { db, select, updateSet } = createDb({ selectResults: [] });
 
     await expect(
-      callerWithDb(db).updateInvoiceStatus({ id: INVOICE_ID, status: "void" })
-    ).resolves.toMatchObject({ status: "void" });
+      callerWithDb(db).updateInvoiceStatus({
+        id: INVOICE_ID,
+        status: "void",
+      } as never)
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
-    expect(updateSet).toHaveBeenNthCalledWith(1, { status: "void" });
-    expect(updateSet).toHaveBeenNthCalledWith(2, {
-      stockQuantity: expect.anything(),
-    });
-  });
-
-  it("does not restore stock when a void status update is repeated", async () => {
-    const { db, updateSet } = createDb({
-      selectResults: [
-        [
-          {
-            id: INVOICE_ID,
-            total: "30.00",
-            paidAmount: "0.00",
-            status: "void",
-            isEstimate: false,
-          },
-        ],
-      ],
-    });
-
-    await expect(
-      callerWithDb(db).updateInvoiceStatus({ id: INVOICE_ID, status: "void" })
-    ).resolves.toMatchObject({ status: "void" });
-
+    expect(select).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
   });
 
-  it("does not restore stock when voiding an estimate", async () => {
-    const { db, updateSet } = createDb({
+  it("requires reconciled visit work before sending an invoice", async () => {
+    const visitInvoice = {
+      id: INVOICE_ID,
+      total: "30.00",
+      paidAmount: "0.00",
+      status: "draft",
+      isEstimate: false,
+      appointmentId: APPOINTMENT_ID,
+    };
+    const { db, execute, updateSet } = createDb({
       selectResults: [
-        [
-          {
-            id: INVOICE_ID,
-            total: "30.00",
-            paidAmount: "0.00",
-            status: "sent",
-            isEstimate: true,
-          },
-        ],
-        [],
+        [visitInvoice],
+        [{ id: APPOINTMENT_ID }],
+        [{ status: "clinical_finalized" }],
       ],
-      updateReturns: [[{ id: INVOICE_ID, status: "void", isEstimate: true }]],
+      executeResults: Array.from({ length: 6 }, () => [
+        { id: "unresolved-work" },
+      ]),
     });
 
     await expect(
-      callerWithDb(db).updateInvoiceStatus({ id: INVOICE_ID, status: "void" })
-    ).resolves.toMatchObject({ status: "void" });
+      callerWithDb(db).updateInvoiceStatus({
+        id: INVOICE_ID,
+        status: "sent",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Resolve every performed vaccination, lab, procedure, and prescription before sending or collecting this visit invoice.",
+    });
+    expect(execute).toHaveBeenCalledTimes(6);
+    expect(updateSet).not.toHaveBeenCalled();
+  });
 
-    expect(updateSet).toHaveBeenCalledTimes(1);
-    expect(updateSet).toHaveBeenCalledWith({ status: "void" });
+  it("sends a clinically finalized visit invoice after reconciliation", async () => {
+    const visitInvoice = {
+      id: INVOICE_ID,
+      total: "30.00",
+      paidAmount: "0.00",
+      status: "draft",
+      isEstimate: false,
+      appointmentId: APPOINTMENT_ID,
+    };
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [visitInvoice],
+        [{ id: APPOINTMENT_ID }],
+        [{ status: "clinical_finalized" }],
+      ],
+      executeResults: [[], [], [], [], [], []],
+      updateReturns: [[{ ...visitInvoice, status: "sent" }]],
+    });
+
+    await expect(
+      callerWithDb(db).updateInvoiceStatus({
+        id: INVOICE_ID,
+        status: "sent",
+      })
+    ).resolves.toMatchObject({ status: "sent" });
+    expect(updateSet).toHaveBeenCalledWith({ status: "sent" });
   });
 
   it("restores product stock when using the dedicated void endpoint", async () => {
@@ -1585,6 +1583,7 @@ describe("billing invoice integrity", () => {
         ],
         [],
         [],
+        [],
         [{ itemType: "product", itemId: PRODUCT_ID, quantity: 2 }],
       ],
       updateReturns: [
@@ -1594,13 +1593,69 @@ describe("billing invoice integrity", () => {
     });
 
     await expect(
-      callerWithDb(db).voidInvoice({ id: INVOICE_ID })
+      callerWithDb(db).voidInvoice({
+        id: INVOICE_ID,
+        reason: "Duplicate invoice",
+      })
     ).resolves.toMatchObject({ status: "void" });
 
     expect(updateSet).toHaveBeenNthCalledWith(1, { status: "void" });
     expect(updateSet).toHaveBeenNthCalledWith(2, {
       stockQuantity: expect.anything(),
     });
+  });
+
+  it("atomically reopens charged visit work and audits a dedicated void", async () => {
+    const workItemId = "00000000-0000-0000-0000-00000000000b";
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [
+          {
+            id: INVOICE_ID,
+            total: "30.00",
+            paidAmount: "0.00",
+            status: "sent",
+            isEstimate: false,
+            appointmentId: APPOINTMENT_ID,
+          },
+        ],
+        [{ id: APPOINTMENT_ID }],
+        [],
+        [],
+        [{ id: workItemId }],
+        [],
+      ],
+      executeResults: [[]],
+      updateReturns: [[{ id: INVOICE_ID, status: "void", isEstimate: false }]],
+    });
+
+    await callerWithDb(db).voidInvoice({
+      id: INVOICE_ID,
+      reason: "Duplicate invoice",
+    });
+
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "unresolved",
+        invoiceId: null,
+        invoiceItemId: null,
+        resolvedBy: null,
+        resolvedAt: null,
+      })
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "invoice_voided",
+        entityType: "invoice",
+        entityId: INVOICE_ID,
+        changes: expect.objectContaining({
+          reason: "Duplicate invoice",
+          priorStatus: "sent",
+          nextStatus: "void",
+          reopenedVisitWorkItemIds: [workItemId],
+        }),
+      })
+    );
   });
 
   it("does not void an invoice referenced by a completed visit closeout", async () => {
@@ -1622,7 +1677,10 @@ describe("billing invoice integrity", () => {
     });
 
     await expect(
-      callerWithDb(db).voidInvoice({ id: INVOICE_ID })
+      callerWithDb(db).voidInvoice({
+        id: INVOICE_ID,
+        reason: "Duplicate invoice",
+      })
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -1650,7 +1708,10 @@ describe("billing invoice integrity", () => {
     });
 
     await expect(
-      callerWithDb(db).voidInvoice({ id: INVOICE_ID })
+      callerWithDb(db).voidInvoice({
+        id: INVOICE_ID,
+        reason: "Duplicate invoice",
+      })
     ).resolves.toMatchObject({ status: "void" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -1674,7 +1735,10 @@ describe("billing invoice integrity", () => {
     });
 
     await expect(
-      callerWithDb(db).voidInvoice({ id: INVOICE_ID })
+      callerWithDb(db).voidInvoice({
+        id: INVOICE_ID,
+        reason: "Duplicate invoice",
+      })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).toHaveBeenCalledTimes(1);

--- a/apps/web/server/__tests__/billing-payments.test.ts
+++ b/apps/web/server/__tests__/billing-payments.test.ts
@@ -26,6 +26,8 @@ const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const INVOICE_ID = "00000000-0000-0000-0000-000000000002";
 const OPERATION_ID = "00000000-0000-0000-0000-000000000009";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-00000000000a";
+const CLOSEOUT_ID = "00000000-0000-0000-0000-00000000000b";
 
 const baseInvoice = {
   id: INVOICE_ID,
@@ -65,11 +67,13 @@ function callerWithDb(
 }
 
 function thenableRows(result: unknown[]) {
-  return {
-    limit: vi.fn(async () => result),
+  const builder = {
+    limit: vi.fn(() => builder),
+    for: vi.fn(async () => result),
     then: (resolve: (value: unknown[]) => unknown, reject?: (e: unknown) => unknown) =>
       Promise.resolve(result).then(resolve, reject),
   };
+  return builder;
 }
 
 function createDb(opts: {
@@ -428,6 +432,55 @@ describe("billing payments", () => {
     );
   });
 
+  it("atomically settles a completed accounts-receivable visit", async () => {
+    const linkedInvoice = { ...baseInvoice, appointmentId: APPOINTMENT_ID };
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [linkedInvoice],
+        [{ id: APPOINTMENT_ID }],
+        [linkedInvoice],
+        [{ status: "completed" }],
+        [],
+        [{
+          id: CLOSEOUT_ID,
+          chargeDisposition: "accounts_receivable",
+          revision: 3,
+        }],
+      ],
+      updateReturns: [[{ id: INVOICE_ID }], [{ id: CLOSEOUT_ID }]],
+    });
+
+    await callerWithDb(db).recordPayment({
+      invoiceId: INVOICE_ID,
+      amount: "80.00",
+      method: "credit_card",
+    });
+
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chargeDisposition: "paid",
+        revision: 4,
+      })
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        userId: USER_ID,
+        action: "visit_closeout_settled",
+        entityType: "visit_closeout",
+        entityId: CLOSEOUT_ID,
+        changes: expect.objectContaining({
+          invoiceId: INVOICE_ID,
+          source: "dashboard_payment",
+          priorChargeDisposition: "accounts_receivable",
+          nextChargeDisposition: "paid",
+          priorRevision: 3,
+          nextRevision: 4,
+        }),
+      })
+    );
+  });
+
   it("requires a payment or adjustment to settle an invoice", async () => {
     const { db, updateSet } = createDb({
       selectResults: [[baseInvoice]],
@@ -448,25 +501,23 @@ describe("billing payments", () => {
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
   });
 
-  it("does not void an invoice when history changed concurrently", async () => {
-    const { db, updateSet } = createDb({
-      selectResults: [[{ ...baseInvoice, paidAmount: "0.00" }], []],
+  it("rejects generic status updates that attempt to void", async () => {
+    const { db, select, updateSet } = createDb({
+      selectResults: [],
       includeOperationLookup: false,
-      updateReturns: [[]],
     });
 
     await expect(
       callerWithDb(db).updateInvoiceStatus({
         id: INVOICE_ID,
         status: "void",
-      })
+      } as never)
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
-      message:
-        "Invoice status changed while updating. Refresh and try again.",
     });
 
-    expect(updateSet).toHaveBeenCalledWith({ status: "void" });
+    expect(select).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
     expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
   });
 

--- a/apps/web/server/__tests__/billing-refunds.test.ts
+++ b/apps/web/server/__tests__/billing-refunds.test.ts
@@ -38,6 +38,8 @@ const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const INVOICE_ID = "00000000-0000-0000-0000-000000000002";
 const PAYMENT_ID = "00000000-0000-0000-0000-000000000003";
+const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000004";
+const CLOSEOUT_ID = "00000000-0000-0000-0000-000000000005";
 
 const paidInvoice = {
   id: INVOICE_ID,
@@ -69,13 +71,15 @@ function callerWithDb(db: Record<string, unknown>, role = "admin") {
 }
 
 function thenableRows(result: unknown[]) {
-  return {
-    limit: vi.fn(async () => result),
+  const rows = {
+    limit: vi.fn(() => rows),
+    for: vi.fn(async () => result),
     then: (
       resolve: (value: unknown[]) => unknown,
       reject?: (e: unknown) => unknown
     ) => Promise.resolve(result).then(resolve, reject),
   };
+  return rows;
 }
 
 function createDb(opts: {
@@ -135,8 +139,8 @@ describe("billing refunds", () => {
     const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [cardPayment], // payment lookup
+        [paidInvoice], // invoice identity
         [], // no existing refund
-        [paidInvoice], // invoice
         [], // adjustments
       ],
     });
@@ -179,11 +183,43 @@ describe("billing refunds", () => {
     );
   });
 
+  it("audits only a due date that the refund actually persisted", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [[cardPayment], [paidInvoice], [], []],
+    });
+
+    await callerWithDb(db).refundPayment({
+      paymentId: PAYMENT_ID,
+      reason: "Owner cancelled",
+      dueDate: "2026-09-15",
+    });
+
+    expect(updateSet).toHaveBeenCalledWith({
+      paidAmount: "0.00",
+      status: "sent",
+    });
+    expect(updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ dueDate: expect.anything() })
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "payment_refunded",
+        changes: expect.objectContaining({
+          priorDueDate: null,
+          nextDueDate: null,
+        }),
+      })
+    );
+  });
+
   it("requires the admin role", async () => {
     const { db } = createDb({ selectResults: [] });
 
     await expect(
-      callerWithDb(db, "front_desk").refundPayment({ paymentId: PAYMENT_ID })
+      callerWithDb(db, "front_desk").refundPayment({
+        paymentId: PAYMENT_ID,
+        reason: "Owner request",
+      })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(mocks.refundStripeCheckoutPayment).not.toHaveBeenCalled();
   });
@@ -192,12 +228,16 @@ describe("billing refunds", () => {
     const { db, insert } = createDb({
       selectResults: [
         [cardPayment],
+        [paidInvoice],
         [{ id: "existing-refund" }], // refund already recorded
       ],
     });
 
     await expect(
-      callerWithDb(db).refundPayment({ paymentId: PAYMENT_ID })
+      callerWithDb(db).refundPayment({
+        paymentId: PAYMENT_ID,
+        reason: "Owner request",
+      })
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "This payment has already been refunded.",
@@ -212,7 +252,10 @@ describe("billing refunds", () => {
     });
 
     await expect(
-      callerWithDb(db).refundPayment({ paymentId: PAYMENT_ID })
+      callerWithDb(db).refundPayment({
+        paymentId: PAYMENT_ID,
+        reason: "Owner request",
+      })
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Only payments can be refunded.",
@@ -228,6 +271,7 @@ describe("billing refunds", () => {
       callerWithDb(db).refundPayment({
         paymentId: PAYMENT_ID,
         amount: "150.00",
+        reason: "Owner request",
       })
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
@@ -238,7 +282,7 @@ describe("billing refunds", () => {
 
   it("surfaces a Stripe refund failure and records nothing", async () => {
     const { db } = createDb({
-      selectResults: [[cardPayment], [], [paidInvoice], []],
+      selectResults: [[cardPayment], [paidInvoice], [], []],
     });
     const errorSpy = vi
       .spyOn(console, "error")
@@ -249,7 +293,10 @@ describe("billing refunds", () => {
 
     try {
       await expect(
-        callerWithDb(db).refundPayment({ paymentId: PAYMENT_ID })
+        callerWithDb(db).refundPayment({
+          paymentId: PAYMENT_ID,
+          reason: "Owner request",
+        })
       ).rejects.toMatchObject({
         code: "BAD_GATEWAY",
         message: "Stripe could not process the refund. Nothing was recorded.",
@@ -267,10 +314,13 @@ describe("billing refunds", () => {
       externalId: null,
     };
     const { db, insertValues } = createDb({
-      selectResults: [[manualPayment], [], [paidInvoice], []],
+      selectResults: [[manualPayment], [paidInvoice], [], []],
     });
 
-    await callerWithDb(db).refundPayment({ paymentId: PAYMENT_ID });
+    await callerWithDb(db).refundPayment({
+      paymentId: PAYMENT_ID,
+      reason: "Owner request",
+    });
 
     // The helper is still consulted, but a null externalId is not a Stripe
     // payment, so no Stripe refund happens (mock resolves null).
@@ -284,6 +334,104 @@ describe("billing refunds", () => {
         amount: "-100.00",
         method: "cash",
         externalId: `refund:payment:${PAYMENT_ID}`,
+      })
+    );
+  });
+
+  it("requires a due date before reopening a completed paid visit", async () => {
+    const visitInvoice = {
+      ...paidInvoice,
+      appointmentId: APPOINTMENT_ID,
+      dueDate: null,
+    };
+    const { db, insert } = createDb({
+      selectResults: [
+        [cardPayment],
+        [visitInvoice],
+        [{ id: APPOINTMENT_ID }],
+        [],
+        [visitInvoice],
+        [],
+        [
+          {
+            id: CLOSEOUT_ID,
+            chargeDisposition: "paid",
+            revision: 4,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).refundPayment({
+        paymentId: PAYMENT_ID,
+        reason: "Owner requested refund",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Choose a due date before refunding this paid visit into accounts receivable.",
+    });
+    expect(insert).not.toHaveBeenCalled();
+    expect(mocks.refundStripeCheckoutPayment).not.toHaveBeenCalled();
+  });
+
+  it("atomically reopens paid visit AR and audits an attributed refund", async () => {
+    const visitInvoice = {
+      ...paidInvoice,
+      appointmentId: APPOINTMENT_ID,
+      dueDate: null,
+    };
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [cardPayment],
+        [visitInvoice],
+        [{ id: APPOINTMENT_ID }],
+        [],
+        [visitInvoice],
+        [],
+        [
+          {
+            id: CLOSEOUT_ID,
+            chargeDisposition: "paid",
+            revision: 4,
+          },
+        ],
+      ],
+      updateReturns: [[{ id: INVOICE_ID }], [{ id: CLOSEOUT_ID }]],
+    });
+
+    await callerWithDb(db).refundPayment({
+      paymentId: PAYMENT_ID,
+      reason: "Owner requested refund",
+      dueDate: "2026-08-31",
+    });
+
+    expect(updateSet).toHaveBeenCalledWith({
+      paidAmount: "0.00",
+      status: "sent",
+      dueDate: "2026-08-31",
+    });
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chargeDisposition: "accounts_receivable",
+        revision: 5,
+      })
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "payment_refunded",
+        entityType: "invoice",
+        entityId: INVOICE_ID,
+        changes: expect.objectContaining({
+          reason: "Owner requested refund",
+          closeoutId: CLOSEOUT_ID,
+          priorChargeDisposition: "paid",
+          nextChargeDisposition: "accounts_receivable",
+          priorCloseoutRevision: 4,
+          nextCloseoutRevision: 5,
+          nextDueDate: "2026-08-31",
+        }),
       })
     );
   });

--- a/apps/web/server/__tests__/notifications-safety.test.ts
+++ b/apps/web/server/__tests__/notifications-safety.test.ts
@@ -1286,6 +1286,63 @@ describe("notification target safety", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
+  it("does not email a draft invoice", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [
+          {
+            id: INVOICE_ID,
+            total: "123.45",
+            paidAmount: "25.00",
+            dueDate: null,
+            status: "draft",
+            isEstimate: false,
+            clientId: CLIENT_ID,
+            clientFirstName: "Ada",
+            clientLastName: "Lovelace",
+            clientEmail: "ada@example.com",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Only sent or overdue invoices can be emailed. Use the receipt for paid invoices.",
+    });
+    expect(mocks.sendInvoiceEmail).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("does not email a paid invoice as though its total were still due", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [
+          {
+            id: INVOICE_ID,
+            total: "123.45",
+            dueDate: null,
+            status: "paid",
+            isEstimate: false,
+            clientId: CLIENT_ID,
+            clientFirstName: "Ada",
+            clientLastName: "Lovelace",
+            clientEmail: "ada@example.com",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID })
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    expect(mocks.sendInvoiceEmail).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("brands manual invoice emails with practice identity and formatted due dates", async () => {
     mocks.sendInvoiceEmail.mockResolvedValueOnce({
       success: true,
@@ -1298,13 +1355,17 @@ describe("notification target safety", () => {
           {
             id: INVOICE_ID,
             total: "123.45",
+            paidAmount: "25.00",
             dueDate: "2026-07-01",
+            status: "sent",
+            isEstimate: false,
             clientId: CLIENT_ID,
             clientFirstName: "Ada",
             clientLastName: "Lovelace",
             clientEmail: " Ada@Example.COM ",
           },
         ],
+        [{ amount: "10.00" }],
         [PRACTICE_SETTINGS],
       ],
     });
@@ -1317,7 +1378,7 @@ describe("notification target safety", () => {
       expect.objectContaining({
         to: "ada@example.com",
         clientName: "Ada Lovelace",
-        invoiceTotal: "$123.45",
+        invoiceTotal: "$88.45",
         dueDate: "Jul 1, 2026",
         practiceName: "Neighborhood Veterinary",
         practicePhone: "555-0100",
@@ -1329,7 +1390,7 @@ describe("notification target safety", () => {
         clientId: CLIENT_ID,
         channel: "email",
         subject: "Invoice",
-        content: "Invoice sent — total: $123.45",
+        content: "Invoice sent — amount due: $88.45",
         status: "sent",
         providerMessageId: "email-invoice-1",
       })
@@ -1343,7 +1404,10 @@ describe("notification target safety", () => {
           {
             id: INVOICE_ID,
             total: "123.45",
+            paidAmount: "0.00",
             dueDate: "2026-07-01",
+            status: "sent",
+            isEstimate: false,
             clientId: CLIENT_ID,
             clientFirstName: "Ada",
             clientLastName: "Lovelace",
@@ -1379,12 +1443,15 @@ describe("notification target safety", () => {
             id: INVOICE_ID,
             total: "123.45",
             dueDate: "2026-07-01",
+            status: "sent",
+            isEstimate: false,
             clientId: CLIENT_ID,
             clientFirstName: "Ada",
             clientLastName: "Lovelace",
             clientEmail: "ada@example.com",
           },
         ],
+        [],
         [PRACTICE_SETTINGS],
       ],
     });

--- a/apps/web/server/__tests__/stripe-checkout-resolution.test.ts
+++ b/apps/web/server/__tests__/stripe-checkout-resolution.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  refundInvalidStripeCheckoutPayment: vi.fn(),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  refundInvalidStripeCheckoutPayment:
+    mocks.refundInvalidStripeCheckoutPayment,
+}));
+
+const { resolveInvalidInvoiceCheckout } = await import(
+  "../stripe-checkout-resolution"
+);
+const { auditLog } = await import("@openpims/db");
+
+function auditDb() {
+  const onConflictDoNothing = vi.fn(async () => undefined);
+  const values = vi.fn((_value: unknown) => ({ onConflictDoNothing }));
+  const insert = vi.fn(() => ({ values }));
+  return { db: { insert }, insert, values, onConflictDoNothing };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("invalid Stripe Checkout resolution ledger", () => {
+  it("persists refund outcome and context with one stable audit identity", async () => {
+    mocks.refundInvalidStripeCheckoutPayment.mockResolvedValue({
+      outcome: "refunded",
+      refundId: "re_123",
+      amountCents: 4200,
+    });
+    const first = auditDb();
+    const second = auditDb();
+    const baseInput = {
+      endpoint: "client-invoice-connect" as const,
+      externalId: "stripe:connect:acct_123:checkout:cs_123",
+      sessionId: "cs_123",
+      invoiceId: "00000000-0000-0000-0000-000000000001",
+      practiceId: "00000000-0000-0000-0000-000000000002",
+      connectedAccountId: "acct_123",
+      amountCents: 5000,
+      reason: "invoice_void",
+    };
+
+    await resolveInvalidInvoiceCheckout(first.db as never, {
+      ...baseInput,
+      eventId: "evt_first",
+    });
+    await resolveInvalidInvoiceCheckout(second.db as never, {
+      ...baseInput,
+      eventId: "evt_retry",
+    });
+
+    expect(mocks.refundInvalidStripeCheckoutPayment).toHaveBeenNthCalledWith(
+      1,
+      {
+        externalId: baseInput.externalId,
+        amountCents: 5000,
+        idempotencyKey: `invalid:${baseInput.externalId}`,
+      }
+    );
+    const firstAudit = first.values.mock.calls[0]![0] as Record<string, any>;
+    const retryAudit = second.values.mock.calls[0]![0] as Record<string, any>;
+    expect(firstAudit.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+    expect(retryAudit.id).toBe(firstAudit.id);
+    expect(firstAudit.entityId).toBe(firstAudit.id);
+    expect(firstAudit).toEqual(
+      expect.objectContaining({
+        practiceId: baseInput.practiceId,
+        action: "stripe_checkout_invalid_resolved",
+        entityType: "stripe_checkout_resolution",
+        changes: {
+          eventId: "evt_first",
+          endpoint: "client-invoice-connect",
+          sessionId: "cs_123",
+          externalId: baseInput.externalId,
+          invoiceId: baseInput.invoiceId,
+          practiceId: baseInput.practiceId,
+          connectedAccountId: "acct_123",
+          reason: "invoice_void",
+          outcome: "refunded",
+          refundId: "re_123",
+          refundAmountCents: 4200,
+          checkoutAmountCents: 5000,
+        },
+      })
+    );
+    expect(first.onConflictDoNothing).toHaveBeenCalledWith({
+      target: auditLog.id,
+    });
+    expect(second.onConflictDoNothing).toHaveBeenCalledWith({
+      target: auditLog.id,
+    });
+  });
+});

--- a/apps/web/server/__tests__/visit-work-reconciliation.test.ts
+++ b/apps/web/server/__tests__/visit-work-reconciliation.test.ts
@@ -348,7 +348,12 @@ describe("visit work reconciliation", () => {
     };
     const reopened = { ...unresolvedWork };
     const { db, updateSet, insertValues } = createDb({
-      selectResults: [[openAppointment], [{ id: PATIENT_ID }], [charged]],
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [],
+        [charged],
+      ],
       updateResults: [[reopened]],
     });
 
@@ -383,6 +388,30 @@ describe("visit work reconciliation", () => {
     );
   });
 
+  it("requires the finalized invoice to be voided before reopening visit work", async () => {
+    const { db, updateSet, insertValues } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [{ status: "sent" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).reopenVisitWork({
+        appointmentId: APPOINTMENT_ID,
+        workItemId: WORK_ITEM_ID,
+        reason: "Linked the wrong invoice line",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Void the finalized visit invoice with a reason before reopening its reconciled work.",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
   it("returns a waived medication dispense to pending when reopening no-charge work", async () => {
     const noChargeWork = {
       ...unresolvedWork,
@@ -400,6 +429,7 @@ describe("visit work reconciliation", () => {
       selectResults: [
         [openAppointment],
         [{ id: PATIENT_ID }],
+        [],
         [noChargeWork],
         [
           {
@@ -462,6 +492,10 @@ describe("visit work reconciliation", () => {
       new URL("../routers/records.ts", import.meta.url),
       "utf8",
     );
+    const integrity = readFileSync(
+      new URL("../visit-billing-integrity.ts", import.meta.url),
+      "utf8",
+    );
     const migration = readFileSync(
       new URL(
         "../../../../packages/db/drizzle/0045_visit_work_ledger.sql",
@@ -476,13 +510,26 @@ describe("visit work reconciliation", () => {
     );
     expect(router).toContain("eq(invoices.practiceId, ctx.practiceId)");
     expect(router).toContain("eq(invoices.appointmentId, input.appointmentId)");
-    expect(router).toContain(
+    expect(integrity).toContain(
       "(practice_id, appointment_id, vaccination_record_id)",
+    );
+    expect(integrity).toContain(
+      "eq(visitCloseouts.practiceId, ctx.practiceId)",
+    );
+    expect(integrity).toContain(
+      "eq(visitCloseouts.appointmentId, input.appointmentId)",
+    );
+    expect(integrity).toContain(
+      "eq(visitCloseouts.invoiceId, input.invoiceId)",
+    );
+    expect(integrity).toContain(
+      'eq(visitCloseouts.chargeDisposition, "accounts_receivable")',
     );
     expect(recordsRouter).toContain(
       "(practice_id, appointment_id, vaccination_record_id)",
     );
     expect(router).not.toContain("(${visitWorkItems.practiceId}");
+    expect(integrity).not.toContain("(${visitWorkItems.practiceId}");
     expect(recordsRouter).not.toContain("(${visitWorkItems.practiceId}");
     expect(migration).toContain("visit_work_items_vaccination_source_fk");
     expect(migration).toContain("visit_work_items_lab_result_source_fk");

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -88,6 +88,11 @@ import {
 } from "@/lib/records/clinical-inputs";
 import { listOffsetInput } from "./pagination";
 import { rowsFromExecute } from "@/lib/db/execute-rows";
+import {
+  assertVisitInvoiceReadyForFinancialAction,
+  assertVisitReconciliationMutable,
+  markCompletedVisitCloseoutPaid,
+} from "../visit-billing-integrity";
 
 type BillingDb = Pick<Database, "select" | "insert" | "update" | "execute">;
 type ServiceCatalogDb = Pick<Database, "select" | "execute">;
@@ -104,6 +109,7 @@ type InvoiceForPayment = {
   status: "draft" | "sent" | "paid" | "overdue" | "void";
   isEstimate: boolean;
   appointmentId?: string | null;
+  dueDate?: string | null;
 };
 
 type InvoiceAdjustmentType = "credit" | "write_off";
@@ -136,9 +142,9 @@ const allowedInvoiceStatusTransitions: Record<
   InvoiceStatus,
   readonly InvoiceStatus[]
 > = {
-  draft: ["sent", "void"],
-  sent: ["overdue", "void"],
-  overdue: ["sent", "void"],
+  draft: ["sent"],
+  sent: ["overdue"],
+  overdue: ["sent"],
   paid: [],
   void: [],
 };
@@ -446,6 +452,7 @@ async function getInvoiceForPractice(
       status: invoices.status,
       isEstimate: invoices.isEstimate,
       appointmentId: invoices.appointmentId,
+      dueDate: invoices.dueDate,
     })
     .from(invoices)
     .where(
@@ -2078,6 +2085,7 @@ export const billingRouter = createRouter({
           });
         }
         if (charge.appointmentId) {
+          await assertVisitReconciliationMutable(txCtx, charge.appointmentId);
           const [workItem] = await tx
             .select()
             .from(visitWorkItems)
@@ -2357,7 +2365,7 @@ export const billingRouter = createRouter({
     .input(
       z.object({
         id: z.string().uuid(),
-        status: z.enum(["draft", "sent", "paid", "overdue", "void"]),
+        status: z.enum(["draft", "sent", "paid", "overdue"]),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -2369,20 +2377,17 @@ export const billingRouter = createRouter({
             "Record a payment or apply an adjustment to settle this invoice.",
         });
       }
-      if (existing.isEstimate && input.status !== "void") {
+      if (existing.isEstimate) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "Convert the estimate before changing invoice status.",
         });
       }
-      if (existing.status === "void" && input.status !== "void") {
+      if (existing.status === "void") {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "Cannot reopen a void invoice.",
         });
-      }
-      if (existing.status === "void" && input.status === "void") {
-        return existing;
       }
       if (!canTransitionInvoiceStatus(existing.status, input.status)) {
         throw new TRPCError({
@@ -2399,27 +2404,13 @@ export const billingRouter = createRouter({
         eq(invoices.isEstimate, existing.isEstimate),
         eq(invoices.paidAmount, existing.paidAmount ?? "0"),
       ];
-      if (input.status === "void") {
+      if (input.status === "sent" && existing.appointmentId) {
         return ctx.db.transaction(async (tx) => {
           const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
-          await lockAppointmentForInvoiceMutation(
+          await lockAppointmentForInvoiceMutation(txCtx, existing.appointmentId);
+          await assertVisitInvoiceReadyForFinancialAction(
             txCtx,
             existing.appointmentId
-          );
-          await assertInvoiceNotCompletedCloseout(txCtx, input.id);
-          const adjustedCents = await getInvoiceAdjustmentTotalCents(
-            txCtx,
-            input.id
-          );
-          if (moneyToCents(existing.paidAmount) > 0 || adjustedCents > 0) {
-            throw new TRPCError({
-              code: "BAD_REQUEST",
-              message: "Cannot void an invoice with payments or adjustments.",
-            });
-          }
-          updateConditions.push(
-            noActivePaymentsForInvoice(),
-            noActiveAdjustmentsForInvoice()
           );
           const [invoice] = await tx
             .update(invoices)
@@ -2433,11 +2424,6 @@ export const billingRouter = createRouter({
               message:
                 "Invoice status changed while updating. Refresh and try again.",
             });
-          }
-
-          if (!existing.isEstimate) {
-            const items = await invoiceProductItemsForStock(txCtx, input.id);
-            await restoreProductStock(txCtx, items);
           }
 
           return invoice!;
@@ -3058,8 +3044,19 @@ export const billingRouter = createRouter({
           return { payment: existingPayment, replayed: true as const };
         }
 
-        const invoice = await getInvoiceForPractice(txCtx, input.invoiceId);
+        const invoiceIdentity = await getInvoiceForPractice(txCtx, input.invoiceId);
+        await lockAppointmentForInvoiceMutation(
+          txCtx,
+          invoiceIdentity.appointmentId
+        );
+        const invoice = invoiceIdentity.appointmentId
+          ? await getInvoiceForPractice(txCtx, input.invoiceId)
+          : invoiceIdentity;
         assertCanRecordPayment(invoice);
+        await assertVisitInvoiceReadyForFinancialAction(
+          txCtx,
+          invoice.appointmentId
+        );
         const totalCents = moneyToCents(invoice.total);
         const paidBeforeCents = moneyToCents(invoice.paidAmount);
         const adjustedCents = await getInvoiceAdjustmentTotalCents(
@@ -3119,6 +3116,17 @@ export const billingRouter = createRouter({
             externalId: operationKey,
           })
           .returning();
+
+        if (updates.status === "paid") {
+          await markCompletedVisitCloseoutPaid(txCtx, {
+            appointmentId: invoice.appointmentId,
+            invoiceId: invoice.id,
+            source: "dashboard_payment",
+            userId: ctx.user.id,
+            paymentId: createdPayment!.id,
+            paymentExternalId: operationKey,
+          });
+        }
 
         return {
           payment: createdPayment!,
@@ -3207,11 +3215,11 @@ export const billingRouter = createRouter({
       z.object({
         paymentId: z.string().uuid(),
         amount: paymentAmountSchema.optional(),
-        reason: z
-          .string()
-          .trim()
-          .max(BILLING_ADJUSTMENT_REASON_MAX_LENGTH)
-          .optional(),
+        reason: clinicalTextInput(
+          "Refund reason",
+          BILLING_ADJUSTMENT_REASON_MAX_LENGTH
+        ).min(5, "Explain why the payment is being refunded."),
+        dueDate: clinicalDateInput("Due date").optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -3245,24 +3253,6 @@ export const billingRouter = createRouter({
         });
       }
 
-      const refundExternalId = `refund:payment:${payment.id}`;
-      const [existingRefund] = await ctx.db
-        .select({ id: payments.id })
-        .from(payments)
-        .where(
-          and(
-            eq(payments.externalId, refundExternalId),
-            isNull(payments.deletedAt)
-          )
-        )
-        .limit(1);
-      if (existingRefund) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "This payment has already been refunded.",
-        });
-      }
-
       const amountCents = input.amount
         ? moneyToCents(input.amount)
         : originalCents;
@@ -3273,25 +3263,96 @@ export const billingRouter = createRouter({
         });
       }
 
-      const invoice = await getInvoiceForPractice(ctx, payment.invoiceId);
-      const adjustedCents = await getInvoiceAdjustmentTotalCents(
-        ctx,
-        payment.invoiceId
-      );
-      const paidBeforeCents = moneyToCents(invoice.paidAmount);
-      const paidAfterCents = paidBeforeCents - amountCents;
-      const updates: Record<string, any> = {
-        paidAmount: centsToMoney(paidAfterCents),
-      };
-      if (
-        invoice.status === "paid" &&
-        paidAfterCents + adjustedCents < moneyToCents(invoice.total)
-      ) {
-        // A refunded balance reopens the invoice for collection.
-        updates.status = "sent";
-      }
+      const refundExternalId = `refund:payment:${payment.id}`;
+      const invoiceIdentity = await getInvoiceForPractice(ctx, payment.invoiceId);
 
-      const refund = await ctx.db.transaction(async (tx) => {
+      const result = await ctx.db.transaction(async (tx) => {
+        const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+        await lockAppointmentForInvoiceMutation(
+          txCtx,
+          invoiceIdentity.appointmentId
+        );
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${refundExternalId}, 0))`
+        );
+
+        const [existingRefund] = await tx
+          .select({ id: payments.id })
+          .from(payments)
+          .where(
+            and(
+              eq(payments.externalId, refundExternalId),
+              isNull(payments.deletedAt)
+            )
+          )
+          .limit(1);
+        if (existingRefund) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "This payment has already been refunded.",
+          });
+        }
+
+        const invoice = invoiceIdentity.appointmentId
+          ? await getInvoiceForPractice(txCtx, payment.invoiceId)
+          : invoiceIdentity;
+        const adjustedCents = await getInvoiceAdjustmentTotalCents(
+          txCtx,
+          payment.invoiceId
+        );
+        const paidBeforeCents = moneyToCents(invoice.paidAmount);
+        if (amountCents > paidBeforeCents) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Refund exceeds the amount currently paid on the invoice.",
+          });
+        }
+        const paidAfterCents = paidBeforeCents - amountCents;
+        const reopensInvoice =
+          invoice.status === "paid" &&
+          paidAfterCents + adjustedCents < moneyToCents(invoice.total);
+        const [closeout] = invoice.appointmentId
+          ? await tx
+              .select({
+                id: visitCloseouts.id,
+                chargeDisposition: visitCloseouts.chargeDisposition,
+                revision: visitCloseouts.revision,
+              })
+              .from(visitCloseouts)
+              .where(
+                and(
+                  eq(visitCloseouts.practiceId, ctx.practiceId),
+                  eq(visitCloseouts.appointmentId, invoice.appointmentId),
+                  eq(visitCloseouts.invoiceId, invoice.id),
+                  eq(visitCloseouts.status, "completed"),
+                  isNull(visitCloseouts.deletedAt)
+                )
+              )
+              .limit(1)
+              .for("update")
+          : [];
+        const reopensCompletedPaidCloseout =
+          reopensInvoice && closeout?.chargeDisposition === "paid";
+        if (reopensCompletedPaidCloseout && !invoice.dueDate && !input.dueDate) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Choose a due date before refunding this paid visit into accounts receivable.",
+          });
+        }
+        const nextStatus = reopensInvoice ? "sent" : invoice.status;
+        const updates: Record<string, any> = {
+          paidAmount: centsToMoney(paidAfterCents),
+          status: nextStatus,
+        };
+        if (reopensCompletedPaidCloseout && !invoice.dueDate) {
+          updates.dueDate = input.dueDate;
+        }
+        const nextDueDate =
+          "dueDate" in updates
+            ? (updates.dueDate ?? null)
+            : (invoice.dueDate ?? null);
+
         const [createdRefund] = await tx
           .insert(payments)
           .values({
@@ -3300,9 +3361,7 @@ export const billingRouter = createRouter({
             method: payment.method,
             receivedBy: ctx.user.id,
             externalId: refundExternalId,
-            notes: input.reason
-              ? `Refund: ${input.reason}`
-              : "Refund of recorded payment",
+            notes: `Refund: ${input.reason}`,
           })
           .returning();
 
@@ -3330,6 +3389,64 @@ export const billingRouter = createRouter({
           });
         }
 
+        if (reopensCompletedPaidCloseout) {
+          const [updatedCloseout] = await tx
+            .update(visitCloseouts)
+            .set({
+              chargeDisposition: "accounts_receivable",
+              revision: closeout.revision + 1,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(visitCloseouts.id, closeout.id),
+                eq(visitCloseouts.practiceId, ctx.practiceId),
+                eq(visitCloseouts.status, "completed"),
+                eq(visitCloseouts.chargeDisposition, "paid"),
+                eq(visitCloseouts.revision, closeout.revision),
+                isNull(visitCloseouts.deletedAt)
+              )
+            )
+            .returning({ id: visitCloseouts.id });
+          if (!updatedCloseout) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "Visit closeout changed while refunding. Refresh and try again.",
+            });
+          }
+        }
+
+        await tx.insert(auditLog).values({
+          practiceId: ctx.practiceId,
+          userId: ctx.user.id,
+          action: "payment_refunded",
+          entityType: "invoice",
+          entityId: invoice.id,
+          changes: {
+            reason: input.reason,
+            originalPaymentId: payment.id,
+            refundPaymentId: createdRefund!.id,
+            amount: centsToMoney(amountCents),
+            method: payment.method,
+            priorStatus: invoice.status,
+            nextStatus,
+            priorPaidAmount: centsToMoney(paidBeforeCents),
+            nextPaidAmount: centsToMoney(paidAfterCents),
+            priorDueDate: invoice.dueDate ?? null,
+            nextDueDate,
+            closeoutId: closeout?.id ?? null,
+            priorChargeDisposition: closeout?.chargeDisposition ?? null,
+            nextChargeDisposition: reopensCompletedPaidCloseout
+              ? "accounts_receivable"
+              : closeout?.chargeDisposition ?? null,
+            priorCloseoutRevision: closeout?.revision ?? null,
+            nextCloseoutRevision: reopensCompletedPaidCloseout
+              ? closeout.revision + 1
+              : closeout?.revision ?? null,
+          },
+        });
+
         // Real money moves last so any failure above (including the unique
         // refund id) means Stripe was never called; a Stripe failure here
         // rolls back the local record.
@@ -3355,20 +3472,24 @@ export const billingRouter = createRouter({
             .where(eq(payments.id, createdRefund!.id));
         }
 
-        return createdRefund!;
+        return {
+          refund: createdRefund!,
+          invoice,
+          paidAfterCents,
+        };
       });
 
       await dispatchWebhookEvent(ctx.practiceId, "invoice.refunded", {
         id: payment.invoiceId,
         paymentId: payment.id,
-        refundId: refund.id,
+        refundId: result.refund.id,
         amount: centsToMoney(amountCents),
-        paidAmount: centsToMoney(paidAfterCents),
-        total: invoice.total,
+        paidAmount: centsToMoney(result.paidAfterCents),
+        total: result.invoice.total,
         source: "dashboard",
       });
 
-      return refund;
+      return result.refund;
     }),
 
   /**
@@ -3436,6 +3557,7 @@ export const billingRouter = createRouter({
           paidAmount: invoices.paidAmount,
           status: invoices.status,
           isEstimate: invoices.isEstimate,
+          appointmentId: invoices.appointmentId,
           clientFirstName: clients.firstName,
           clientLastName: clients.lastName,
           clientEmail: clients.email,
@@ -3482,6 +3604,19 @@ export const billingRouter = createRouter({
       }
 
       assertCanRecordPayment(invoice);
+
+      if (invoice.appointmentId) {
+        await ctx.db.transaction(async (tx) => {
+          const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
+          await lockAppointmentForInvoiceMutation(txCtx, invoice.appointmentId);
+          const currentInvoice = await getInvoiceForPractice(txCtx, invoice.id);
+          assertCanRecordPayment(currentInvoice);
+          await assertVisitInvoiceReadyForFinancialAction(
+            txCtx,
+            currentInvoice.appointmentId
+          );
+        });
+      }
 
       const adjustedCents = await getInvoiceAdjustmentTotalCents(
         ctx,
@@ -3660,8 +3795,19 @@ export const billingRouter = createRouter({
           };
         }
 
-        const invoice = await getInvoiceForPractice(txCtx, input.invoiceId);
+        const invoiceIdentity = await getInvoiceForPractice(txCtx, input.invoiceId);
+        await lockAppointmentForInvoiceMutation(
+          txCtx,
+          invoiceIdentity.appointmentId
+        );
+        const invoice = invoiceIdentity.appointmentId
+          ? await getInvoiceForPractice(txCtx, input.invoiceId)
+          : invoiceIdentity;
         assertCanAdjustInvoice(invoice);
+        await assertVisitInvoiceReadyForFinancialAction(
+          txCtx,
+          invoice.appointmentId
+        );
         const adjustedBeforeCents = await getInvoiceAdjustmentTotalCents(
           txCtx,
           input.invoiceId
@@ -3722,6 +3868,16 @@ export const billingRouter = createRouter({
           })
           .returning();
 
+        if (closesInvoice) {
+          await markCompletedVisitCloseoutPaid(txCtx, {
+            appointmentId: invoice.appointmentId,
+            invoiceId: invoice.id,
+            source: "dashboard_adjustment",
+            userId: ctx.user.id,
+            adjustmentId: createdAdjustment!.id,
+          });
+        }
+
         return {
           adjustment: createdAdjustment!,
           replayed: false as const,
@@ -3767,8 +3923,7 @@ export const billingRouter = createRouter({
           .string()
           .trim()
           .min(5, "Explain why the invoice is being voided.")
-          .max(500)
-          .default("Invoice voided by billing staff."),
+          .max(500),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -3787,7 +3942,6 @@ export const billingRouter = createRouter({
         const txCtx: BillingContext = { db: tx, practiceId: ctx.practiceId };
         await lockAppointmentForInvoiceMutation(txCtx, invoice.appointmentId);
         await assertInvoiceNotCompletedCloseout(txCtx, input.id);
-        await assertInvoiceItemsNotReconciled(txCtx, input.id);
         const adjustedCents = await getInvoiceAdjustmentTotalCents(
           txCtx,
           input.id
@@ -3798,6 +3952,18 @@ export const billingRouter = createRouter({
             message: "Cannot void an invoice with payments or adjustments.",
           });
         }
+        const linkedWork = await tx
+          .select({ id: visitWorkItems.id })
+          .from(visitWorkItems)
+          .where(
+            and(
+              eq(visitWorkItems.practiceId, ctx.practiceId),
+              eq(visitWorkItems.invoiceId, input.id),
+              eq(visitWorkItems.status, "charged"),
+              isNull(visitWorkItems.deletedAt)
+            )
+          )
+          .for("update");
         const [updated] = await tx
           .update(invoices)
           .set({ status: "void" })
@@ -3827,6 +3993,47 @@ export const billingRouter = createRouter({
           await restoreProductStock(txCtx, items);
         }
         await reopenInvoiceDispenseCharges(txCtx, input.id);
+        if (linkedWork.length > 0) {
+          await tx
+            .update(visitWorkItems)
+            .set({
+              status: "unresolved",
+              invoiceId: null,
+              invoiceItemId: null,
+              noChargeReason: null,
+              voidReason: null,
+              resolvedBy: null,
+              resolvedAt: null,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(visitWorkItems.practiceId, ctx.practiceId),
+                inArray(
+                  visitWorkItems.id,
+                  linkedWork.map((work) => work.id)
+                ),
+                eq(visitWorkItems.status, "charged"),
+                eq(visitWorkItems.invoiceId, input.id),
+                isNull(visitWorkItems.deletedAt)
+              )
+            );
+        }
+        await tx.insert(auditLog).values({
+          practiceId: ctx.practiceId,
+          userId: ctx.user.id,
+          action: "invoice_voided",
+          entityType: "invoice",
+          entityId: input.id,
+          changes: {
+            reason: input.reason,
+            priorStatus: invoice.status,
+            nextStatus: "void",
+            isEstimate: invoice.isEstimate,
+            restoredInventory: !invoice.isEstimate,
+            reopenedVisitWorkItemIds: linkedWork.map((work) => work.id),
+          },
+        });
 
         return updated!;
       });

--- a/apps/web/server/routers/encounters.ts
+++ b/apps/web/server/routers/encounters.ts
@@ -55,7 +55,11 @@ import { canTransitionAppointmentStatus } from "@/lib/scheduling/appointment-sta
 import { formatDateInputForTimeZone } from "@/lib/date-input";
 import { clinicalDateInput } from "@/lib/records/clinical-inputs";
 import { effectivePrescriptionStatus } from "@/lib/records/prescription-lifecycle";
-import { rowsFromExecute } from "@/lib/db/execute-rows";
+import {
+  assertNoUnresolvedVisitWork,
+  assertVisitReconciliationMutable,
+  syncVisitWorkItems,
+} from "../visit-billing-integrity";
 
 type EncounterDb = Pick<Database, "select" | "insert" | "update" | "execute">;
 
@@ -512,57 +516,6 @@ async function invoiceReadiness(
   };
 }
 
-/**
- * Re-materialize any visit-linked source records that predate the ledger or
- * arrived through a trusted non-dashboard path. Each statement is tenant and
- * appointment scoped, and unique source indexes make retries idempotent.
- */
-async function syncVisitWorkItems(
-  ctx: EncounterContext,
-  appointmentId: string
-) {
-  await ctx.db.execute(sql`
-    insert into ${visitWorkItems}
-      (practice_id, appointment_id, vaccination_record_id)
-    select ${vaccinationRecords.practiceId}, ${vaccinationRecords.appointmentId}, ${vaccinationRecords.id}
-    from ${vaccinationRecords}
-    where ${vaccinationRecords.practiceId} = ${ctx.practiceId}
-      and ${vaccinationRecords.appointmentId} = ${appointmentId}
-      and ${vaccinationRecords.deletedAt} is null
-    on conflict do nothing
-  `);
-  await ctx.db.execute(sql`
-    insert into ${visitWorkItems}
-      (practice_id, appointment_id, lab_result_id)
-    select ${labResults.practiceId}, ${labResults.appointmentId}, ${labResults.id}
-    from ${labResults}
-    where ${labResults.practiceId} = ${ctx.practiceId}
-      and ${labResults.appointmentId} = ${appointmentId}
-      and ${labResults.deletedAt} is null
-    on conflict do nothing
-  `);
-  await ctx.db.execute(sql`
-    insert into ${visitWorkItems}
-      (practice_id, appointment_id, procedure_id)
-    select ${procedures.practiceId}, ${procedures.appointmentId}, ${procedures.id}
-    from ${procedures}
-    where ${procedures.practiceId} = ${ctx.practiceId}
-      and ${procedures.appointmentId} = ${appointmentId}
-      and ${procedures.deletedAt} is null
-    on conflict do nothing
-  `);
-  await ctx.db.execute(sql`
-    insert into ${visitWorkItems}
-      (practice_id, appointment_id, prescription_id)
-    select ${prescriptions.practiceId}, ${prescriptions.appointmentId}, ${prescriptions.id}
-    from ${prescriptions}
-    where ${prescriptions.practiceId} = ${ctx.practiceId}
-      and ${prescriptions.appointmentId} = ${appointmentId}
-      and ${prescriptions.deletedAt} is null
-    on conflict do nothing
-  `);
-}
-
 async function lockInitialDispenseCharge(
   ctx: EncounterContext,
   prescriptionId: string,
@@ -595,47 +548,6 @@ async function lockInitialDispenseCharge(
     .limit(1)
     .for("update");
   return charge ?? null;
-}
-
-async function assertNoUnresolvedVisitWork(
-  ctx: EncounterContext,
-  appointmentId: string
-) {
-  const rows = await ctx.db.execute(sql`
-    select ${visitWorkItems.id}
-    from ${visitWorkItems}
-    left join ${invoiceItems}
-      on ${invoiceItems.id} = ${visitWorkItems.invoiceItemId}
-    left join ${invoices}
-      on ${invoices.id} = ${visitWorkItems.invoiceId}
-      and ${invoices.practiceId} = ${ctx.practiceId}
-      and ${invoices.appointmentId} = ${appointmentId}
-    where ${visitWorkItems.practiceId} = ${ctx.practiceId}
-      and ${visitWorkItems.appointmentId} = ${appointmentId}
-      and (
-        ${visitWorkItems.status} = 'unresolved'
-        or (
-          ${visitWorkItems.status} = 'charged'
-          and (
-            ${invoiceItems.id} is null
-            or ${invoiceItems.deletedAt} is not null
-            or ${invoices.id} is null
-            or ${invoices.deletedAt} is not null
-            or ${invoices.status} = 'void'
-          )
-        )
-      )
-      and ${visitWorkItems.deletedAt} is null
-    order by ${visitWorkItems.createdAt}, ${visitWorkItems.id}
-    limit 1
-  `);
-  if (rowsFromExecute<{ id: string }>(rows).length > 0) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message:
-        "Resolve every performed vaccination, lab, procedure, and prescription as charged, no charge, or void/corrected before checkout.",
-    });
-  }
 }
 
 export const encountersRouter = createRouter({
@@ -1405,6 +1317,7 @@ export const encountersRouter = createRouter({
               "Visit reconciliation can be corrected only while the exam is open.",
           });
         }
+        await assertVisitReconciliationMutable(txCtx, input.appointmentId);
         const [workItem] = await tx
           .select()
           .from(visitWorkItems)

--- a/apps/web/server/routers/notifications.ts
+++ b/apps/web/server/routers/notifications.ts
@@ -19,6 +19,7 @@ import {
   users,
   communications,
   invoices,
+  invoiceAdjustments,
   vaccinationRecords,
   practices,
   locationMessaging,
@@ -50,6 +51,12 @@ import {
   getVaccinationRecallPreview,
   sendVaccinationRecallReminders,
 } from "../vaccination-recalls";
+import { assertVisitInvoiceReadyForFinancialAction } from "../visit-billing-integrity";
+import {
+  centsToMoney,
+  invoiceBalanceCents,
+  moneyToCents,
+} from "@/lib/billing/invoice-balance";
 
 const DEFAULT_PRACTICE_NAME = "your clinic";
 
@@ -406,7 +413,11 @@ export const notificationsRouter = createRouter({
         .select({
           id: invoices.id,
           total: invoices.total,
+          paidAmount: invoices.paidAmount,
           dueDate: invoices.dueDate,
+          status: invoices.status,
+          isEstimate: invoices.isEstimate,
+          appointmentId: invoices.appointmentId,
           clientId: invoices.clientId,
           clientFirstName: clients.firstName,
           clientLastName: clients.lastName,
@@ -446,6 +457,25 @@ export const notificationsRouter = createRouter({
       if (!invoice) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Invoice not found" });
       }
+      if (invoice.isEstimate) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Convert the estimate before emailing an invoice.",
+        });
+      }
+      if (
+        invoice.status !== "sent" &&
+        invoice.status !== "overdue"
+      ) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "Only sent or overdue invoices can be emailed. Use the receipt for paid invoices.",
+        });
+      }
+      await assertVisitInvoiceReadyForFinancialAction(
+        ctx,
+        invoice.appointmentId
+      );
       const clientEmail = normalizeEmailSuppressionAddress(invoice.clientEmail);
       if (!clientEmail) {
         throw new TRPCError({ code: "BAD_REQUEST", message: "Client does not have an email address on file" });
@@ -459,10 +489,35 @@ export const notificationsRouter = createRouter({
         });
       }
 
-      // Format the total in the practice's region currency.
+      const adjustmentRows = await ctx.db
+        .select({ amount: invoiceAdjustments.amount })
+        .from(invoiceAdjustments)
+        .where(
+          and(
+            eq(invoiceAdjustments.invoiceId, invoice.id),
+            sql`exists (
+              select 1
+              from ${invoices}
+              where ${invoices.id} = ${invoiceAdjustments.invoiceId}
+                and ${invoices.practiceId} = ${ctx.practiceId}
+                and ${invoices.clientId} = ${invoice.clientId}
+                and ${invoices.deletedAt} is null
+            )`,
+            isNull(invoiceAdjustments.deletedAt)
+          )
+        );
+      const adjustedCents = adjustmentRows.reduce(
+        (sum, row) => sum + moneyToCents(row.amount),
+        0
+      );
+      const amountDue = centsToMoney(
+        invoiceBalanceCents(invoice, adjustedCents)
+      );
+
+      // Format the live balance in the practice's region currency.
       const practice = await practiceNotificationSettings(ctx);
       const totalFormatted = formatCurrency(
-        invoice.total ?? 0,
+        amountDue,
         practice.currency,
         practice.country
       );
@@ -490,7 +545,7 @@ export const notificationsRouter = createRouter({
         channel: "email",
         direction: "outbound",
         subject: "Invoice",
-        content: `Invoice sent — total: ${totalFormatted}`,
+        content: `Invoice sent — amount due: ${totalFormatted}`,
         status: "sent",
         providerMessageId: emailResult.id,
       });

--- a/apps/web/server/stripe-checkout-resolution.ts
+++ b/apps/web/server/stripe-checkout-resolution.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import { auditLog } from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+import { refundInvalidStripeCheckoutPayment } from "@/lib/stripe";
+
+export type StripeCheckoutResolution = Awaited<
+  ReturnType<typeof refundInvalidStripeCheckoutPayment>
+>;
+
+function resolutionAuditId(externalId: string): string {
+  const digest = createHash("sha256")
+    .update(`openvpm:stripe-checkout-resolution:${externalId}`)
+    .digest("hex");
+  const variant = ((Number.parseInt(digest[16]!, 16) & 0x3) | 0x8).toString(16);
+
+  return [
+    digest.slice(0, 8),
+    digest.slice(8, 12),
+    `5${digest.slice(13, 16)}`,
+    `${variant}${digest.slice(17, 20)}`,
+    digest.slice(20, 32),
+  ].join("-");
+}
+
+/**
+ * Resolve an invalid invoice Checkout and durably record the result.
+ *
+ * The caller must pass its active webhook transaction. Stripe runs before the
+ * audit insert, so a failed DB commit can be retried safely: the external call
+ * uses a stable Stripe idempotency key and the audit row uses a deterministic
+ * primary key. A retry therefore converges on one external resolution and one
+ * durable, truthful final-state record without requiring another migration.
+ */
+export async function resolveInvalidInvoiceCheckout(
+  db: Database,
+  input: {
+    eventId: string;
+    endpoint: "client-invoice" | "client-invoice-connect";
+    externalId: string;
+    sessionId: string;
+    invoiceId?: string | null;
+    practiceId?: string | null;
+    connectedAccountId?: string | null;
+    amountCents: number;
+    reason: string;
+  }
+): Promise<StripeCheckoutResolution> {
+  const resolution = await refundInvalidStripeCheckoutPayment({
+    externalId: input.externalId,
+    amountCents: input.amountCents,
+    idempotencyKey: `invalid:${input.externalId}`,
+  });
+  const refunded = resolution.outcome === "refunded" ? resolution : null;
+  const auditId = resolutionAuditId(input.externalId);
+
+  await db
+    .insert(auditLog)
+    .values({
+      id: auditId,
+      practiceId: input.practiceId ?? null,
+      action: "stripe_checkout_invalid_resolved",
+      entityType: "stripe_checkout_resolution",
+      entityId: auditId,
+      changes: {
+        eventId: input.eventId,
+        endpoint: input.endpoint,
+        sessionId: input.sessionId,
+        externalId: input.externalId,
+        invoiceId: input.invoiceId ?? null,
+        practiceId: input.practiceId ?? null,
+        connectedAccountId: input.connectedAccountId ?? null,
+        reason: input.reason,
+        outcome: resolution.outcome,
+        refundId: refunded?.refundId ?? null,
+        refundAmountCents: refunded?.amountCents ?? null,
+        checkoutAmountCents: input.amountCents,
+      },
+    })
+    .onConflictDoNothing({ target: auditLog.id });
+
+  return resolution;
+}

--- a/apps/web/server/visit-billing-integrity.ts
+++ b/apps/web/server/visit-billing-integrity.ts
@@ -1,0 +1,264 @@
+import { and, eq, isNull, ne, sql } from "drizzle-orm";
+import { TRPCError } from "@trpc/server";
+import type { Database } from "@openpims/db/client";
+import {
+  invoiceItems,
+  invoices,
+  auditLog,
+  labResults,
+  prescriptions,
+  procedures,
+  vaccinationRecords,
+  visitCloseouts,
+  visitWorkItems,
+} from "@openpims/db";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
+
+type VisitBillingDb = Pick<Database, "select" | "insert" | "update" | "execute">;
+
+export type VisitBillingContext = {
+  db: VisitBillingDb;
+  practiceId: string;
+};
+
+export async function markCompletedVisitCloseoutPaid(
+  ctx: VisitBillingContext,
+  input: {
+    appointmentId: string | null | undefined;
+    invoiceId: string;
+    source: "dashboard_payment" | "dashboard_adjustment" | "stripe" | "stripe_connect";
+    userId?: string | null;
+    paymentId?: string | null;
+    adjustmentId?: string | null;
+    paymentExternalId?: string | null;
+  }
+) {
+  if (!input.appointmentId) return null;
+
+  const [closeout] = await ctx.db
+    .select({
+      id: visitCloseouts.id,
+      chargeDisposition: visitCloseouts.chargeDisposition,
+      revision: visitCloseouts.revision,
+    })
+    .from(visitCloseouts)
+    .where(
+      and(
+        eq(visitCloseouts.practiceId, ctx.practiceId),
+        eq(visitCloseouts.appointmentId, input.appointmentId),
+        eq(visitCloseouts.invoiceId, input.invoiceId),
+        eq(visitCloseouts.status, "completed"),
+        isNull(visitCloseouts.deletedAt)
+      )
+    )
+    .limit(1)
+    .for("update");
+
+  if (!closeout || closeout.chargeDisposition !== "accounts_receivable") {
+    return null;
+  }
+
+  const nextRevision = closeout.revision + 1;
+  const [updatedCloseout] = await ctx.db
+    .update(visitCloseouts)
+    .set({
+      chargeDisposition: "paid",
+      revision: nextRevision,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(visitCloseouts.id, closeout.id),
+        eq(visitCloseouts.practiceId, ctx.practiceId),
+        eq(visitCloseouts.status, "completed"),
+        eq(visitCloseouts.chargeDisposition, "accounts_receivable"),
+        eq(visitCloseouts.revision, closeout.revision),
+        isNull(visitCloseouts.deletedAt)
+      )
+    )
+    .returning({ id: visitCloseouts.id });
+  if (!updatedCloseout) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: "Visit closeout changed while settling payment. Retry the operation.",
+    });
+  }
+
+  await ctx.db.insert(auditLog).values({
+    practiceId: ctx.practiceId,
+    userId: input.userId ?? null,
+    action: "visit_closeout_settled",
+    entityType: "visit_closeout",
+    entityId: closeout.id,
+    changes: {
+      invoiceId: input.invoiceId,
+      source: input.source,
+      paymentId: input.paymentId ?? null,
+      adjustmentId: input.adjustmentId ?? null,
+      paymentExternalId: input.paymentExternalId ?? null,
+      priorChargeDisposition: "accounts_receivable",
+      nextChargeDisposition: "paid",
+      priorRevision: closeout.revision,
+      nextRevision,
+    },
+  });
+
+  return { closeoutId: closeout.id, priorRevision: closeout.revision, nextRevision };
+}
+
+/**
+ * Re-materialize source rows that arrived through a trusted non-dashboard path.
+ * Callers intentionally invoke this only for an open visit; historical closed
+ * visits must not acquire new unresolved work after the fact.
+ */
+export async function syncVisitWorkItems(ctx: VisitBillingContext, appointmentId: string) {
+  await ctx.db.execute(sql`
+    insert into ${visitWorkItems}
+      (practice_id, appointment_id, vaccination_record_id)
+    select ${vaccinationRecords.practiceId}, ${vaccinationRecords.appointmentId}, ${vaccinationRecords.id}
+    from ${vaccinationRecords}
+    where ${vaccinationRecords.practiceId} = ${ctx.practiceId}
+      and ${vaccinationRecords.appointmentId} = ${appointmentId}
+      and ${vaccinationRecords.deletedAt} is null
+    on conflict do nothing
+  `);
+  await ctx.db.execute(sql`
+    insert into ${visitWorkItems}
+      (practice_id, appointment_id, lab_result_id)
+    select ${labResults.practiceId}, ${labResults.appointmentId}, ${labResults.id}
+    from ${labResults}
+    where ${labResults.practiceId} = ${ctx.practiceId}
+      and ${labResults.appointmentId} = ${appointmentId}
+      and ${labResults.deletedAt} is null
+    on conflict do nothing
+  `);
+  await ctx.db.execute(sql`
+    insert into ${visitWorkItems}
+      (practice_id, appointment_id, procedure_id)
+    select ${procedures.practiceId}, ${procedures.appointmentId}, ${procedures.id}
+    from ${procedures}
+    where ${procedures.practiceId} = ${ctx.practiceId}
+      and ${procedures.appointmentId} = ${appointmentId}
+      and ${procedures.deletedAt} is null
+    on conflict do nothing
+  `);
+  await ctx.db.execute(sql`
+    insert into ${visitWorkItems}
+      (practice_id, appointment_id, prescription_id)
+    select ${prescriptions.practiceId}, ${prescriptions.appointmentId}, ${prescriptions.id}
+    from ${prescriptions}
+    where ${prescriptions.practiceId} = ${ctx.practiceId}
+      and ${prescriptions.appointmentId} = ${appointmentId}
+      and ${prescriptions.deletedAt} is null
+    on conflict do nothing
+  `);
+}
+
+export async function assertNoUnresolvedVisitWork(
+  ctx: VisitBillingContext,
+  appointmentId: string,
+  message = "Resolve every performed vaccination, lab, procedure, and prescription as charged, no charge, or void/corrected before checkout."
+) {
+  const rows = await ctx.db.execute(sql`
+    select ${visitWorkItems.id}
+    from ${visitWorkItems}
+    left join ${invoiceItems}
+      on ${invoiceItems.id} = ${visitWorkItems.invoiceItemId}
+    left join ${invoices}
+      on ${invoices.id} = ${visitWorkItems.invoiceId}
+      and ${invoices.practiceId} = ${ctx.practiceId}
+      and ${invoices.appointmentId} = ${appointmentId}
+    where ${visitWorkItems.practiceId} = ${ctx.practiceId}
+      and ${visitWorkItems.appointmentId} = ${appointmentId}
+      and (
+        ${visitWorkItems.status} = 'unresolved'
+        or (
+          ${visitWorkItems.status} = 'charged'
+          and (
+            ${invoiceItems.id} is null
+            or ${invoiceItems.deletedAt} is not null
+            or ${invoices.id} is null
+            or ${invoices.deletedAt} is not null
+            or ${invoices.status} = 'void'
+          )
+        )
+      )
+      and ${visitWorkItems.deletedAt} is null
+    order by ${visitWorkItems.createdAt}, ${visitWorkItems.id}
+    limit 1
+  `);
+  if (rowsFromExecute<{ id: string }>(rows).length > 0) {
+    throw new TRPCError({ code: "PRECONDITION_FAILED", message });
+  }
+}
+
+/**
+ * Financial actions are stable only after the clinical handoff is signed and
+ * all performed work has an explicit billing disposition.
+ */
+export async function assertVisitInvoiceReadyForFinancialAction(
+  ctx: VisitBillingContext,
+  appointmentId: string | null | undefined
+) {
+  if (!appointmentId) return;
+
+  const [closeout] = await ctx.db
+    .select({ status: visitCloseouts.status })
+    .from(visitCloseouts)
+    .where(
+      and(
+        eq(visitCloseouts.practiceId, ctx.practiceId),
+        eq(visitCloseouts.appointmentId, appointmentId),
+        isNull(visitCloseouts.deletedAt)
+      )
+    )
+    .limit(1);
+
+  if (closeout?.status !== "clinical_finalized" && closeout?.status !== "completed") {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "Finalize the clinical handoff before sending or collecting this visit invoice.",
+    });
+  }
+
+  if (closeout.status === "clinical_finalized") {
+    await syncVisitWorkItems(ctx, appointmentId);
+  }
+  await assertNoUnresolvedVisitWork(
+    ctx,
+    appointmentId,
+    "Resolve every performed vaccination, lab, procedure, and prescription before sending or collecting this visit invoice."
+  );
+}
+
+/**
+ * Once a visit invoice is sent, its reconciliations make checkout/payment
+ * stable. Corrections go through the audited invoice-void transaction, which
+ * reopens every linked work item atomically.
+ */
+export async function assertVisitReconciliationMutable(
+  ctx: VisitBillingContext,
+  appointmentId: string
+) {
+  const [invoice] = await ctx.db
+    .select({ status: invoices.status })
+    .from(invoices)
+    .where(
+      and(
+        eq(invoices.practiceId, ctx.practiceId),
+        eq(invoices.appointmentId, appointmentId),
+        eq(invoices.isEstimate, false),
+        ne(invoices.status, "void"),
+        isNull(invoices.deletedAt)
+      )
+    )
+    .limit(1);
+
+  if (invoice && invoice.status !== "draft") {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Void the finalized visit invoice with a reason before reopening its reconciled work.",
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Makes the visit-to-invoice-to-payment handoff financially final and safe across staff checkout, client portal checkout, Platform Stripe, and Stripe Connect.

- requires finalized clinical work and explicit charge dispositions before invoices can be sent or collected
- serializes appointment, invoice, and closeout settlement to prevent stale or duplicate payment transitions
- gives invoice voids and refunds dedicated, reasoned, audited flows that restore inventory, work items, AR status, and closeout state correctly
- resolves invalid legacy Checkout captures with idempotent full refunds based on authoritative PaymentIntent funds and durable audit records
- caps manual and portal captures at the live balance, including payments and adjustments, and prorates Connect fees safely
- updates re-emailed invoices to show the current amount due rather than the original total
- prevents portal infrastructure errors from leaking internal details as visit-readiness messages

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactoring / code quality
- [ ] Documentation

## Testing

- [x] Web typecheck passes
- [x] Full test suite passes: 295 files, 2,790 tests
- [x] Production build succeeds: 42 static pages generated
- [x] Targeted Stripe, Connect, portal checkout, notification, refund, adjustment, payment, and closeout tests pass
- [x] Independent billing-integrity audit returned SHIP with no unresolved blockers

## Safety

- [x] Rebased onto current main after request-only booking merged
- [x] Diff check passes
- [x] Changed-lines credential pattern scan is clean
- [x] Tenant scoping, CAS guards, idempotency, and lock ordering reviewed
- [x] No database migration required

## Checklist

- [x] Code follows existing TypeScript, Tailwind, and tRPC patterns
- [x] No hardcoded secrets or credentials
- [x] New public error paths return controlled or sanitized messages
- [x] Billing UI confirmation dialogs remain accessible