### PR TITLE
Harden hosted texting number setup

### DIFF
--- a/apps/web/components/onboarding/steps/set-up-texting.tsx
+++ b/apps/web/components/onboarding/steps/set-up-texting.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import { MessageSquare, Check, Loader2 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
@@ -54,15 +55,44 @@ export function SetUpTextingStep({
   })();
 
   const messaging = location?.messaging ?? null;
-  const isConfigured = !!messaging?.senderE164;
-  const isActive = messaging?.registrationStatus === "active" && !!messaging?.enabled;
+  const hasSender = Boolean(
+    messaging?.senderE164?.trim() && messaging?.messagingProfileId?.trim()
+  );
+  const isFailed = messaging?.registrationStatus === "failed";
+  const isConfigured = hasSender && !isFailed;
+  const isActive =
+    messaging?.registrationStatus === "active" && !!messaging?.enabled;
+  const statusDetail = (() => {
+    if (!messaging) return null;
+    if (isFailed) {
+      return "Number setup did not finish. Reconcile the saved provider setup in Messaging settings; OpenVPM will not buy another number automatically.";
+    }
+    if (messaging.registrationStatus === "not_started" && hasSender) {
+      return "Number order accepted. Carrier registration has not been submitted; complete the clinic details in Messaging settings.";
+    }
+    if (messaging.registrationStatus === "pending") {
+      return "Carrier registration is under review. Sending remains off until approval.";
+    }
+    if (messaging.registrationStatus === "active" && !messaging.enabled) {
+      return "Carrier registration is approved. An admin still needs to enable sending in Messaging settings.";
+    }
+    if (isActive) return "Texting is active.";
+    if (messaging.registrationStatus === "action_required") {
+      return "Carrier registration needs more clinic information. Review the request in Messaging settings.";
+    }
+    if (messaging.registrationStatus === "suspended") {
+      return "Texting is suspended. Review Messaging settings and contact OpenVPM support.";
+    }
+    return "Texting is not ready yet. Review Messaging settings before sending.";
+  })();
 
   return (
     <div className="space-y-5">
       <p className="text-sm leading-6 text-slate-600">
         Text your clients about appointments, reminders, and results, and let them
-        text you back. You can text from your existing number or get a new local
-        one. This is optional, so skip it and set it up later if you like.
+        text you back. OpenVPM can set up a new local texting number; your existing
+        clinic voice line stays unchanged. This is optional, so skip it and set it
+        up later if you like.
       </p>
 
       <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4">
@@ -76,15 +106,22 @@ export function SetUpTextingStep({
                 <Loader2 className="h-4 w-4 animate-spin" />
                 Checking your texting setup…
               </p>
-            ) : isConfigured ? (
+            ) : status.error ? (
               <div className="space-y-1">
                 <p className="text-sm font-medium text-slate-900">
-                  {messaging?.senderE164}
+                  Unable to check texting setup
                 </p>
                 <p className="text-xs text-slate-500">
-                  {isActive
-                    ? "Texting is active."
-                    : "Number set up. Carrier registration is pending. Sending turns on once it's approved."}
+                  Retry this step before starting or changing setup.
+                </p>
+              </div>
+            ) : messaging ? (
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-slate-900">
+                  {messaging.senderE164 ?? "Texting setup needs attention"}
+                </p>
+                <p className="text-xs text-slate-500">
+                  {statusDetail}
                 </p>
               </div>
             ) : (
@@ -98,22 +135,24 @@ export function SetUpTextingStep({
               </div>
             )}
           </div>
-          {!status.isLoading && location ? (
+          {!status.isLoading && !status.error && location ? (
+            messaging ? (
+              <Button asChild type="button" variant="outline" size="sm">
+                <Link href="/settings?tab=messaging">
+                  {isConfigured ? <Check className="mr-1.5 h-4 w-4" /> : null}
+                  Review
+                </Link>
+              </Button>
+            ) : (
             <Button
               type="button"
-              variant={isConfigured ? "outline" : "default"}
+              variant="default"
               size="sm"
               onClick={() => setWizardOpen(true)}
             >
-              {isConfigured ? (
-                <>
-                  <Check className="mr-1.5 h-4 w-4" />
-                  Manage
-                </>
-              ) : (
-                "Set up texting"
-              )}
+              Set up texting
             </Button>
+            )
           ) : null}
         </div>
       </div>

--- a/apps/web/components/settings/messaging-tab.tsx
+++ b/apps/web/components/settings/messaging-tab.tsx
@@ -227,7 +227,10 @@ function LocationCard({
       </div>
 
       {loc.messaging ? (
-        <ConfiguredLocation loc={loc} onChanged={refresh} />
+        <ConfiguredLocation
+          loc={loc}
+          onChanged={refresh}
+        />
       ) : (
         <UnconfiguredLocation loc={loc} onStartSetup={onStartSetup} />
       )}
@@ -259,6 +262,13 @@ function ConfiguredLocation({
     onSuccess: () => toast.success("Test message sent"),
     onError: (e) => toast.error(e.message),
   });
+  const reconcileSetup = trpc.messaging.provisionNumber.useMutation({
+    onSuccess: () => {
+      toast.success("Provider setup reconciled. No additional number was purchased.");
+      onChanged();
+    },
+    onError: (e) => toast.error(e.message),
+  });
 
   return (
     <div className="mt-4 space-y-4">
@@ -281,6 +291,25 @@ function ConfiguredLocation({
           {m.registrationDetail}
         </p>
       )}
+
+      {m.registrationStatus === "failed" && !m.enabled ? (
+        <Button
+          variant="outline"
+          disabled={reconcileSetup.isPending}
+          onClick={() =>
+            reconcileSetup.mutate({
+              locationId: loc.locationId,
+              mode: "buy",
+              action: "resume",
+            })
+          }
+        >
+          {reconcileSetup.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : null}
+          Reconcile provider setup
+        </Button>
+      ) : null}
 
       <label className="flex items-center gap-2 text-sm">
         <Checkbox
@@ -338,8 +367,8 @@ function UnconfiguredLocation({
         <div className="space-y-1">
           <p className="text-sm font-medium">Texting is not set up yet</p>
           <p className="text-sm text-muted-foreground">
-            Start a guided setup for this location. You can text-enable an
-            existing number or choose a new local texting number.
+            Start a guided setup and choose a new local texting number. Your
+            existing clinic phone line will not be ported or changed.
           </p>
           {loc.existingPhone ? (
             <p className="text-xs text-muted-foreground">

--- a/apps/web/components/settings/messaging-wizard.tsx
+++ b/apps/web/components/settings/messaging-wizard.tsx
@@ -50,21 +50,32 @@ export type MessagingSetupLocation = {
 };
 
 type Step = "choose" | "confirm" | "registration" | "done";
-type SearchNumber = { phoneNumber: string; monthlyCost: string | null };
+type SearchNumber = {
+  phoneNumber: string;
+  upfrontCost: string;
+  monthlyCost: string;
+  currency: string;
+};
 
-/** Format a provider's raw monthly cost (e.g. "1.00000") as "$1.00". */
-function formatMonthlyCost(cost: string | null): string | null {
-  if (!cost) return null;
+/** Format a provider's raw cost (e.g. "1.00000") using its quoted currency. */
+function formatCost(cost: string, currency: string): string {
   const value = Number(cost);
-  if (!Number.isFinite(value)) return null;
-  return `$${value.toFixed(2)}`;
+  if (!Number.isFinite(value)) return `${cost} ${currency}`;
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+    }).format(value);
+  } catch {
+    return `${value.toFixed(2)} ${currency}`;
+  }
 }
 
 const STEPS: { id: Step; title: string }[] = [
   { id: "choose", title: "Choose a texting number" },
   { id: "confirm", title: "Confirm the number" },
-  { id: "registration", title: "Carrier registration" },
-  { id: "done", title: "Registration pending" },
+  { id: "registration", title: "Review and purchase" },
+  { id: "done", title: "Number ordered; registration not started" },
 ];
 
 export function MessagingWizard({
@@ -92,8 +103,10 @@ export function MessagingWizard({
   const [checking, setChecking] = useState(false);
   const [areaCode, setAreaCode] = useState("");
   const [numbers, setNumbers] = useState<SearchNumber[]>([]);
-  const [selectedNumber, setSelectedNumber] = useState<string | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [selectedNumber, setSelectedNumber] = useState<SearchNumber | null>(null);
   const [provisionedSender, setProvisionedSender] = useState<string | null>(null);
+  const [chargeAcknowledged, setChargeAcknowledged] = useState(false);
 
   useEffect(() => {
     if (!open || !location) return;
@@ -103,15 +116,19 @@ export function MessagingWizard({
     setChecking(false);
     setAreaCode("");
     setNumbers([]);
+    setHasSearched(false);
     setSelectedNumber(null);
     setProvisionedSender(null);
+    setChargeAcknowledged(false);
   }, [open, location]);
 
   const provision = trpc.messaging.provisionNumber.useMutation({
     onSuccess: (result) => {
       setProvisionedSender(result.senderE164);
       setStep("done");
-      toast.success("Number set up. Carrier registration is now pending.");
+      toast.success(
+        "Number order accepted. Sending stays off until carrier approval."
+      );
       onChanged();
     },
     onError: (e) => toast.error(e.message),
@@ -123,10 +140,14 @@ export function MessagingWizard({
   const currentIndex = STEPS.findIndex((s) => s.id === step);
   const canContinue =
     step === "choose" ||
-    step === "registration" ||
     step === "done" ||
-    (mode === "host" && eligibility?.eligible === true) ||
-    (mode === "buy" && Boolean(selectedNumber));
+    (step === "confirm" &&
+      ((mode === "host" && eligibility?.eligible === true) ||
+        (mode === "buy" && Boolean(selectedNumber)))) ||
+    (step === "registration" &&
+      mode === "buy" &&
+      Boolean(selectedNumber) &&
+      chargeAcknowledged);
 
   async function checkExisting() {
     if (!location) return;
@@ -146,12 +167,16 @@ export function MessagingWizard({
   async function searchNumbers() {
     if (!isMessagingAreaCodeInputValid(areaCode)) return;
     setChecking(true);
+    setChargeAcknowledged(false);
+    setSelectedNumber(null);
+    setHasSearched(false);
     try {
       const result = await utils.messaging.searchNumbers.fetch(
         areaCode ? { areaCode } : {}
       );
       setNumbers(result);
-      setSelectedNumber(result[0]?.phoneNumber ?? null);
+      setSelectedNumber(result[0] ?? null);
+      setHasSearched(true);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Number search failed");
     } finally {
@@ -177,10 +202,18 @@ export function MessagingWizard({
       return;
     }
     if (step === "registration") {
+      if (mode !== "buy" || !selectedNumber || !chargeAcknowledged) return;
       provision.mutate({
         locationId: activeLocation.locationId,
-        mode,
-        phoneNumber: mode === "buy" ? selectedNumber ?? undefined : undefined,
+        mode: "buy",
+        action: "start",
+        phoneNumber: selectedNumber.phoneNumber,
+        quote: {
+          upfrontCost: selectedNumber.upfrontCost,
+          monthlyCost: selectedNumber.monthlyCost,
+          currency: selectedNumber.currency,
+        },
+        confirmProviderCharges: true,
       });
       return;
     }
@@ -242,7 +275,10 @@ export function MessagingWizard({
             {step === "choose" ? (
               <ChooseStep
                 mode={mode}
-                setMode={setMode}
+                setMode={(nextMode) => {
+                  setMode(nextMode);
+                  setChargeAcknowledged(false);
+                }}
                 existingPhone={location.existingPhone}
               />
             ) : null}
@@ -254,10 +290,20 @@ export function MessagingWizard({
                 checking={checking}
                 checkExisting={checkExisting}
                 areaCode={areaCode}
-                setAreaCode={setAreaCode}
+                setAreaCode={(nextAreaCode) => {
+                  setAreaCode(nextAreaCode);
+                  setNumbers([]);
+                  setHasSearched(false);
+                  setSelectedNumber(null);
+                  setChargeAcknowledged(false);
+                }}
                 numbers={numbers}
+                hasSearched={hasSearched}
                 selectedNumber={selectedNumber}
-                setSelectedNumber={setSelectedNumber}
+                setSelectedNumber={(number) => {
+                  setSelectedNumber(number);
+                  setChargeAcknowledged(false);
+                }}
                 searchNumbers={searchNumbers}
               />
             ) : null}
@@ -266,6 +312,8 @@ export function MessagingWizard({
                 mode={mode}
                 location={location}
                 selectedNumber={selectedNumber}
+                chargeAcknowledged={chargeAcknowledged}
+                setChargeAcknowledged={setChargeAcknowledged}
               />
             ) : null}
             {step === "done" ? (
@@ -320,35 +368,26 @@ function ChooseStep({
   return (
     <div className="space-y-4">
       <p className="text-sm leading-6 text-slate-600">
-        Most clinics start by text-enabling the phone number clients already
-        know. You can also get a new local number for texting only.
+        OpenVPM currently sets up a new local number for texting. Your clinic&apos;s
+        existing voice line stays unchanged.
       </p>
-      <button
-        type="button"
-        onClick={() => setMode("host")}
-        disabled={!existingPhone}
-        className={cn(
-          "w-full rounded-xl border p-4 text-left transition-colors",
-          mode === "host"
-            ? "border-emerald-500 bg-emerald-50"
-            : "border-slate-200 hover:border-emerald-300",
-          !existingPhone && "cursor-not-allowed opacity-60"
-        )}
+      <div
+        className="w-full rounded-xl border border-slate-200 bg-slate-50 p-4 text-left"
       >
         <div className="flex items-start gap-3">
-          <ShieldCheck className="mt-0.5 h-5 w-5 text-emerald-600" />
+          <ShieldCheck className="mt-0.5 h-5 w-5 text-slate-500" />
           <div>
             <p className="font-medium text-slate-950">
-              Text from your existing number
+              Existing-number texting is not available yet
             </p>
             <p className="mt-1 text-sm text-slate-600">
               {existingPhone
-                ? `Keep ${existingPhone} for calls while OpenVPM adds texting.`
-                : "Add a phone number in Practice Info to use this option."}
+                ? `${existingPhone} will not be ported, hosted, or changed.`
+                : "Your clinic phone line will not be ported, hosted, or changed."}
             </p>
           </div>
         </div>
-      </button>
+      </div>
       <button
         type="button"
         onClick={() => setMode("buy")}
@@ -384,6 +423,7 @@ function ConfirmStep({
   areaCode,
   setAreaCode,
   numbers,
+  hasSearched,
   selectedNumber,
   setSelectedNumber,
   searchNumbers,
@@ -396,8 +436,9 @@ function ConfirmStep({
   areaCode: string;
   setAreaCode: (areaCode: string) => void;
   numbers: SearchNumber[];
-  selectedNumber: string | null;
-  setSelectedNumber: (phoneNumber: string) => void;
+  hasSearched: boolean;
+  selectedNumber: SearchNumber | null;
+  setSelectedNumber: (number: SearchNumber) => void;
   searchNumbers: () => void;
 }) {
   if (mode === "host") {
@@ -445,7 +486,8 @@ function ConfirmStep({
     <div className="space-y-5">
       <p className="text-sm leading-6 text-slate-600">
         Search for a local number. The selected number will be assigned to this
-        location and carrier registration will begin after setup.
+        location. Carrier registration remains not started until you complete
+        the clinic details and OpenVPM reviews them.
       </p>
       <div className="flex flex-wrap items-end gap-2">
         <label className="space-y-1.5">
@@ -487,27 +529,31 @@ function ConfirmStep({
             <button
               type="button"
               key={n.phoneNumber}
-              onClick={() => setSelectedNumber(n.phoneNumber)}
+              onClick={() => setSelectedNumber(n)}
               className={cn(
                 "flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm transition-colors",
-                selectedNumber === n.phoneNumber
+                selectedNumber?.phoneNumber === n.phoneNumber
                   ? "bg-emerald-50"
                   : "hover:bg-slate-50"
               )}
             >
               <span className="font-medium text-slate-950">{n.phoneNumber}</span>
               <span className="flex items-center gap-2">
-                {formatMonthlyCost(n.monthlyCost) ? (
-                  <span className="text-xs text-slate-500">
-                    {formatMonthlyCost(n.monthlyCost)}/mo
-                  </span>
-                ) : null}
-                {selectedNumber === n.phoneNumber ? (
+                <span className="text-xs text-slate-500">
+                  {formatCost(n.upfrontCost, n.currency)} today ·{" "}
+                  {formatCost(n.monthlyCost, n.currency)}/mo
+                </span>
+                {selectedNumber?.phoneNumber === n.phoneNumber ? (
                   <Badge variant="success">Selected</Badge>
                 ) : null}
               </span>
             </button>
           ))}
+        </div>
+      ) : hasSearched ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          No available numbers returned a complete upfront price, monthly price,
+          and currency. Nothing can be selected or purchased; search again later.
         </div>
       ) : null}
     </div>
@@ -518,13 +564,19 @@ function RegistrationStep({
   mode,
   location,
   selectedNumber,
+  chargeAcknowledged,
+  setChargeAcknowledged,
 }: {
   mode: MessagingSetupMode;
   location: MessagingSetupLocation;
-  selectedNumber: string | null;
+  selectedNumber: SearchNumber | null;
+  chargeAcknowledged: boolean;
+  setChargeAcknowledged: (checked: boolean) => void;
 }) {
   const number =
-    mode === "host" ? location.existingPhone ?? "your number" : selectedNumber;
+    mode === "host"
+      ? location.existingPhone ?? "your number"
+      : selectedNumber?.phoneNumber;
 
   return (
     <div className="space-y-5">
@@ -534,6 +586,16 @@ function RegistrationStep({
         </p>
         <p className="mt-1 text-sm text-slate-600">{number}</p>
       </div>
+      {mode === "buy" && selectedNumber ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+          <p className="text-sm font-medium text-amber-950">Provider charges</p>
+          <p className="mt-2 text-sm text-amber-900">
+            {formatCost(selectedNumber.upfrontCost, selectedNumber.currency)} due
+            now, then {formatCost(selectedNumber.monthlyCost, selectedNumber.currency)}
+            /month for the number.
+          </p>
+        </div>
+      ) : null}
       <div className="rounded-xl border border-teal-200 bg-teal-50 p-4">
         <p className="text-sm font-medium text-teal-950">
           Carrier approval is required before live US texting.
@@ -545,6 +607,19 @@ function RegistrationStep({
           submission.
         </p>
       </div>
+      <label className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950">
+        <input
+          type="checkbox"
+          checked={chargeAcknowledged}
+          onChange={(event) => setChargeAcknowledged(event.target.checked)}
+          className="mt-0.5 h-4 w-4 rounded border-amber-400"
+        />
+        <span>
+          I authorize the exact upfront and monthly provider charges shown above
+          for this selected number. Texting and fee-bearing carrier registration
+          stay off until later approval.
+        </span>
+      </label>
     </div>
   );
 }
@@ -555,12 +630,12 @@ function DoneStep({ sender }: { sender: string | null }) {
       <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4">
         <p className="flex items-center gap-2 text-sm font-medium text-emerald-900">
           <Check className="h-4 w-4" />
-          Number setup started
+          Number order accepted; sending remains off
         </p>
         <p className="mt-2 text-sm leading-6 text-emerald-800">
-          {sender ?? "Your number"} is saved and registration is pending. SMS
-          sending stays off until carrier approval is active and an admin turns
-          sending on.
+          {sender ?? "Your number"} is saved while the provider finishes any
+          activation work. Carrier registration has not been submitted yet, and
+          SMS sending stays off until approval is active and an admin turns it on.
         </p>
       </div>
       <div className="rounded-xl border border-slate-200 p-4">
@@ -595,7 +670,7 @@ function continueLabel({
   if (step === "confirm" && mode === "buy" && numbers.length === 0) {
     return "Search numbers";
   }
-  if (step === "registration") return "Start setup";
+  if (step === "registration") return "Purchase number and start setup";
   if (step === "done") return "Done";
   return "Continue";
 }

--- a/apps/web/lib/__tests__/messaging-settings-ui.test.ts
+++ b/apps/web/lib/__tests__/messaging-settings-ui.test.ts
@@ -16,6 +16,10 @@ describe("messaging settings UI", () => {
     "utf8"
   );
   const routerSource = readFileSync("server/routers/messaging.ts", "utf8");
+  const onboardingSource = readFileSync(
+    "components/onboarding/steps/set-up-texting.tsx",
+    "utf8"
+  );
 
   it("keeps messaging phone policy aligned across settings and router", () => {
     expect(MESSAGING_PHONE_MIN_LENGTH).toBe(7);
@@ -84,5 +88,39 @@ describe("messaging settings UI", () => {
     expect(tabSource).not.toContain("data?.locations ?? []");
     expect(tabSource).not.toContain("const usage = data?.usage");
     expect(tabSource).not.toContain("const consent = data?.consent");
+  });
+
+  it("is explicit about unsupported existing numbers, charges, and recoverable setup", () => {
+    expect(wizardSource).toContain(
+      "Existing-number texting is not available yet"
+    );
+    expect(wizardSource).toContain(
+      "will not be ported, hosted, or changed"
+    );
+    expect(wizardSource).toContain("chargeAcknowledged");
+    expect(wizardSource).toContain(
+      "I authorize the exact upfront and monthly provider charges"
+    );
+    expect(wizardSource).toContain("confirmProviderCharges: true");
+    expect(wizardSource).toContain(
+      '(step === "registration" &&\n      mode === "buy" &&\n      Boolean(selectedNumber) &&\n      chargeAcknowledged)'
+    );
+    expect(wizardSource).toContain("upfrontCost");
+    expect(wizardSource).toContain("monthlyCost");
+    expect(wizardSource).toContain("currency");
+    expect(wizardSource).toContain("Purchase number and start setup");
+    expect(tabSource).toContain("Reconcile provider setup");
+    expect(tabSource).toContain('action: "resume"');
+    expect(onboardingSource).not.toContain(
+      "You can text from your existing number"
+    );
+    expect(onboardingSource).toContain("Number order accepted");
+    expect(onboardingSource).toContain("Carrier registration is under review");
+    expect(onboardingSource).toContain("Carrier registration is approved");
+    expect(onboardingSource).toContain("Number setup did not finish");
+    expect(routerSource).toContain("pg_advisory_xact_lock");
+    expect(routerSource).toContain("assertProvisioningEnabled();");
+    expect(routerSource).toContain("confirmProviderCharges: z.literal(true)");
+    expect(routerSource).toContain("findNumberOrdersByCustomerReference");
   });
 });

--- a/apps/web/lib/messaging/__tests__/provisioning-attempt-gate.test.ts
+++ b/apps/web/lib/messaging/__tests__/provisioning-attempt-gate.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  releaseMessagingProfileAttemptWithDatabase,
+  reserveMessagingProfileAttemptWithDatabase,
+} from "../provisioning-attempt-gate";
+
+const INPUT = {
+  practiceId: "00000000-0000-0000-0000-0000000000aa",
+  locationId: "00000000-0000-0000-0000-000000000002",
+  senderE164: "+15555550100",
+  customerReference:
+    "openvpm:00000000-0000-0000-0000-0000000000aa:00000000-0000-0000-0000-000000000002",
+  detail: "Profile attempt reserved; sending remains disabled.",
+};
+
+describe("messaging profile attempt gate", () => {
+  it("returns true only when the independent insert/update returns the target location", async () => {
+    const execute = vi.fn(async (_statement: unknown) => [
+      { locationId: INPUT.locationId },
+    ]);
+
+    await expect(
+      reserveMessagingProfileAttemptWithDatabase({ execute } as never, INPUT)
+    ).resolves.toBe(true);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when an active row prevents reserving a fresh attempt", async () => {
+    const execute = vi.fn(async (_statement: unknown) => []);
+
+    await expect(
+      reserveMessagingProfileAttemptWithDatabase({ execute } as never, INPUT)
+    ).resolves.toBe(false);
+  });
+
+  it("releases only when the exact untouched gate update returns the location", async () => {
+    const execute = vi
+      .fn(async (_statement: unknown) => [{ locationId: INPUT.locationId }]);
+
+    await expect(
+      releaseMessagingProfileAttemptWithDatabase({ execute } as never, INPUT)
+    ).resolves.toBe(true);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/messaging/__tests__/setup-wizard.test.ts
+++ b/apps/web/lib/messaging/__tests__/setup-wizard.test.ts
@@ -5,9 +5,9 @@ import {
 } from "../setup-wizard";
 
 describe("messaging setup wizard helpers", () => {
-  it("prefers hosting an existing location number when one is present", () => {
-    expect(defaultMessagingSetupMode("+1 555 555 0100")).toBe("host");
-    expect(defaultMessagingSetupMode("  (555) 555-0100  ")).toBe("host");
+  it("fails closed to a new number even when a clinic phone is present", () => {
+    expect(defaultMessagingSetupMode("+1 555 555 0100")).toBe("buy");
+    expect(defaultMessagingSetupMode("  (555) 555-0100  ")).toBe("buy");
   });
 
   it("falls back to buying a new number when no phone is on file", () => {
@@ -17,7 +17,9 @@ describe("messaging setup wizard helpers", () => {
   });
 
   it("labels setup modes for the wizard confirmation step", () => {
-    expect(setupModeTitle("host")).toBe("Text-enable your existing number");
+    expect(setupModeTitle("host")).toBe(
+      "Existing-number texting is not available"
+    );
     expect(setupModeTitle("buy")).toBe("Get a new local number");
   });
 });

--- a/apps/web/lib/messaging/__tests__/telnyx-provisioning.test.ts
+++ b/apps/web/lib/messaging/__tests__/telnyx-provisioning.test.ts
@@ -4,7 +4,15 @@ import {
   parseAvailableNumbers,
   searchAvailableNumbers,
   TelnyxNotConfiguredError,
+  TelnyxMutationUncertainError,
   createMessagingProfile,
+  buyNumber,
+  deleteMessagingProfile,
+  deleteOwnedPhoneNumber,
+  findMessagingProfilesByName,
+  findOwnedPhoneNumbers,
+  findAvailableNumberQuotes,
+  findNumberOrdersByCustomerReference,
   createA2pBrand,
   createA2pCampaign,
   ensureA2pNumberAssignment,
@@ -19,26 +27,61 @@ afterEach(() => {
 });
 
 describe("parseAvailableNumbers", () => {
-  it("maps phone numbers and monthly cost", () => {
+  it("maps phone numbers only when the complete provider quote is present", () => {
     expect(
       parseAvailableNumbers({
         data: [
-          { phone_number: "+15555550100", cost_information: { monthly_cost: "1.00000" } },
-          { phone_number: "+15555550101", cost_information: { monthly_cost: "1.00000" } },
+          {
+            phone_number: "+15555550100",
+            cost_information: {
+              upfront_cost: "3.21000",
+              monthly_cost: "1.00000",
+              currency: "USD",
+            },
+          },
+          {
+            phone_number: "+15555550101",
+            cost_information: {
+              upfront_cost: "0.00",
+              monthly_cost: "1.00000",
+              currency: "USD",
+            },
+          },
         ],
       })
     ).toEqual([
-      { phoneNumber: "+15555550100", monthlyCost: "1.00000" },
-      { phoneNumber: "+15555550101", monthlyCost: "1.00000" },
+      {
+        phoneNumber: "+15555550100",
+        upfrontCost: "3.21000",
+        monthlyCost: "1.00000",
+        currency: "USD",
+      },
+      {
+        phoneNumber: "+15555550101",
+        upfrontCost: "0.00",
+        monthlyCost: "1.00000",
+        currency: "USD",
+      },
     ]);
   });
 
-  it("drops entries without a phone number and tolerates missing cost", () => {
+  it("fails closed by dropping incomplete or invalid quotes", () => {
     expect(
       parseAvailableNumbers({
-        data: [{ cost_information: { monthly_cost: "1.0" } }, { phone_number: "+15555550100" }],
+        data: [
+          { cost_information: { monthly_cost: "1.0" } },
+          { phone_number: "+15555550100" },
+          {
+            phone_number: "+15555550101",
+            cost_information: {
+              upfront_cost: "0",
+              monthly_cost: "not-a-price",
+              currency: "USD",
+            },
+          },
+        ],
       })
-    ).toEqual([{ phoneNumber: "+15555550100", monthlyCost: null }]);
+    ).toEqual([]);
   });
 
   it("returns [] for an empty/missing data array", () => {
@@ -59,7 +102,11 @@ describe("Telnyx provisioning requests", () => {
             data: [
               {
                 phone_number: "+15555550100",
-                cost_information: { monthly_cost: "1.00000" },
+                cost_information: {
+                  upfront_cost: "3.21000",
+                  monthly_cost: "1.00000",
+                  currency: "USD",
+                },
               },
             ],
           })
@@ -70,7 +117,12 @@ describe("Telnyx provisioning requests", () => {
     await expect(
       searchAvailableNumbers({ areaCode: "555", limit: 3 })
     ).resolves.toEqual([
-      { phoneNumber: "+15555550100", monthlyCost: "1.00000" },
+      {
+        phoneNumber: "+15555550100",
+        upfrontCost: "3.21000",
+        monthlyCost: "1.00000",
+        currency: "USD",
+      },
     ]);
 
     const [url, init] = fetchMock.mock.calls[0] ?? [];
@@ -133,6 +185,7 @@ describe("Telnyx provisioning requests", () => {
     ) as Record<string, unknown>;
     expect(body).toEqual({
       name: "Healthy Pets — OpenVPM",
+      enabled: false,
       webhook_url: "https://app.openvpm.com/api/webhooks/telnyx",
       webhook_api_version: "2",
       whitelisted_destinations: ["US"],
@@ -140,6 +193,277 @@ describe("Telnyx provisioning requests", () => {
       daily_spend_limit: "10.00",
       smart_encoding: true,
     });
+  });
+
+  it.each([408, 429, 500, 503])(
+    "classifies a messaging-profile HTTP %s as uncertain",
+    async (status) => {
+      vi.stubEnv("TELNYX_API_KEY", "KEY123");
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          new Response(JSON.stringify({ errors: [{ detail: "temporary" }] }), {
+            status,
+          })
+        )
+      );
+
+      await expect(
+        createMessagingProfile({
+          name: "OpenVPM provision location-1",
+          webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+        })
+      ).rejects.toBeInstanceOf(TelnyxMutationUncertainError);
+    }
+  );
+
+  it("classifies profile transport and malformed success responses as uncertain", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("connection reset"))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: {} })))
+      .mockResolvedValueOnce(new Response("not-json"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = () =>
+      createMessagingProfile({
+        name: "OpenVPM provision location-1",
+        webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+      });
+    await expect(request()).rejects.toBeInstanceOf(
+      TelnyxMutationUncertainError
+    );
+    await expect(request()).rejects.toBeInstanceOf(
+      TelnyxMutationUncertainError
+    );
+    await expect(request()).rejects.toBeInstanceOf(
+      TelnyxMutationUncertainError
+    );
+  });
+
+  it("finds only exact durable profile and owned-number identities", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "profile-1",
+                name: "OpenVPM provision location-1",
+                webhook_url: "https://app.example.com/api/webhooks/telnyx",
+                enabled: false,
+              },
+              { id: "profile-2", name: "not-an-exact-match" },
+            ],
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "number-1",
+                phone_number: "+15555550100",
+                messaging_profile_id: "profile-1",
+                status: "active",
+              },
+              { id: "number-2", phone_number: "+15555550101" },
+            ],
+          })
+        )
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      findMessagingProfilesByName("OpenVPM provision location-1")
+    ).resolves.toEqual([
+      {
+        id: "profile-1",
+        name: "OpenVPM provision location-1",
+        webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+        enabled: false,
+      },
+    ]);
+    await expect(findOwnedPhoneNumbers("+15555550100")).resolves.toEqual([
+      {
+        id: "number-1",
+        phoneNumber: "+15555550100",
+        messagingProfileId: "profile-1",
+        status: "active",
+      },
+    ]);
+
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      "filter%5Bname%5D%5Beq%5D=OpenVPM+provision+location-1"
+    );
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
+      "filter%5Bphone_number%5D=%2B15555550100"
+    );
+  });
+
+  it("re-reads an exact selected quote and exact customer-reference orders", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                phone_number: "+15555550100",
+                cost_information: {
+                  upfront_cost: "3.21",
+                  monthly_cost: "6.54",
+                  currency: "USD",
+                },
+              },
+              {
+                phone_number: "+15555550101",
+                cost_information: {
+                  upfront_cost: "3.21",
+                  monthly_cost: "6.54",
+                  currency: "USD",
+                },
+              },
+            ],
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "order-1",
+                status: "pending",
+                customer_reference: "openvpm:practice-1:location-1",
+                messaging_profile_id: "profile-1",
+                phone_numbers: [{ phone_number: "+15555550100" }],
+              },
+            ],
+          })
+        )
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(findAvailableNumberQuotes("+15555550100")).resolves.toEqual([
+      {
+        phoneNumber: "+15555550100",
+        upfrontCost: "3.21",
+        monthlyCost: "6.54",
+        currency: "USD",
+      },
+    ]);
+    await expect(
+      findNumberOrdersByCustomerReference("openvpm:practice-1:location-1")
+    ).resolves.toEqual([
+      {
+        id: "order-1",
+        status: "pending",
+        customerReference: "openvpm:practice-1:location-1",
+        messagingProfileId: "profile-1",
+        phoneNumbers: ["+15555550100"],
+      },
+    ]);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+      "filter%5Bphone_number%5D%5Bstarts_with%5D=5555550100"
+    );
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
+      "filter%5Bcustomer_reference%5D=openvpm%3Apractice-1%3Alocation-1"
+    );
+  });
+
+  it("uses a stable customer reference and exposes exact cleanup mutations", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { id: "order-1", status: "pending" } }))
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      buyNumber({
+        phoneNumber: "+15555550100",
+        messagingProfileId: "profile-1",
+        customerReference: "openvpm:practice-1:location-1",
+      })
+    ).resolves.toEqual({ orderId: "order-1", status: "pending" });
+    await deleteOwnedPhoneNumber("number/1");
+    await deleteMessagingProfile("profile/1");
+
+    const body = JSON.parse(
+      String(fetchMock.mock.calls[0]?.[1]?.body)
+    ) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      customer_reference: "openvpm:practice-1:location-1",
+      messaging_profile_id: "profile-1",
+      phone_numbers: [{ phone_number: "+15555550100" }],
+    });
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://api.telnyx.com/v2/phone_numbers/number%2F1"
+    );
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({ method: "DELETE" });
+    expect(fetchMock.mock.calls[2]?.[0]).toBe(
+      "https://api.telnyx.com/v2/messaging_profiles/profile%2F1"
+    );
+  });
+
+  it.each([408, 429, 500, 503])(
+    "classifies an order HTTP %s as uncertain",
+    async (status) => {
+      vi.stubEnv("TELNYX_API_KEY", "KEY123");
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          new Response(JSON.stringify({ errors: [{ detail: "temporary" }] }), {
+            status,
+          })
+        )
+      );
+
+      await expect(
+        buyNumber({
+          phoneNumber: "+15555550100",
+          messagingProfileId: "profile-1",
+          customerReference: "openvpm:practice-1:location-1",
+        })
+      ).rejects.toBeInstanceOf(TelnyxMutationUncertainError);
+    }
+  );
+
+  it("classifies transport and malformed successful order responses as uncertain", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("connection reset"))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: { status: "pending" } }))
+      )
+      .mockResolvedValueOnce(new Response("not-json"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = () =>
+      buyNumber({
+        phoneNumber: "+15555550100",
+        messagingProfileId: "profile-1",
+        customerReference: "openvpm:practice-1:location-1",
+      });
+    await expect(request()).rejects.toBeInstanceOf(
+      TelnyxMutationUncertainError
+    );
+    await expect(request()).rejects.toBeInstanceOf(
+      TelnyxMutationUncertainError
+    );
+    await expect(request()).rejects.toBeInstanceOf(
+      TelnyxMutationUncertainError
+    );
   });
 
   it("aborts hung hosted eligibility checks", async () => {

--- a/apps/web/lib/messaging/provisioning-attempt-gate.ts
+++ b/apps/web/lib/messaging/provisioning-attempt-gate.ts
@@ -1,0 +1,145 @@
+import { sql } from "drizzle-orm";
+import {
+  locations,
+  locationMessaging,
+  practices,
+} from "@openpims/db";
+import { db, type Database } from "@openpims/db/client";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
+import { withSystem } from "@/lib/tenant-db";
+
+type ReserveProfileAttemptInput = {
+  practiceId: string;
+  locationId: string;
+  senderE164: string;
+  customerReference: string;
+  detail: string;
+};
+
+/**
+ * Persist the disabled profile-attempt gate through the root database pool,
+ * outside the tenant request transaction. That independent commit is required:
+ * if the subsequent provider POST times out or the request process exits, the
+ * request transaction can roll back without erasing the retry gate.
+ */
+export async function reserveMessagingProfileAttempt(
+  input: ReserveProfileAttemptInput
+): Promise<boolean> {
+  return withSystem(db, (tx) =>
+    reserveMessagingProfileAttemptWithDatabase(tx, input)
+  );
+}
+
+/** Exported for isolated SQL/result-shape tests; callers use the wrapper above. */
+export async function reserveMessagingProfileAttemptWithDatabase(
+  database: Pick<Database, "execute">,
+  input: ReserveProfileAttemptInput
+): Promise<boolean> {
+  const result = await database.execute(sql`
+    with operation_lock as (
+      select pg_advisory_xact_lock(
+        hashtextextended(${input.customerReference}, 0)
+      )
+    ), target_location as (
+      select ${locations.id}
+      from ${locations}
+      cross join operation_lock
+      where ${locations.id} = ${input.locationId}
+        and ${locations.practiceId} = ${input.practiceId}
+        and ${locations.deletedAt} is null
+        and exists (
+          select 1
+          from ${practices}
+          where ${practices.id} = ${input.practiceId}
+            and ${practices.deletedAt} is null
+        )
+    )
+    insert into ${locationMessaging} (
+      practice_id,
+      location_id,
+      provider,
+      messaging_profile_id,
+      sender_e164,
+      number_source,
+      a2p_brand_id,
+      a2p_campaign_id,
+      registration_status,
+      registration_detail,
+      enabled
+    )
+    select
+      ${input.practiceId},
+      target_location.id,
+      'telnyx',
+      null,
+      ${input.senderE164},
+      'purchased',
+      null,
+      null,
+      'failed',
+      ${input.detail},
+      false
+    from target_location
+    on conflict (location_id) do update
+    set
+      practice_id = excluded.practice_id,
+      provider = excluded.provider,
+      messaging_profile_id = null,
+      sender_e164 = excluded.sender_e164,
+      number_source = excluded.number_source,
+      a2p_brand_id = null,
+      a2p_campaign_id = null,
+      registration_status = excluded.registration_status,
+      registration_detail = excluded.registration_detail,
+      enabled = false,
+      deleted_at = null,
+      updated_at = now()
+    where ${locationMessaging.deletedAt} is not null
+    returning ${locationMessaging.locationId} as "locationId"
+  `);
+
+  return rowsFromExecute<{ locationId: string }>(result).some(
+    (row) => row.locationId === input.locationId
+  );
+}
+
+/**
+ * Remove only the exact untouched reservation. This is safe solely before any
+ * profile POST and after provider reconciliation conclusively returned no
+ * matching state. A soft delete lets a later fresh reservation revive the same
+ * unique location row without losing history timestamps.
+ */
+export async function releaseMessagingProfileAttempt(
+  input: ReserveProfileAttemptInput
+): Promise<boolean> {
+  return withSystem(db, (tx) =>
+    releaseMessagingProfileAttemptWithDatabase(tx, input)
+  );
+}
+
+export async function releaseMessagingProfileAttemptWithDatabase(
+  database: Pick<Database, "execute">,
+  input: ReserveProfileAttemptInput
+): Promise<boolean> {
+  const result = await database.execute(sql`
+    update ${locationMessaging}
+    set
+      deleted_at = now(),
+      updated_at = now()
+    where ${locationMessaging.practiceId} = ${input.practiceId}
+      and ${locationMessaging.locationId} = ${input.locationId}
+      and ${locationMessaging.provider} = 'telnyx'
+      and ${locationMessaging.messagingProfileId} is null
+      and ${locationMessaging.senderE164} = ${input.senderE164}
+      and ${locationMessaging.numberSource} = 'purchased'
+      and ${locationMessaging.registrationStatus} = 'failed'
+      and ${locationMessaging.registrationDetail} = ${input.detail}
+      and ${locationMessaging.enabled} = false
+      and ${locationMessaging.deletedAt} is null
+    returning ${locationMessaging.locationId} as "locationId"
+  `);
+
+  return rowsFromExecute<{ locationId: string }>(result).some(
+    (row) => row.locationId === input.locationId
+  );
+}

--- a/apps/web/lib/messaging/setup-wizard.ts
+++ b/apps/web/lib/messaging/setup-wizard.ts
@@ -1,13 +1,13 @@
 export type MessagingSetupMode = "host" | "buy";
 
 export function defaultMessagingSetupMode(
-  existingPhone: string | null | undefined
+  _existingPhone: string | null | undefined
 ): MessagingSetupMode {
-  return existingPhone?.trim() ? "host" : "buy";
+  return "buy";
 }
 
 export function setupModeTitle(mode: MessagingSetupMode): string {
   return mode === "host"
-    ? "Text-enable your existing number"
+    ? "Existing-number texting is not available"
     : "Get a new local number";
 }

--- a/apps/web/lib/messaging/telnyx-provisioning.ts
+++ b/apps/web/lib/messaging/telnyx-provisioning.ts
@@ -3,8 +3,8 @@
  * the API integration; the messaging tRPC router orchestrates it and persists
  * results to `location_messaging`.
  *
- * Read-only operations (number search, hosted-SMS eligibility) are safe to call
- * anytime. Mutating operations (buy/host a number, register A2P brand/campaign)
+ * Read-only operations (number and account inventory searches) are safe to call
+ * anytime. Mutating operations (buy a number, register A2P brand/campaign)
  * spend money / require an L2-verified account and are added as the self-serve
  * flow is wired up.
  */
@@ -28,6 +28,18 @@ export class TelnyxNotConfiguredError extends Error {
   constructor() {
     super("Telnyx is not configured (TELNYX_API_KEY missing).");
     this.name = "TelnyxNotConfiguredError";
+  }
+}
+
+/**
+ * A mutating request may have reached Telnyx even though OpenVPM did not
+ * receive a durable response. Callers must reconcile provider state before
+ * considering another mutation.
+ */
+export class TelnyxMutationUncertainError extends Error {
+  constructor(message: string, readonly cause?: unknown) {
+    super(message);
+    this.name = "TelnyxMutationUncertainError";
   }
 }
 
@@ -79,8 +91,9 @@ function telnyxErrorMessage(json: unknown): string | undefined {
 
 export interface AvailableNumber {
   phoneNumber: string;
-  /** Monthly cost in USD, as returned by Telnyx (string). */
-  monthlyCost: string | null;
+  upfrontCost: string;
+  monthlyCost: string;
+  currency: string;
 }
 
 /**
@@ -105,7 +118,24 @@ export async function searchAvailableNumbers(opts: {
 
 interface TelnyxAvailableNumber {
   phone_number?: string;
-  cost_information?: { monthly_cost?: string };
+  cost_information?: {
+    upfront_cost?: string;
+    monthly_cost?: string;
+    currency?: string;
+  };
+}
+
+function isProviderPrice(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^\d+(?:\.\d+)?$/.test(value) &&
+    Number.isFinite(Number(value)) &&
+    Number(value) >= 0
+  );
+}
+
+function isCurrency(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Z]{3}$/.test(value);
 }
 
 /** Pure: map a Telnyx available-numbers response to our shape. */
@@ -113,18 +143,230 @@ export function parseAvailableNumbers(json: {
   data?: TelnyxAvailableNumber[];
 }): AvailableNumber[] {
   return (json.data ?? [])
-    .filter((n): n is TelnyxAvailableNumber & { phone_number: string } =>
-      Boolean(n.phone_number)
+    .filter((n): n is TelnyxAvailableNumber & {
+      phone_number: string;
+      cost_information: {
+        upfront_cost: string;
+        monthly_cost: string;
+        currency: string;
+      };
+    } =>
+      Boolean(n.phone_number) &&
+      isProviderPrice(n.cost_information?.upfront_cost) &&
+      isProviderPrice(n.cost_information?.monthly_cost) &&
+      isCurrency(n.cost_information?.currency)
     )
     .map((n) => ({
       phoneNumber: n.phone_number,
-      monthlyCost: n.cost_information?.monthly_cost ?? null,
+      upfrontCost: n.cost_information.upfront_cost,
+      monthlyCost: n.cost_information.monthly_cost,
+      currency: n.cost_information.currency,
     }));
+}
+
+/**
+ * Re-read the exact selected number immediately before purchase. An incomplete
+ * or missing price is intentionally returned as no quote so callers fail
+ * closed instead of authorizing an unknown charge.
+ */
+export async function findAvailableNumberQuotes(
+  phoneNumber: string
+): Promise<AvailableNumber[]> {
+  const nationalNumber = phoneNumber.replace(/^\+1/, "").replace(/\D/g, "");
+  const params = new URLSearchParams();
+  params.set("filter[country_code]", "US");
+  params.set("filter[features][]", "sms");
+  params.set("filter[phone_number][starts_with]", nationalNumber);
+  params.set("filter[limit]", "10");
+  const json = await telnyxRequest<{ data?: TelnyxAvailableNumber[] }>(
+    "GET",
+    `/available_phone_numbers?${params.toString()}`
+  );
+  return parseAvailableNumbers(json).filter(
+    (number) => number.phoneNumber === phoneNumber
+  );
 }
 
 export interface HostedEligibility {
   eligible: boolean;
   detail?: string;
+}
+
+export interface TelnyxMessagingProfile {
+  id: string;
+  name: string;
+  webhookUrl: string | null;
+  enabled: boolean | null;
+}
+
+/** Find profiles by an exact, durable operation name. Read-only. */
+export async function findMessagingProfilesByName(
+  name: string
+): Promise<TelnyxMessagingProfile[]> {
+  const params = new URLSearchParams();
+  params.set("filter[name][eq]", name);
+  params.set("page[size]", "10");
+  const json = await telnyxRequest<{
+    data?: Array<{
+      id?: string;
+      name?: string;
+      webhook_url?: string | null;
+      enabled?: boolean;
+    }>;
+  }>("GET", `/messaging_profiles?${params.toString()}`);
+
+  if (!Array.isArray(json.data)) {
+    throw new TelnyxError(
+      "The provider returned incomplete messaging-profile reconciliation data.",
+      502
+    );
+  }
+  const exactProfiles = json.data.filter((profile) => profile.name === name);
+  if (exactProfiles.some((profile) => !profile.id)) {
+    throw new TelnyxError(
+      "The provider returned a messaging profile without a durable identity.",
+      502
+    );
+  }
+  return exactProfiles
+    .filter(
+      (profile): profile is typeof profile & { id: string; name: string } =>
+        Boolean(profile.id)
+    )
+    .map((profile) => ({
+      id: profile.id,
+      name: profile.name,
+      webhookUrl: profile.webhook_url ?? null,
+      enabled: profile.enabled ?? null,
+    }));
+}
+
+export interface OwnedPhoneNumber {
+  id: string;
+  phoneNumber: string;
+  messagingProfileId: string | null;
+  status: string | null;
+}
+
+export interface TelnyxNumberOrder {
+  id: string;
+  status: string;
+  customerReference: string;
+  messagingProfileId: string;
+  phoneNumbers: string[];
+}
+
+/** Find exact provider orders for a durable operation reference. Read-only. */
+export async function findNumberOrdersByCustomerReference(
+  customerReference: string
+): Promise<TelnyxNumberOrder[]> {
+  const params = new URLSearchParams();
+  params.set("filter[customer_reference]", customerReference);
+  params.set("page[size]", "10");
+  const json = await telnyxRequest<{
+    data?: Array<{
+      id?: string;
+      status?: string;
+      customer_reference?: string;
+      messaging_profile_id?: string;
+      phone_numbers?: Array<{ phone_number?: string }>;
+    }>;
+  }>("GET", `/number_orders?${params.toString()}`);
+
+  if (!Array.isArray(json.data)) {
+    throw new TelnyxError(
+      "The provider returned incomplete number-order reconciliation data.",
+      502
+    );
+  }
+  if (
+    json.data.some((order) => order.customer_reference !== customerReference)
+  ) {
+    throw new TelnyxError(
+      "The provider returned a number order for a different operation reference.",
+      502
+    );
+  }
+  if (
+    json.data.some(
+      (order) =>
+        !order.id ||
+        !order.status ||
+        !order.messaging_profile_id ||
+        !Array.isArray(order.phone_numbers)
+    )
+  ) {
+    throw new TelnyxError(
+      "The provider returned an incomplete number-order identity.",
+      502
+    );
+  }
+  return json.data
+    .filter(
+      (order): order is typeof order & {
+        id: string;
+        status: string;
+        customer_reference: string;
+        messaging_profile_id: string;
+      } =>
+        Boolean(order.id) &&
+        Boolean(order.status) &&
+        order.customer_reference === customerReference &&
+        Boolean(order.messaging_profile_id)
+    )
+    .map((order) => ({
+      id: order.id,
+      status: order.status,
+      customerReference: order.customer_reference,
+      messagingProfileId: order.messaging_profile_id,
+      phoneNumbers: order.phone_numbers!
+        .map((number) => number.phone_number)
+        .filter((number): number is string => Boolean(number)),
+    }));
+}
+
+/** Find an account-owned phone number by exact E.164 value. Read-only. */
+export async function findOwnedPhoneNumbers(
+  phoneNumber: string
+): Promise<OwnedPhoneNumber[]> {
+  const params = new URLSearchParams();
+  params.set("filter[phone_number]", phoneNumber);
+  params.set("page[size]", "10");
+  const json = await telnyxRequest<{
+    data?: Array<{
+      id?: string;
+      phone_number?: string;
+      messaging_profile_id?: string | null;
+      status?: string;
+    }>;
+  }>("GET", `/phone_numbers?${params.toString()}`);
+
+  if (!Array.isArray(json.data)) {
+    throw new TelnyxError(
+      "The provider returned incomplete phone-number reconciliation data.",
+      502
+    );
+  }
+  const exactNumbers = json.data.filter(
+    (number) => number.phone_number === phoneNumber
+  );
+  if (exactNumbers.some((number) => !number.id)) {
+    throw new TelnyxError(
+      "The provider returned a phone number without a durable identity.",
+      502
+    );
+  }
+  return exactNumbers
+    .filter(
+      (number): number is typeof number & { id: string; phone_number: string } =>
+        Boolean(number.id) && number.phone_number === phoneNumber
+    )
+    .map((number) => ({
+      id: number.id,
+      phoneNumber: number.phone_number,
+      messagingProfileId: number.messaging_profile_id ?? null,
+      status: number.status ?? null,
+    }));
 }
 
 /**
@@ -160,11 +402,11 @@ export async function createMessagingProfile(opts: {
   name: string;
   webhookUrl: string;
 }): Promise<{ id: string }> {
-  const json = await telnyxRequest<{ data?: { id?: string } }>(
-    "POST",
-    "/messaging_profiles",
-    {
+  let json: { data?: { id?: string } };
+  try {
+    json = await telnyxRequest("POST", "/messaging_profiles", {
       name: opts.name,
+      enabled: false,
       webhook_url: opts.webhookUrl,
       webhook_api_version: "2",
       // Telnyx rejects new profiles without an explicit destination allowlist.
@@ -175,43 +417,73 @@ export async function createMessagingProfile(opts: {
       daily_spend_limit_enabled: true,
       daily_spend_limit: "10.00",
       smart_encoding: true,
+    });
+  } catch (error) {
+    if (
+      !(error instanceof TelnyxError) ||
+      error.status === 408 ||
+      error.status === 429 ||
+      error.status >= 500
+    ) {
+      throw new TelnyxMutationUncertainError(
+        "The messaging-profile outcome is uncertain and must be reconciled before retrying.",
+        error
+      );
     }
-  );
-  const id = json.data?.id;
-  if (!id) throw new TelnyxError("Telnyx did not return a messaging profile id", 502);
+    throw error;
+  }
+  const id = json?.data?.id;
+  if (!id) {
+    throw new TelnyxMutationUncertainError(
+      "The provider accepted the messaging-profile request without returning a durable identity."
+    );
+  }
   return { id };
+}
+
+/** Delete an unused messaging profile created by an incomplete attempt. */
+export async function deleteMessagingProfile(profileId: string): Promise<void> {
+  await telnyxRequest("DELETE", `/messaging_profiles/${encodeURIComponent(profileId)}`);
 }
 
 /** Purchase a new local number and assign it to a messaging profile. */
 export async function buyNumber(opts: {
   phoneNumber: string;
   messagingProfileId: string;
+  customerReference: string;
 }): Promise<{ orderId: string; status: string | null }> {
-  const json = await telnyxRequest<{ data?: { id?: string; status?: string } }>(
-    "POST",
-    "/number_orders",
-    {
+  let json: { data?: { id?: string; status?: string } };
+  try {
+    json = await telnyxRequest("POST", "/number_orders", {
       phone_numbers: [{ phone_number: opts.phoneNumber }],
       messaging_profile_id: opts.messagingProfileId,
+      customer_reference: opts.customerReference,
+    });
+  } catch (error) {
+    if (
+      !(error instanceof TelnyxError) ||
+      error.status === 408 ||
+      error.status === 429 ||
+      error.status >= 500
+    ) {
+      throw new TelnyxMutationUncertainError(
+        "The number order outcome is uncertain and must be reconciled before retrying.",
+        error
+      );
     }
-  );
-  return { orderId: json.data?.id ?? "", status: json.data?.status ?? null };
+    throw error;
+  }
+  if (!json?.data?.id) {
+    throw new TelnyxMutationUncertainError(
+      "The provider accepted the request without returning a durable order identity."
+    );
+  }
+  return { orderId: json.data.id, status: json.data.status ?? null };
 }
 
-/** Text-enable an existing (non-Telnyx) number via a hosted-SMS order. */
-export async function createHostedOrder(opts: {
-  phoneNumber: string;
-  messagingProfileId: string;
-}): Promise<{ orderId: string; status: string | null }> {
-  const json = await telnyxRequest<{ data?: { id?: string; status?: string } }>(
-    "POST",
-    "/messaging_hosted_number_orders",
-    {
-      phone_numbers: [opts.phoneNumber],
-      messaging_profile_id: opts.messagingProfileId,
-    }
-  );
-  return { orderId: json.data?.id ?? "", status: json.data?.status ?? null };
+/** Release a purchased number that could not be durably attached in OpenVPM. */
+export async function deleteOwnedPhoneNumber(phoneNumberId: string): Promise<void> {
+  await telnyxRequest("DELETE", `/phone_numbers/${encodeURIComponent(phoneNumberId)}`);
 }
 
 // --- A2P 10DLC registration --------------------------------------------------

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -1,15 +1,29 @@
 import { readFileSync } from "node:fs";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   class MockTelnyxNotConfiguredError extends Error {}
+  class MockTelnyxError extends Error {
+    constructor(message: string, readonly status: number) {
+      super(message);
+    }
+  }
+  class MockTelnyxMutationUncertainError extends Error {}
   return {
     sendSms: vi.fn(),
     searchAvailableNumbers: vi.fn(),
-    checkHostedEligibility: vi.fn(),
+    findAvailableNumberQuotes: vi.fn(),
     createMessagingProfile: vi.fn(),
     buyNumber: vi.fn(),
-    createHostedOrder: vi.fn(),
+    deleteMessagingProfile: vi.fn(),
+    deleteOwnedPhoneNumber: vi.fn(),
+    findMessagingProfilesByName: vi.fn(),
+    findOwnedPhoneNumbers: vi.fn(),
+    findNumberOrdersByCustomerReference: vi.fn(),
+    reserveMessagingProfileAttempt: vi.fn(),
+    releaseMessagingProfileAttempt: vi.fn(),
+    TelnyxError: MockTelnyxError,
+    TelnyxMutationUncertainError: MockTelnyxMutationUncertainError,
     TelnyxNotConfiguredError: MockTelnyxNotConfiguredError,
     usageForPractice: vi.fn(async () => 0),
     currentPeriodMonth: vi.fn(() => "2026-06"),
@@ -22,11 +36,23 @@ vi.mock("@/lib/sms", () => ({
 
 vi.mock("@/lib/messaging/telnyx-provisioning", () => ({
   searchAvailableNumbers: mocks.searchAvailableNumbers,
-  checkHostedEligibility: mocks.checkHostedEligibility,
+  findAvailableNumberQuotes: mocks.findAvailableNumberQuotes,
   createMessagingProfile: mocks.createMessagingProfile,
   buyNumber: mocks.buyNumber,
-  createHostedOrder: mocks.createHostedOrder,
+  deleteMessagingProfile: mocks.deleteMessagingProfile,
+  deleteOwnedPhoneNumber: mocks.deleteOwnedPhoneNumber,
+  findMessagingProfilesByName: mocks.findMessagingProfilesByName,
+  findOwnedPhoneNumbers: mocks.findOwnedPhoneNumbers,
+  findNumberOrdersByCustomerReference:
+    mocks.findNumberOrdersByCustomerReference,
+  TelnyxError: mocks.TelnyxError,
+  TelnyxMutationUncertainError: mocks.TelnyxMutationUncertainError,
   TelnyxNotConfiguredError: mocks.TelnyxNotConfiguredError,
+}));
+
+vi.mock("@/lib/messaging/provisioning-attempt-gate", () => ({
+  reserveMessagingProfileAttempt: mocks.reserveMessagingProfileAttempt,
+  releaseMessagingProfileAttempt: mocks.releaseMessagingProfileAttempt,
 }));
 
 vi.mock("@/lib/billing/usage", () => ({
@@ -39,6 +65,40 @@ const { messagingRouter } = await import("../routers/messaging");
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
 const LOCATION_ID = "00000000-0000-0000-0000-000000000002";
+const SELECTED_QUOTE = {
+  upfrontCost: "3.21",
+  monthlyCost: "6.54",
+  currency: "USD",
+} as const;
+
+function startNumberInput() {
+  return {
+    locationId: LOCATION_ID,
+    mode: "buy" as const,
+    action: "start" as const,
+    phoneNumber: "+15555550100",
+    quote: SELECTED_QUOTE,
+    confirmProviderCharges: true as const,
+  };
+}
+
+function resumeNumberInput() {
+  return {
+    locationId: LOCATION_ID,
+    mode: "buy" as const,
+    action: "resume" as const,
+  };
+}
+
+function preparedMessagingGate() {
+  return {
+    provider: "telnyx",
+    messagingProfileId: null,
+    senderE164: "+15555550100",
+    numberSource: "purchased",
+    registrationStatus: "failed",
+  };
+}
 
 function callerWithDb(db: Record<string, unknown>) {
   const session = {
@@ -130,19 +190,40 @@ function createDb(opts?: {
   }));
   const insert = vi.fn(() => ({ values: insertValues }));
 
+  const execute = vi.fn(async () => undefined);
   const db: Record<string, unknown> = {
     transaction: async (fn: (tx: unknown) => unknown) => fn(db),
-    execute: vi.fn(async () => undefined),
+    execute,
     select,
     update,
     insert,
   };
 
-  return { db, select, updateSet, updateWhere, insertValues, insertUpdate };
+  return {
+    db,
+    select,
+    execute,
+    updateSet,
+    updateWhere,
+    insertValues,
+    insertUpdate,
+  };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.findMessagingProfilesByName.mockResolvedValue([]);
+  mocks.findOwnedPhoneNumbers.mockResolvedValue([]);
+  mocks.findNumberOrdersByCustomerReference.mockResolvedValue([]);
+  mocks.findAvailableNumberQuotes.mockResolvedValue([
+    { phoneNumber: "+15555550100", ...SELECTED_QUOTE },
+  ]);
+  mocks.reserveMessagingProfileAttempt.mockResolvedValue(true);
+  mocks.releaseMessagingProfileAttempt.mockResolvedValue(true);
+  mocks.createMessagingProfile.mockResolvedValue({ id: "profile_123" });
+  mocks.buyNumber.mockResolvedValue({ orderId: "order_123", status: "pending" });
+  mocks.deleteMessagingProfile.mockResolvedValue(undefined);
+  mocks.deleteOwnedPhoneNumber.mockResolvedValue(undefined);
   delete process.env.NEXT_PUBLIC_APP_URL;
   delete process.env.NEXTAUTH_URL;
   delete process.env.HOSTED_BILLING_ENABLED;
@@ -152,13 +233,17 @@ beforeEach(() => {
   vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("messaging provisioning kill-switch", () => {
   it("blocks number search and provisioning until ops enables it", async () => {
     vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "");
     const { db, select } = createDb();
 
     await expect(
-      callerWithDb(db).provisionNumber({ locationId: LOCATION_ID, mode: "host" })
+      callerWithDb(db).provisionNumber(startNumberInput())
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining("almost ready"),
@@ -185,7 +270,7 @@ describe("messaging provisioning kill-switch", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber({ locationId: LOCATION_ID, mode: "host" })
+      callerWithDb(db).provisionNumber(startNumberInput())
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining("approved pilot clinics"),
@@ -195,7 +280,7 @@ describe("messaging provisioning kill-switch", () => {
     // stops before its practice/location queries or any provider call.
     expect(select).toHaveBeenCalledTimes(1);
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
-    expect(mocks.createHostedOrder).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
   });
 });
 
@@ -366,8 +451,7 @@ describe("messaging location target safety", () => {
 
     await expect(
       callerWithDb(db).provisionNumber({
-        locationId: LOCATION_ID,
-        mode: "buy",
+        ...startNumberInput(),
         phoneNumber: "12345",
       })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
@@ -381,7 +465,6 @@ describe("messaging location target safety", () => {
 
     expect(select).not.toHaveBeenCalled();
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
-    expect(mocks.createHostedOrder).not.toHaveBeenCalled();
     expect(mocks.buyNumber).not.toHaveBeenCalled();
     expect(mocks.sendSms).not.toHaveBeenCalled();
   });
@@ -408,7 +491,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      caller.provisionNumber({ locationId: LOCATION_ID, mode: "host" })
+      caller.provisionNumber(startNumberInput())
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -416,7 +499,6 @@ describe("messaging location target safety", () => {
 
     expect(mocks.searchAvailableNumbers).not.toHaveBeenCalled();
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
-    expect(mocks.createHostedOrder).not.toHaveBeenCalled();
     expect(mocks.buyNumber).not.toHaveBeenCalled();
     expect(mocks.sendSms).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
@@ -447,18 +529,49 @@ describe("messaging location target safety", () => {
       callerWithDb(db).checkEligibility({ locationId: LOCATION_ID })
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
-    expect(mocks.checkHostedEligibility).not.toHaveBeenCalled();
+    expect(mocks.findMessagingProfilesByName).not.toHaveBeenCalled();
   });
 
-  it("rejects provisioning stale or deleted locations before provider calls", async () => {
-    const { db } = createDb({ selectResults: [[]] });
+  it("reports existing-number hosting as unavailable without contacting a provider", async () => {
+    const { db } = createDb({
+      selectResults: [[{ phone: "+15555550100" }]],
+    });
+
+    await expect(
+      callerWithDb(db).checkEligibility({ locationId: LOCATION_ID })
+    ).resolves.toEqual({
+      eligible: false,
+      detail: expect.stringContaining("has not ported or changed"),
+    });
+
+    expect(mocks.findMessagingProfilesByName).not.toHaveBeenCalled();
+    expect(mocks.findOwnedPhoneNumbers).not.toHaveBeenCalled();
+  });
+
+  it("truthfully rejects existing-number hosting without provider mutation", async () => {
+    const { db } = createDb();
 
     await expect(
       callerWithDb(db).provisionNumber({ locationId: LOCATION_ID, mode: "host" })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("has not ported or changed"),
+    });
+
+    expect(mocks.findMessagingProfilesByName).not.toHaveBeenCalled();
+    expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+  });
+
+  it("rejects provisioning stale or deleted locations before provider calls", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    const { db } = createDb({ selectResults: [[]] });
+
+    await expect(
+      callerWithDb(db).provisionNumber(startNumberInput())
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
-    expect(mocks.createHostedOrder).not.toHaveBeenCalled();
     expect(mocks.buyNumber).not.toHaveBeenCalled();
   });
 
@@ -470,10 +583,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(missingEnv.db).provisionNumber({
-        locationId: LOCATION_ID,
-        mode: "host",
-      })
+      callerWithDb(missingEnv.db).provisionNumber(startNumberInput())
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -488,79 +598,88 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(localEnv.db).provisionNumber({
-        locationId: LOCATION_ID,
-        mode: "host",
-      })
+      callerWithDb(localEnv.db).provisionNumber(startNumberInput())
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
     });
 
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
-    expect(mocks.createHostedOrder).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+  });
+
+  it("never calls the provider when a fresh durable attempt cannot be reserved", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    mocks.reserveMessagingProfileAttempt.mockResolvedValueOnce(false);
+    const { db } = createDb({
+      selectResults: [[{ id: LOCATION_ID }], []],
+    });
+
+    await expect(
+      callerWithDb(db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("could not reserve"),
+    });
+    expect(mocks.findMessagingProfilesByName).not.toHaveBeenCalled();
+    expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
     expect(mocks.buyNumber).not.toHaveBeenCalled();
   });
 
   it("falls back to NEXTAUTH_URL when NEXT_PUBLIC_APP_URL is blank", async () => {
     process.env.NEXT_PUBLIC_APP_URL = "   ";
     process.env.NEXTAUTH_URL = "https://auth.example.com/settings";
-    mocks.createMessagingProfile.mockResolvedValue({ id: "profile_123" });
-    mocks.createHostedOrder.mockResolvedValue({ id: "hosted_123" });
     const { db } = createDb({
       selectResults: [
-        [{ id: LOCATION_ID, name: "Main Clinic", phone: "(555) 555-0100" }],
+        [{ id: LOCATION_ID }],
+        [],
       ],
     });
 
     await expect(
-      callerWithDb(db).provisionNumber({
-        locationId: LOCATION_ID,
-        mode: "host",
-      })
+      callerWithDb(db).provisionNumber(startNumberInput())
     ).resolves.toMatchObject({
       ok: true,
       senderE164: "+15555550100",
-      numberSource: "hosted",
+      numberSource: "purchased",
     });
 
     expect(mocks.createMessagingProfile).toHaveBeenCalledWith({
-      name: "Main Clinic — OpenVPM",
+      name: `OpenVPM provision ${LOCATION_ID}`,
       webhookUrl: "https://auth.example.com/api/webhooks/telnyx",
     });
-    expect(mocks.createHostedOrder).toHaveBeenCalledWith({
+    expect(mocks.buyNumber).toHaveBeenCalledWith({
       phoneNumber: "+15555550100",
       messagingProfileId: "profile_123",
+      customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
     });
   });
 
   it("passes the public Telnyx webhook URL and reactivates sender rows", async () => {
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
-    mocks.createMessagingProfile.mockResolvedValue({ id: "profile_123" });
-    mocks.createHostedOrder.mockResolvedValue({ id: "hosted_123" });
     const { db, insertValues, insertUpdate } = createDb({
       selectResults: [
-        [{ id: LOCATION_ID, name: "Main Clinic", phone: "(555) 555-0100" }],
+        [{ id: LOCATION_ID }],
+        [],
       ],
     });
 
     await expect(
-      callerWithDb(db).provisionNumber({
-        locationId: LOCATION_ID,
-        mode: "host",
-      })
+      callerWithDb(db).provisionNumber(startNumberInput())
     ).resolves.toEqual({
       ok: true,
       senderE164: "+15555550100",
-      numberSource: "hosted",
+      numberSource: "purchased",
+      recovered: false,
     });
 
     expect(mocks.createMessagingProfile).toHaveBeenCalledWith({
-      name: "Main Clinic — OpenVPM",
+      name: `OpenVPM provision ${LOCATION_ID}`,
       webhookUrl: "https://app.example.com/api/webhooks/telnyx",
     });
-    expect(mocks.createHostedOrder).toHaveBeenCalledWith({
+    expect(mocks.buyNumber).toHaveBeenCalledWith({
       phoneNumber: "+15555550100",
       messagingProfileId: "profile_123",
+      customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
     });
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -568,8 +687,8 @@ describe("messaging location target safety", () => {
         locationId: LOCATION_ID,
         messagingProfileId: "profile_123",
         senderE164: "+15555550100",
-        registrationStatus: "pending",
-        registrationDetail: expect.stringContaining("Carrier registration"),
+        registrationStatus: "not_started",
+        registrationDetail: expect.stringContaining("Number order accepted"),
         enabled: false,
       })
     );
@@ -578,12 +697,659 @@ describe("messaging location target safety", () => {
         set: expect.objectContaining({
           messagingProfileId: "profile_123",
           senderE164: "+15555550100",
-          registrationStatus: "pending",
-          registrationDetail: expect.stringContaining("Carrier registration"),
+          registrationStatus: "not_started",
+          registrationDetail: expect.stringContaining("Number order accepted"),
           enabled: false,
           deletedAt: null,
           updatedAt: expect.any(Date),
         }),
+      })
+    );
+  });
+
+  it("returns an existing completed operation without another provider call", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    const { db } = createDb({
+      selectResults: [
+        [{ id: LOCATION_ID }],
+        [
+          {
+            provider: "telnyx",
+            messagingProfileId: "profile_123",
+            senderE164: "+15555550100",
+            numberSource: "purchased",
+            registrationStatus: "not_started",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).provisionNumber(startNumberInput())
+    ).resolves.toEqual({
+      ok: true,
+      senderE164: "+15555550100",
+      numberSource: "purchased",
+      recovered: true,
+    });
+
+    expect(mocks.findMessagingProfilesByName).not.toHaveBeenCalled();
+    expect(mocks.findOwnedPhoneNumbers).not.toHaveBeenCalled();
+    expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+  });
+
+  it("reconciles an interrupted purchase without buying the number twice", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    mocks.findMessagingProfilesByName.mockResolvedValue([
+      {
+        id: "profile_123",
+        name: `OpenVPM provision ${LOCATION_ID}`,
+        webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+        enabled: false,
+      },
+    ]);
+    mocks.findOwnedPhoneNumbers.mockResolvedValue([
+      {
+        id: "number_123",
+        phoneNumber: "+15555550100",
+        messagingProfileId: "profile_123",
+        status: "active",
+      },
+    ]);
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [{ id: LOCATION_ID }],
+        [
+          {
+            provider: "telnyx",
+            messagingProfileId: "profile_123",
+            senderE164: "+15555550100",
+            numberSource: "purchased",
+            registrationStatus: "failed",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).provisionNumber(resumeNumberInput())
+    ).resolves.toMatchObject({ recovered: true, numberSource: "purchased" });
+
+    expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registrationStatus: "not_started",
+        enabled: false,
+      })
+    );
+  });
+
+  it("recovers a pending exact customer-reference order before phone inventory appears", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    mocks.findMessagingProfilesByName.mockResolvedValue([
+      {
+        id: "profile_123",
+        name: `OpenVPM provision ${LOCATION_ID}`,
+        webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+        enabled: false,
+      },
+    ]);
+    mocks.findNumberOrdersByCustomerReference.mockResolvedValue([
+      {
+        id: "order_123",
+        status: "pending",
+        customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
+        messagingProfileId: "profile_123",
+        phoneNumbers: ["+15555550100"],
+      },
+    ]);
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [{ id: LOCATION_ID }],
+        [
+          {
+            provider: "telnyx",
+            messagingProfileId: "profile_123",
+            senderE164: "+15555550100",
+            numberSource: "purchased",
+            registrationStatus: "failed",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).provisionNumber(resumeNumberInput())
+    ).resolves.toMatchObject({ recovered: true, senderE164: "+15555550100" });
+
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messagingProfileId: "profile_123",
+        senderE164: "+15555550100",
+        registrationStatus: "not_started",
+      })
+    );
+  });
+
+  it.each([
+    "transport timeout",
+    "HTTP 408",
+    "HTTP 429",
+    "HTTP 500",
+    "malformed successful response",
+  ])("never issues a second order POST after %s", async (scenario) => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    mocks.findMessagingProfilesByName
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "profile_123",
+          name: `OpenVPM provision ${LOCATION_ID}`,
+          webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+          enabled: false,
+        },
+      ]);
+    mocks.findNumberOrdersByCustomerReference
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "order_123",
+          status: "pending",
+          customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
+          messagingProfileId: "profile_123",
+          phoneNumbers: ["+15555550100"],
+        },
+      ]);
+    mocks.buyNumber.mockRejectedValueOnce(
+      new mocks.TelnyxMutationUncertainError(`${scenario}: reconcile required`)
+    );
+
+    const first = createDb({ selectResults: [[{ id: LOCATION_ID }], []] });
+    await expect(
+      callerWithDb(first.db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+
+    const retry = createDb({
+      selectResults: [
+        [{ id: LOCATION_ID }],
+        [
+          {
+            provider: "telnyx",
+            messagingProfileId: "profile_123",
+            senderE164: "+15555550100",
+            numberSource: "purchased",
+            registrationStatus: "failed",
+          },
+        ],
+      ],
+    });
+    await expect(
+      callerWithDb(retry.db).provisionNumber(resumeNumberInput())
+    ).resolves.toMatchObject({ recovered: true });
+    expect(mocks.buyNumber).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    "profile transport timeout",
+    "profile HTTP 408",
+    "profile HTTP 429",
+    "profile HTTP 500",
+    "malformed profile success response",
+  ])(
+    "persists a pre-attempt gate and never repeats profile creation after %s",
+    async (scenario) => {
+      process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+      mocks.createMessagingProfile.mockRejectedValueOnce(
+        new mocks.TelnyxMutationUncertainError(
+          `${scenario}: profile reconciliation required`
+        )
+      );
+      mocks.reserveMessagingProfileAttempt.mockResolvedValueOnce(true);
+      const gate = preparedMessagingGate();
+      const first = createDb({
+        selectResults: [[{ id: LOCATION_ID }], [gate], [gate]],
+      });
+
+      await expect(
+        callerWithDb(first.db).provisionNumber(startNumberInput())
+      ).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+      expect(mocks.reserveMessagingProfileAttempt).toHaveBeenCalledWith({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        senderE164: "+15555550100",
+        customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
+        detail: expect.stringContaining("will not create another provider profile"),
+      });
+      expect(
+        mocks.reserveMessagingProfileAttempt.mock.invocationCallOrder[0]
+      ).toBeLessThan(mocks.createMessagingProfile.mock.invocationCallOrder[0]!);
+      expect(first.insertValues).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          messagingProfileId: null,
+          senderE164: "+15555550100",
+          numberSource: "purchased",
+          registrationStatus: "failed",
+          enabled: false,
+        })
+      );
+
+      const retry = createDb({
+        selectResults: [[{ id: LOCATION_ID }], [gate]],
+      });
+      await expect(
+        callerWithDb(retry.db).provisionNumber(resumeNumberInput())
+      ).rejects.toMatchObject({
+        code: "CONFLICT",
+        message: expect.stringContaining("No additional purchase"),
+      });
+
+      expect(mocks.createMessagingProfile).toHaveBeenCalledTimes(1);
+      expect(mocks.buyNumber).not.toHaveBeenCalled();
+      expect(mocks.releaseMessagingProfileAttempt).not.toHaveBeenCalled();
+    }
+  );
+
+  it("keeps resume read-only when the exact profile later becomes visible", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    const gate = preparedMessagingGate();
+    mocks.reserveMessagingProfileAttempt.mockResolvedValueOnce(true);
+    mocks.findMessagingProfilesByName
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "profile_123",
+          name: `OpenVPM provision ${LOCATION_ID}`,
+          webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+          enabled: false,
+        },
+      ]);
+    mocks.createMessagingProfile.mockRejectedValueOnce(
+      new mocks.TelnyxMutationUncertainError("profile response timed out")
+    );
+    const first = createDb({
+      selectResults: [[{ id: LOCATION_ID }], [gate], [gate]],
+    });
+    await expect(
+      callerWithDb(first.db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+
+    const retry = createDb({
+      selectResults: [[{ id: LOCATION_ID }], [gate], [gate]],
+    });
+    await expect(
+      callerWithDb(retry.db).provisionNumber(resumeNumberInput())
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+
+    expect(mocks.createMessagingProfile).toHaveBeenCalledTimes(1);
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+    expect(mocks.releaseMessagingProfileAttempt).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on duplicate, mismatched, and inconclusive order records", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    mocks.findMessagingProfilesByName.mockResolvedValue([
+      {
+        id: "profile_123",
+        name: `OpenVPM provision ${LOCATION_ID}`,
+        webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+        enabled: false,
+      },
+    ]);
+    mocks.findNumberOrdersByCustomerReference.mockResolvedValue([
+      {
+        id: "order_1",
+        status: "pending",
+        customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
+        messagingProfileId: "different_profile",
+        phoneNumbers: ["+15555550100"],
+      },
+    ]);
+    const { db } = createDb({
+      selectResults: [
+        [{ id: LOCATION_ID }],
+        [
+          {
+            provider: "telnyx",
+            messagingProfileId: "profile_123",
+            senderE164: "+15555550100",
+            numberSource: "purchased",
+            registrationStatus: "failed",
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).provisionNumber(resumeNumberInput())
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("No additional purchase"),
+    });
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+  });
+
+  it("requires literal charge authorization and a current immutable quote", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    const noConfirmation = createDb();
+    await expect(
+      callerWithDb(noConfirmation.db).provisionNumber({
+        ...startNumberInput(),
+        confirmProviderCharges: false,
+      } as never)
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    mocks.reserveMessagingProfileAttempt
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true);
+    mocks.findAvailableNumberQuotes
+      .mockResolvedValueOnce([
+        {
+          phoneNumber: "+15555550100",
+          upfrontCost: "4.00",
+          monthlyCost: "6.54",
+          currency: "USD",
+        },
+      ])
+      .mockResolvedValueOnce([
+        { phoneNumber: "+15555550100", ...SELECTED_QUOTE },
+      ]);
+    const gate = preparedMessagingGate();
+    const changedQuote = createDb({
+      selectResults: [[{ id: LOCATION_ID }], [gate]],
+    });
+    await expect(
+      callerWithDb(changedQuote.db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("price changed"),
+    });
+    expect(mocks.releaseMessagingProfileAttempt).toHaveBeenCalledWith({
+      practiceId: PRACTICE_ID,
+      locationId: LOCATION_ID,
+      senderE164: "+15555550100",
+      customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
+      detail: expect.stringContaining("will not create another provider profile"),
+    });
+    expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+
+    const retryAfterRelease = createDb({
+      selectResults: [[{ id: LOCATION_ID }], [gate]],
+    });
+    await expect(
+      callerWithDb(retryAfterRelease.db).provisionNumber(startNumberInput())
+    ).resolves.toMatchObject({
+      ok: true,
+      senderE164: "+15555550100",
+    });
+    expect(mocks.createMessagingProfile).toHaveBeenCalledTimes(1);
+    expect(mocks.buyNumber).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases an untouched gate when provider configuration is missing before the first request", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    const gate = preparedMessagingGate();
+    mocks.findMessagingProfilesByName.mockRejectedValueOnce(
+      new mocks.TelnyxNotConfiguredError()
+    );
+
+    const missingConfig = createDb({
+      selectResults: [[{ id: LOCATION_ID }], [gate], [gate]],
+    });
+    await expect(
+      callerWithDb(missingConfig.db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(mocks.releaseMessagingProfileAttempt).toHaveBeenCalledWith({
+      practiceId: PRACTICE_ID,
+      locationId: LOCATION_ID,
+      senderE164: "+15555550100",
+      customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
+      detail: expect.stringContaining("will not create another provider profile"),
+    });
+    expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+
+    const retryAfterConfiguration = createDb({
+      selectResults: [[{ id: LOCATION_ID }], [gate]],
+    });
+    await expect(
+      callerWithDb(retryAfterConfiguration.db).provisionNumber(
+        startNumberInput()
+      )
+    ).resolves.toMatchObject({
+      ok: true,
+      senderE164: "+15555550100",
+    });
+    expect(mocks.createMessagingProfile).toHaveBeenCalledTimes(1);
+    expect(mocks.buyNumber).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains the gate when provider configuration disappears after profile creation", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    const gate = preparedMessagingGate();
+    mocks.findOwnedPhoneNumbers.mockRejectedValueOnce(
+      new mocks.TelnyxNotConfiguredError()
+    );
+
+    const interruptedAfterProfile = createDb({
+      selectResults: [[{ id: LOCATION_ID }], [gate], [gate]],
+    });
+    await expect(
+      callerWithDb(interruptedAfterProfile.db).provisionNumber(
+        startNumberInput()
+      )
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(mocks.createMessagingProfile).toHaveBeenCalledTimes(1);
+    expect(mocks.releaseMessagingProfileAttempt).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+
+    mocks.findMessagingProfilesByName.mockResolvedValueOnce([
+      {
+        id: "profile_123",
+        name: `OpenVPM provision ${LOCATION_ID}`,
+        webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+        enabled: false,
+      },
+    ]);
+    const retry = createDb({
+      selectResults: [
+        [{ id: LOCATION_ID }],
+        [
+          {
+            ...gate,
+            messagingProfileId: "profile_123",
+          },
+        ],
+      ],
+    });
+    await expect(
+      callerWithDb(retry.db).provisionNumber(resumeNumberInput())
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("No additional purchase"),
+    });
+
+    expect(mocks.createMessagingProfile).toHaveBeenCalledTimes(1);
+    expect(mocks.releaseMessagingProfileAttempt).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when deterministic provider profiles are duplicated", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    mocks.findMessagingProfilesByName.mockResolvedValue([
+      {
+        id: "profile_1",
+        name: `OpenVPM provision ${LOCATION_ID}`,
+        webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+        enabled: false,
+      },
+      {
+        id: "profile_2",
+        name: `OpenVPM provision ${LOCATION_ID}`,
+        webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+        enabled: false,
+      },
+    ]);
+    const { db } = createDb({
+      selectResults: [[{ id: LOCATION_ID }], []],
+    });
+
+    await expect(
+      callerWithDb(db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("more than one incomplete"),
+    });
+
+    expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+  });
+
+  it("refuses to recover a provider profile that is already enabled", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    mocks.findMessagingProfilesByName.mockResolvedValue([
+      {
+        id: "profile_123",
+        name: `OpenVPM provision ${LOCATION_ID}`,
+        webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+        enabled: true,
+      },
+    ]);
+    const { db } = createDb({
+      selectResults: [[{ id: LOCATION_ID }], []],
+    });
+
+    await expect(
+      callerWithDb(db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("unsafe settings"),
+    });
+
+    expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+  });
+
+  it("retains an accepted order identity when the durable write fails", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.findOwnedPhoneNumbers
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "number_123",
+          phoneNumber: "+15555550100",
+          messagingProfileId: "profile_123",
+          status: "active",
+        },
+      ]);
+    const { db, insertUpdate, insertValues } = createDb({
+      selectResults: [[{ id: LOCATION_ID }], []],
+    });
+    insertUpdate
+      .mockRejectedValueOnce(new Error("database write failed"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      callerWithDb(db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+      message: expect.not.stringContaining("database write failed"),
+    });
+
+    expect(mocks.deleteOwnedPhoneNumber).not.toHaveBeenCalled();
+    expect(mocks.deleteMessagingProfile).not.toHaveBeenCalled();
+    expect(insertValues).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messagingProfileId: "profile_123",
+        senderE164: "+15555550100",
+        registrationStatus: "failed",
+        enabled: false,
+      })
+    );
+    expect(errorLog).toHaveBeenCalledWith(
+      "Unexpected messaging provisioning failure",
+      expect.any(Error)
+    );
+  });
+
+  it("does not let older compensation overwrite a newer completed retry", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { db, insertUpdate, insertValues } = createDb({
+      selectResults: [
+        [{ id: LOCATION_ID }],
+        [],
+        [
+          {
+            provider: "telnyx",
+            messagingProfileId: "profile_123",
+            senderE164: "+15555550100",
+            numberSource: "purchased",
+            registrationStatus: "not_started",
+          },
+        ],
+      ],
+    });
+    insertUpdate.mockRejectedValueOnce(new Error("database write failed"));
+
+    await expect(
+      callerWithDb(db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
+
+    expect(mocks.deleteOwnedPhoneNumber).not.toHaveBeenCalled();
+    expect(mocks.deleteMessagingProfile).not.toHaveBeenCalled();
+    expect(insertValues).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a deterministic profile recoverable after an uncertain order timeout", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    mocks.buyNumber.mockRejectedValue(
+      new mocks.TelnyxMutationUncertainError("request outcome uncertain")
+    );
+    const { db, insertValues } = createDb({
+      selectResults: [[{ id: LOCATION_ID }], []],
+    });
+
+    await expect(
+      callerWithDb(db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+
+    expect(mocks.deleteOwnedPhoneNumber).not.toHaveBeenCalled();
+    expect(mocks.deleteMessagingProfile).not.toHaveBeenCalled();
+    expect(insertValues).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messagingProfileId: "profile_123",
+        registrationStatus: "failed",
+      })
+    );
+  });
+
+  it("rechecks the kill switch immediately before a number purchase", async () => {
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+    mocks.createMessagingProfile.mockImplementation(async () => {
+      process.env.MESSAGING_PROVISIONING_ENABLED = "false";
+      return { id: "profile_123" };
+    });
+    const { db, insertValues } = createDb({
+      selectResults: [[{ id: LOCATION_ID }], []],
+    });
+
+    await expect(
+      callerWithDb(db).provisionNumber(startNumberInput())
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+
+    expect(mocks.buyNumber).not.toHaveBeenCalled();
+    expect(mocks.deleteMessagingProfile).not.toHaveBeenCalled();
+    expect(insertValues).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messagingProfileId: "profile_123",
+        registrationStatus: "failed",
       })
     );
   });

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -25,10 +25,15 @@ import {
 import { sendSms } from "@/lib/sms";
 import {
   searchAvailableNumbers,
-  checkHostedEligibility,
+  findAvailableNumberQuotes,
   createMessagingProfile,
   buyNumber,
-  createHostedOrder,
+  deleteMessagingProfile,
+  findMessagingProfilesByName,
+  findOwnedPhoneNumbers,
+  findNumberOrdersByCustomerReference,
+  TelnyxError,
+  TelnyxMutationUncertainError,
   TelnyxNotConfiguredError,
 } from "@/lib/messaging/telnyx-provisioning";
 import { appBaseUrl, normalizeAppBaseUrl } from "@/lib/app-url";
@@ -37,10 +42,36 @@ import {
   MessagingRegistrationEncryptionError,
 } from "@/lib/messaging/registration-crypto";
 import { messagingProgramUrls } from "@/lib/messaging/public-program";
+import {
+  releaseMessagingProfileAttempt,
+  reserveMessagingProfileAttempt,
+} from "@/lib/messaging/provisioning-attempt-gate";
 
 const adminOnly = protectedProcedure.use(requireRole("admin"));
-const MESSAGING_REGISTRATION_PENDING_DETAIL =
-  "Carrier registration (A2P 10DLC) in progress — required before messages can send; typically 1–2 weeks.";
+const MESSAGING_NUMBER_ORDERED_DETAIL =
+  "Number order accepted. The provider may still be activating it, and sending is off. Complete the clinic carrier details; OpenVPM will review them before registration submission.";
+const MESSAGING_PROVISIONING_FAILED_DETAIL =
+  "Number setup did not finish. No sending was enabled. Reconcile the saved provider setup from this location, or contact OpenVPM support.";
+const MESSAGING_PROVISIONING_PREPARED_DETAIL =
+  "Number setup is reserved but not complete. No sending was enabled. Reconcile this saved setup; OpenVPM will not create another provider profile or purchase another number automatically.";
+const EXISTING_NUMBER_UNAVAILABLE_DETAIL =
+  "Texting from your clinic's existing phone number is not supported yet. OpenVPM has not ported or changed that number. Choose a new local texting number instead.";
+const INCONCLUSIVE_ORDER_DETAIL =
+  "OpenVPM could not conclusively reconcile the earlier number order. No additional purchase was attempted. Contact OpenVPM support before trying another number.";
+
+const providerPriceInput = z
+  .string()
+  .trim()
+  .regex(/^\d+(?:\.\d+)?$/, "A complete provider price is required.")
+  .refine((value) => Number.isFinite(Number(value)) && Number(value) >= 0, {
+    message: "A valid non-negative provider price is required.",
+  });
+
+const selectedQuoteInput = z.object({
+  upfrontCost: providerPriceInput,
+  monthlyCost: providerPriceInput,
+  currency: z.string().trim().regex(/^[A-Z]{3}$/),
+});
 
 const messagingPhoneInput = z
   .string()
@@ -131,13 +162,43 @@ const a2pRegistrationInput = z.object({
 
 /** Map a thrown provisioning error to a tRPC error the UI can show. */
 function provisioningError(e: unknown): TRPCError {
+  if (e instanceof TRPCError) return e;
   if (e instanceof TelnyxNotConfiguredError) {
     return new TRPCError({ code: "PRECONDITION_FAILED", message: e.message });
   }
+  if (e instanceof TelnyxMutationUncertainError) {
+    return new TRPCError({ code: "BAD_GATEWAY", message: e.message });
+  }
+  if (e instanceof TelnyxError) {
+    return new TRPCError({ code: "BAD_GATEWAY", message: e.message });
+  }
+  console.error("Unexpected messaging provisioning failure", e);
   return new TRPCError({
-    code: "BAD_GATEWAY",
-    message: e instanceof Error ? e.message : "Messaging provider request failed",
+    code: "INTERNAL_SERVER_ERROR",
+    message:
+      "Texting setup could not be completed safely. No additional purchase was attempted. Retry reconciliation or contact OpenVPM support.",
   });
+}
+
+function quotesMatch(
+  selected: z.infer<typeof selectedQuoteInput>,
+  current: z.infer<typeof selectedQuoteInput>
+): boolean {
+  return (
+    selected.currency === current.currency &&
+    Number(selected.upfrontCost) === Number(current.upfrontCost) &&
+    Number(selected.monthlyCost) === Number(current.monthlyCost)
+  );
+}
+
+function isFailedOrderStatus(status: string): boolean {
+  return ["failure", "failed", "cancelled", "canceled", "deleted"].includes(
+    status.toLowerCase()
+  );
+}
+
+function isRecoverableOrderStatus(status: string): boolean {
+  return ["pending", "success"].includes(status.toLowerCase());
 }
 
 function activePracticeWhere(practiceId: string) {
@@ -190,11 +251,11 @@ function assertProvisioningEnabled(): void {
 }
 
 /**
- * Hosted number orders can incur immediate and recurring provider charges.
+ * Number orders can incur immediate and recurring provider charges.
  * During controlled rollout, require an explicit tenant allowlist in addition
- * to the global kill-switch. Self-hosters retain the existing switch-only path.
+ * to the global kill-switch. Self-hosters retain the switch-only path.
  */
-function assertHostedProvisioningPracticeAllowed(practiceId: string): void {
+function assertProvisioningPracticeAllowed(practiceId: string): void {
   if (!billingEnforced()) return;
   const allowed = new Set(
     (process.env.MESSAGING_PROVISIONING_PRACTICE_IDS ?? "")
@@ -209,6 +270,21 @@ function assertHostedProvisioningPracticeAllowed(practiceId: string): void {
         "Texting number setup is available only to approved pilot clinics. Contact OpenVPM support.",
     });
   }
+}
+
+function provisioningOperationReference(
+  practiceId: string,
+  locationId: string
+): string {
+  return `openvpm:${practiceId}:${locationId}`;
+}
+
+function provisioningProfileName(locationId: string): string {
+  return `OpenVPM provision ${locationId}`;
+}
+
+function provisioningConflict(message: string): TRPCError {
+  return new TRPCError({ code: "CONFLICT", message });
 }
 
 function telnyxWebhookUrl(): string {
@@ -651,7 +727,9 @@ export const messagingRouter = createRouter({
         )
       );
     return {
-      hasAnyNumber: rows.some((r) => !!r.senderE164),
+      hasAnyNumber: rows.some(
+        (r) => !!r.senderE164 && r.registrationStatus !== "failed"
+      ),
       hasActiveNumber: rows.some(
         (r) => r.registrationStatus === "active" && r.enabled
       ),
@@ -682,13 +760,13 @@ export const messagingRouter = createRouter({
       }
     }),
 
-  /** Can this location's existing number be text-enabled (hosted SMS, no port)? */
+  /** Existing-number hosting is intentionally closed until it works end-to-end. */
   checkEligibility: adminOnly
     .input(z.object({ locationId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
       const [loc] = await ctx.db
-        .select({ phone: locations.phone })
+        .select({ id: locations.id })
         .from(locations)
         .where(
           and(
@@ -702,113 +780,505 @@ export const messagingRouter = createRouter({
       if (!loc) {
         throw new TRPCError({ code: "NOT_FOUND", message: "Location not found" });
       }
-      const e164 = normalizeE164(loc.phone);
-      if (!e164) {
-        return {
-          eligible: false,
-          detail:
-            "Add a valid phone number to this location before checking eligibility.",
-        };
-      }
-      try {
-        return await checkHostedEligibility(e164);
-      } catch (e) {
-        throw provisioningError(e);
-      }
+      return {
+        eligible: false,
+        detail: EXISTING_NUMBER_UNAVAILABLE_DETAIL,
+      };
     }),
 
   /**
-   * Stand up a texting number for a location: create a messaging profile (with
-   * our inbound webhook), then either text-enable the location's existing number
-   * (host) or buy a new local number, and save the config. Leaves the location
-   * disabled + registration pending (carrier A2P approval precedes sending).
+   * Stand up a new texting number for a location. A location-scoped PostgreSQL
+   * advisory lock serializes clicks, while a deterministic provider profile
+   * name and customer reference let retries reconcile an interrupted attempt.
+   * Sending stays disabled until carrier approval.
    */
   provisionNumber: adminOnly
     .input(
-      z.object({
-        locationId: z.string().uuid(),
-        mode: z.enum(["host", "buy"]),
-        // Required for "buy"; for "host" we use the location's existing number.
-        phoneNumber: messagingPhoneInput.optional(),
-      })
+      z.union([
+        z.object({
+          locationId: z.string().uuid(),
+          mode: z.literal("host"),
+        }),
+        z.object({
+          locationId: z.string().uuid(),
+          mode: z.literal("buy"),
+          action: z.literal("start"),
+          phoneNumber: messagingPhoneInput,
+          quote: selectedQuoteInput,
+          confirmProviderCharges: z.literal(true),
+        }),
+        z.object({
+          locationId: z.string().uuid(),
+          mode: z.literal("buy"),
+          action: z.literal("resume"),
+        }),
+      ])
     )
     .mutation(async ({ ctx, input }) => {
-      assertProvisioningEnabled();
-      assertHostedProvisioningPracticeAllowed(ctx.practiceId);
-      await assertActivePractice(ctx);
-      const [loc] = await ctx.db
-        .select({ id: locations.id, name: locations.name, phone: locations.phone })
-        .from(locations)
-        .where(
-          and(
-            eq(locations.id, input.locationId),
-            eq(locations.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(locations.deletedAt)
-          )
-        )
-        .limit(1);
-      if (!loc) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Location not found" });
-      }
-
-      const e164 = normalizeE164(
-        input.mode === "host" ? loc.phone : input.phoneNumber
-      );
-      if (!e164) {
+      if (input.mode === "host") {
         throw new TRPCError({
-          code: "BAD_REQUEST",
-          message:
-            input.mode === "host"
-              ? "Add a valid phone number to this location before text-enabling it."
-              : "Select a valid number to purchase.",
+          code: "PRECONDITION_FAILED",
+          message: EXISTING_NUMBER_UNAVAILABLE_DETAIL,
         });
       }
+      assertProvisioningEnabled();
+      assertProvisioningPracticeAllowed(ctx.practiceId);
+      await assertActivePractice(ctx);
 
       const webhookUrl = telnyxWebhookUrl();
+      const profileName = provisioningProfileName(input.locationId);
+      const customerReference = provisioningOperationReference(
+        ctx.practiceId,
+        input.locationId
+      );
+      let profileId: string | null = null;
+      let profileCreated = false;
+      let profileMutationAttempted = false;
+      let conclusiveEmptyProfileState = false;
+      let orderMutationAttempted = false;
+      let purchaseOutcomeUncertain = false;
+      let failureRecordAllowed = false;
+      let preparedThisRequest = false;
+      let e164: string | null =
+        input.action === "start" ? normalizeE164(input.phoneNumber) : null;
 
       try {
-        const profile = await createMessagingProfile({
-          name: `${loc.name} — OpenVPM`,
-          webhookUrl,
-        });
-        const numberSource = input.mode === "host" ? "hosted" : "purchased";
-        if (input.mode === "host") {
-          await createHostedOrder({ phoneNumber: e164, messagingProfileId: profile.id });
-        } else {
-          await buyNumber({ phoneNumber: e164, messagingProfileId: profile.id });
+        if (input.action === "start") {
+          if (!e164) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "Select a valid number to purchase.",
+            });
+          }
+          // Commit a durable, disabled gate before the first provider profile
+          // POST. A timeout, 5xx, malformed response, or process exit can then
+          // never look like a fresh attempt: every later request sees this row
+          // and must use the read-only resume/reconciliation path.
+          preparedThisRequest = await reserveMessagingProfileAttempt({
+            practiceId: ctx.practiceId,
+            locationId: input.locationId,
+            senderE164: e164,
+            customerReference,
+            detail: MESSAGING_PROVISIONING_PREPARED_DETAIL,
+          });
+          failureRecordAllowed = preparedThisRequest;
         }
 
-        await ctx.db
-          .insert(locationMessaging)
-          .values({
-            practiceId: ctx.practiceId,
-            locationId: loc.id,
-            provider: "telnyx",
-            messagingProfileId: profile.id,
-            senderE164: e164,
-            numberSource,
-            registrationStatus: "pending",
-            registrationDetail: MESSAGING_REGISTRATION_PENDING_DETAIL,
-            enabled: false,
-          })
-          .onConflictDoUpdate({
-            target: locationMessaging.locationId,
-            set: {
-              provider: "telnyx",
-              messagingProfileId: profile.id,
-              senderE164: e164,
-              numberSource,
-              registrationStatus: "pending",
-              registrationDetail: MESSAGING_REGISTRATION_PENDING_DETAIL,
-              enabled: false,
-              deletedAt: null,
-              updatedAt: new Date(),
-            },
-          });
+        return await ctx.db.transaction(async (tx) => {
+          await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${customerReference}, 0))`
+          );
+          // A request may have waited on the lock. Re-check immediately before
+          // every possible provider mutation, not only at request entry.
+          assertProvisioningEnabled();
 
-        return { ok: true, senderE164: e164, numberSource };
+          const [loc] = await tx
+            .select({ id: locations.id })
+            .from(locations)
+            .where(
+              and(
+                eq(locations.id, input.locationId),
+                eq(locations.practiceId, ctx.practiceId),
+                activePracticePredicate(ctx.practiceId),
+                isNull(locations.deletedAt)
+              )
+            )
+            .limit(1);
+          if (!loc) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Location not found",
+            });
+          }
+
+          const [existing] = await tx
+            .select({
+              provider: locationMessaging.provider,
+              messagingProfileId: locationMessaging.messagingProfileId,
+              senderE164: locationMessaging.senderE164,
+              numberSource: locationMessaging.numberSource,
+              registrationStatus: locationMessaging.registrationStatus,
+            })
+            .from(locationMessaging)
+            .where(
+              and(
+                eq(locationMessaging.locationId, input.locationId),
+                eq(locationMessaging.practiceId, ctx.practiceId),
+                isNull(locationMessaging.deletedAt)
+              )
+            )
+            .limit(1);
+
+          if (
+            input.action === "start" &&
+            !existing &&
+            !preparedThisRequest
+          ) {
+            throw provisioningConflict(
+              "OpenVPM could not reserve a durable texting setup attempt. No provider profile or number was created; refresh and try again."
+            );
+          }
+
+          if (input.action === "resume") {
+            if (
+              !existing ||
+              existing.provider !== "telnyx" ||
+              existing.numberSource !== "purchased" ||
+              existing.registrationStatus !== "failed" ||
+              !existing.senderE164
+            ) {
+              throw provisioningConflict(
+                "There is no failed number setup to reconcile for this location. Start a new setup or contact OpenVPM support."
+              );
+            }
+            e164 = existing.senderE164;
+          }
+          if (!e164) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "Select a valid number to purchase.",
+            });
+          }
+
+          let isThisRequestPreparedGate = false;
+          if (existing) {
+            isThisRequestPreparedGate = Boolean(
+              input.action === "start" && preparedThisRequest
+            );
+            if (
+              existing.provider !== "telnyx" ||
+              (existing.numberSource && existing.numberSource !== "purchased") ||
+              (existing.senderE164 && existing.senderE164 !== e164)
+            ) {
+              throw provisioningConflict(
+                "This location already has a different texting setup. Contact OpenVPM support before changing numbers."
+              );
+            }
+            if (
+              existing.messagingProfileId &&
+              existing.senderE164 === e164 &&
+              existing.registrationStatus !== "failed"
+            ) {
+              return {
+                ok: true,
+                senderE164: e164,
+                numberSource: "purchased" as const,
+                recovered: true,
+              };
+            }
+            if (input.action === "start" && !isThisRequestPreparedGate) {
+              throw provisioningConflict(
+                "This location has an incomplete number setup. Use Reconcile provider setup; OpenVPM will not purchase another number automatically."
+              );
+            }
+            profileId = existing.messagingProfileId;
+          }
+          failureRecordAllowed ||= Boolean(existing);
+
+          const profiles = await findMessagingProfilesByName(profileName);
+          if (profiles.length > 1) {
+            throw provisioningConflict(
+              "OpenVPM found more than one incomplete provider setup for this location. No number was purchased; contact support to reconcile it."
+            );
+          }
+          const recoveredProfile = profiles[0];
+          if (
+            recoveredProfile &&
+            (recoveredProfile.webhookUrl !== webhookUrl ||
+              recoveredProfile.enabled !== false)
+          ) {
+            throw provisioningConflict(
+              "OpenVPM found an incomplete provider profile with unsafe settings. No number was purchased; contact support to reconcile it."
+            );
+          }
+          if (
+            profileId &&
+            (!recoveredProfile || recoveredProfile.id !== profileId)
+          ) {
+            throw provisioningConflict(
+              "The saved provider identity does not match the recoverable setup. No number was purchased; contact support to reconcile it."
+            );
+          }
+          profileId = recoveredProfile?.id ?? profileId;
+          failureRecordAllowed ||= Boolean(recoveredProfile);
+
+          const orders = await findNumberOrdersByCustomerReference(
+            customerReference
+          );
+          if (orders.length > 1) {
+            throw provisioningConflict(
+              "OpenVPM found duplicate provider orders for this location. No additional purchase was attempted; contact support to reconcile them."
+            );
+          }
+          const recoveredOrder = orders[0];
+          if (recoveredOrder) {
+            if (
+              !profileId ||
+              recoveredOrder.customerReference !== customerReference ||
+              recoveredOrder.messagingProfileId !== profileId ||
+              recoveredOrder.phoneNumbers.length !== 1 ||
+              recoveredOrder.phoneNumbers[0] !== e164
+            ) {
+              throw provisioningConflict(INCONCLUSIVE_ORDER_DETAIL);
+            }
+            if (isFailedOrderStatus(recoveredOrder.status)) {
+              throw provisioningConflict(
+                "The earlier provider order is in a failed or cancelled state. No additional purchase was attempted; contact OpenVPM support."
+              );
+            }
+            if (!isRecoverableOrderStatus(recoveredOrder.status)) {
+              throw provisioningConflict(INCONCLUSIVE_ORDER_DETAIL);
+            }
+          }
+
+          if (!profileId) {
+            if (recoveredOrder || input.action === "resume") {
+              throw provisioningConflict(INCONCLUSIVE_ORDER_DETAIL);
+            }
+            // Exact profile and order reads both completed with no matching
+            // state. Until the profile POST begins, failures such as a changed
+            // quote are definitively mutation-free and may release the gate.
+            conclusiveEmptyProfileState = Boolean(
+              preparedThisRequest && !recoveredProfile && !recoveredOrder
+            );
+            const currentQuotes = await findAvailableNumberQuotes(e164);
+            if (
+              currentQuotes.length !== 1 ||
+              !quotesMatch(input.quote, currentQuotes[0]!)
+            ) {
+              throw provisioningConflict(
+                "The selected number or its price changed before purchase. No charge was made. Search again and review the current price."
+              );
+            }
+            assertProvisioningEnabled();
+            profileMutationAttempted = true;
+            const profile = await createMessagingProfile({
+              name: profileName,
+              webhookUrl,
+            });
+            profileId = profile.id;
+            profileCreated = true;
+            failureRecordAllowed = true;
+          }
+          const activeProfileId = profileId;
+          if (!activeProfileId) {
+            throw new Error(
+              "The provider setup did not return a durable profile identity. Retry setup or contact OpenVPM support."
+            );
+          }
+
+          const ownedNumbers = await findOwnedPhoneNumbers(e164);
+          if (ownedNumbers.length > 1) {
+            throw provisioningConflict(
+              "The provider returned duplicate ownership records for this number. No new purchase was made; contact support to reconcile it."
+            );
+          }
+          const ownedNumber = ownedNumbers[0];
+          if (
+            ownedNumber &&
+            ["deleted", "failed", "cancelled", "canceled"].some((status) =>
+              ownedNumber.status?.toLowerCase().includes(status)
+            )
+          ) {
+            throw provisioningConflict(
+              "The provider reports this number in a failed or released state. No new purchase was made; search again or contact support."
+            );
+          }
+          if (ownedNumber && ownedNumber.messagingProfileId !== activeProfileId) {
+            throw provisioningConflict(
+              "This number is already owned under a different provider setup. No new purchase was made; contact support before reassigning it."
+            );
+          }
+
+          if (!ownedNumber && !recoveredOrder) {
+            if (
+              input.action === "resume" ||
+              recoveredProfile ||
+              (existing && !isThisRequestPreparedGate)
+            ) {
+              throw provisioningConflict(INCONCLUSIVE_ORDER_DETAIL);
+            }
+            assertProvisioningEnabled();
+            let order: Awaited<ReturnType<typeof buyNumber>>;
+            try {
+              orderMutationAttempted = true;
+              order = await buyNumber({
+                phoneNumber: e164,
+                messagingProfileId: activeProfileId,
+                customerReference,
+              });
+            } catch (error) {
+              purchaseOutcomeUncertain =
+                error instanceof TelnyxMutationUncertainError;
+              throw error;
+            }
+            if (
+              !order.orderId ||
+              !order.status ||
+              !isRecoverableOrderStatus(order.status)
+            ) {
+              purchaseOutcomeUncertain = true;
+              throw new TelnyxMutationUncertainError(
+                "The provider returned an inconclusive order status. No second purchase will be attempted automatically."
+              );
+            }
+          }
+
+          await tx
+            .insert(locationMessaging)
+            .values({
+              practiceId: ctx.practiceId,
+              locationId: loc.id,
+              provider: "telnyx",
+              messagingProfileId: activeProfileId,
+              senderE164: e164,
+              numberSource: "purchased",
+              registrationStatus: "not_started",
+              registrationDetail: MESSAGING_NUMBER_ORDERED_DETAIL,
+              enabled: false,
+            })
+            .onConflictDoUpdate({
+              target: locationMessaging.locationId,
+              set: {
+                provider: "telnyx",
+                messagingProfileId: activeProfileId,
+                senderE164: e164,
+                numberSource: "purchased",
+                registrationStatus: "not_started",
+                registrationDetail: MESSAGING_NUMBER_ORDERED_DETAIL,
+                enabled: false,
+                deletedAt: null,
+                updatedAt: new Date(),
+              },
+            });
+
+          return {
+            ok: true,
+            senderE164: e164,
+            numberSource: "purchased" as const,
+            recovered: Boolean(ownedNumber || recoveredOrder),
+          };
+        });
       } catch (e) {
+        if (
+          preparedThisRequest &&
+          e164 &&
+          !profileMutationAttempted &&
+          (e instanceof TelnyxNotConfiguredError ||
+            conclusiveEmptyProfileState)
+        ) {
+          try {
+            const released = await releaseMessagingProfileAttempt({
+              practiceId: ctx.practiceId,
+              locationId: input.locationId,
+              senderE164: e164,
+              customerReference,
+              detail: MESSAGING_PROVISIONING_PREPARED_DETAIL,
+            });
+            if (released) failureRecordAllowed = false;
+          } catch (releaseError) {
+            // Fail closed by retaining the gate if its exact release cannot be
+            // confirmed. Never mask the original setup error.
+            console.error(
+              "Unable to release untouched messaging profile attempt",
+              releaseError
+            );
+          }
+        }
+        if (failureRecordAllowed && e164) {
+          try {
+            await ctx.db.transaction(async (tx) => {
+              // Serialize compensation with a retry. If the retry won the lock
+              // and completed first, its durable sender owns the resources and
+              // must never be deleted or overwritten by this older attempt.
+              await tx.execute(
+                sql`select pg_advisory_xact_lock(hashtextextended(${customerReference}, 0))`
+              );
+              const [current] = await tx
+                .select({
+                  provider: locationMessaging.provider,
+                  messagingProfileId: locationMessaging.messagingProfileId,
+                  senderE164: locationMessaging.senderE164,
+                  numberSource: locationMessaging.numberSource,
+                  registrationStatus: locationMessaging.registrationStatus,
+                })
+                .from(locationMessaging)
+                .where(
+                  and(
+                    eq(locationMessaging.locationId, input.locationId),
+                    eq(locationMessaging.practiceId, ctx.practiceId),
+                    isNull(locationMessaging.deletedAt)
+                  )
+                )
+                .limit(1);
+              const newerAttemptCompleted = Boolean(
+                current?.provider === "telnyx" &&
+                  current.messagingProfileId &&
+                  current.senderE164 === e164 &&
+                  current.numberSource === "purchased" &&
+                  current.registrationStatus !== "failed"
+              );
+              const differentSetupExists = Boolean(
+                current &&
+                  (current.provider !== "telnyx" ||
+                    (current.senderE164 && current.senderE164 !== e164) ||
+                    (current.numberSource &&
+                      current.numberSource !== "purchased"))
+              );
+              if (newerAttemptCompleted || differentSetupExists) return;
+
+              // Keep any accepted or ambiguous order intact: the exact
+              // customer reference is the durable idempotency key a retry uses
+              // to reconcile without a second POST. Only remove a brand-new,
+              // unused profile after a definitive pre-order failure.
+              if (
+                profileId &&
+                profileCreated &&
+                !orderMutationAttempted &&
+                !purchaseOutcomeUncertain
+              ) {
+                try {
+                  assertProvisioningEnabled();
+                  await deleteMessagingProfile(profileId);
+                  profileId = null;
+                } catch {
+                  // Persist the recoverable provider identity below.
+                }
+              }
+
+              await tx
+                .insert(locationMessaging)
+                .values({
+                  practiceId: ctx.practiceId,
+                  locationId: input.locationId,
+                  provider: "telnyx",
+                  messagingProfileId: profileId,
+                  senderE164: e164,
+                  numberSource: "purchased",
+                  registrationStatus: "failed",
+                  registrationDetail: MESSAGING_PROVISIONING_FAILED_DETAIL,
+                  enabled: false,
+                })
+                .onConflictDoUpdate({
+                  target: locationMessaging.locationId,
+                  set: {
+                    provider: "telnyx",
+                    messagingProfileId: profileId,
+                    senderE164: e164,
+                    numberSource: "purchased",
+                    registrationStatus: "failed",
+                    registrationDetail: MESSAGING_PROVISIONING_FAILED_DETAIL,
+                    enabled: false,
+                    deletedAt: null,
+                    updatedAt: new Date(),
+                  },
+                });
+            });
+          } catch {
+            // Preserve the original provider/transaction error. Deterministic
+            // provider identities still let a later retry reconcile safely.
+          }
+        }
         throw provisioningError(e);
       }
     }),


### PR DESCRIPTION
## Summary

- fail closed on existing-number hosting until the supported carrier workflow exists
- require admin, tenant, global kill-switch, and practice allowlist checks before hosted number provisioning
- reconcile deterministic disabled carrier profiles and exact customer-reference orders before any repeat mutation
- persist an independent durable attempt gate before profile creation so timeouts, 408/429/5xx responses, malformed successes, retries, and process failures cannot duplicate a profile or number purchase
- require a current exact quote plus server-validated charge acknowledgment and disclose upfront, monthly, and currency amounts
- keep all messaging profiles, senders, and carrier registration disabled pending operator review and approval
- provide a read-only reconcile flow and accurate onboarding/status copy

## Verification

- focused messaging safety: 88 tests passed across 5 files
- full web suite: 2,840 tests passed across 297 files
- root and web typechecks passed
- production build passed (42 static pages)
- diff, schema/migration, secret, and private-handoff scans clean
- independent adversarial safety review: SHIP

## Safety

This PR does not activate messaging, submit carrier registration, purchase a number during tests, call a live carrier, or enable outbound SMS. Provider operations remain kill-switch and allowlist gated; created provider resources and database senders default disabled.