### PR TITLE
Add a default-off texting launch interlock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ EMAIL_COMPANY_ADDRESS=
 EMAIL_FROM=
 
 # Messaging / SMS. Provider-agnostic (lib/messaging): set MESSAGING_PROVIDER to
-# "telnyx" (recommended — supports text-enabling a clinic's existing number) or
+# "telnyx" (recommended for the controlled hosted pilot) or
 # "twilio" (fallback). Leave unset to auto-pick whichever is configured (Telnyx
 # preferred), or fall back to console logging in local dev.
 MESSAGING_PROVIDER=
@@ -48,6 +48,14 @@ MESSAGING_PROVISIONING_ENABLED=false
 # Hosted production also requires the pilot clinic's practice UUID here before
 # that clinic can create a fee-bearing number order. Comma-separate UUIDs.
 MESSAGING_PROVISIONING_PRACTICE_IDS=
+# Outbound hosted SMS is independently default-off. Production sends require
+# this global flag plus both comma-separated UUID allowlists. Keep false/empty
+# until the location is carrier-active and explicitly approved. Hosted rollout
+# permits one enabled Telnyx location per practice; self-host sends do not use
+# these hosted-only gates.
+MESSAGING_SENDING_ENABLED=false
+MESSAGING_SENDING_PRACTICE_IDS=
+MESSAGING_SENDING_LOCATION_IDS=
 
 # Twilio (fallback SMS provider)
 TWILIO_ACCOUNT_SID=

--- a/apps/web/app/(dashboard)/clients/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/clients/[id]/edit/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { AlertCircle, ArrowLeft, Loader2 } from "lucide-react";
+import { AlertCircle, ArrowLeft, Ban, Loader2 } from "lucide-react";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -108,6 +108,7 @@ function EditClientForm() {
     data: client,
     isLoading,
     error: loadError,
+    refetch,
   } = trpc.clients.getById.useQuery(
     { id: params.id },
     { enabled: !!params.id }
@@ -140,8 +141,23 @@ function EditClientForm() {
       setError(err.message);
     },
   });
+  const revokeSms = trpc.clients.revokeSms.useMutation({
+    onSuccess: async ({ clientsRevoked }) => {
+      toast.success(
+        `Texting revoked for this number${clientsRevoked > 1 ? ` across ${clientsRevoked} matching client records` : ""}.`
+      );
+      setSmsConsent(false);
+      setSmsConsentTouched(false);
+      await refetch();
+    },
+    onError: (err) => {
+      toast.error(err.message);
+      setError(err.message);
+    },
+  });
 
   const smsPhoneValid = normalizeE164(form.phone) !== null;
+  const persistedSmsPhone = normalizeE164(client?.phone);
   const phoneChanged = client
     ? !phoneNumbersMatchForConsent(client.phone, form.phone)
     : false;
@@ -165,7 +181,9 @@ function EditClientForm() {
       return;
     }
     if (smsConsentTouched && smsConsent && !smsPhoneValid) {
-      setError("Enter a valid mobile phone number before recording SMS consent.");
+      setError(
+        "Enter a valid mobile phone number before recording SMS consent."
+      );
       return;
     }
     if (!canSubmit) {
@@ -336,6 +354,46 @@ function EditClientForm() {
             </span>
           </span>
         </label>
+
+        <div className="rounded-md border border-border p-3">
+          <p className="text-sm font-medium">Practice-wide do-not-text</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Use this when the client asks staff to stop texts. It immediately
+            suppresses this phone number and clears SMS consent on every active
+            client record that shares it. Saving the client or checking consent
+            later will not silently remove the manual suppression.
+            {phoneChanged
+              ? " Save or discard the unsaved phone change before using this action."
+              : ""}
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="mt-3"
+            disabled={!persistedSmsPhone || phoneChanged || revokeSms.isPending}
+            onClick={() => {
+              setError(null);
+              if (
+                window.confirm(
+                  "Stop all SMS to this phone number across the practice?"
+                )
+              ) {
+                revokeSms.mutate({
+                  id: params.id,
+                  expectedPhone: persistedSmsPhone!,
+                });
+              }
+            }}
+          >
+            {revokeSms.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Ban className="mr-2 h-4 w-4" />
+            )}
+            Do not text this number
+          </Button>
+        </div>
 
         <div>
           <label className="text-sm font-medium" htmlFor="address">

--- a/apps/web/app/api/cron/reminders/route.test.ts
+++ b/apps/web/app/api/cron/reminders/route.test.ts
@@ -63,11 +63,8 @@ const mocks = vi.hoisted(() => {
       fn(db)
     ),
     withTenant: vi.fn(
-      async (
-        _db: unknown,
-        _practiceId: string,
-        fn: (tx: unknown) => unknown
-      ) => fn(db)
+      async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
+        fn(db)
     ),
   };
 });
@@ -236,6 +233,7 @@ describe("appointment reminder cron", () => {
         appointment({
           startTime: new Date("2026-07-02T16:00:00Z"),
           practiceTimezone: " America/Los_Angeles ",
+          locationId: LOCATION_ID,
         }),
       ],
       [{ locationId: LOCATION_ID }]
@@ -259,6 +257,7 @@ describe("appointment reminder cron", () => {
         appointmentTime: "9:00 AM",
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
       })
     );
     expect(mocks.insertValues).toHaveBeenCalledWith(
@@ -668,14 +667,12 @@ describe("appointment reminder cron query scoping", () => {
     expect(source).toContain(
       "formatAppointmentReminderDateTime(startDate, appt.practiceTimezone)"
     );
-    expect(source).not.toContain(
-      'startDate.toLocaleTimeString("en-US", {'
-    );
+    expect(source).not.toContain('startDate.toLocaleTimeString("en-US", {');
   });
 
   it("reclaims failed or stale reminder claims with scoped predicates", () => {
     expect(source).toContain("const REMINDER_PENDING_RECLAIM_MS");
-    expect(source).toContain("existing.status === \"failed\"");
+    expect(source).toContain('existing.status === "failed"');
     expect(source).toContain("lte(communications.createdAt, staleBefore)");
     expect(source).toContain("eq(communications.practiceId, opts.practiceId)");
     expect(source).toContain("eq(communications.dedupeKey, opts.dedupeKey)");

--- a/apps/web/app/api/cron/reminders/route.ts
+++ b/apps/web/app/api/cron/reminders/route.ts
@@ -1,12 +1,5 @@
 import { NextResponse } from "next/server";
-import {
-  eq,
-  and,
-  isNull,
-  gte,
-  lte,
-  sql,
-} from "drizzle-orm";
+import { eq, and, isNull, gte, lte, sql } from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import {
   appointments,
@@ -293,10 +286,10 @@ export async function GET(request: Request) {
             isNull(clients.deletedAt),
             gte(appointments.startTime, now),
             lte(appointments.startTime, in24h),
-            eq(appointments.status, "confirmed"),
-          ),
+            eq(appointments.status, "confirmed")
+          )
         )
-        .orderBy(appointments.startTime),
+        .orderBy(appointments.startTime)
     );
 
     let sent = 0;
@@ -317,8 +310,8 @@ export async function GET(request: Request) {
         return senderLocationCache.get(cacheKey) ?? null;
       }
 
-      const findSender = async (locationId?: string): Promise<string | null> => {
-        const [sender] = await withSystem(db, (tx) =>
+      const findSender = async (locationId: string): Promise<string | null> => {
+        const senders = await withSystem(db, (tx) =>
           tx
             .select({ locationId: locationMessaging.locationId })
             .from(locationMessaging)
@@ -331,35 +324,28 @@ export async function GET(request: Request) {
               )
             )
             .where(
-              locationId
-                ? and(
-                    eq(locationMessaging.locationId, locationId),
-                    eq(locationMessaging.practiceId, practiceId),
-                    isNull(locationMessaging.deletedAt),
-                    eq(locations.practiceId, practiceId),
-                    isNull(locations.deletedAt),
-                    eq(locationMessaging.enabled, true),
-                    eq(locationMessaging.registrationStatus, "active"),
-                    hasNonBlankMessagingSender()
-                  )
-                : and(
-                    eq(locationMessaging.practiceId, practiceId),
-                    isNull(locationMessaging.deletedAt),
-                    eq(locations.practiceId, practiceId),
-                    isNull(locations.deletedAt),
-                    eq(locationMessaging.enabled, true),
-                    eq(locationMessaging.registrationStatus, "active"),
-                    hasNonBlankMessagingSender()
-                  )
+              and(
+                eq(locationMessaging.locationId, locationId),
+                eq(locationMessaging.practiceId, practiceId),
+                isNull(locationMessaging.deletedAt),
+                eq(locations.practiceId, practiceId),
+                isNull(locations.deletedAt),
+                eq(locationMessaging.enabled, true),
+                eq(locationMessaging.registrationStatus, "active"),
+                hasNonBlankMessagingSender()
+              )
             )
-            .limit(1)
+            .limit(2)
         );
-        return sender?.locationId ?? null;
+        return senders.length === 1 ? senders[0]!.locationId : null;
       };
 
-      const locationId =
-        (preferredLocationId ? await findSender(preferredLocationId) : null) ??
-        (await findSender());
+      // Appointment reminders are tied to the appointment room's exact clinic
+      // location. Missing/ambiguous location data must never choose a random
+      // practice sender.
+      const locationId = preferredLocationId
+        ? await findSender(preferredLocationId)
+        : null;
       senderLocationCache.set(cacheKey, locationId);
       return locationId;
     };
@@ -388,7 +374,9 @@ export async function GET(request: Request) {
 
       // Email reminder + communications log (the existing path, reused as the
       // fallback whenever SMS isn't chosen or a send is blocked).
-      const emailReminder = async (communicationId: string): Promise<boolean> => {
+      const emailReminder = async (
+        communicationId: string
+      ): Promise<boolean> => {
         const clientEmail = normalizeEmailSuppressionAddress(appt.clientEmail);
         if (!clientEmail) return false;
         if (appt.emailSuppressionReason) {
@@ -498,10 +486,12 @@ export async function GET(request: Request) {
                 practicePhone: appt.practicePhone ?? undefined,
                 practiceId: appt.practiceId,
                 locationId: senderLocationId,
+                clientId: appt.clientId,
               })
             : {
                 success: false,
-                error: "Set up an active texting number before sending SMS reminders",
+                error:
+                  "Set up an active texting number before sending SMS reminders",
               };
           if (result.success) {
             await recordReminderOutcome({
@@ -549,7 +539,7 @@ export async function GET(request: Request) {
         }
         console.error(
           `Failed to send reminder for appointment ${appt.id}:`,
-          error,
+          error
         );
         failed++;
       }
@@ -587,10 +577,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ sent, failed, skipped, deduped, suppressed });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    void alertOps(
-      "Reminder cron job crashed",
-      message,
-    );
+    void alertOps("Reminder cron job crashed", message);
     console.error("Cron reminder job failed:", error);
     await reportCronHeartbeat({
       job: "reminders",
@@ -599,7 +586,7 @@ export async function GET(request: Request) {
     });
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 },
+      { status: 500 }
     );
   }
 }

--- a/apps/web/app/api/webhooks/telnyx/route.test.ts
+++ b/apps/web/app/api/webhooks/telnyx/route.test.ts
@@ -42,13 +42,20 @@ const mocks = vi.hoisted(() => {
   const insertConflict = vi.fn(async (_config?: unknown) => undefined);
   const insertValues = vi.fn((_values: unknown) => ({
     onConflictDoNothing: insertConflict,
+    onConflictDoUpdate: insertConflict,
   }));
   const insert = vi.fn(() => ({ values: insertValues }));
 
   const deleteWhere = vi.fn(async (_condition: unknown) => undefined);
   const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
 
-  const db = { select, update, insert, delete: deleteFrom };
+  const db = {
+    execute: vi.fn(async () => undefined),
+    select,
+    update,
+    insert,
+    delete: deleteFrom,
+  };
 
   return {
     db,
@@ -68,11 +75,8 @@ const mocks = vi.hoisted(() => {
       fn(db)
     ),
     withTenant: vi.fn(
-      async (
-        _db: unknown,
-        _practiceId: string,
-        fn: (tx: unknown) => unknown
-      ) => fn(db)
+      async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
+        fn(db)
     ),
   };
 });
@@ -92,12 +96,10 @@ vi.mock("@/lib/messaging/telnyx-signature", () => ({
 
 const { POST } = await import("./route");
 const { communications } = await import("@openpims/db");
-const { inboundSmsOptInEvidence, SMS_INBOUND_OPT_IN } = await import(
-  "@/lib/messaging/consent"
-);
-const { MESSAGING_WEBHOOK_BODY_MAX_BYTES } = await import(
-  "@/lib/messaging-webhook-limits"
-);
+const { inboundSmsOptInEvidence, SMS_INBOUND_OPT_IN } =
+  await import("@/lib/messaging/consent");
+const { MESSAGING_WEBHOOK_BODY_MAX_BYTES } =
+  await import("@/lib/messaging-webhook-limits");
 
 function sqlIncludesColumnParamPair(
   value: unknown,
@@ -595,9 +597,9 @@ describe("Telnyx webhook", () => {
     });
     expect(mocks.withSystem).toHaveBeenCalledTimes(3);
     const profileCondition = mocks.selectWhere.mock.calls[1]?.[0];
-    expect(sqlIncludesColumnName(profileCondition, "messaging_profile_id")).toBe(
-      true
-    );
+    expect(
+      sqlIncludesColumnName(profileCondition, "messaging_profile_id")
+    ).toBe(true);
     expect(sqlIncludesValue(profileCondition, "profile-1")).toBe(true);
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -839,6 +841,57 @@ describe("Telnyx webhook", () => {
     });
   });
 
+  it("keeps consent off when START encounters a manual suppression", async () => {
+    process.env.TELNYX_PUBLIC_KEY = "test-public-key";
+    const clientId = "00000000-0000-0000-0000-000000000003";
+    mocks.selectResults.push(
+      [
+        {
+          practiceId: "00000000-0000-0000-0000-0000000000aa",
+          locationId: "00000000-0000-0000-0000-000000000002",
+        },
+      ],
+      [{ id: clientId }],
+      [{ id: "00000000-0000-0000-0000-000000000099" }]
+    );
+    const body = JSON.stringify({
+      data: {
+        event_type: "message.received",
+        payload: {
+          id: "msg-start-manual-block",
+          from: { phone_number: "+15555550199" },
+          to: [{ phone_number: "+15555550100" }],
+          text: "START",
+        },
+      },
+    });
+
+    const response = await POST(
+      new Request("https://openvpm.test/api/webhooks/telnyx", {
+        method: "POST",
+        headers: {
+          "telnyx-signature-ed25519": "sig",
+          "telnyx-timestamp": "123",
+        },
+        body,
+      })
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      action: "suppressed",
+    });
+    expect(mocks.deleteWhere).toHaveBeenCalled();
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId,
+        subject: "SMS opt-in blocked for +15555550199",
+        providerMessageId: "msg-start-manual-block",
+      })
+    );
+  });
+
   it("does not broadly restore client SMS consent on START when the sender phone is ambiguous", async () => {
     process.env.TELNYX_PUBLIC_KEY = "test-public-key";
     mocks.selectResults.push(
@@ -1058,7 +1111,7 @@ describe("Telnyx webhook", () => {
 
   it("requires active practices when resolving inbound sender locations", () => {
     const senderLookup = INBOUND_SOURCE.match(
-      /async function findMessagingLocationMatching[\s\S]+?return matches\.length === 1 \? matches\[0\] \?\? null : null;/
+      /async function findMessagingLocationMatching[\s\S]+?return matches\.length === 1 \? \(?matches\[0\] \?\? null\)? : null;/
     )?.[0];
 
     expect(senderLookup).toContain("innerJoin(");

--- a/apps/web/app/api/webhooks/twilio/route.test.ts
+++ b/apps/web/app/api/webhooks/twilio/route.test.ts
@@ -36,13 +36,20 @@ const mocks = vi.hoisted(() => {
   const insertConflict = vi.fn(async (_config?: unknown) => undefined);
   const insertValues = vi.fn((_values: unknown) => ({
     onConflictDoNothing: insertConflict,
+    onConflictDoUpdate: insertConflict,
   }));
   const insert = vi.fn(() => ({ values: insertValues }));
 
   const deleteWhere = vi.fn(async (_condition: unknown) => undefined);
   const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
 
-  const db = { select, update, insert, delete: deleteFrom };
+  const db = {
+    execute: vi.fn(async () => undefined),
+    select,
+    update,
+    insert,
+    delete: deleteFrom,
+  };
 
   return {
     db,
@@ -59,11 +66,8 @@ const mocks = vi.hoisted(() => {
       fn(db)
     ),
     withTenant: vi.fn(
-      async (
-        _db: unknown,
-        _practiceId: string,
-        fn: (tx: unknown) => unknown
-      ) => fn(db)
+      async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
+        fn(db)
     ),
   };
 });
@@ -85,12 +89,10 @@ vi.mock("twilio", () => ({
 
 const { POST } = await import("./route");
 const { communications } = await import("@openpims/db");
-const { inboundSmsOptInEvidence, SMS_INBOUND_OPT_IN } = await import(
-  "@/lib/messaging/consent"
-);
-const { MESSAGING_WEBHOOK_BODY_MAX_BYTES } = await import(
-  "@/lib/messaging-webhook-limits"
-);
+const { inboundSmsOptInEvidence, SMS_INBOUND_OPT_IN } =
+  await import("@/lib/messaging/consent");
+const { MESSAGING_WEBHOOK_BODY_MAX_BYTES } =
+  await import("@/lib/messaging-webhook-limits");
 
 function twilioRequest(params: Record<string, string>, signature = "sig") {
   return new Request("https://openvpm.test/api/webhooks/twilio", {
@@ -305,8 +307,7 @@ describe("Twilio webhook", () => {
     );
     const inserted = mocks.insertValues.mock.calls.find(
       ([value]) =>
-        (value as { providerMessageId?: string }).providerMessageId ===
-        "SM123"
+        (value as { providerMessageId?: string }).providerMessageId === "SM123"
     )?.[0] as { assignedTo?: unknown };
     expect(inserted.assignedTo).toBeTruthy();
     expect(sqlIncludesColumnName(inserted.assignedTo, "assigned_to")).toBe(
@@ -359,9 +360,9 @@ describe("Twilio webhook", () => {
     });
     expect(mocks.withSystem).toHaveBeenCalledTimes(3);
     const profileCondition = mocks.selectWhere.mock.calls[1]?.[0];
-    expect(sqlIncludesColumnName(profileCondition, "messaging_profile_id")).toBe(
-      true
-    );
+    expect(
+      sqlIncludesColumnName(profileCondition, "messaging_profile_id")
+    ).toBe(true);
     expect(sqlIncludesValue(profileCondition, "MG123")).toBe(true);
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -537,9 +538,9 @@ describe("Twilio webhook", () => {
       expect.any(Function)
     );
     const profileCondition = mocks.selectWhere.mock.calls[0]?.[0];
-    expect(sqlIncludesColumnName(profileCondition, "messaging_profile_id")).toBe(
-      true
-    );
+    expect(
+      sqlIncludesColumnName(profileCondition, "messaging_profile_id")
+    ).toBe(true);
     expect(sqlIncludesValue(profileCondition, "MG123")).toBe(true);
     expect(mocks.updateSet).toHaveBeenCalledWith({ status: "failed" });
     expect(mocks.insertValues).not.toHaveBeenCalled();

--- a/apps/web/components/onboarding/steps/set-up-texting.tsx
+++ b/apps/web/components/onboarding/steps/set-up-texting.tsx
@@ -49,6 +49,7 @@ export function SetUpTextingStep({
             registrationStatus: l.messaging.registrationStatus ?? "not_started",
             registrationDetail: l.messaging.registrationDetail,
             enabled: l.messaging.enabled ?? false,
+            launchEligible: l.messaging.launchEligible,
           }
         : null,
     };
@@ -61,7 +62,9 @@ export function SetUpTextingStep({
   const isFailed = messaging?.registrationStatus === "failed";
   const isConfigured = hasSender && !isFailed;
   const isActive =
-    messaging?.registrationStatus === "active" && !!messaging?.enabled;
+    messaging?.registrationStatus === "active" &&
+    !!messaging?.enabled &&
+    messaging.launchEligible !== false;
   const statusDetail = (() => {
     if (!messaging) return null;
     if (isFailed) {
@@ -76,6 +79,13 @@ export function SetUpTextingStep({
     if (messaging.registrationStatus === "active" && !messaging.enabled) {
       return "Carrier registration is approved. An admin still needs to enable sending in Messaging settings.";
     }
+    if (
+      messaging.registrationStatus === "active" &&
+      messaging.enabled &&
+      messaging.launchEligible === false
+    ) {
+      return "Carrier registration is approved, but outbound texting remains off until OpenVPM approves this clinic location for the controlled pilot.";
+    }
     if (isActive) return "Texting is active.";
     if (messaging.registrationStatus === "action_required") {
       return "Carrier registration needs more clinic information. Review the request in Messaging settings.";
@@ -89,10 +99,10 @@ export function SetUpTextingStep({
   return (
     <div className="space-y-5">
       <p className="text-sm leading-6 text-slate-600">
-        Text your clients about appointments, reminders, and results, and let them
-        text you back. OpenVPM can set up a new local texting number; your existing
-        clinic voice line stays unchanged. This is optional, so skip it and set it
-        up later if you like.
+        Text your clients about appointments, reminders, and results, and let
+        them text you back. OpenVPM can set up a new local texting number; your
+        existing clinic voice line stays unchanged. This is optional, so skip it
+        and set it up later if you like.
       </p>
 
       <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4">
@@ -120,9 +130,7 @@ export function SetUpTextingStep({
                 <p className="text-sm font-medium text-slate-900">
                   {messaging.senderE164 ?? "Texting setup needs attention"}
                 </p>
-                <p className="text-xs text-slate-500">
-                  {statusDetail}
-                </p>
+                <p className="text-xs text-slate-500">{statusDetail}</p>
               </div>
             ) : (
               <div className="space-y-1">
@@ -144,14 +152,14 @@ export function SetUpTextingStep({
                 </Link>
               </Button>
             ) : (
-            <Button
-              type="button"
-              variant="default"
-              size="sm"
-              onClick={() => setWizardOpen(true)}
-            >
-              Set up texting
-            </Button>
+              <Button
+                type="button"
+                variant="default"
+                size="sm"
+                onClick={() => setWizardOpen(true)}
+              >
+                Set up texting
+              </Button>
             )
           ) : null}
         </div>

--- a/apps/web/components/settings/messaging-tab.tsx
+++ b/apps/web/components/settings/messaging-tab.tsx
@@ -27,7 +27,10 @@ import { MessagingRegistrationForm } from "@/components/settings/messaging-regis
 
 const REGISTRATION_BADGE: Record<
   NonNullable<MessagingSetupLocation["messaging"]>["registrationStatus"],
-  { label: string; variant: "success" | "warning" | "destructive" | "secondary" }
+  {
+    label: string;
+    variant: "success" | "warning" | "destructive" | "secondary";
+  }
 > = {
   not_started: { label: "Not started", variant: "secondary" },
   pending: { label: "Registration pending", variant: "warning" },
@@ -107,10 +110,22 @@ export function MessagingTab() {
           <MessageSquare className="h-5 w-5" /> Messaging
         </h2>
         <p className="text-sm text-muted-foreground">
-          Text appointment reminders from each location&apos;s own number. Clients
-          who reply land in your inbox; STOP opt-outs are handled automatically.
+          Text appointment reminders from each location&apos;s own number.
+          Clients who reply land in your inbox; STOP opt-outs are handled
+          automatically.
         </p>
       </div>
+
+      {data.launch.hosted && !data.launch.pilotEnabled ? (
+        <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950">
+          <p className="font-medium">Outbound texting is safely off</p>
+          <p className="mt-1">
+            OpenVPM enables one approved clinic location at a time after carrier
+            activation and pilot review. Setup can continue, but no SMS can send
+            until your clinic and location are explicitly approved.
+          </p>
+        </div>
+      ) : null}
 
       {/* Usage + consent summary */}
       <div className="grid gap-4 sm:grid-cols-3">
@@ -125,8 +140,14 @@ export function MessagingTab() {
           }
           hint={usage?.includedSms != null ? "included" : undefined}
         />
-        <SummaryStat label="Clients opted in" value={String(consent?.optedIn ?? 0)} />
-        <SummaryStat label="Opted out (STOP)" value={String(consent?.suppressed ?? 0)} />
+        <SummaryStat
+          label="Clients opted in"
+          value={String(consent?.optedIn ?? 0)}
+        />
+        <SummaryStat
+          label="Do-not-text numbers"
+          value={String(consent?.suppressed ?? 0)}
+        />
       </div>
 
       {/* Per-location setup */}
@@ -135,6 +156,7 @@ export function MessagingTab() {
           <LocationCard
             key={loc.locationId}
             loc={loc}
+            testSendAllowed={data.launch.testSendAllowed}
             onStartSetup={() => setWizardLocation(loc)}
           />
         ))}
@@ -173,7 +195,12 @@ function MessagingLoadError({
         <div>
           <p className="font-medium">Unable to load messaging settings</p>
           <p className="mt-1">{message}</p>
-          <Button variant="outline" size="sm" onClick={onRetry} className="mt-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRetry}
+            className="mt-3"
+          >
             Retry
           </Button>
         </div>
@@ -196,7 +223,11 @@ function SummaryStat({
       <p className="text-xs text-muted-foreground">{label}</p>
       <p className="mt-1 text-xl font-semibold">
         {value}
-        {hint && <span className="ml-1 text-xs font-normal text-muted-foreground">{hint}</span>}
+        {hint && (
+          <span className="ml-1 text-xs font-normal text-muted-foreground">
+            {hint}
+          </span>
+        )}
       </p>
     </div>
   );
@@ -204,9 +235,11 @@ function SummaryStat({
 
 function LocationCard({
   loc,
+  testSendAllowed,
   onStartSetup,
 }: {
   loc: MessagingSetupLocation;
+  testSendAllowed: boolean;
   onStartSetup: () => void;
 }) {
   const utils = trpc.useUtils();
@@ -220,7 +253,11 @@ function LocationCard({
           {loc.isPrimary && <Badge variant="secondary">Primary</Badge>}
         </div>
         {loc.messaging && (
-          <Badge variant={REGISTRATION_BADGE[loc.messaging.registrationStatus].variant}>
+          <Badge
+            variant={
+              REGISTRATION_BADGE[loc.messaging.registrationStatus].variant
+            }
+          >
             {REGISTRATION_BADGE[loc.messaging.registrationStatus].label}
           </Badge>
         )}
@@ -229,6 +266,7 @@ function LocationCard({
       {loc.messaging ? (
         <ConfiguredLocation
           loc={loc}
+          testSendAllowed={testSendAllowed}
           onChanged={refresh}
         />
       ) : (
@@ -240,9 +278,11 @@ function LocationCard({
 
 function ConfiguredLocation({
   loc,
+  testSendAllowed,
   onChanged,
 }: {
   loc: MessagingSetupLocation;
+  testSendAllowed: boolean;
   onChanged: () => void;
 }) {
   const m = loc.messaging!;
@@ -250,9 +290,14 @@ function ConfiguredLocation({
   const senderLabel =
     m.senderE164?.trim() || m.messagingProfileId?.trim() || "—";
   const canEnableSending =
-    m.registrationStatus === "active" && hasConfiguredSender(m);
+    m.registrationStatus === "active" &&
+    hasConfiguredSender(m) &&
+    m.launchEligible !== false;
   const canSendTest =
-    m.enabled && canEnableSending && isMessagingPhoneInputValid(testTo);
+    testSendAllowed &&
+    m.enabled &&
+    canEnableSending &&
+    isMessagingPhoneInputValid(testTo);
 
   const setEnabled = trpc.messaging.setEnabled.useMutation({
     onSuccess: () => onChanged(),
@@ -264,7 +309,9 @@ function ConfiguredLocation({
   });
   const reconcileSetup = trpc.messaging.provisionNumber.useMutation({
     onSuccess: () => {
-      toast.success("Provider setup reconciled. No additional number was purchased.");
+      toast.success(
+        "Provider setup reconciled. No additional number was purchased."
+      );
       onChanged();
     },
     onError: (e) => toast.error(e.message),
@@ -316,40 +363,50 @@ function ConfiguredLocation({
           checked={m.enabled}
           disabled={setEnabled.isPending || (!m.enabled && !canEnableSending)}
           onChange={(e) =>
-            setEnabled.mutate({ locationId: loc.locationId, enabled: e.target.checked })
+            setEnabled.mutate({
+              locationId: loc.locationId,
+              enabled: e.target.checked,
+            })
           }
         />
         Sending enabled
       </label>
 
-      <div className="flex flex-wrap items-end gap-2 border-t border-border pt-4">
-        <label className="space-y-1.5">
-          <span className="text-xs font-medium text-muted-foreground">
-            Send a test message to
-          </span>
-          <Input
-            value={testTo}
-            onChange={(e) => setTestTo(e.target.value)}
-            maxLength={MESSAGING_PHONE_MAX_LENGTH}
-            placeholder="+1 555 555 0123"
-            className="w-48"
-          />
-        </label>
-        <Button
-          variant="outline"
-          disabled={!canSendTest || testSend.isPending}
-          onClick={() =>
-            testSend.mutate({ locationId: loc.locationId, to: testTo.trim() })
-          }
-        >
-          {testSend.isPending ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : (
-            <Send className="mr-2 h-4 w-4" />
-          )}
-          Send test
-        </Button>
-      </div>
+      {testSendAllowed ? (
+        <div className="flex flex-wrap items-end gap-2 border-t border-border pt-4">
+          <label className="space-y-1.5">
+            <span className="text-xs font-medium text-muted-foreground">
+              Send a test message to
+            </span>
+            <Input
+              value={testTo}
+              onChange={(e) => setTestTo(e.target.value)}
+              maxLength={MESSAGING_PHONE_MAX_LENGTH}
+              placeholder="+1 555 555 0123"
+              className="w-48"
+            />
+          </label>
+          <Button
+            variant="outline"
+            disabled={!canSendTest || testSend.isPending}
+            onClick={() =>
+              testSend.mutate({ locationId: loc.locationId, to: testTo.trim() })
+            }
+          >
+            {testSend.isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="mr-2 h-4 w-4" />
+            )}
+            Send test
+          </Button>
+        </div>
+      ) : (
+        <p className="border-t border-border pt-4 text-xs text-muted-foreground">
+          Arbitrary test destinations are disabled for hosted clinics during the
+          controlled pilot. Use a consented client workflow after activation.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/web/components/settings/messaging-wizard.tsx
+++ b/apps/web/components/settings/messaging-wizard.tsx
@@ -46,6 +46,7 @@ export type MessagingSetupLocation = {
       | "suspended";
     registrationDetail: string | null;
     enabled: boolean;
+    launchEligible?: boolean;
   } | null;
 };
 
@@ -104,8 +105,12 @@ export function MessagingWizard({
   const [areaCode, setAreaCode] = useState("");
   const [numbers, setNumbers] = useState<SearchNumber[]>([]);
   const [hasSearched, setHasSearched] = useState(false);
-  const [selectedNumber, setSelectedNumber] = useState<SearchNumber | null>(null);
-  const [provisionedSender, setProvisionedSender] = useState<string | null>(null);
+  const [selectedNumber, setSelectedNumber] = useState<SearchNumber | null>(
+    null
+  );
+  const [provisionedSender, setProvisionedSender] = useState<string | null>(
+    null
+  );
   const [chargeAcknowledged, setChargeAcknowledged] = useState(false);
 
   useEffect(() => {
@@ -316,9 +321,7 @@ export function MessagingWizard({
                 setChargeAcknowledged={setChargeAcknowledged}
               />
             ) : null}
-            {step === "done" ? (
-              <DoneStep sender={provisionedSender} />
-            ) : null}
+            {step === "done" ? <DoneStep sender={provisionedSender} /> : null}
           </div>
 
           <div className="mt-6 flex items-center justify-between border-t border-slate-200 pt-5">
@@ -368,12 +371,10 @@ function ChooseStep({
   return (
     <div className="space-y-4">
       <p className="text-sm leading-6 text-slate-600">
-        OpenVPM currently sets up a new local number for texting. Your clinic&apos;s
-        existing voice line stays unchanged.
+        OpenVPM currently sets up a new local number for texting. Your
+        clinic&apos;s existing voice line stays unchanged.
       </p>
-      <div
-        className="w-full rounded-xl border border-slate-200 bg-slate-50 p-4 text-left"
-      >
+      <div className="w-full rounded-xl border border-slate-200 bg-slate-50 p-4 text-left">
         <div className="flex items-start gap-3">
           <ShieldCheck className="mt-0.5 h-5 w-5 text-slate-500" />
           <div>
@@ -491,9 +492,7 @@ function ConfirmStep({
       </p>
       <div className="flex flex-wrap items-end gap-2">
         <label className="space-y-1.5">
-          <span className="text-xs font-medium text-slate-600">
-            Area code
-          </span>
+          <span className="text-xs font-medium text-slate-600">Area code</span>
           <Input
             value={areaCode}
             onChange={(e) =>
@@ -537,7 +536,9 @@ function ConfirmStep({
                   : "hover:bg-slate-50"
               )}
             >
-              <span className="font-medium text-slate-950">{n.phoneNumber}</span>
+              <span className="font-medium text-slate-950">
+                {n.phoneNumber}
+              </span>
               <span className="flex items-center gap-2">
                 <span className="text-xs text-slate-500">
                   {formatCost(n.upfrontCost, n.currency)} today ·{" "}
@@ -553,7 +554,8 @@ function ConfirmStep({
       ) : hasSearched ? (
         <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
           No available numbers returned a complete upfront price, monthly price,
-          and currency. Nothing can be selected or purchased; search again later.
+          and currency. Nothing can be selected or purchased; search again
+          later.
         </div>
       ) : null}
     </div>
@@ -575,7 +577,7 @@ function RegistrationStep({
 }) {
   const number =
     mode === "host"
-      ? location.existingPhone ?? "your number"
+      ? (location.existingPhone ?? "your number")
       : selectedNumber?.phoneNumber;
 
   return (
@@ -590,8 +592,9 @@ function RegistrationStep({
         <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
           <p className="text-sm font-medium text-amber-950">Provider charges</p>
           <p className="mt-2 text-sm text-amber-900">
-            {formatCost(selectedNumber.upfrontCost, selectedNumber.currency)} due
-            now, then {formatCost(selectedNumber.monthlyCost, selectedNumber.currency)}
+            {formatCost(selectedNumber.upfrontCost, selectedNumber.currency)}{" "}
+            due now, then{" "}
+            {formatCost(selectedNumber.monthlyCost, selectedNumber.currency)}
             /month for the number.
           </p>
         </div>
@@ -635,7 +638,8 @@ function DoneStep({ sender }: { sender: string | null }) {
         <p className="mt-2 text-sm leading-6 text-emerald-800">
           {sender ?? "Your number"} is saved while the provider finishes any
           activation work. Carrier registration has not been submitted yet, and
-          SMS sending stays off until approval is active and an admin turns it on.
+          SMS sending stays off until approval is active and an admin turns it
+          on.
         </p>
       </div>
       <div className="rounded-xl border border-slate-200 p-4">
@@ -644,8 +648,9 @@ function DoneStep({ sender }: { sender: string | null }) {
         </p>
         <p className="mt-2 text-sm leading-6 text-slate-600">
           Complete the US carrier registration form in Messaging settings.
-          OpenVPM will review and submit it. When registration is active, turn
-          sending on and send a test from the active location card.
+          OpenVPM will review and submit it. Hosted sending remains off until
+          the clinic and one location are explicitly approved for the pilot;
+          after approval, validate through a current consented client workflow.
         </p>
       </div>
     </div>

--- a/apps/web/lib/__tests__/client-sms-consent-ui.test.ts
+++ b/apps/web/lib/__tests__/client-sms-consent-ui.test.ts
@@ -29,4 +29,17 @@ describe("client SMS consent forms", () => {
     expect(EDIT_CLIENT_SOURCE).toContain("phoneNumbersMatchForConsent");
     expect(EDIT_CLIENT_SOURCE).toContain("setSmsConsentTouched(false)");
   });
+
+  it("cannot revoke a different unsaved phone than the persisted destination", () => {
+    expect(EDIT_CLIENT_SOURCE).toContain(
+      "const persistedSmsPhone = normalizeE164(client?.phone)"
+    );
+    expect(EDIT_CLIENT_SOURCE).toContain(
+      "!persistedSmsPhone || phoneChanged || revokeSms.isPending"
+    );
+    expect(EDIT_CLIENT_SOURCE).toContain("expectedPhone: persistedSmsPhone!");
+    expect(EDIT_CLIENT_SOURCE).toContain(
+      "Save or discard the unsaved phone change"
+    );
+  });
 });

--- a/apps/web/lib/__tests__/messaging-settings-ui.test.ts
+++ b/apps/web/lib/__tests__/messaging-settings-ui.test.ts
@@ -10,7 +10,10 @@ import {
 } from "../messaging/policy";
 
 describe("messaging settings UI", () => {
-  const tabSource = readFileSync("components/settings/messaging-tab.tsx", "utf8");
+  const tabSource = readFileSync(
+    "components/settings/messaging-tab.tsx",
+    "utf8"
+  );
   const wizardSource = readFileSync(
     "components/settings/messaging-wizard.tsx",
     "utf8"
@@ -44,28 +47,36 @@ describe("messaging settings UI", () => {
     expect(tabSource).toContain("messaging.senderE164?.trim()");
     expect(tabSource).toContain("messaging.messagingProfileId?.trim()");
     expect(tabSource).toContain("const canEnableSending =");
-    expect(tabSource).toContain(
-      'm.registrationStatus === "active" && hasConfiguredSender(m)'
-    );
-    expect(tabSource).toContain(
-      "const canSendTest =\n    m.enabled && canEnableSending && isMessagingPhoneInputValid(testTo)"
-    );
+    expect(tabSource).toContain('m.registrationStatus === "active"');
+    expect(tabSource).toContain("hasConfiguredSender(m)");
+    expect(tabSource).toContain("m.launchEligible !== false");
+    expect(tabSource).toContain("testSendAllowed &&");
+    expect(tabSource).toContain("isMessagingPhoneInputValid(testTo)");
     expect(tabSource).toContain("maxLength={MESSAGING_PHONE_MAX_LENGTH}");
     expect(tabSource).toContain(
       "disabled={setEnabled.isPending || (!m.enabled && !canEnableSending)}"
     );
-    expect(tabSource).toContain("disabled={!canSendTest || testSend.isPending}");
+    expect(tabSource).toContain(
+      "disabled={!canSendTest || testSend.isPending}"
+    );
     expect(tabSource).toContain("to: testTo.trim()");
+    expect(tabSource).toContain("Outbound texting is safely off");
+    expect(tabSource).toContain("Arbitrary test destinations are disabled");
     expect(wizardSource).toContain("MESSAGING_AREA_CODE_LENGTH");
     expect(wizardSource).toContain("isMessagingAreaCodeInputValid(areaCode)");
-    expect(wizardSource).toContain("disabled={checking || !isMessagingAreaCodeInputValid(areaCode)}");
     expect(wizardSource).toContain(
-      "When registration is active, turn\n          sending on and send a test"
+      "disabled={checking || !isMessagingAreaCodeInputValid(areaCode)}"
     );
+    expect(wizardSource).toContain(
+      "validate through a current consented client workflow"
+    );
+    expect(wizardSource).not.toContain("send a test from the active location");
     expect(tabSource).toContain("<MessagingRegistrationForm />");
     expect(wizardSource).not.toContain("trpc.messaging.testSend.useMutation");
     expect(wizardSource).not.toContain("isMessagingPhoneInputValid(testTo)");
-    expect(wizardSource).not.toContain("maxLength={MESSAGING_PHONE_MAX_LENGTH}");
+    expect(wizardSource).not.toContain(
+      "maxLength={MESSAGING_PHONE_MAX_LENGTH}"
+    );
     expect(wizardSource).not.toContain("to: testTo.trim()");
     expect(wizardSource).not.toContain("Send test");
   });
@@ -84,7 +95,9 @@ describe("messaging settings UI", () => {
     expect(tabSource.indexOf("if (!data)")).toBeLessThan(
       tabSource.indexOf("const usage = data.usage")
     );
-    expect(tabSource).toContain("const locations = data.locations as MessagingSetupLocation[]");
+    expect(tabSource).toContain(
+      "const locations = data.locations as MessagingSetupLocation[]"
+    );
     expect(tabSource).not.toContain("data?.locations ?? []");
     expect(tabSource).not.toContain("const usage = data?.usage");
     expect(tabSource).not.toContain("const consent = data?.consent");
@@ -94,9 +107,7 @@ describe("messaging settings UI", () => {
     expect(wizardSource).toContain(
       "Existing-number texting is not available yet"
     );
-    expect(wizardSource).toContain(
-      "will not be ported, hosted, or changed"
-    );
+    expect(wizardSource).toContain("will not be ported, hosted, or changed");
     expect(wizardSource).toContain("chargeAcknowledged");
     expect(wizardSource).toContain(
       "I authorize the exact upfront and monthly provider charges"

--- a/apps/web/lib/__tests__/self-hosting-ops.test.ts
+++ b/apps/web/lib/__tests__/self-hosting-ops.test.ts
@@ -89,6 +89,15 @@ describe("self-hosting operations docs", () => {
     expect(requiredHostedEnvBlock).toContain("EMAIL_SUPPORT_ADDRESS=");
     expect(requiredHostedEnvBlock).toContain("EMAIL_COMPANY_ADDRESS=...");
     expect(requiredHostedEnvBlock).toContain("STRIPE_TAX_ENABLED=true");
+    expect(requiredHostedEnvBlock).toContain(
+      "MESSAGING_SENDING_ENABLED=false"
+    );
+    expect(requiredHostedEnvBlock).toContain(
+      "MESSAGING_SENDING_PRACTICE_IDS="
+    );
+    expect(requiredHostedEnvBlock).toContain(
+      "MESSAGING_SENDING_LOCATION_IDS="
+    );
     expect(requiredHostedEnvBlock).not.toContain("TWILIO_");
     expect(requiredHostedEnvBlock).not.toContain("STRIPE_PRICE_CLOUD_USER");
 
@@ -100,6 +109,9 @@ describe("self-hosting operations docs", () => {
     expect(envExample).toContain("TELNYX_PUBLIC_KEY=");
     expect(envExample).toContain("TELNYX_MESSAGING_PROFILE_ID=");
     expect(envExample).toContain("TELNYX_FROM_NUMBER=");
+    expect(envExample).toContain("MESSAGING_SENDING_ENABLED=false");
+    expect(envExample).toContain("MESSAGING_SENDING_PRACTICE_IDS=");
+    expect(envExample).toContain("MESSAGING_SENDING_LOCATION_IDS=");
     expect(envExample).toContain("RESEND_WEBHOOK_SECRET=");
     expect(envExample).toContain("EMAIL_SUPPORT_ADDRESS=");
     expect(envExample).toContain("EMAIL_COMPANY_ADDRESS=");

--- a/apps/web/lib/__tests__/sms.test.ts
+++ b/apps/web/lib/__tests__/sms.test.ts
@@ -48,7 +48,40 @@ vi.mock("@/lib/messaging", async (importOriginal) => {
 
 const { sendAppointmentReminderSms, sendSms, sendVaccinationReminderSms } =
   await import("../sms");
+const { revokeSmsConsentByPhoneInTransaction } =
+  await import("@/lib/messaging/suppression");
 const smsSource = readFileSync(new URL("../sms.ts", import.meta.url), "utf8");
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const LOCATION_ID = "00000000-0000-0000-0000-000000000002";
+const CLIENT_ID = "00000000-0000-0000-0000-000000000003";
+
+function allowHostedPilot() {
+  vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+  vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", PRACTICE_ID);
+  vi.stubEnv("MESSAGING_SENDING_LOCATION_IDS", LOCATION_ID);
+}
+
+function hostedDispatchDb(rows: Array<unknown[] | Error>) {
+  const select = vi.fn(() => {
+    const result = rows.shift() ?? [];
+    const settle = () =>
+      result instanceof Error
+        ? Promise.reject(result)
+        : Promise.resolve(result);
+    const builder = {
+      from: () => builder,
+      where: () => builder,
+      limit: () => builder,
+      for: settle,
+      then: (
+        resolve: (value: unknown[]) => unknown,
+        reject?: (reason: unknown) => unknown
+      ) => settle().then(resolve, reject),
+    };
+    return builder;
+  });
+  return { execute: vi.fn(async () => undefined), select };
+}
 
 function deferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -81,26 +114,430 @@ afterEach(() => {
   });
   mocks.billingEnforced.mockReturnValue(false);
   mocks.hasHostedFullAccess.mockReturnValue(true);
-  mocks.withSystem.mockImplementation(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-    fn({
-      select: () => ({
-        from: () => ({
-          where: () => ({
-            limit: async () => [
-              {
-                tier: "cloud",
-                billingStatus: "active",
-                trialEndsAt: null,
-              },
-            ],
+  mocks.withSystem.mockImplementation(
+    async (_db: unknown, fn: (tx: unknown) => unknown) =>
+      fn({
+        select: () => ({
+          from: () => ({
+            where: () => ({
+              limit: async () => [
+                {
+                  tier: "cloud",
+                  billingStatus: "active",
+                  trialEndsAt: null,
+                },
+              ],
+            }),
           }),
         }),
-      }),
-    })
+      })
   );
 });
 
 describe("sendSms", () => {
+  it("keeps hosted SMS default-off before any DB, transport, or provider work", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+
+    await expect(
+      sendSms({
+        to: "+15555550199",
+        body: "Reminder",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
+      })
+    ).resolves.toEqual({
+      success: false,
+      error:
+        "Texting is not enabled for this clinic pilot. Contact OpenVPM support.",
+    });
+
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.resolveMessagingTransport).not.toHaveBeenCalled();
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+  });
+
+  it("requires explicit hosted practice, location, and client scope", async () => {
+    allowHostedPilot();
+    mocks.billingEnforced.mockReturnValue(true);
+
+    await expect(
+      sendSms({
+        to: "+15555550199",
+        body: "Reminder",
+        practiceId: PRACTICE_ID,
+      })
+    ).resolves.toMatchObject({ success: false });
+    await expect(
+      sendSms({
+        to: "+15555550199",
+        body: "Reminder",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: "Hosted SMS requires an explicit consented client.",
+    });
+
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-Telnyx hosted transports before provider dispatch", async () => {
+    allowHostedPilot();
+    mocks.billingEnforced.mockReturnValue(true);
+    const twilioSend = vi.fn();
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" }, "twilio", twilioSend)
+    );
+
+    await expect(
+      sendSms({
+        to: "+15555550199",
+        body: "Reminder",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
+      })
+    ).resolves.toEqual({
+      success: false,
+      error:
+        "Hosted texting is available only through the approved Telnyx pilot.",
+    });
+    expect(twilioSend).not.toHaveBeenCalled();
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+  });
+
+  it("rechecks current consent and phone after sender resolution before hosted dispatch", async () => {
+    allowHostedPilot();
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
+    mocks.withSystem
+      .mockImplementationOnce(
+        async (_db: unknown, fn: (tx: unknown) => unknown) =>
+          fn(
+            hostedDispatchDb([
+              [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
+            ])
+          )
+      )
+      .mockImplementationOnce(
+        async (_db: unknown, fn: (tx: unknown) => unknown) =>
+          fn(
+            hostedDispatchDb([
+              [
+                {
+                  phone: "+15555550199",
+                  smsConsent: false,
+                  smsConsentAt: null,
+                  smsConsentSource: null,
+                  smsConsentDisclosure: null,
+                },
+              ],
+            ])
+          )
+      );
+
+    await expect(
+      sendSms({
+        to: "+15555550199",
+        body: "Stale automation snapshot",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
+      })
+    ).resolves.toEqual({
+      success: false,
+      error:
+        "Client SMS consent or phone changed before sending; delivery was blocked.",
+    });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+    expect(mocks.recordUsage).not.toHaveBeenCalled();
+  });
+
+  it("dispatches an allowlisted Telnyx hosted send only after current consent and suppression checks", async () => {
+    allowHostedPilot();
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
+    mocks.providerSend.mockResolvedValue({ success: true, id: "sms-hosted-1" });
+    mocks.withSystem
+      .mockImplementationOnce(
+        async (_db: unknown, fn: (tx: unknown) => unknown) =>
+          fn(
+            hostedDispatchDb([
+              [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
+            ])
+          )
+      )
+      .mockImplementationOnce(
+        async (_db: unknown, fn: (tx: unknown) => unknown) =>
+          fn(
+            hostedDispatchDb([
+              [
+                {
+                  phone: "(555) 555-0199",
+                  smsConsent: true,
+                  smsConsentAt: new Date("2026-08-01T00:00:00Z"),
+                  smsConsentSource: "staff_attested_form:v1",
+                  smsConsentDisclosure: "Disclosure",
+                },
+              ],
+              [],
+            ])
+          )
+      );
+
+    await expect(
+      sendSms({
+        to: "+15555550199",
+        body: "Reminder",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
+      })
+    ).resolves.toEqual({
+      success: true,
+      sid: "sms-hosted-1",
+      error: undefined,
+    });
+    expect(mocks.providerSend).toHaveBeenCalledOnce();
+  });
+
+  it("blocks a hosted send when the JIT suppression check finds the recipient", async () => {
+    allowHostedPilot();
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
+    mocks.withSystem
+      .mockImplementationOnce(
+        async (_db: unknown, fn: (tx: unknown) => unknown) =>
+          fn(
+            hostedDispatchDb([
+              [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
+            ])
+          )
+      )
+      .mockImplementationOnce(
+        async (_db: unknown, fn: (tx: unknown) => unknown) =>
+          fn(
+            hostedDispatchDb([
+              [
+                {
+                  phone: "+15555550199",
+                  smsConsent: true,
+                  smsConsentAt: new Date("2026-08-01T00:00:00Z"),
+                  smsConsentSource: "staff_attested_form:v1",
+                  smsConsentDisclosure: "Disclosure",
+                },
+              ],
+              [{ id: "suppression-1" }],
+            ])
+          )
+      );
+
+    await expect(
+      sendSms({
+        to: "+15555550199",
+        body: "Reminder",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: "Recipient has opted out of SMS (STOP).",
+    });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+    expect(mocks.recordUsage).not.toHaveBeenCalled();
+  });
+
+  it("fails closed with zero provider calls when the JIT suppression query errors", async () => {
+    allowHostedPilot();
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
+    mocks.withSystem
+      .mockImplementationOnce(
+        async (_db: unknown, fn: (tx: unknown) => unknown) =>
+          fn(
+            hostedDispatchDb([
+              [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
+            ])
+          )
+      )
+      .mockImplementationOnce(
+        async (_db: unknown, fn: (tx: unknown) => unknown) =>
+          fn(
+            hostedDispatchDb([
+              [
+                {
+                  phone: "+15555550199",
+                  smsConsent: true,
+                  smsConsentAt: new Date("2026-08-01T00:00:00Z"),
+                  smsConsentSource: "staff_attested_form:v1",
+                  smsConsentDisclosure: "Disclosure",
+                },
+              ],
+              new Error("suppression database unavailable"),
+            ])
+          )
+      );
+
+    await expect(
+      sendSms({
+        to: "+15555550199",
+        body: "Reminder",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: "Could not verify SMS consent; send blocked.",
+    });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+    expect(mocks.recordUsage).not.toHaveBeenCalled();
+  });
+
+  it("serializes revocation ahead of hosted dispatch without a lock-order rollback", async () => {
+    allowHostedPilot();
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({ from: "+15555550100" })
+    );
+
+    const revokeReachedWrite = deferred();
+    const allowRevokeCommit = deferred();
+    const sendWaitingForRecipient = deferred();
+    let recipientLocked = false;
+    const recipientWaiters: Array<() => void> = [];
+    const acquireRecipient = async () => {
+      if (!recipientLocked) {
+        recipientLocked = true;
+        return;
+      }
+      sendWaitingForRecipient.resolve();
+      await new Promise<void>((resolve) => recipientWaiters.push(resolve));
+      recipientLocked = true;
+    };
+    const releaseRecipient = () => {
+      recipientLocked = false;
+      recipientWaiters.shift()?.();
+    };
+    const state = { consent: true, suppressed: false };
+
+    const revokeTx = {
+      execute: vi.fn(acquireRecipient),
+      insert: () => ({
+        values: () => ({ onConflictDoUpdate: async () => undefined }),
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => ({
+            returning: async () => {
+              revokeReachedWrite.resolve();
+              await allowRevokeCommit.promise;
+              return [{ id: CLIENT_ID }];
+            },
+          }),
+        }),
+      }),
+    };
+    const revokePromise = (async () => {
+      const result = await revokeSmsConsentByPhoneInTransaction(
+        revokeTx as never,
+        {
+          practiceId: PRACTICE_ID,
+          phone: "+15555550199",
+          reason: "manual",
+        }
+      );
+      state.consent = false;
+      state.suppressed = true;
+      releaseRecipient();
+      return result;
+    })();
+    await revokeReachedWrite.promise;
+
+    let sendSelectCount = 0;
+    const sendTx = {
+      execute: vi.fn(acquireRecipient),
+      select: () => {
+        sendSelectCount += 1;
+        const result =
+          sendSelectCount === 1
+            ? [
+                {
+                  phone: "+15555550199",
+                  smsConsent: state.consent,
+                  smsConsentAt: state.consent
+                    ? new Date("2026-08-01T00:00:00Z")
+                    : null,
+                  smsConsentSource: state.consent
+                    ? "staff_attested_form:v1"
+                    : null,
+                  smsConsentDisclosure: state.consent ? "Disclosure" : null,
+                },
+              ]
+            : state.suppressed
+              ? [{ id: "suppression-1" }]
+              : [];
+        const builder = {
+          from: () => builder,
+          where: () => builder,
+          limit: () => builder,
+          for: async () => result,
+          then: (
+            resolve: (value: unknown[]) => unknown,
+            reject?: (reason: unknown) => unknown
+          ) => Promise.resolve(result).then(resolve, reject),
+        };
+        return builder;
+      },
+    };
+    mocks.withSystem
+      .mockImplementationOnce(
+        async (_db: unknown, fn: (tx: unknown) => unknown) =>
+          fn(
+            hostedDispatchDb([
+              [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
+            ])
+          )
+      )
+      .mockImplementationOnce(
+        async (_db: unknown, fn: (tx: unknown) => unknown) => {
+          const result = await fn(sendTx);
+          releaseRecipient();
+          return result;
+        }
+      );
+
+    const sendPromise = sendSms({
+      to: "+15555550199",
+      body: "Must wait for revocation",
+      practiceId: PRACTICE_ID,
+      locationId: LOCATION_ID,
+      clientId: CLIENT_ID,
+    });
+    await sendWaitingForRecipient.promise;
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+
+    allowRevokeCommit.resolve();
+    await expect(revokePromise).resolves.toEqual({
+      phone: "+15555550199",
+      clientsRevoked: 1,
+    });
+    await expect(sendPromise).resolves.toMatchObject({ success: false });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+  });
+
   it("requires an active practice for hosted billing entitlement checks", () => {
     expect(smsSource).toMatch(
       /where\(\s*and\(\s*eq\(practices\.id, options\.practiceId!\),\s*isNull\(practices\.deletedAt\)\s*\)\s*\)/s
@@ -167,7 +604,8 @@ describe("sendSms", () => {
       })
     ).resolves.toEqual({
       success: false,
-      error: "SMS recipient phone number must be a valid E.164 or US/CA number.",
+      error:
+        "SMS recipient phone number must be a valid E.164 or US/CA number.",
     });
 
     expect(mocks.isSuppressed).not.toHaveBeenCalled();
@@ -211,7 +649,10 @@ describe("sendSms", () => {
     mocks.resolveMessagingTransport.mockResolvedValue(
       transport({ from: "+15555550100" })
     );
-    mocks.providerSend.mockResolvedValue({ success: true, id: "sms-reminder-1" });
+    mocks.providerSend.mockResolvedValue({
+      success: true,
+      id: "sms-reminder-1",
+    });
 
     await expect(
       sendAppointmentReminderSms({
@@ -300,25 +741,34 @@ describe("sendSms", () => {
   });
 
   it("fails closed when hosted sending would use the console fallback", async () => {
+    allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
     mocks.getMessagingProvider.mockReturnValue({
       name: "console",
       isConfigured: () => true,
       send: mocks.providerSend,
     });
+    mocks.resolveMessagingTransport.mockResolvedValue(transport({}, "console"));
 
     await expect(
       sendSms({
         to: "+15555550199",
         body: "Reminder",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
       })
     ).resolves.toEqual({
       success: false,
-      error: "SMS provider is not configured for hosted sending.",
+      error:
+        "Hosted texting is available only through the approved Telnyx pilot.",
     });
 
-    expect(mocks.resolveMessagingTransport).not.toHaveBeenCalled();
+    expect(mocks.resolveMessagingTransport).toHaveBeenCalledWith({
+      practiceId: PRACTICE_ID,
+      locationId: LOCATION_ID,
+      hosted: true,
+    });
     expect(mocks.providerSend).not.toHaveBeenCalled();
     expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
@@ -356,6 +806,7 @@ describe("sendSms", () => {
   });
 
   it("fails closed when hosted SMS practice entitlement lookup is stale", async () => {
+    allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
     mocks.withSystem.mockImplementationOnce(
       async (_db: unknown, fn: (tx: unknown) => unknown) =>
@@ -374,7 +825,9 @@ describe("sendSms", () => {
       sendSms({
         to: "+15555550199",
         body: "Reminder",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
       })
     ).resolves.toEqual({
       success: false,
@@ -410,7 +863,9 @@ describe("sendSms", () => {
   });
 
   it("dispatches an explicit location through its persisted provider, not the global provider", async () => {
-    const twilioSend = vi.fn().mockResolvedValue({ success: true, id: "SM-location" });
+    const twilioSend = vi
+      .fn()
+      .mockResolvedValue({ success: true, id: "SM-location" });
     mocks.isSuppressed.mockResolvedValue(false);
     mocks.resolveMessagingTransport.mockResolvedValue(
       transport(

--- a/apps/web/lib/messaging/__tests__/inbound-classifier.test.ts
+++ b/apps/web/lib/messaging/__tests__/inbound-classifier.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { classifyInboundSms } from "../inbound";
+
+describe("classifyInboundSms", () => {
+  it.each([
+    "STOP",
+    " stop! ",
+    "UNSUBSCRIBE",
+    "please stop texting me",
+    "Kindly stop messaging me.",
+    "do not text me",
+    "don't send me text messages",
+    "don’t text me",
+    "stop texting",
+    "stop sending me texts",
+    "stop sending me messages",
+    "no more texts",
+    "remove me from your text list",
+    "take me off the SMS list",
+    "unsubscribe me from SMS messages",
+  ])("classifies an unambiguous opt-out: %s", (text) => {
+    expect(classifyInboundSms(text)).toBe("stop");
+  });
+
+  it.each(["START", "yes", "UNSTOP!"])(
+    "classifies an exact opt-in keyword: %s",
+    (text) => {
+      expect(classifyInboundSms(text)).toBe("start");
+    }
+  );
+
+  it.each(["HELP", "info!"])("classifies exact HELP: %s", (text) => {
+    expect(classifyInboundSms(text)).toBe("help");
+  });
+
+  it.each([
+    "do not stop texting me",
+    "please stop by tomorrow",
+    "can you help me reschedule?",
+    "I said start next week",
+    "stopping in at 3",
+    "do not stop sending me messages",
+    "I don't want you to stop texting",
+    "no more texts?",
+    "can you remove me from your text list?",
+  ])("does not guess at ambiguous conversation: %s", (text) => {
+    expect(classifyInboundSms(text)).toBe("other");
+  });
+});

--- a/apps/web/lib/messaging/__tests__/index.test.ts
+++ b/apps/web/lib/messaging/__tests__/index.test.ts
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => {
     db,
     senderRows,
     selectInnerJoin,
+    selectWhere,
+    selectLimit,
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
       fn(tx)
     ),
@@ -36,6 +38,35 @@ import {
   resolveMessagingTransport,
   resolveSender,
 } from "../index";
+
+function sqlIncludesColumnParamPair(
+  value: unknown,
+  columnName: string,
+  paramValue: unknown
+): boolean {
+  if (!value || typeof value !== "object") return false;
+  const chunk = value as { name?: unknown; queryChunks?: unknown[] };
+  if (!Array.isArray(chunk.queryChunks)) return false;
+  const hasColumn = chunk.queryChunks.some(
+    (item) =>
+      !!item &&
+      typeof item === "object" &&
+      (item as { name?: unknown }).name === columnName
+  );
+  const hasParam = chunk.queryChunks.some(
+    (item) =>
+      !!item &&
+      typeof item === "object" &&
+      Object.prototype.hasOwnProperty.call(item, "value") &&
+      Object.is((item as { value?: unknown }).value, paramValue)
+  );
+  return (
+    (hasColumn && hasParam) ||
+    chunk.queryChunks.some((item) =>
+      sqlIncludesColumnParamPair(item, columnName, paramValue)
+    )
+  );
+}
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -329,7 +360,9 @@ describe("resolveMessagingTransport", () => {
     vi.stubEnv("TWILIO_MESSAGING_SERVICE_SID", "MG-env");
     vi.stubEnv("TWILIO_PHONE_NUMBER", "+15555550111");
 
-    await expect(resolveMessagingTransport({ practiceId: "p1" })).resolves.toEqual({
+    await expect(
+      resolveMessagingTransport({ practiceId: "p1" })
+    ).resolves.toEqual({
       provider: expect.objectContaining({ name: "twilio" }),
       sender: {
         messagingServiceId: "MG-env",
@@ -337,5 +370,100 @@ describe("resolveMessagingTransport", () => {
       },
     });
     expect(mocks.selectInnerJoin).not.toHaveBeenCalled();
+  });
+
+  it("resolves exactly one Telnyx sender for a hosted one-location pilot", async () => {
+    clearMessagingEnv();
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    mocks.senderRows.push([
+      {
+        locationId: "00000000-0000-0000-0000-000000000002",
+        provider: "telnyx",
+        messagingProfileId: "profile-1",
+        senderE164: "+15555550122",
+      },
+    ]);
+
+    await expect(
+      resolveMessagingTransport({
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        locationId: "00000000-0000-0000-0000-000000000002",
+        hosted: true,
+      })
+    ).resolves.toEqual({
+      provider: expect.objectContaining({ name: "telnyx" }),
+      sender: {
+        messagingServiceId: "profile-1",
+        from: "+15555550122",
+      },
+    });
+    const condition = (mocks.selectWhere.mock.calls as unknown[][]).at(-1)?.[0];
+    expect(sqlIncludesColumnParamPair(condition, "enabled", true)).toBe(true);
+    expect(
+      sqlIncludesColumnParamPair(condition, "registration_status", "active")
+    ).toBe(true);
+    expect(mocks.selectLimit).toHaveBeenLastCalledWith(2);
+  });
+
+  it("fails closed for ambiguous hosted senders instead of selecting the first", async () => {
+    clearMessagingEnv();
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    mocks.senderRows.push([
+      {
+        locationId: "00000000-0000-0000-0000-000000000002",
+        provider: "telnyx",
+        messagingProfileId: "profile-1",
+        senderE164: "+15555550122",
+      },
+      {
+        locationId: "00000000-0000-0000-0000-000000000003",
+        provider: "telnyx",
+        messagingProfileId: "profile-2",
+        senderE164: "+15555550123",
+      },
+    ]);
+
+    await expect(
+      resolveMessagingTransport({
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        locationId: "00000000-0000-0000-0000-000000000002",
+        hosted: true,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails closed for a missing requested hosted location or Twilio row", async () => {
+    clearMessagingEnv();
+    mocks.senderRows.push([
+      {
+        locationId: "00000000-0000-0000-0000-000000000099",
+        provider: "telnyx",
+        messagingProfileId: "profile-1",
+        senderE164: "+15555550122",
+      },
+    ]);
+    await expect(
+      resolveMessagingTransport({
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        locationId: "00000000-0000-0000-0000-000000000002",
+        hosted: true,
+      })
+    ).resolves.toBeUndefined();
+
+    mocks.senderRows.push([
+      {
+        locationId: "00000000-0000-0000-0000-000000000002",
+        provider: "twilio",
+        messagingProfileId: "MG-1",
+        senderE164: "+15555550122",
+      },
+    ]);
+    await expect(
+      resolveMessagingTransport({
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        locationId: "00000000-0000-0000-0000-000000000002",
+        hosted: true,
+      })
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/web/lib/messaging/__tests__/launch-gate.test.ts
+++ b/apps/web/lib/messaging/__tests__/launch-gate.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  hostedMessagingLaunchDecision,
+  MESSAGING_SENDING_ENABLED_ENV,
+  MESSAGING_SENDING_LOCATION_IDS_ENV,
+  MESSAGING_SENDING_PRACTICE_IDS_ENV,
+} from "../launch-gate";
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const LOCATION_ID = "00000000-0000-0000-0000-000000000002";
+
+afterEach(() => vi.unstubAllEnvs());
+
+function enablePilot() {
+  vi.stubEnv(MESSAGING_SENDING_ENABLED_ENV, "true");
+  vi.stubEnv(MESSAGING_SENDING_PRACTICE_IDS_ENV, PRACTICE_ID);
+  vi.stubEnv(MESSAGING_SENDING_LOCATION_IDS_ENV, LOCATION_ID);
+}
+
+describe("hostedMessagingLaunchDecision", () => {
+  it("is default-off", () => {
+    expect(
+      hostedMessagingLaunchDecision({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      })
+    ).toEqual({ allowed: false, reason: "platform_disabled" });
+  });
+
+  it("requires explicit practice and location scope", () => {
+    enablePilot();
+    expect(hostedMessagingLaunchDecision({ practiceId: PRACTICE_ID })).toEqual({
+      allowed: false,
+      reason: "missing_scope",
+    });
+    expect(hostedMessagingLaunchDecision({ locationId: LOCATION_ID })).toEqual({
+      allowed: false,
+      reason: "missing_scope",
+    });
+  });
+
+  it("requires both allowlists", () => {
+    enablePilot();
+    vi.stubEnv(MESSAGING_SENDING_PRACTICE_IDS_ENV, "another-practice");
+    expect(
+      hostedMessagingLaunchDecision({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      })
+    ).toEqual({ allowed: false, reason: "practice_not_allowed" });
+
+    vi.stubEnv(MESSAGING_SENDING_PRACTICE_IDS_ENV, PRACTICE_ID);
+    vi.stubEnv(MESSAGING_SENDING_LOCATION_IDS_ENV, "another-location");
+    expect(
+      hostedMessagingLaunchDecision({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      })
+    ).toEqual({ allowed: false, reason: "location_not_allowed" });
+  });
+
+  it("trims comma-separated allowlist entries", () => {
+    vi.stubEnv(MESSAGING_SENDING_ENABLED_ENV, "true");
+    vi.stubEnv(MESSAGING_SENDING_PRACTICE_IDS_ENV, ` other, ${PRACTICE_ID} `);
+    vi.stubEnv(MESSAGING_SENDING_LOCATION_IDS_ENV, ` other, ${LOCATION_ID} `);
+    expect(
+      hostedMessagingLaunchDecision({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+      })
+    ).toEqual({ allowed: true });
+  });
+});

--- a/apps/web/lib/messaging/__tests__/suppression.test.ts
+++ b/apps/web/lib/messaging/__tests__/suppression.test.ts
@@ -1,20 +1,34 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { smsSuppressions } from "@openpims/db";
 
 const mocks = vi.hoisted(() => {
   const deleteWhere = vi.fn(async (_condition: unknown) => undefined);
   const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
   const insertConflict = vi.fn(async () => undefined);
-  const insertValues = vi.fn(() => ({ onConflictDoNothing: insertConflict }));
+  const insertValues = vi.fn(() => ({
+    onConflictDoNothing: insertConflict,
+    onConflictDoUpdate: insertConflict,
+  }));
   const insert = vi.fn(() => ({ values: insertValues }));
+  const updateReturning = vi.fn(async () => [{ id: "c1" }, { id: "c2" }]);
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set: updateSet }));
+  const execute = vi.fn(async () => undefined);
   const tx = {
     delete: deleteFrom,
     insert,
+    update,
+    execute,
   };
   return {
     tx,
     deleteWhere,
     insertValues,
     insertConflict,
+    updateSet,
+    updateWhere,
+    execute,
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
       fn(tx)
     ),
@@ -29,7 +43,8 @@ vi.mock("@/lib/tenant-db", () => ({
   withSystem: mocks.withSystem,
 }));
 
-const { addSuppression, removeSuppression } = await import("../suppression");
+const { addSuppression, removeSuppression, revokeSmsConsentByPhone } =
+  await import("../suppression");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 
@@ -102,5 +117,60 @@ describe("SMS suppression helpers", () => {
 
     const condition = mocks.deleteWhere.mock.calls[0]?.[0];
     expect(sqlIncludesColumnParamPair(condition, "reason", "stop")).toBe(true);
+  });
+
+  it("writes one practice-wide manual suppression and clears every duplicate consent", async () => {
+    await expect(
+      revokeSmsConsentByPhone({
+        practiceId: PRACTICE_ID,
+        phone: "(555) 555-0100",
+        reason: "manual",
+        detail: "Staff request",
+      })
+    ).resolves.toEqual({ phone: "+15555550100", clientsRevoked: 2 });
+
+    expect(mocks.execute).toHaveBeenCalledOnce();
+    expect(mocks.insertValues).toHaveBeenCalledWith({
+      practiceId: PRACTICE_ID,
+      locationId: undefined,
+      phone: "+15555550100",
+      reason: "manual",
+      detail: "Staff request",
+    });
+    expect(mocks.insertConflict).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          reason: "manual",
+          deletedAt: null,
+        }),
+      })
+    );
+    expect(mocks.updateSet).toHaveBeenCalledWith({
+      smsConsent: false,
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
+    });
+  });
+
+  it("does not let a later carrier STOP downgrade a staff suppression", async () => {
+    await revokeSmsConsentByPhone({
+      practiceId: PRACTICE_ID,
+      phone: "(555) 555-0100",
+      locationId: "00000000-0000-0000-0000-000000000002",
+      reason: "stop",
+      detail: "STOP",
+    });
+
+    expect(mocks.insertConflict).toHaveBeenCalledWith(
+      expect.objectContaining({
+        set: expect.objectContaining({
+          locationId: smsSuppressions.locationId,
+          reason: smsSuppressions.reason,
+          detail: smsSuppressions.detail,
+          deletedAt: null,
+        }),
+      })
+    );
   });
 });

--- a/apps/web/lib/messaging/inbound.ts
+++ b/apps/web/lib/messaging/inbound.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { and, eq, isNull, sql, type SQL } from "drizzle-orm";
+import { and, eq, isNull, or, sql, type SQL } from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import {
   clients,
@@ -10,15 +10,21 @@ import {
 } from "@openpims/db";
 import { withSystem, withTenant } from "@/lib/tenant-db";
 import { normalizeE164 } from "./phone";
-import { addSuppression, removeSuppression } from "./suppression";
 import {
-  inboundSmsOptInEvidence,
-  SMS_INBOUND_OPT_IN,
-} from "./consent";
+  isSuppressed,
+  removeSuppression,
+  revokeSmsConsentByPhone,
+} from "./suppression";
+import { inboundSmsOptInEvidence, SMS_INBOUND_OPT_IN } from "./consent";
 import { latestAssignedToForClient } from "@/lib/communications/assignment";
 
 export type InboundSmsProvider = "telnyx" | "twilio";
-export type InboundSmsAction = "ignored" | "suppressed" | "unsuppressed" | "logged";
+export type InboundSmsAction =
+  | "ignored"
+  | "suppressed"
+  | "unsuppressed"
+  | "logged";
+export type InboundSmsClassification = "stop" | "start" | "help" | "other";
 
 const STOP_KEYWORDS = new Set([
   "STOP",
@@ -31,9 +37,40 @@ const STOP_KEYWORDS = new Set([
   "OPTOUT",
 ]);
 const START_KEYWORDS = new Set(["START", "YES", "UNSTOP"]);
+const HELP_KEYWORDS = new Set(["HELP", "INFO"]);
 
 function normalizedKeyword(text: string): string {
   return text.toUpperCase().replace(/[^A-Z]/g, "");
+}
+
+/**
+ * Carrier keywords must be the whole message. A small, anchored set of plain
+ * language requests covers unmistakable revocations without guessing at
+ * ambiguous conversational messages (for example, “do not stop texting me”).
+ */
+export function classifyInboundSms(text: string): InboundSmsClassification {
+  const trimmed = text.trim();
+  if (!trimmed) return "other";
+  const keyword = normalizedKeyword(trimmed);
+  if (STOP_KEYWORDS.has(keyword)) return "stop";
+  if (START_KEYWORDS.has(keyword)) return "start";
+  if (HELP_KEYWORDS.has(keyword)) return "help";
+  if (/\?\s*$/.test(trimmed)) return "other";
+
+  const sentence = trimmed
+    .toLowerCase()
+    .replace(/[.!,;:]+$/g, "")
+    .replace(/\s+/g, " ");
+  const naturalOptOut = [
+    /^(?:please |kindly )?stop (?:texting|messaging)(?: me)?$/,
+    /^(?:please |kindly )?stop sending me (?:texts|text messages|messages|sms messages)$/,
+    /^(?:please |kindly )?(?:do not|don['’]t) (?:text|message) me$/,
+    /^(?:please |kindly )?(?:do not|don['’]t) send me (?:texts|text messages|sms messages)$/,
+    /^(?:please |kindly )?no more (?:texts|text messages|sms messages)$/,
+    /^(?:please |kindly )?(?:remove me from|take me off) (?:your |the )?(?:text|texting|sms) list$/,
+    /^(?:please |kindly )?unsubscribe me from (?:texts|text messages|sms messages)$/,
+  ].some((pattern) => pattern.test(sentence));
+  return naturalOptOut ? "stop" : "other";
 }
 
 export function inboundSmsDedupeKey(
@@ -51,6 +88,20 @@ export function inboundSmsDedupeKey(
 function nonBlank(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
+}
+
+function normalizedClientPhoneCondition(e164: string): SQL | null {
+  const normalized = normalizeE164(e164);
+  if (!normalized) return null;
+  const fullDigits = normalized.replace(/\D/g, "");
+  const nationalDigits =
+    normalized.startsWith("+1") && fullDigits.length === 11
+      ? fullDigits.slice(1)
+      : fullDigits;
+  return or(
+    sql`regexp_replace(${clients.phone}, '\D', '', 'g') = ${fullDigits}`,
+    sql`regexp_replace(${clients.phone}, '\D', '', 'g') = ${nationalDigits}`
+  )!;
 }
 
 async function findMessagingLocationMatching(
@@ -90,7 +141,7 @@ async function findMessagingLocationMatching(
       )
       .limit(2)
   );
-  return matches.length === 1 ? matches[0] ?? null : null;
+  return matches.length === 1 ? (matches[0] ?? null) : null;
 }
 
 export async function findMessagingLocationBySender(
@@ -133,8 +184,8 @@ export async function findClientIdByPhone(
   practiceId: string,
   e164: string
 ): Promise<string | null> {
-  const digits = e164.replace(/\D/g, "").slice(-10);
-  if (digits.length < 10) return null;
+  const phoneCondition = normalizedClientPhoneCondition(e164);
+  if (!phoneCondition) return null;
   const matches = await withSystem(db, (tx) =>
     tx
       .select({ id: clients.id })
@@ -143,12 +194,12 @@ export async function findClientIdByPhone(
         and(
           eq(clients.practiceId, practiceId),
           isNull(clients.deletedAt),
-          sql`right(regexp_replace(${clients.phone}, '\D', '', 'g'), 10) = ${digits}`
+          phoneCondition
         )
       )
       .limit(2)
   );
-  return matches.length === 1 ? matches[0]?.id ?? null : null;
+  return matches.length === 1 ? (matches[0]?.id ?? null) : null;
 }
 
 /** Flip a client's SMS consent flag after carrier opt-out / opt-in callbacks. */
@@ -159,8 +210,8 @@ export async function setClientSmsConsentByPhone(
   matchedClientId?: string | null,
   optInKeyword?: string
 ): Promise<void> {
-  const digits = e164.replace(/\D/g, "").slice(-10);
-  if (digits.length < 10) return;
+  const phoneCondition = normalizedClientPhoneCondition(e164);
+  if (!phoneCondition) return;
 
   if (consent) {
     const clientId =
@@ -204,7 +255,7 @@ export async function setClientSmsConsentByPhone(
         and(
           eq(clients.practiceId, practiceId),
           isNull(clients.deletedAt),
-          sql`right(regexp_replace(${clients.phone}, '\D', '', 'g'), 10) = ${digits}`
+          phoneCondition
         )
       )
   );
@@ -267,17 +318,17 @@ export async function handleInboundSmsReply(opts: {
   });
   if (!loc) return { ok: true, action: "ignored" };
 
+  const classification = classifyInboundSms(text);
   const keyword = normalizedKeyword(text);
   const clientId = await findClientIdByPhone(loc.practiceId, fromPhone);
-  if (STOP_KEYWORDS.has(keyword)) {
-    await addSuppression({
+  if (classification === "stop") {
+    await revokeSmsConsentByPhone({
       practiceId: loc.practiceId,
       locationId: loc.locationId,
       phone: fromPhone,
       reason: "stop",
       detail: `Inbound opt-out: "${text}"`,
     });
-    await setClientSmsConsentByPhone(loc.practiceId, fromPhone, false);
     await logInboundSmsCommunication({
       practiceId: loc.practiceId,
       clientId,
@@ -290,15 +341,20 @@ export async function handleInboundSmsReply(opts: {
     return { ok: true, action: "suppressed" };
   }
 
-  if (START_KEYWORDS.has(keyword)) {
+  if (classification === "start") {
     await removeSuppression(loc.practiceId, fromPhone);
-    await setClientSmsConsentByPhone(
-      loc.practiceId,
-      fromPhone,
-      true,
-      clientId,
-      keyword
-    );
+    // START can remove only a carrier STOP. A manual, complaint, or bounce
+    // suppression remains authoritative and must not silently restore consent.
+    const remainsSuppressed = await isSuppressed(loc.practiceId, fromPhone);
+    if (!remainsSuppressed) {
+      await setClientSmsConsentByPhone(
+        loc.practiceId,
+        fromPhone,
+        true,
+        clientId,
+        keyword
+      );
+    }
     await logInboundSmsCommunication({
       practiceId: loc.practiceId,
       clientId,
@@ -306,9 +362,29 @@ export async function handleInboundSmsReply(opts: {
       fromPhone,
       text,
       providerMessageId: opts.providerMessageId,
-      subject: `SMS opt-in from ${fromPhone}`,
+      subject: remainsSuppressed
+        ? `SMS opt-in blocked for ${fromPhone}`
+        : `SMS opt-in from ${fromPhone}`,
     });
-    return { ok: true, action: "unsuppressed" };
+    return {
+      ok: true,
+      action: remainsSuppressed ? "suppressed" : "unsuppressed",
+    };
+  }
+
+  if (classification === "help") {
+    // Carriers commonly generate their own HELP response. Log one staff-visible
+    // request but do not dispatch a second automated reply.
+    await logInboundSmsCommunication({
+      practiceId: loc.practiceId,
+      clientId,
+      provider: opts.provider,
+      fromPhone,
+      text,
+      providerMessageId: opts.providerMessageId,
+      subject: `SMS help request from ${fromPhone}`,
+    });
+    return { ok: true, action: "logged" };
   }
 
   await logInboundSmsCommunication({

--- a/apps/web/lib/messaging/inbox-status.ts
+++ b/apps/web/lib/messaging/inbox-status.ts
@@ -8,10 +8,13 @@ export type InboxSmsRegistrationStatus =
 
 export type InboxSmsLocation = {
   messaging: {
+    provider?: string | null;
     senderE164: string | null;
     messagingProfileId: string | null;
     registrationStatus: InboxSmsRegistrationStatus;
     enabled: boolean;
+    /** Server-computed hosted rollout policy. Omitted for self-host/back-compat. */
+    launchEligible?: boolean;
   } | null;
 };
 
@@ -40,15 +43,19 @@ export function summarizeInboxSmsStatus(
 ): InboxSmsStatusSummary {
   const configured = locations
     .map((location) => location.messaging)
-    .filter((messaging): messaging is NonNullable<InboxSmsLocation["messaging"]> =>
-      Boolean(messaging)
+    .filter(
+      (messaging): messaging is NonNullable<InboxSmsLocation["messaging"]> =>
+        Boolean(messaging)
     );
   const hasSender = (messaging: NonNullable<InboxSmsLocation["messaging"]>) =>
-    Boolean(messaging.senderE164?.trim() || messaging.messagingProfileId?.trim());
+    Boolean(
+      messaging.senderE164?.trim() || messaging.messagingProfileId?.trim()
+    );
 
   const ready = configured.some(
     (messaging) =>
       messaging.enabled &&
+      messaging.launchEligible !== false &&
       messaging.registrationStatus === "active" &&
       hasSender(messaging)
   );
@@ -61,6 +68,22 @@ export function summarizeInboxSmsStatus(
       title: "Texting is ready",
       description: "SMS is available from your active clinic number.",
       badge: { label: "SMS ready", variant: "success" },
+      actionLabel: null,
+    };
+  }
+
+  const launchBlocked = configured.some(
+    (messaging) => messaging.launchEligible === false
+  );
+  if (launchBlocked) {
+    return {
+      kind: "disabled",
+      smsComposeEnabled: false,
+      showBanner: true,
+      title: "Texting pilot is not active for this clinic",
+      description:
+        "OpenVPM has kept outbound SMS off. Contact support when this clinic is ready for the controlled texting pilot.",
+      badge: { label: "Pilot off", variant: "warning" },
       actionLabel: null,
     };
   }

--- a/apps/web/lib/messaging/index.ts
+++ b/apps/web/lib/messaging/index.ts
@@ -16,7 +16,15 @@ import type {
 
 export * from "./types";
 export { normalizeE164 } from "./phone";
-export { isSuppressed, addSuppression, removeSuppression } from "./suppression";
+export {
+  isSuppressed,
+  addSuppression,
+  removeSuppression,
+  acquireSmsRecipientLockInTransaction,
+  revokeSmsConsentAfterRecipientLockInTransaction,
+  revokeSmsConsentByPhone,
+  revokeSmsConsentByPhoneInTransaction,
+} from "./suppression";
 
 /**
  * Resolve the active messaging provider. Explicit override via MESSAGING_PROVIDER
@@ -77,15 +85,18 @@ function providerByName(name: string): MessagingProvider | undefined {
 export async function resolveMessagingTransport(opts: {
   practiceId?: string;
   locationId?: string;
+  /** Hosted pilot resolution is Telnyx-only and unambiguous per practice. */
+  hosted?: boolean;
 }): Promise<ResolvedMessagingTransport | undefined> {
   if (opts.locationId) {
     // A location UUID is not an authorization boundary. Never resolve an
     // explicit clinic sender unless its owning practice is supplied too.
     if (!opts.practiceId) return undefined;
     try {
-      const [row] = await withSystem(db, (tx) =>
+      const rows = await withSystem(db, (tx) =>
         tx
           .select({
+            locationId: locationMessaging.locationId,
             provider: locationMessaging.provider,
             messagingProfileId: locationMessaging.messagingProfileId,
             senderE164: locationMessaging.senderE164,
@@ -100,20 +111,39 @@ export async function resolveMessagingTransport(opts: {
             )
           )
           .where(
-            and(
-              eq(locationMessaging.locationId, opts.locationId!),
-              eq(locationMessaging.practiceId, opts.practiceId!),
-              isNull(locationMessaging.deletedAt),
-              eq(locations.practiceId, opts.practiceId!),
-              isNull(locations.deletedAt),
-              eq(locationMessaging.enabled, true),
-              eq(locationMessaging.registrationStatus, "active"),
-              hasNonBlankMessagingSender()
-            )
+            opts.hosted
+              ? and(
+                  eq(locationMessaging.practiceId, opts.practiceId!),
+                  isNull(locationMessaging.deletedAt),
+                  eq(locations.practiceId, opts.practiceId!),
+                  isNull(locations.deletedAt),
+                  eq(locationMessaging.enabled, true),
+                  eq(locationMessaging.registrationStatus, "active"),
+                  hasNonBlankMessagingSender()
+                )
+              : and(
+                  eq(locationMessaging.locationId, opts.locationId!),
+                  eq(locationMessaging.practiceId, opts.practiceId!),
+                  isNull(locationMessaging.deletedAt),
+                  eq(locations.practiceId, opts.practiceId!),
+                  isNull(locations.deletedAt),
+                  eq(locationMessaging.enabled, true),
+                  eq(locationMessaging.registrationStatus, "active"),
+                  hasNonBlankMessagingSender()
+                )
           )
-          .limit(1)
+          .limit(opts.hosted ? 2 : 1)
       );
+      // Hosted rollout is deliberately one location per practice. More than
+      // one active/enabled sender is ambiguous and must never become “first row
+      // wins”; the selected row must also be the explicitly requested location.
+      const row = opts.hosted
+        ? rows.length === 1 && rows[0]?.provider === "telnyx"
+          ? rows[0]
+          : undefined
+        : rows[0];
       if (row) {
+        if (opts.hosted && row.locationId !== opts.locationId) return undefined;
         const messagingServiceId = nonBlank(row.messagingProfileId);
         const from = nonBlank(row.senderE164);
         if (!messagingServiceId && !from) return undefined;
@@ -148,6 +178,7 @@ export async function resolveMessagingTransport(opts: {
 export async function resolveSender(opts: {
   practiceId?: string;
   locationId?: string;
+  hosted?: boolean;
 }): Promise<MessagingSender> {
   return (await resolveMessagingTransport(opts))?.sender ?? {};
 }

--- a/apps/web/lib/messaging/launch-gate.ts
+++ b/apps/web/lib/messaging/launch-gate.ts
@@ -1,0 +1,62 @@
+import { envFlagEnabled } from "@/lib/env-bool";
+
+export const MESSAGING_SENDING_ENABLED_ENV = "MESSAGING_SENDING_ENABLED";
+export const MESSAGING_SENDING_PRACTICE_IDS_ENV =
+  "MESSAGING_SENDING_PRACTICE_IDS";
+export const MESSAGING_SENDING_LOCATION_IDS_ENV =
+  "MESSAGING_SENDING_LOCATION_IDS";
+
+export type HostedMessagingLaunchBlock =
+  | "platform_disabled"
+  | "missing_scope"
+  | "practice_not_allowed"
+  | "location_not_allowed";
+
+export type HostedMessagingLaunchDecision =
+  | { allowed: true }
+  | { allowed: false; reason: HostedMessagingLaunchBlock };
+
+function allowlist(name: string): ReadonlySet<string> {
+  return new Set(
+    (process.env[name] ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+  );
+}
+
+/**
+ * Hosted SMS is an operator-controlled pilot. All three switches are required:
+ * the global default-off flag, the practice allowlist, and the location
+ * allowlist. Empty, malformed, or partial configuration therefore fails closed.
+ *
+ * Self-host callers must skip this policy and retain their explicit provider
+ * configuration; this helper intentionally describes hosted rollout only.
+ */
+export function hostedMessagingLaunchDecision(opts: {
+  practiceId?: string;
+  locationId?: string;
+}): HostedMessagingLaunchDecision {
+  if (!envFlagEnabled(MESSAGING_SENDING_ENABLED_ENV)) {
+    return { allowed: false, reason: "platform_disabled" };
+  }
+  if (!opts.practiceId?.trim() || !opts.locationId?.trim()) {
+    return { allowed: false, reason: "missing_scope" };
+  }
+  if (!allowlist(MESSAGING_SENDING_PRACTICE_IDS_ENV).has(opts.practiceId)) {
+    return { allowed: false, reason: "practice_not_allowed" };
+  }
+  if (!allowlist(MESSAGING_SENDING_LOCATION_IDS_ENV).has(opts.locationId)) {
+    return { allowed: false, reason: "location_not_allowed" };
+  }
+  return { allowed: true };
+}
+
+export function hostedMessagingLaunchBlockMessage(
+  reason: HostedMessagingLaunchBlock
+): string {
+  if (reason === "missing_scope") {
+    return "Hosted SMS requires an explicit clinic practice and location.";
+  }
+  return "Texting is not enabled for this clinic pilot. Contact OpenVPM support.";
+}

--- a/apps/web/lib/messaging/suppression.ts
+++ b/apps/web/lib/messaging/suppression.ts
@@ -1,10 +1,28 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull, or, sql } from "drizzle-orm";
 import { db } from "@openpims/db/client";
-import { smsSuppressions } from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+import { clients, smsSuppressions } from "@openpims/db";
 import { withSystem } from "@/lib/tenant-db";
 import { normalizeE164 } from "./phone";
 
 export type SuppressionReason = "stop" | "manual" | "bounce" | "complaint";
+type SmsRevocationDatabase = Pick<Database, "execute" | "insert" | "update">;
+type SmsRecipientLockDatabase = Pick<Database, "execute">;
+
+export async function acquireSmsRecipientLockInTransaction(
+  tx: SmsRecipientLockDatabase,
+  practiceId: string,
+  phone: string
+): Promise<string> {
+  const e164 = normalizeE164(phone);
+  if (!e164) {
+    throw new Error("A valid SMS phone number is required for revocation.");
+  }
+  await tx.execute(
+    sql`select pg_advisory_xact_lock(hashtextextended(${`sms:${practiceId}:${e164}`}, 0))`
+  );
+  return e164;
+}
 
 /**
  * Is this number on the practice's do-not-text list? Opt-out is practice-wide
@@ -59,6 +77,127 @@ export async function addSuppression(opts: {
         target: [smsSuppressions.practiceId, smsSuppressions.phone],
       })
   );
+}
+
+/**
+ * Practice-wide revocation primitive shared by carrier opt-outs and staff
+ * actions. The suppression and every active duplicate client consent row change
+ * in one transaction, under the same recipient lock used by hosted dispatch.
+ */
+async function revokeSmsConsentAfterLock(
+  tx: SmsRevocationDatabase,
+  e164: string,
+  opts: {
+    practiceId: string;
+    locationId?: string;
+    reason: "stop" | "manual";
+    detail?: string;
+  }
+): Promise<{ phone: string; clientsRevoked: number }> {
+  const fullDigits = e164.replace(/\D/g, "");
+  const nationalDigits =
+    e164.startsWith("+1") && fullDigits.length === 11
+      ? fullDigits.slice(1)
+      : fullDigits;
+
+  await tx
+    .insert(smsSuppressions)
+    .values({
+      practiceId: opts.practiceId,
+      locationId: opts.locationId,
+      phone: e164,
+      reason: opts.reason,
+      detail: opts.detail,
+    })
+    .onConflictDoUpdate({
+      target: [smsSuppressions.practiceId, smsSuppressions.phone],
+      set: {
+        // A carrier STOP must never downgrade a prior staff/complaint/bounce
+        // suppression into a removable STOP. Manual revocation is the only
+        // path here that intentionally upgrades an existing row.
+        locationId:
+          opts.reason === "manual"
+            ? opts.locationId
+            : smsSuppressions.locationId,
+        reason: opts.reason === "manual" ? "manual" : smsSuppressions.reason,
+        detail: opts.reason === "manual" ? opts.detail : smsSuppressions.detail,
+        deletedAt: null,
+        updatedAt: new Date(),
+      },
+    });
+
+  const revoked = await tx
+    .update(clients)
+    .set({
+      smsConsent: false,
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
+    })
+    .where(
+      and(
+        eq(clients.practiceId, opts.practiceId),
+        isNull(clients.deletedAt),
+        or(
+          sql`regexp_replace(${clients.phone}, '\D', '', 'g') = ${fullDigits}`,
+          sql`regexp_replace(${clients.phone}, '\D', '', 'g') = ${nationalDigits}`
+        )
+      )
+    )
+    .returning({ id: clients.id });
+
+  return { phone: e164, clientsRevoked: revoked.length };
+}
+
+/**
+ * Apply revocation after the caller has acquired the practice/recipient
+ * advisory lock and, where applicable, revalidated any row it then locked.
+ * This explicit variant keeps every route on the same advisory-before-row
+ * ordering as hosted dispatch.
+ */
+export async function revokeSmsConsentAfterRecipientLockInTransaction(
+  tx: SmsRevocationDatabase,
+  opts: {
+    practiceId: string;
+    phone: string;
+    locationId?: string;
+    reason: "stop" | "manual";
+    detail?: string;
+  }
+): Promise<{ phone: string; clientsRevoked: number }> {
+  const e164 = normalizeE164(opts.phone);
+  if (!e164) {
+    throw new Error("A valid SMS phone number is required for revocation.");
+  }
+  return revokeSmsConsentAfterLock(tx, e164, opts);
+}
+
+export async function revokeSmsConsentByPhoneInTransaction(
+  tx: SmsRevocationDatabase,
+  opts: {
+    practiceId: string;
+    phone: string;
+    locationId?: string;
+    reason: "stop" | "manual";
+    detail?: string;
+  }
+): Promise<{ phone: string; clientsRevoked: number }> {
+  const e164 = await acquireSmsRecipientLockInTransaction(
+    tx,
+    opts.practiceId,
+    opts.phone
+  );
+  return revokeSmsConsentAfterLock(tx, e164, opts);
+}
+
+export async function revokeSmsConsentByPhone(opts: {
+  practiceId: string;
+  phone: string;
+  locationId?: string;
+  reason: "stop" | "manual";
+  detail?: string;
+}): Promise<{ phone: string; clientsRevoked: number }> {
+  return withSystem(db, (tx) => revokeSmsConsentByPhoneInTransaction(tx, opts));
 }
 
 /**

--- a/apps/web/lib/sms.ts
+++ b/apps/web/lib/sms.ts
@@ -1,6 +1,6 @@
 import { recordUsage } from "@/lib/billing/usage";
 import { db } from "@openpims/db/client";
-import { practices } from "@openpims/db";
+import { clients, practices, smsSuppressions } from "@openpims/db";
 import { and, eq, isNull } from "drizzle-orm";
 import { withSystem } from "@/lib/tenant-db";
 import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
@@ -9,8 +9,13 @@ import {
   normalizeE164,
   resolveMessagingTransport,
   isSuppressed,
+  acquireSmsRecipientLockInTransaction,
 } from "@/lib/messaging";
 import { envFlagEnabled } from "@/lib/env-bool";
+import {
+  hostedMessagingLaunchBlockMessage,
+  hostedMessagingLaunchDecision,
+} from "@/lib/messaging/launch-gate";
 
 // ---------------------------------------------------------------------------
 // Core send function
@@ -28,15 +33,36 @@ export async function sendSms(options: {
   practiceId?: string;
   /** Selects the location's bound provider and number/messaging profile. */
   locationId?: string;
+  /** Client whose current consent and destination must match immediately before dispatch. */
+  clientId?: string;
 }): Promise<{ success: boolean; sid?: string; error?: string }> {
   const hostedBilling = billingEnforced();
+  const demoMode = envFlagEnabled("NEXT_PUBLIC_DEMO_MODE");
+  const hostedExternalSend = hostedBilling && !demoMode;
   const recipient = normalizeE164(options.to);
 
   if (!recipient) {
     return {
       success: false,
-      error: "SMS recipient phone number must be a valid E.164 or US/CA number.",
+      error:
+        "SMS recipient phone number must be a valid E.164 or US/CA number.",
     };
+  }
+
+  if (hostedExternalSend) {
+    const launch = hostedMessagingLaunchDecision(options);
+    if (!launch.allowed) {
+      return {
+        success: false,
+        error: hostedMessagingLaunchBlockMessage(launch.reason),
+      };
+    }
+    if (!options.clientId) {
+      return {
+        success: false,
+        error: "Hosted SMS requires an explicit consented client.",
+      };
+    }
   }
 
   // Preserve the locationless hosted guard without consulting the global
@@ -45,7 +71,7 @@ export async function sendSms(options: {
     !options.locationId &&
     getMessagingProvider().name === "console" &&
     hostedBilling &&
-    !envFlagEnabled("NEXT_PUBLIC_DEMO_MODE")
+    !demoMode
   ) {
     return {
       success: false,
@@ -90,10 +116,16 @@ export async function sendSms(options: {
 
   // Hard opt-out gate: never text a number on the practice's suppression list.
   // Fail closed — if we can't verify opt-out status, block rather than risk it.
-  if (options.practiceId) {
+  // Hosted dispatch repeats this check under a per-recipient transaction lock
+  // immediately before the provider call, so stale automation snapshots cannot
+  // outrun a concurrent STOP/manual revoke.
+  if (options.practiceId && !hostedExternalSend) {
     try {
       if (await isSuppressed(options.practiceId, recipient)) {
-        return { success: false, error: "Recipient has opted out of SMS (STOP)." };
+        return {
+          success: false,
+          error: "Recipient has opted out of SMS (STOP).",
+        };
       }
     } catch {
       return {
@@ -106,6 +138,7 @@ export async function sendSms(options: {
   const transport = await resolveMessagingTransport({
     practiceId: options.practiceId,
     locationId: options.locationId,
+    hosted: hostedExternalSend,
   });
   if (options.locationId && !transport) {
     return {
@@ -119,22 +152,94 @@ export async function sendSms(options: {
   }
 
   const { provider, sender } = transport;
-  if (
-    provider.name === "console" &&
-    hostedBilling &&
-    !envFlagEnabled("NEXT_PUBLIC_DEMO_MODE")
-  ) {
+  if (hostedExternalSend && provider.name !== "telnyx") {
+    return {
+      success: false,
+      error:
+        "Hosted texting is available only through the approved Telnyx pilot.",
+    };
+  }
+  if (provider.name === "console" && hostedBilling && !demoMode) {
     return {
       success: false,
       error: "SMS provider is not configured for hosted sending.",
     };
   }
 
-  const result = await provider.send({
-    to: recipient,
-    body: options.body,
-    sender,
-  });
+  const result = hostedExternalSend
+    ? await withSystem(db, async (tx) => {
+        try {
+          const practiceId = options.practiceId!;
+          const clientId = options.clientId!;
+          await acquireSmsRecipientLockInTransaction(tx, practiceId, recipient);
+
+          const [client] = await tx
+            .select({
+              phone: clients.phone,
+              smsConsent: clients.smsConsent,
+              smsConsentAt: clients.smsConsentAt,
+              smsConsentSource: clients.smsConsentSource,
+              smsConsentDisclosure: clients.smsConsentDisclosure,
+            })
+            .from(clients)
+            .where(
+              and(
+                eq(clients.id, clientId),
+                eq(clients.practiceId, practiceId),
+                isNull(clients.deletedAt)
+              )
+            )
+            .limit(1)
+            .for("share");
+          if (
+            !client?.smsConsent ||
+            !client.smsConsentAt ||
+            !client.smsConsentSource?.trim() ||
+            !client.smsConsentDisclosure?.trim() ||
+            normalizeE164(client.phone) !== recipient
+          ) {
+            return {
+              success: false,
+              error:
+                "Client SMS consent or phone changed before sending; delivery was blocked.",
+            };
+          }
+
+          const [suppression] = await tx
+            .select({ id: smsSuppressions.id })
+            .from(smsSuppressions)
+            .where(
+              and(
+                eq(smsSuppressions.practiceId, practiceId),
+                eq(smsSuppressions.phone, recipient)
+              )
+            )
+            .limit(1);
+          if (suppression) {
+            return {
+              success: false,
+              error: "Recipient has opted out of SMS (STOP).",
+            };
+          }
+
+          return provider.send({
+            to: recipient,
+            body: options.body,
+            sender,
+          });
+        } catch (error) {
+          console.error("[messaging] hosted dispatch preflight failed", error);
+          return {
+            success: false,
+            error: "Could not verify SMS consent; send blocked.",
+          };
+        }
+      })
+    : await provider.send({
+        to: recipient,
+        body: options.body,
+        sender,
+      });
 
   // Meter only real sends (not the dev-console fallback); no-op on self-host.
   if (result.success && provider.name !== "console" && options.practiceId) {
@@ -157,6 +262,7 @@ export async function sendAppointmentReminderSms(data: {
   practicePhone?: string;
   practiceId?: string;
   locationId?: string;
+  clientId?: string;
 }): Promise<{ success: boolean; sid?: string; error?: string }> {
   const phoneInfo = data.practicePhone
     ? `Call ${data.practicePhone} to reschedule.`
@@ -169,6 +275,7 @@ export async function sendAppointmentReminderSms(data: {
     body,
     practiceId: data.practiceId,
     locationId: data.locationId,
+    clientId: data.clientId,
   });
   return { success: result.success, sid: result.sid, error: result.error };
 }
@@ -185,6 +292,7 @@ export async function sendVaccinationReminderSms(data: {
   practicePhone?: string;
   practiceId?: string;
   locationId?: string;
+  clientId?: string;
 }): Promise<{ success: boolean; sid?: string; error?: string }> {
   const phoneInfo = data.practicePhone
     ? `Call ${data.practicePhone} to schedule.`
@@ -197,6 +305,7 @@ export async function sendVaccinationReminderSms(data: {
     body,
     practiceId: data.practiceId,
     locationId: data.locationId,
+    clientId: data.clientId,
   });
   return { success: result.success, sid: result.sid, error: result.error };
 }

--- a/apps/web/server/__tests__/clients-safety.test.ts
+++ b/apps/web/server/__tests__/clients-safety.test.ts
@@ -43,11 +43,25 @@ function callerWithDb(db: Record<string, unknown>, role = "admin") {
   return clientsRouter.createCaller({ db, session } as never);
 }
 
+function objectContainsText(
+  value: unknown,
+  needle: string,
+  seen = new WeakSet<object>()
+): boolean {
+  if (typeof value === "string") return value.includes(needle);
+  if (!value || typeof value !== "object" || seen.has(value)) return false;
+  seen.add(value);
+  return Object.values(value as Record<string, unknown>).some((item) =>
+    objectContainsText(item, needle, seen)
+  );
+}
+
 function createDb(opts?: {
   selectResults?: unknown[][];
   insertedRows?: unknown[];
   updatedRows?: unknown[];
 }) {
+  const lockEvents: string[] = [];
   const selectResults = [...(opts?.selectResults ?? [])];
   const select = vi.fn(() => {
     const result = selectResults.shift() ?? [];
@@ -56,7 +70,10 @@ function createDb(opts?: {
       where: vi.fn(() => builder),
       orderBy: vi.fn(() => builder),
       limit: vi.fn(() => builder),
-      for: vi.fn(() => builder),
+      for: vi.fn((mode: string) => {
+        lockEvents.push(`row:${mode}`);
+        return builder;
+      }),
       offset: vi.fn(async () => result),
       then: (
         resolve: (value: unknown[]) => unknown,
@@ -66,21 +83,30 @@ function createDb(opts?: {
     return builder;
   });
   const insertReturning = vi.fn(async () => opts?.insertedRows ?? []);
-  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insertConflict = vi.fn(async () => undefined);
+  const insertValues = vi.fn(() => ({
+    returning: insertReturning,
+    onConflictDoUpdate: insertConflict,
+  }));
   const insert = vi.fn(() => ({ values: insertValues }));
 
   const updateReturning = vi.fn(async () => opts?.updatedRows ?? []);
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
+  const execute = vi.fn(async (query: unknown) => {
+    if (objectContainsText(query, "pg_advisory_xact_lock")) {
+      lockEvents.push("advisory");
+    }
+  });
   const db: Record<string, unknown> = {
     transaction: async (fn: (tx: unknown) => unknown) => fn(db),
-    execute: vi.fn(async () => undefined),
+    execute,
     select,
     insert,
     update,
   };
-  return { db, select, insertValues, updateSet };
+  return { db, select, insertValues, updateSet, execute, lockEvents };
 }
 
 afterEach(() => {
@@ -486,9 +512,106 @@ describe("clients mutation safety", () => {
     });
   });
 
-  it("clears prior evidence when staff explicitly withdraws SMS consent", async () => {
+  it("does not let ordinary re-consent bypass a manual suppression", async () => {
     const { db, updateSet } = createDb({
-      selectResults: [[{ id: CLIENT_ID, phone: "+15555550123" }]],
+      selectResults: [
+        [{ id: CLIENT_ID, phone: "+15555550123" }],
+        [{ id: "suppression-1" }],
+      ],
+      updatedRows: [{ id: CLIENT_ID }],
+    });
+
+    await expect(
+      callerWithDb(db).update({ id: CLIENT_ID, smsConsent: true })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining(
+        "manually placed on the do-not-text list"
+      ),
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("manually revokes a normalized phone practice-wide across duplicate clients", async () => {
+    const { db, insertValues, updateSet, lockEvents } = createDb({
+      selectResults: [
+        [{ phone: "(555) 555-0123" }],
+        [{ phone: "+15555550123" }],
+      ],
+      updatedRows: [{ id: CLIENT_ID }, { id: PATIENT_ID }],
+    });
+
+    await expect(
+      callerWithDb(db, "front_desk").revokeSms({
+        id: CLIENT_ID,
+        expectedPhone: "+15555550123",
+      })
+    ).resolves.toEqual({
+      phone: "+15555550123",
+      clientsRevoked: 2,
+    });
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        phone: "+15555550123",
+        reason: "manual",
+      })
+    );
+    expect(updateSet).toHaveBeenCalledWith({
+      smsConsent: false,
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
+    });
+    expect(lockEvents.slice(0, 2)).toEqual(["advisory", "row:update"]);
+  });
+
+  it("fails closed when the revoke page has a stale persisted phone", async () => {
+    const { db, insertValues, updateSet, lockEvents } = createDb({
+      selectResults: [[{ phone: "+15555550999" }]],
+    });
+
+    await expect(
+      callerWithDb(db, "front_desk").revokeSms({
+        id: CLIENT_ID,
+        expectedPhone: "+15555550123",
+      })
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("no longer matches"),
+    });
+
+    expect(lockEvents).toEqual([]);
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("rechecks the persisted phone after the recipient lock before revoking", async () => {
+    const { db, insertValues, updateSet, lockEvents } = createDb({
+      selectResults: [[{ phone: "+15555550123" }], [{ phone: "+15555550999" }]],
+    });
+
+    await expect(
+      callerWithDb(db, "front_desk").revokeSms({
+        id: CLIENT_ID,
+        expectedPhone: "+15555550123",
+      })
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("changed while revoking"),
+    });
+
+    expect(lockEvents).toEqual(["advisory", "row:update"]);
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("clears prior evidence when staff explicitly withdraws SMS consent", async () => {
+    const { db, updateSet, lockEvents } = createDb({
+      selectResults: [
+        [{ phone: "+15555550123" }],
+        [{ id: CLIENT_ID, phone: "+15555550123" }],
+      ],
       updatedRows: [{ id: CLIENT_ID, smsConsent: false }],
     });
 
@@ -503,6 +626,57 @@ describe("clients mutation safety", () => {
       smsConsentSource: null,
       smsConsentDisclosure: null,
     });
+    expect(lockEvents.slice(0, 2)).toEqual(["advisory", "row:update"]);
+  });
+
+  it("withdraws from the persisted phone rather than an unsaved replacement", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [{ phone: "+15555550123" }],
+        [{ id: CLIENT_ID, phone: "+15555550123" }],
+      ],
+      updatedRows: [{ id: CLIENT_ID, smsConsent: false }],
+    });
+
+    await callerWithDb(db).update({
+      id: CLIENT_ID,
+      phone: "+15555550999",
+      smsConsent: false,
+    });
+
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({ phone: "+15555550123", reason: "manual" })
+    );
+    expect(insertValues).not.toHaveBeenCalledWith(
+      expect.objectContaining({ phone: "+15555550999" })
+    );
+    expect(updateSet).toHaveBeenCalledWith({
+      phone: "+15555550999",
+      smsConsent: false,
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
+    });
+  });
+
+  it("rechecks the withdrawal phone after the recipient lock", async () => {
+    const { db, insertValues, updateSet, lockEvents } = createDb({
+      selectResults: [
+        [{ phone: "+15555550123" }],
+        [{ id: CLIENT_ID, phone: "+15555550999" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).update({ id: CLIENT_ID, smsConsent: false })
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("changed while withdrawing"),
+    });
+
+    expect(lockEvents).toEqual(["advisory", "row:update"]);
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(updateSet).not.toHaveBeenCalled();
   });
 
   it("rejects stale, deleted, or cross-tenant client updates", async () => {
@@ -582,9 +756,9 @@ describe("clients mutation safety", () => {
       updatedRows: [{ id: CLIENT_ID }],
     });
 
-    await expect(
-      callerWithDb(db).delete({ id: CLIENT_ID })
-    ).resolves.toEqual({ success: true });
+    await expect(callerWithDb(db).delete({ id: CLIENT_ID })).resolves.toEqual({
+      success: true,
+    });
 
     expect(updateSet).toHaveBeenCalledWith({ deletedAt: expect.any(Date) });
   });
@@ -630,9 +804,7 @@ describe("clients delete dependency safety", () => {
     expect(deleteBlock).toContain(
       "inArray(appointments.status, activeSchedulingStatuses)"
     );
-    expect(deleteBlock).toContain(
-      "eq(appointmentWaitlist.clientId, input.id)"
-    );
+    expect(deleteBlock).toContain("eq(appointmentWaitlist.clientId, input.id)");
     expect(deleteBlock).toContain(
       "eq(appointmentWaitlist.practiceId, ctx.practiceId)"
     );

--- a/apps/web/server/__tests__/communications-send.test.ts
+++ b/apps/web/server/__tests__/communications-send.test.ts
@@ -214,11 +214,13 @@ describe("communications.create delivery", () => {
       "sql`${emailSuppressions.email} = lower(trim(${clients.email}))`"
     );
     expect(createBlock).toContain("hasNonBlankMessagingSender()");
-    expect(createBlock).not.toContain("isNotNull(locationMessaging.senderE164)");
+    expect(createBlock).not.toContain(
+      "isNotNull(locationMessaging.senderE164)"
+    );
     expect(createBlock).not.toContain(
       "isNotNull(locationMessaging.messagingProfileId)"
     );
-    expect(createBlock).not.toContain(": [{ name: \"OpenVPM\"");
+    expect(createBlock).not.toContain(': [{ name: "OpenVPM"');
     expect(createBlock).not.toContain("practice?.name");
     expect(createBlock).not.toContain("practice?.email");
     expect(createBlock).not.toContain("practice?.timezone");
@@ -565,6 +567,7 @@ describe("communications.create delivery", () => {
       body: "Your refill is ready.",
       practiceId: PRACTICE_ID,
       locationId: LOCATION_ID,
+      clientId: CLIENT_ID,
     });
     expect(updateSet).toHaveBeenCalledWith({
       status: "sent",

--- a/apps/web/server/__tests__/messaging-inbox-status.test.ts
+++ b/apps/web/server/__tests__/messaging-inbox-status.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { messagingRouter } = await import("../routers/messaging");
 
@@ -44,6 +44,8 @@ function createDb(rows: Record<string, unknown>[]) {
   return { db, where };
 }
 
+afterEach(() => vi.unstubAllEnvs());
+
 describe("messaging.getInboxStatus", () => {
   it("is visible to non-admin staff and reports setup prompts", async () => {
     const { db } = createDb([
@@ -81,12 +83,38 @@ describe("messaging.getInboxStatus", () => {
       },
     ]);
 
-    await expect(callerWithDb(db, "admin").getInboxStatus()).resolves.toMatchObject({
+    await expect(
+      callerWithDb(db, "admin").getInboxStatus()
+    ).resolves.toMatchObject({
       canManage: true,
       summary: {
         kind: "ready",
         smsComposeEnabled: true,
         showBanner: false,
+      },
+    });
+  });
+
+  it("reports an active DB sender as unavailable while the hosted launch gate is off", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    const { db } = createDb([
+      {
+        locationId: "00000000-0000-0000-0000-000000000002",
+        name: "Main Clinic",
+        provider: "telnyx",
+        senderE164: "+15555550100",
+        messagingProfileId: null,
+        registrationStatus: "active",
+        enabled: true,
+      },
+    ]);
+
+    await expect(callerWithDb(db).getInboxStatus()).resolves.toMatchObject({
+      locations: [{ messaging: { launchEligible: false } }],
+      summary: {
+        kind: "disabled",
+        smsComposeEnabled: false,
+        title: "Texting pilot is not active for this clinic",
       },
     });
   });
@@ -133,5 +161,30 @@ describe("messaging.getInboxStatus", () => {
         showBanner: true,
       },
     });
+  });
+});
+
+describe("messaging.activationSummary", () => {
+  const activeRow = {
+    locationId: "00000000-0000-0000-0000-000000000002",
+    provider: "telnyx",
+    senderE164: "+15555550100",
+    registrationStatus: "active",
+    enabled: true,
+  };
+
+  it("does not claim hosted texting is active while launch remains off", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    const { db } = createDb([activeRow]);
+    await expect(
+      callerWithDb(db, "admin").activationSummary()
+    ).resolves.toEqual({ hasAnyNumber: true, hasActiveNumber: false });
+  });
+
+  it("preserves self-host active sender behavior", async () => {
+    const { db } = createDb([activeRow]);
+    await expect(
+      callerWithDb(db, "admin").activationSummary()
+    ).resolves.toEqual({ hasAnyNumber: true, hasActiveNumber: true });
   });
 });

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -4,7 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => {
   class MockTelnyxNotConfiguredError extends Error {}
   class MockTelnyxError extends Error {
-    constructor(message: string, readonly status: number) {
+    constructor(
+      message: string,
+      readonly status: number
+    ) {
       super(message);
     }
   }
@@ -221,13 +224,19 @@ beforeEach(() => {
   mocks.reserveMessagingProfileAttempt.mockResolvedValue(true);
   mocks.releaseMessagingProfileAttempt.mockResolvedValue(true);
   mocks.createMessagingProfile.mockResolvedValue({ id: "profile_123" });
-  mocks.buyNumber.mockResolvedValue({ orderId: "order_123", status: "pending" });
+  mocks.buyNumber.mockResolvedValue({
+    orderId: "order_123",
+    status: "pending",
+  });
   mocks.deleteMessagingProfile.mockResolvedValue(undefined);
   mocks.deleteOwnedPhoneNumber.mockResolvedValue(undefined);
   delete process.env.NEXT_PUBLIC_APP_URL;
   delete process.env.NEXTAUTH_URL;
   delete process.env.HOSTED_BILLING_ENABLED;
   delete process.env.MESSAGING_PROVISIONING_PRACTICE_IDS;
+  delete process.env.MESSAGING_SENDING_ENABLED;
+  delete process.env.MESSAGING_SENDING_PRACTICE_IDS;
+  delete process.env.MESSAGING_SENDING_LOCATION_IDS;
   // The platform kill-switch is on for behavior tests; the gate itself is
   // covered in "messaging provisioning kill-switch".
   vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
@@ -309,8 +318,7 @@ describe("messaging location target safety", () => {
       businessPhone: "+15555550100",
       website: "https://example.com",
       programUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}`,
-      privacyPolicyUrl:
-        `https://app.openvpm.com/sms/${PRACTICE_ID}/privacy`,
+      privacyPolicyUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/privacy`,
       termsUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/terms`,
       optInUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/opt-in`,
     });
@@ -366,8 +374,7 @@ describe("messaging location target safety", () => {
       businessPhone: "+15555550100",
       website: "",
       programUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}`,
-      privacyPolicyUrl:
-        `https://app.openvpm.com/sms/${PRACTICE_ID}/privacy`,
+      privacyPolicyUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/privacy`,
       termsUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/terms`,
       optInUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/opt-in`,
     });
@@ -440,8 +447,7 @@ describe("messaging location target safety", () => {
     });
 
     expect(insertValues.mock.calls[0]?.[0]).toMatchObject({
-      privacyPolicyUrl:
-        `https://app.openvpm.com/sms/${PRACTICE_ID}/privacy`,
+      privacyPolicyUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/privacy`,
       termsUrl: `https://app.openvpm.com/sms/${PRACTICE_ID}/terms`,
     });
   });
@@ -552,7 +558,10 @@ describe("messaging location target safety", () => {
     const { db } = createDb();
 
     await expect(
-      callerWithDb(db).provisionNumber({ locationId: LOCATION_ID, mode: "host" })
+      callerWithDb(db).provisionNumber({
+        locationId: LOCATION_ID,
+        mode: "host",
+      })
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining("has not ported or changed"),
@@ -629,10 +638,7 @@ describe("messaging location target safety", () => {
     process.env.NEXT_PUBLIC_APP_URL = "   ";
     process.env.NEXTAUTH_URL = "https://auth.example.com/settings";
     const { db } = createDb({
-      selectResults: [
-        [{ id: LOCATION_ID }],
-        [],
-      ],
+      selectResults: [[{ id: LOCATION_ID }], []],
     });
 
     await expect(
@@ -657,10 +663,7 @@ describe("messaging location target safety", () => {
   it("passes the public Telnyx webhook URL and reactivates sender rows", async () => {
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
     const { db, insertValues, insertUpdate } = createDb({
-      selectResults: [
-        [{ id: LOCATION_ID }],
-        [],
-      ],
+      selectResults: [[{ id: LOCATION_ID }], []],
     });
 
     await expect(
@@ -921,7 +924,9 @@ describe("messaging location target safety", () => {
         locationId: LOCATION_ID,
         senderE164: "+15555550100",
         customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
-        detail: expect.stringContaining("will not create another provider profile"),
+        detail: expect.stringContaining(
+          "will not create another provider profile"
+        ),
       });
       expect(
         mocks.reserveMessagingProfileAttempt.mock.invocationCallOrder[0]
@@ -1071,7 +1076,9 @@ describe("messaging location target safety", () => {
       locationId: LOCATION_ID,
       senderE164: "+15555550100",
       customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
-      detail: expect.stringContaining("will not create another provider profile"),
+      detail: expect.stringContaining(
+        "will not create another provider profile"
+      ),
     });
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
     expect(mocks.buyNumber).not.toHaveBeenCalled();
@@ -1108,7 +1115,9 @@ describe("messaging location target safety", () => {
       locationId: LOCATION_ID,
       senderE164: "+15555550100",
       customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
-      detail: expect.stringContaining("will not create another provider profile"),
+      detail: expect.stringContaining(
+        "will not create another provider profile"
+      ),
     });
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
     expect(mocks.buyNumber).not.toHaveBeenCalled();
@@ -1237,7 +1246,9 @@ describe("messaging location target safety", () => {
 
   it("retains an accepted order identity when the durable write fails", async () => {
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
-    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const errorLog = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     mocks.findOwnedPhoneNumbers
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
@@ -1373,7 +1384,8 @@ describe("messaging location target safety", () => {
       callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true })
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
-      message: "Carrier registration must be active before enabling SMS sending.",
+      message:
+        "Carrier registration must be active before enabling SMS sending.",
     });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -1389,7 +1401,8 @@ describe("messaging location target safety", () => {
       callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true })
     ).rejects.toMatchObject({
       code: "CONFLICT",
-      message: "Messaging sender changed while enabling. Refresh and try again.",
+      message:
+        "Messaging sender changed while enabling. Refresh and try again.",
     });
 
     expect(updateSet).toHaveBeenCalledWith({
@@ -1397,9 +1410,9 @@ describe("messaging location target safety", () => {
       updatedAt: expect.any(Date),
     });
     const condition = updateWhere.mock.calls[0]?.[0];
-    expect(sqlIncludesColumnParamPair(condition, "registration_status", "active")).toBe(
-      true
-    );
+    expect(
+      sqlIncludesColumnParamPair(condition, "registration_status", "active")
+    ).toBe(true);
   });
 
   it("allows disabling an inactive sender so stale enabled state can be cleared", async () => {
@@ -1414,6 +1427,60 @@ describe("messaging location target safety", () => {
 
     expect(updateSet).toHaveBeenCalledWith({
       enabled: false,
+      updatedAt: expect.any(Date),
+    });
+  });
+
+  it("keeps hosted location enablement default-off even for an active Telnyx sender", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    const { db, updateSet } = createDb({
+      practiceRows: [
+        {
+          tier: "cloud",
+          billingStatus: "active",
+          trialEndsAt: null,
+        },
+      ],
+      selectResults: [[{ id: PRACTICE_ID }], [{ id: LOCATION_ID }]],
+    });
+
+    await expect(
+      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("not enabled for this clinic pilot"),
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+    expect(mocks.sendSms).not.toHaveBeenCalled();
+  });
+
+  it("allows one explicitly allowlisted active Telnyx hosted location to be enabled", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+    vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", PRACTICE_ID);
+    vi.stubEnv("MESSAGING_SENDING_LOCATION_IDS", LOCATION_ID);
+    const { db, updateSet } = createDb({
+      practiceRows: [
+        {
+          tier: "cloud",
+          billingStatus: "active",
+          trialEndsAt: null,
+        },
+      ],
+      selectResults: [
+        [{ id: PRACTICE_ID }],
+        [{ id: LOCATION_ID }],
+        [{ locationId: LOCATION_ID, provider: "telnyx" }],
+        [],
+      ],
+      updateRows: [{ enabled: true }],
+    });
+
+    await expect(
+      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true })
+    ).resolves.toEqual({ ok: true, enabled: true });
+    expect(updateSet).toHaveBeenCalledWith({
+      enabled: true,
       updatedAt: expect.any(Date),
     });
   });
@@ -1433,6 +1500,31 @@ describe("messaging location target safety", () => {
     expect(mocks.sendSms).not.toHaveBeenCalled();
   });
 
+  it("disables arbitrary hosted test destinations before sender or provider work", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    const { db, select } = createDb({
+      practiceRows: [
+        {
+          tier: "cloud",
+          billingStatus: "active",
+          trialEndsAt: null,
+        },
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).testSend({
+        locationId: LOCATION_ID,
+        to: "+15555550100",
+      })
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("test sends are disabled"),
+    });
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(mocks.sendSms).not.toHaveBeenCalled();
+  });
+
   it("sends a test SMS after validating the active location sender", async () => {
     mocks.sendSms.mockResolvedValue({ success: true, sid: "sms_123" });
     const { db } = createDb({
@@ -1440,7 +1532,10 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).testSend({ locationId: LOCATION_ID, to: "(555) 555-0100" })
+      callerWithDb(db).testSend({
+        locationId: LOCATION_ID,
+        to: "(555) 555-0100",
+      })
     ).resolves.toEqual({ ok: true, id: "sms_123" });
 
     expect(mocks.sendSms).toHaveBeenCalledWith({
@@ -1496,9 +1591,7 @@ describe("messaging location sender join scoping", () => {
 
     expect(statusJoins).toHaveLength(2);
     for (const join of statusJoins ?? []) {
-      expect(join).toContain(
-        "eq(locationMessaging.locationId, locations.id)"
-      );
+      expect(join).toContain("eq(locationMessaging.locationId, locations.id)");
       expect(join).toContain(
         "eq(locationMessaging.practiceId, ctx.practiceId)"
       );
@@ -1574,7 +1667,7 @@ describe("messaging location sender join scoping", () => {
       'provider: "twilio"'
     );
     expect(readSource("app/api/webhooks/twilio/route.ts")).toContain(
-      'handleInboundSmsReply({'
+      "handleInboundSmsReply({"
     );
   });
 

--- a/apps/web/server/__tests__/notifications-safety.test.ts
+++ b/apps/web/server/__tests__/notifications-safety.test.ts
@@ -45,9 +45,8 @@ vi.mock("@/lib/audit", () => ({
   recordAuditLog: mocks.recordAuditLog,
 }));
 
-const { REMINDER_BATCH_MAX_TARGETS, notificationsRouter } = await import(
-  "../routers/notifications"
-);
+const { REMINDER_BATCH_MAX_TARGETS, notificationsRouter } =
+  await import("../routers/notifications");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
@@ -188,7 +187,9 @@ describe("notification target safety", () => {
     const { db, insertValues } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+      callerWithDb(db).sendAppointmentReminder({
+        appointmentId: APPOINTMENT_ID,
+      })
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
@@ -218,7 +219,9 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+      callerWithDb(db).sendAppointmentReminder({
+        appointmentId: APPOINTMENT_ID,
+      })
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: "Confirm the appointment before sending a reminder.",
@@ -258,6 +261,7 @@ describe("notification target safety", () => {
             practiceName: "Neighborhood Veterinary",
             practicePhone: "555-0100",
             practiceTimezone: "America/Los_Angeles",
+            locationId: LOCATION_ID,
           },
         ],
         [{ locationId: LOCATION_ID }],
@@ -265,7 +269,9 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+      callerWithDb(db).sendAppointmentReminder({
+        appointmentId: APPOINTMENT_ID,
+      })
     ).resolves.toEqual({ success: true, channel: "sms" });
 
     expect(mocks.sendAppointmentReminderSms).toHaveBeenCalledWith(
@@ -277,6 +283,7 @@ describe("notification target safety", () => {
         practicePhone: "555-0100",
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
       })
     );
     expect(insertValues).toHaveBeenCalledWith(
@@ -284,8 +291,7 @@ describe("notification target safety", () => {
         practiceId: PRACTICE_ID,
         clientId: CLIENT_ID,
         channel: "sms",
-        content:
-          "Appointment reminder sent for Miso on Tuesday, June 30, 2026",
+        content: "Appointment reminder sent for Miso on Tuesday, June 30, 2026",
         status: "sent",
         providerMessageId: "sms-manual-1",
       })
@@ -312,13 +318,16 @@ describe("notification target safety", () => {
             practiceName: "Neighborhood Veterinary",
             practicePhone: "555-0100",
             practiceTimezone: "America/Los_Angeles",
+            locationId: LOCATION_ID,
           },
         ],
       ],
     });
 
     await expect(
-      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+      callerWithDb(db).sendAppointmentReminder({
+        appointmentId: APPOINTMENT_ID,
+      })
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -350,13 +359,16 @@ describe("notification target safety", () => {
             practiceName: "Neighborhood Veterinary",
             practicePhone: "555-0100",
             practiceTimezone: "America/Los_Angeles",
+            locationId: LOCATION_ID,
           },
         ],
       ],
     });
 
     await expect(
-      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+      callerWithDb(db).sendAppointmentReminder({
+        appointmentId: APPOINTMENT_ID,
+      })
     ).resolves.toEqual({ success: true, channel: "email" });
 
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
@@ -396,7 +408,9 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+      callerWithDb(db).sendAppointmentReminder({
+        appointmentId: APPOINTMENT_ID,
+      })
     ).resolves.toEqual({ success: true, channel: "email" });
 
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
@@ -437,7 +451,9 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+      callerWithDb(db).sendAppointmentReminder({
+        appointmentId: APPOINTMENT_ID,
+      })
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message:
@@ -473,7 +489,9 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+      callerWithDb(db).sendAppointmentReminder({
+        appointmentId: APPOINTMENT_ID,
+      })
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
@@ -499,6 +517,7 @@ describe("notification target safety", () => {
             practiceName: "Neighborhood Veterinary",
             practicePhone: "555-0100",
             practiceTimezone: "America/Los_Angeles",
+            locationId: LOCATION_ID,
           },
         ],
       ],
@@ -550,6 +569,7 @@ describe("notification target safety", () => {
             practiceName: "Neighborhood Veterinary",
             practicePhone: "555-0100",
             practiceTimezone: "America/Los_Angeles",
+            locationId: LOCATION_ID,
           },
         ],
         [{ locationId: LOCATION_ID }],
@@ -572,6 +592,7 @@ describe("notification target safety", () => {
         practicePhone: "555-0100",
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
       })
     );
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
@@ -610,6 +631,7 @@ describe("notification target safety", () => {
             practiceName: "Neighborhood Veterinary",
             practicePhone: "555-0100",
             practiceTimezone: "America/Los_Angeles",
+            locationId: LOCATION_ID,
           },
         ],
         [],
@@ -653,6 +675,7 @@ describe("notification target safety", () => {
             practiceName: "Neighborhood Veterinary",
             practicePhone: "555-0100",
             practiceTimezone: "America/Los_Angeles",
+            locationId: LOCATION_ID,
           },
         ],
       ],
@@ -687,6 +710,7 @@ describe("notification target safety", () => {
             practiceName: "Neighborhood Veterinary",
             practicePhone: "555-0100",
             practiceTimezone: "America/Los_Angeles",
+            locationId: LOCATION_ID,
           },
         ],
         [{ locationId: LOCATION_ID }],
@@ -1547,12 +1571,14 @@ describe("notification query scoping", () => {
     expect(senderBlock).toContain("eq(locations.practiceId, ctx.practiceId)");
     expect(senderBlock).toContain("isNull(locationMessaging.deletedAt)");
     expect(senderBlock).toContain("isNull(locations.deletedAt)");
-    expect(senderBlock).toContain('eq(locationMessaging.enabled, true)');
+    expect(senderBlock).toContain("eq(locationMessaging.enabled, true)");
     expect(senderBlock).toContain(
       'eq(locationMessaging.registrationStatus, "active")'
     );
     expect(senderBlock).toContain("hasNonBlankMessagingSender()");
-    expect(senderBlock).not.toContain("isNotNull(locationMessaging.senderE164)");
+    expect(senderBlock).not.toContain(
+      "isNotNull(locationMessaging.senderE164)"
+    );
     expect(senderBlock).not.toContain(
       "isNotNull(locationMessaging.messagingProfileId)"
     );
@@ -1606,7 +1632,9 @@ describe("notification query scoping", () => {
     expect(source).toContain(
       "formatDateInputForTimeZone(new Date(), practice.timezone)"
     );
-    expect(vaccinationBlock).toContain("const today = await practiceDateInput(ctx)");
+    expect(vaccinationBlock).toContain(
+      "const today = await practiceDateInput(ctx)"
+    );
     expect(recallPreviewBlock).toContain(
       "const today = formatDateInputForTimeZone(new Date(), practice.timezone)"
     );
@@ -1623,8 +1651,12 @@ describe("notification query scoping", () => {
       "function formatTime(d: Date | string, timeZone?: string | null)"
     );
     expect(source).toContain("practiceTimezone: practices.timezone");
-    expect(source).toContain("formatDate(appt.startTime, appt.practiceTimezone)");
-    expect(source).toContain("formatTime(appt.startTime, appt.practiceTimezone)");
+    expect(source).toContain(
+      "formatDate(appt.startTime, appt.practiceTimezone)"
+    );
+    expect(source).toContain(
+      "formatTime(appt.startTime, appt.practiceTimezone)"
+    );
     expect(source).not.toContain("formatDate(appt.startTime)");
     expect(source).not.toContain("formatTime(appt.startTime)");
   });
@@ -1632,7 +1664,9 @@ describe("notification query scoping", () => {
   it("keeps customer notification emails branded with a practice display name", () => {
     expect(source).toContain("function practiceDisplayName");
     expect(source).toContain("async function practiceNotificationSettings");
-    expect(source).toContain("practiceName: practiceDisplayName(appt.practiceName)");
+    expect(source).toContain(
+      "practiceName: practiceDisplayName(appt.practiceName)"
+    );
     expect(source).toContain("name: practiceDisplayName(practice.name)");
     expect(source).not.toContain("practice?.name");
     expect(source).not.toContain("practice?.phone");

--- a/apps/web/server/routers/clients.ts
+++ b/apps/web/server/routers/clients.ts
@@ -9,6 +9,7 @@ import {
   invoices,
   patients,
   practices,
+  smsSuppressions,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import { generatePortalAccessToken } from "@/lib/portal/tokens";
@@ -29,6 +30,10 @@ import {
   phoneNumbersMatchForConsent,
   SMS_CONSENT_DISCLOSURE,
 } from "@/lib/messaging/consent";
+import {
+  acquireSmsRecipientLockInTransaction,
+  revokeSmsConsentAfterRecipientLockInTransaction,
+} from "@/lib/messaging/suppression";
 
 const clientNameInput = z.string().trim().min(1).max(CLIENT_NAME_MAX_LENGTH);
 const clientEmailInput = z
@@ -56,6 +61,21 @@ const optionalClientString = (maxLength: number) =>
     .transform((value) => value || undefined);
 const clientAddressInput = optionalClientString(CLIENT_ADDRESS_MAX_LENGTH);
 const clientNotesInput = optionalClientString(2000);
+const normalizedClientPhoneInput = z
+  .string()
+  .trim()
+  .max(CLIENT_PHONE_MAX_LENGTH)
+  .transform((value, ctx) => {
+    const normalized = normalizeE164(value);
+    if (!normalized) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "A valid SMS phone number is required",
+      });
+      return z.NEVER;
+    }
+    return normalized;
+  });
 const activeSchedulingStatuses = [
   "scheduled",
   "confirmed",
@@ -104,9 +124,9 @@ function canReadPortalAccessTokenRole(role?: string | null): boolean {
   );
 }
 
-function redactClientPortalAccessToken<T extends { accessToken: string | null }>(
-  client: T
-): Omit<T, "accessToken"> & { accessToken: null } {
+function redactClientPortalAccessToken<
+  T extends { accessToken: string | null },
+>(client: T): Omit<T, "accessToken"> & { accessToken: null } {
   return { ...client, accessToken: null };
 }
 
@@ -275,6 +295,27 @@ export const clientsRouter = createRouter({
       }
 
       await assertActivePractice(ctx);
+      const normalizedPhone = normalizeE164(rest.phone);
+      if (smsConsent && normalizedPhone) {
+        const [manualSuppression] = await ctx.db
+          .select({ id: smsSuppressions.id })
+          .from(smsSuppressions)
+          .where(
+            and(
+              eq(smsSuppressions.practiceId, ctx.practiceId),
+              eq(smsSuppressions.phone, normalizedPhone),
+              eq(smsSuppressions.reason, "manual")
+            )
+          )
+          .limit(1);
+        if (manualSuppression) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "This number was manually placed on the do-not-text list. A staff member must review it before any future opt-in.",
+          });
+        }
+      }
       const consent = smsConsent
         ? {
             smsConsent: true,
@@ -327,6 +368,39 @@ export const clientsRouter = createRouter({
         );
         const { id, smsConsent, phone, ...rest } = input;
         const data: Record<string, unknown> = { ...rest };
+        let withdrawalPhoneSnapshot: string | null | undefined;
+
+        if (smsConsent === false) {
+          // Read without a row lock only to derive the recipient advisory key.
+          // Hosted sends use advisory -> row, so every revocation must follow
+          // that same order. The locked row is rechecked below before writes.
+          const [prelockClient] = await tx
+            .select({ phone: clients.phone })
+            .from(clients)
+            .where(
+              and(
+                eq(clients.id, id),
+                eq(clients.practiceId, ctx.practiceId),
+                activePracticePredicate(ctx.practiceId),
+                isNull(clients.deletedAt)
+              )
+            )
+            .limit(1);
+          if (!prelockClient) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Client not found",
+            });
+          }
+          withdrawalPhoneSnapshot = normalizeE164(prelockClient.phone);
+          if (withdrawalPhoneSnapshot) {
+            await acquireSmsRecipientLockInTransaction(
+              tx,
+              ctx.practiceId,
+              withdrawalPhoneSnapshot
+            );
+          }
+        }
 
         if (phoneWasProvided) {
           // Drizzle ignores undefined values. Use null so an explicitly cleared
@@ -354,7 +428,21 @@ export const clientsRouter = createRouter({
             .for("update");
 
           if (!existingClient) {
-            throw new TRPCError({ code: "NOT_FOUND", message: "Client not found" });
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Client not found",
+            });
+          }
+
+          if (
+            smsConsent === false &&
+            normalizeE164(existingClient.phone) !== withdrawalPhoneSnapshot
+          ) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "Client phone changed while withdrawing SMS consent. Refresh and try again.",
+            });
           }
 
           const nextPhone = phoneWasProvided ? phone : existingClient.phone;
@@ -364,10 +452,31 @@ export const clientsRouter = createRouter({
           );
 
           if (smsConsent === true) {
-            if (!normalizeE164(nextPhone)) {
+            const normalizedNextPhone = normalizeE164(nextPhone);
+            if (!normalizedNextPhone) {
               throw new TRPCError({
                 code: "BAD_REQUEST",
-                message: "A valid mobile phone number is required for SMS consent",
+                message:
+                  "A valid mobile phone number is required for SMS consent",
+              });
+            }
+
+            const [manualSuppression] = await tx
+              .select({ id: smsSuppressions.id })
+              .from(smsSuppressions)
+              .where(
+                and(
+                  eq(smsSuppressions.practiceId, ctx.practiceId),
+                  eq(smsSuppressions.phone, normalizedNextPhone),
+                  eq(smsSuppressions.reason, "manual")
+                )
+              )
+              .limit(1);
+            if (manualSuppression) {
+              throw new TRPCError({
+                code: "PRECONDITION_FAILED",
+                message:
+                  "This number was manually placed on the do-not-text list. A staff member must review it before any future opt-in.",
               });
             }
 
@@ -378,6 +487,16 @@ export const clientsRouter = createRouter({
             data.smsConsentSource = SMS_CONSENT_DISCLOSURE.source;
             data.smsConsentDisclosure = SMS_CONSENT_DISCLOSURE.snapshot;
           } else if (phoneChanged || smsConsent === false) {
+            if (smsConsent === false) {
+              if (withdrawalPhoneSnapshot) {
+                await revokeSmsConsentAfterRecipientLockInTransaction(tx, {
+                  practiceId: ctx.practiceId,
+                  phone: withdrawalPhoneSnapshot,
+                  reason: "manual",
+                  detail: `Staff revoked SMS consent from client ${id}.`,
+                });
+              }
+            }
             // Consent belongs to one destination. Changing that destination (or
             // explicitly withdrawing consent) invalidates all prior evidence.
             data.smsConsent = false;
@@ -400,9 +519,105 @@ export const clientsRouter = createRouter({
           )
           .returning();
         if (!client) {
-          throw new TRPCError({ code: "NOT_FOUND", message: "Client not found" });
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Client not found",
+          });
         }
         return client;
+      });
+    }),
+
+  /** Practice-wide do-not-text action for every active client sharing a phone. */
+  revokeSms: clientManagerProcedure
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        expectedPhone: normalizedClientPhoneInput,
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      return ctx.db.transaction(async (tx) => {
+        const [prelockClient] = await tx
+          .select({ phone: clients.phone })
+          .from(clients)
+          .where(
+            and(
+              eq(clients.id, input.id),
+              eq(clients.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(clients.deletedAt)
+            )
+          )
+          .limit(1);
+        if (!prelockClient) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Client not found",
+          });
+        }
+        const prelockPhone = normalizeE164(prelockClient.phone);
+        if (!prelockPhone) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Client does not have a valid SMS phone number on file",
+          });
+        }
+        if (prelockPhone !== input.expectedPhone) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "The saved client phone no longer matches this page. Refresh before revoking SMS.",
+          });
+        }
+
+        try {
+          await acquireSmsRecipientLockInTransaction(
+            tx,
+            ctx.practiceId,
+            prelockPhone
+          );
+          const [lockedClient] = await tx
+            .select({ phone: clients.phone })
+            .from(clients)
+            .where(
+              and(
+                eq(clients.id, input.id),
+                eq(clients.practiceId, ctx.practiceId),
+                activePracticePredicate(ctx.practiceId),
+                isNull(clients.deletedAt)
+              )
+            )
+            .limit(1)
+            .for("update");
+          if (!lockedClient) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Client not found",
+            });
+          }
+          if (normalizeE164(lockedClient.phone) !== prelockPhone) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "Client phone changed while revoking SMS. Refresh and try again.",
+            });
+          }
+          return await revokeSmsConsentAfterRecipientLockInTransaction(tx, {
+            practiceId: ctx.practiceId,
+            phone: prelockPhone,
+            reason: "manual",
+            detail: `Staff revoked SMS consent from client ${input.id}.`,
+          });
+        } catch (error) {
+          if (error instanceof TRPCError) throw error;
+          console.error("Manual SMS revocation failed", error);
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message:
+              "SMS consent could not be revoked safely. No message was sent.",
+          });
+        }
       });
     }),
 
@@ -451,7 +666,10 @@ export const clientsRouter = createRouter({
           .limit(1);
 
         if (!existingClient) {
-          throw new TRPCError({ code: "NOT_FOUND", message: "Client not found" });
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Client not found",
+          });
         }
 
         const [activePatient] = await tx
@@ -553,7 +771,10 @@ export const clientsRouter = createRouter({
           )
           .returning({ id: clients.id });
         if (!client) {
-          throw new TRPCError({ code: "NOT_FOUND", message: "Client not found" });
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Client not found",
+          });
         }
       });
       return { success: true };

--- a/apps/web/server/routers/communications.ts
+++ b/apps/web/server/routers/communications.ts
@@ -98,7 +98,9 @@ function renderComposedEmail(opts: {
 </html>`;
 }
 
-function validReplyToEmail(value: string | null | undefined): string | undefined {
+function validReplyToEmail(
+  value: string | null | undefined
+): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
   return z.string().email().safeParse(trimmed).success ? trimmed : undefined;
@@ -590,8 +592,7 @@ export const communicationsRouter = createRouter({
           });
         }
 
-        const assignedTo =
-          input.action === "assign_to_me" ? ctx.user.id : null;
+        const assignedTo = input.action === "assign_to_me" ? ctx.user.id : null;
         const updated = await tx
           .update(communications)
           .set({ assignedTo })
@@ -842,11 +843,12 @@ export const communicationsRouter = createRouter({
         if (!smsRecipient) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: "Client phone number must be a valid E.164 or US/CA number",
+            message:
+              "Client phone number must be a valid E.164 or US/CA number",
           });
         }
 
-        const [smsSender] = await ctx.db
+        const smsSenders = await ctx.db
           .select({ locationId: locationMessaging.locationId })
           .from(locationMessaging)
           .innerJoin(
@@ -870,7 +872,9 @@ export const communicationsRouter = createRouter({
               hasNonBlankMessagingSender()
             )
           )
-          .limit(1);
+          .limit(2);
+
+        const smsSender = smsSenders.length === 1 ? smsSenders[0] : null;
 
         if (!smsSender) {
           throw new TRPCError({
@@ -887,7 +891,11 @@ export const communicationsRouter = createRouter({
         input.direction === "outbound" && input.channel === "email"
           ? normalizeEmailSuppressionAddress(client.email)
           : null;
-      if (input.direction === "outbound" && input.channel === "email" && !clientEmail) {
+      if (
+        input.direction === "outbound" &&
+        input.channel === "email" &&
+        !clientEmail
+      ) {
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: "Client does not have an email address on file",
@@ -919,12 +927,12 @@ export const communicationsRouter = createRouter({
           readAt: input.status === "read" ? new Date() : undefined,
           status: isDeliverableOutbound
             ? "pending"
-            : input.status ??
+            : (input.status ??
               (input.direction === "outbound"
                 ? input.channel === "portal"
                   ? "delivered"
                   : "sent"
-                : "pending"),
+                : "pending")),
         })
         .returning();
 
@@ -951,6 +959,7 @@ export const communicationsRouter = createRouter({
             body: content,
             practiceId: ctx.practiceId,
             locationId: smsSenderLocationId,
+            clientId: input.clientId,
           });
           providerMessageId = deliveryResult.sid;
         } else {

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -46,6 +46,10 @@ import {
   releaseMessagingProfileAttempt,
   reserveMessagingProfileAttempt,
 } from "@/lib/messaging/provisioning-attempt-gate";
+import {
+  hostedMessagingLaunchBlockMessage,
+  hostedMessagingLaunchDecision,
+} from "@/lib/messaging/launch-gate";
 
 const adminOnly = protectedProcedure.use(requireRole("admin"));
 const MESSAGING_NUMBER_ORDERED_DETAIL =
@@ -70,7 +74,10 @@ const providerPriceInput = z
 const selectedQuoteInput = z.object({
   upfrontCost: providerPriceInput,
   monthlyCost: providerPriceInput,
-  currency: z.string().trim().regex(/^[A-Z]{3}$/),
+  currency: z
+    .string()
+    .trim()
+    .regex(/^[A-Z]{3}$/),
 });
 
 const messagingPhoneInput = z
@@ -270,6 +277,31 @@ function assertProvisioningPracticeAllowed(practiceId: string): void {
         "Texting number setup is available only to approved pilot clinics. Contact OpenVPM support.",
     });
   }
+}
+
+function assertHostedSendingAllowed(practiceId: string, locationId: string) {
+  if (!billingEnforced()) return;
+  const decision = hostedMessagingLaunchDecision({ practiceId, locationId });
+  if (!decision.allowed) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: hostedMessagingLaunchBlockMessage(decision.reason),
+    });
+  }
+}
+
+function hostedLaunchEligibleLocationIds(
+  practiceId: string,
+  locationIds: string[]
+): ReadonlySet<string> {
+  if (!billingEnforced()) return new Set(locationIds);
+  const eligible = locationIds.filter(
+    (locationId) =>
+      hostedMessagingLaunchDecision({ practiceId, locationId }).allowed
+  );
+  // A hosted pilot is intentionally one location per practice. An operator
+  // allowlisting multiple clinic locations is ambiguous and fails closed.
+  return eligible.length === 1 ? new Set(eligible) : new Set();
 }
 
 function provisioningOperationReference(
@@ -597,14 +629,30 @@ export const messagingRouter = createRouter({
             messagingProfileId: l.messagingProfileId,
             registrationStatus: l.registrationStatus ?? "not_started",
             enabled: l.enabled ?? false,
+            provider: l.provider,
+          }
+        : null,
+    }));
+    const launchEligibleLocationIds = hostedLaunchEligibleLocationIds(
+      ctx.practiceId,
+      locs.map((location) => location.locationId)
+    );
+    const locationsWithLaunchState = locationsForSummary.map((location) => ({
+      ...location,
+      messaging: location.messaging
+        ? {
+            ...location.messaging,
+            launchEligible:
+              launchEligibleLocationIds.has(location.locationId) &&
+              (!billingEnforced() || location.messaging.provider === "telnyx"),
           }
         : null,
     }));
 
     return {
       canManage: ctx.user.role === "admin",
-      locations: locationsForSummary,
-      summary: summarizeInboxSmsStatus(locationsForSummary),
+      locations: locationsWithLaunchState,
+      summary: summarizeInboxSmsStatus(locationsWithLaunchState),
     };
   }),
 
@@ -657,7 +705,12 @@ export const messagingRouter = createRouter({
     if (!practice) {
       throw practiceNotFound();
     }
-    const includedSms = getPlan(practice.tier ?? "free")?.includedSmsPerMonth ?? null;
+    const includedSms =
+      getPlan(practice.tier ?? "free")?.includedSmsPerMonth ?? null;
+    const launchEligibleLocationIds = hostedLaunchEligibleLocationIds(
+      ctx.practiceId,
+      locs.map((location) => location.locationId)
+    );
 
     const [consentRow] = await ctx.db
       .select({ n: sql<number>`count(*)::int` })
@@ -695,6 +748,9 @@ export const messagingRouter = createRouter({
               registrationStatus: l.registrationStatus,
               registrationDetail: l.registrationDetail,
               enabled: l.enabled,
+              launchEligible:
+                launchEligibleLocationIds.has(l.locationId) &&
+                (!billingEnforced() || l.provider === "telnyx"),
             }
           : null,
       })),
@@ -702,6 +758,12 @@ export const messagingRouter = createRouter({
       consent: {
         optedIn: consentRow?.n ?? 0,
         suppressed: suppressedRow?.n ?? 0,
+      },
+      launch: {
+        hosted: billingEnforced(),
+        pilotEnabled:
+          !billingEnforced() || launchEligibleLocationIds.size === 1,
+        testSendAllowed: !billingEnforced(),
       },
     };
   }),
@@ -714,6 +776,8 @@ export const messagingRouter = createRouter({
     await assertActivePractice(ctx);
     const rows = await ctx.db
       .select({
+        locationId: locationMessaging.locationId,
+        provider: locationMessaging.provider,
         registrationStatus: locationMessaging.registrationStatus,
         enabled: locationMessaging.enabled,
         senderE164: locationMessaging.senderE164,
@@ -726,12 +790,20 @@ export const messagingRouter = createRouter({
           isNull(locationMessaging.deletedAt)
         )
       );
+    const launchEligibleLocationIds = hostedLaunchEligibleLocationIds(
+      ctx.practiceId,
+      rows.map((row) => row.locationId)
+    );
     return {
       hasAnyNumber: rows.some(
         (r) => !!r.senderE164 && r.registrationStatus !== "failed"
       ),
       hasActiveNumber: rows.some(
-        (r) => r.registrationStatus === "active" && r.enabled
+        (r) =>
+          r.registrationStatus === "active" &&
+          r.enabled &&
+          launchEligibleLocationIds.has(r.locationId) &&
+          (!billingEnforced() || r.provider === "telnyx")
       ),
     };
   }),
@@ -747,7 +819,12 @@ export const messagingRouter = createRouter({
             `Area code must be ${MESSAGING_AREA_CODE_LENGTH} digits`
           )
           .optional(),
-        limit: z.number().int().min(1).max(MESSAGING_SEARCH_LIMIT_MAX).optional(),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(MESSAGING_SEARCH_LIMIT_MAX)
+          .optional(),
       })
     )
     .query(async ({ ctx, input }) => {
@@ -778,7 +855,10 @@ export const messagingRouter = createRouter({
         )
         .limit(1);
       if (!loc) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Location not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Location not found",
+        });
       }
       return {
         eligible: false,
@@ -909,11 +989,7 @@ export const messagingRouter = createRouter({
             )
             .limit(1);
 
-          if (
-            input.action === "start" &&
-            !existing &&
-            !preparedThisRequest
-          ) {
+          if (input.action === "start" && !existing && !preparedThisRequest) {
             throw provisioningConflict(
               "OpenVPM could not reserve a durable texting setup attempt. No provider profile or number was created; refresh and try again."
             );
@@ -947,7 +1023,8 @@ export const messagingRouter = createRouter({
             );
             if (
               existing.provider !== "telnyx" ||
-              (existing.numberSource && existing.numberSource !== "purchased") ||
+              (existing.numberSource &&
+                existing.numberSource !== "purchased") ||
               (existing.senderE164 && existing.senderE164 !== e164)
             ) {
               throw provisioningConflict(
@@ -1002,9 +1079,8 @@ export const messagingRouter = createRouter({
           profileId = recoveredProfile?.id ?? profileId;
           failureRecordAllowed ||= Boolean(recoveredProfile);
 
-          const orders = await findNumberOrdersByCustomerReference(
-            customerReference
-          );
+          const orders =
+            await findNumberOrdersByCustomerReference(customerReference);
           if (orders.length > 1) {
             throw provisioningConflict(
               "OpenVPM found duplicate provider orders for this location. No additional purchase was attempted; contact support to reconcile them."
@@ -1084,7 +1160,10 @@ export const messagingRouter = createRouter({
               "The provider reports this number in a failed or released state. No new purchase was made; search again or contact support."
             );
           }
-          if (ownedNumber && ownedNumber.messagingProfileId !== activeProfileId) {
+          if (
+            ownedNumber &&
+            ownedNumber.messagingProfileId !== activeProfileId
+          ) {
             throw provisioningConflict(
               "This number is already owned under a different provider setup. No new purchase was made; contact support before reassigning it."
             );
@@ -1164,8 +1243,7 @@ export const messagingRouter = createRouter({
           preparedThisRequest &&
           e164 &&
           !profileMutationAttempted &&
-          (e instanceof TelnyxNotConfiguredError ||
-            conclusiveEmptyProfileState)
+          (e instanceof TelnyxNotConfiguredError || conclusiveEmptyProfileState)
         ) {
           try {
             const released = await releaseMessagingProfileAttempt({
@@ -1213,17 +1291,17 @@ export const messagingRouter = createRouter({
                 .limit(1);
               const newerAttemptCompleted = Boolean(
                 current?.provider === "telnyx" &&
-                  current.messagingProfileId &&
-                  current.senderE164 === e164 &&
-                  current.numberSource === "purchased" &&
-                  current.registrationStatus !== "failed"
+                current.messagingProfileId &&
+                current.senderE164 === e164 &&
+                current.numberSource === "purchased" &&
+                current.registrationStatus !== "failed"
               );
               const differentSetupExists = Boolean(
                 current &&
-                  (current.provider !== "telnyx" ||
-                    (current.senderE164 && current.senderE164 !== e164) ||
-                    (current.numberSource &&
-                      current.numberSource !== "purchased"))
+                (current.provider !== "telnyx" ||
+                  (current.senderE164 && current.senderE164 !== e164) ||
+                  (current.numberSource &&
+                    current.numberSource !== "purchased"))
               );
               if (newerAttemptCompleted || differentSetupExists) return;
 
@@ -1301,12 +1379,24 @@ export const messagingRouter = createRouter({
         )
         .limit(1);
       if (!loc) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Location not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Location not found",
+        });
       }
 
       if (input.enabled) {
+        assertHostedSendingAllowed(ctx.practiceId, input.locationId);
+        if (billingEnforced()) {
+          await ctx.db.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${`hosted-sms:${ctx.practiceId}`}, 0))`
+          );
+        }
         const [readySender] = await ctx.db
-          .select({ locationId: locationMessaging.locationId })
+          .select({
+            locationId: locationMessaging.locationId,
+            provider: locationMessaging.provider,
+          })
           .from(locationMessaging)
           .where(
             and(
@@ -1327,6 +1417,40 @@ export const messagingRouter = createRouter({
               "Carrier registration must be active before enabling SMS sending.",
           });
         }
+        if (billingEnforced() && readySender.provider !== "telnyx") {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Hosted texting is available only through the approved Telnyx pilot.",
+          });
+        }
+
+        const enabledSenders = await ctx.db
+          .select({ locationId: locationMessaging.locationId })
+          .from(locationMessaging)
+          .where(
+            and(
+              eq(locationMessaging.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(locationMessaging.deletedAt),
+              eq(locationMessaging.enabled, true),
+              eq(locationMessaging.registrationStatus, "active"),
+              hasNonBlankMessagingSender()
+            )
+          )
+          .limit(2);
+        if (
+          billingEnforced() &&
+          enabledSenders.some(
+            (sender) => sender.locationId !== input.locationId
+          )
+        ) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "The hosted texting pilot supports one enabled location per practice.",
+          });
+        }
       }
 
       const updateConditions = [
@@ -1340,6 +1464,9 @@ export const messagingRouter = createRouter({
           eq(locationMessaging.registrationStatus, "active"),
           hasNonBlankMessagingSender()
         );
+        if (billingEnforced()) {
+          updateConditions.push(eq(locationMessaging.provider, "telnyx"));
+        }
       }
 
       const [updated] = await ctx.db
@@ -1351,7 +1478,8 @@ export const messagingRouter = createRouter({
         if (input.enabled) {
           throw new TRPCError({
             code: "CONFLICT",
-            message: "Messaging sender changed while enabling. Refresh and try again.",
+            message:
+              "Messaging sender changed while enabling. Refresh and try again.",
           });
         }
         throw new TRPCError({
@@ -1366,6 +1494,13 @@ export const messagingRouter = createRouter({
   testSend: adminOnly
     .input(z.object({ locationId: z.string().uuid(), to: messagingPhoneInput }))
     .mutation(async ({ ctx, input }) => {
+      if (billingEnforced()) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            "Hosted test sends are disabled during the controlled texting pilot.",
+        });
+      }
       await assertActivePractice(ctx);
       const [loc] = await ctx.db
         .select({ id: locations.id })
@@ -1380,7 +1515,10 @@ export const messagingRouter = createRouter({
         )
         .limit(1);
       if (!loc) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Location not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Location not found",
+        });
       }
 
       const [sender] = await ctx.db

--- a/apps/web/server/routers/notifications.ts
+++ b/apps/web/server/routers/notifications.ts
@@ -1,14 +1,5 @@
 import { z } from "zod";
-import {
-  eq,
-  and,
-  isNull,
-  gte,
-  lte,
-  lt,
-  inArray,
-  sql,
-} from "drizzle-orm";
+import { eq, and, isNull, gte, lte, lt, inArray, sql } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
 import type { Database } from "@openpims/db/client";
@@ -24,6 +15,7 @@ import {
   practices,
   locationMessaging,
   locations,
+  rooms,
   emailSuppressions,
 } from "@openpims/db";
 import {
@@ -35,10 +27,7 @@ import {
   sendAppointmentReminderSms,
   sendVaccinationReminderSms,
 } from "@/lib/sms";
-import {
-  isQuietHours,
-  pickReminderChannel,
-} from "@/lib/messaging/reminders";
+import { isQuietHours, pickReminderChannel } from "@/lib/messaging/reminders";
 import { formatCurrency } from "@/lib/locale/format";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
 import { formatClinicalDate } from "@/lib/records/clinical-dates";
@@ -211,11 +200,14 @@ async function practiceDateInput(ctx: {
   return formatDateInputForTimeZone(new Date(), practice.timezone);
 }
 
-async function activeReminderSmsSender(ctx: {
-  db: NotificationsDb;
-  practiceId: string;
-}): Promise<{ locationId: string } | null> {
-  const [smsSender] = await ctx.db
+async function activeReminderSmsSender(
+  ctx: {
+    db: NotificationsDb;
+    practiceId: string;
+  },
+  locationId?: string
+): Promise<{ locationId: string } | null> {
+  const smsSenders = await ctx.db
     .select({ locationId: locationMessaging.locationId })
     .from(locationMessaging)
     .innerJoin(
@@ -237,11 +229,12 @@ async function activeReminderSmsSender(ctx: {
         isNull(locations.deletedAt),
         eq(locationMessaging.enabled, true),
         eq(locationMessaging.registrationStatus, "active"),
+        ...(locationId ? [eq(locationMessaging.locationId, locationId)] : []),
         hasNonBlankMessagingSender()
       )
     )
-    .limit(1);
-  return smsSender ?? null;
+    .limit(2);
+  return smsSenders.length === 1 ? smsSenders[0]! : null;
 }
 
 export const notificationsRouter = createRouter({
@@ -267,6 +260,7 @@ export const notificationsRouter = createRouter({
           practiceName: practices.name,
           practicePhone: practices.phone,
           practiceTimezone: practices.timezone,
+          locationId: rooms.locationId,
         })
         .from(appointments)
         .leftJoin(
@@ -304,6 +298,14 @@ export const notificationsRouter = createRouter({
             isNull(practices.deletedAt)
           )
         )
+        .leftJoin(
+          rooms,
+          and(
+            eq(appointments.roomId, rooms.id),
+            eq(rooms.practiceId, ctx.practiceId),
+            isNull(rooms.deletedAt)
+          )
+        )
         .where(
           and(
             eq(appointments.id, input.appointmentId),
@@ -319,7 +321,10 @@ export const notificationsRouter = createRouter({
         .limit(1);
 
       if (!appt) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Appointment not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Appointment not found",
+        });
       }
       if (appt.status !== "confirmed") {
         throw new TRPCError({
@@ -407,21 +412,31 @@ export const notificationsRouter = createRouter({
       }
 
       if (channel === "sms") {
-        const smsSender = await activeReminderSmsSender(ctx);
+        const smsSender = appt.locationId
+          ? await activeReminderSmsSender(ctx, appt.locationId)
+          : null;
         const result = smsSender
           ? await sendAppointmentReminderSms({
               to: appt.clientPhone!,
               patientName: appt.patientName ?? "Unknown",
-              appointmentDate: formatDate(appt.startTime, appt.practiceTimezone),
-              appointmentTime: formatTime(appt.startTime, appt.practiceTimezone),
+              appointmentDate: formatDate(
+                appt.startTime,
+                appt.practiceTimezone
+              ),
+              appointmentTime: formatTime(
+                appt.startTime,
+                appt.practiceTimezone
+              ),
               practiceName: practiceDisplayName(appt.practiceName),
               practicePhone: appt.practicePhone ?? undefined,
               practiceId: ctx.practiceId,
               locationId: smsSender.locationId,
+              clientId: appt.clientId!,
             })
           : {
               success: false,
-              error: "Set up an active texting number before sending SMS reminders",
+              error:
+                "Set up an active texting number before sending SMS reminders",
             };
         if (result.success) {
           await logReminder("sms", result.sid);
@@ -493,7 +508,10 @@ export const notificationsRouter = createRouter({
         .limit(1);
 
       if (!invoice) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Invoice not found" });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Invoice not found",
+        });
       }
       if (invoice.isEstimate) {
         throw new TRPCError({
@@ -501,13 +519,11 @@ export const notificationsRouter = createRouter({
           message: "Convert the estimate before emailing an invoice.",
         });
       }
-      if (
-        invoice.status !== "sent" &&
-        invoice.status !== "overdue"
-      ) {
+      if (invoice.status !== "sent" && invoice.status !== "overdue") {
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
-          message: "Only sent or overdue invoices can be emailed. Use the receipt for paid invoices.",
+          message:
+            "Only sent or overdue invoices can be emailed. Use the receipt for paid invoices.",
         });
       }
       await assertVisitInvoiceReadyForFinancialAction(
@@ -516,7 +532,10 @@ export const notificationsRouter = createRouter({
       );
       const clientEmail = normalizeEmailSuppressionAddress(invoice.clientEmail);
       if (!clientEmail) {
-        throw new TRPCError({ code: "BAD_REQUEST", message: "Client does not have an email address on file" });
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Client does not have an email address on file",
+        });
       }
       if (invoice.emailSuppressionReason) {
         throw new TRPCError({
@@ -565,7 +584,11 @@ export const notificationsRouter = createRouter({
         clientName: `${invoice.clientFirstName} ${invoice.clientLastName}`,
         invoiceTotal: totalFormatted,
         dueDate: invoice.dueDate
-          ? formatClinicalDate(invoice.dueDate, practice.timezone, invoice.dueDate)
+          ? formatClinicalDate(
+              invoice.dueDate,
+              practice.timezone,
+              invoice.dueDate
+            )
           : undefined,
         practiceName: practice.name,
         practicePhone: practice.phone ?? undefined,
@@ -687,6 +710,7 @@ export const notificationsRouter = createRouter({
           practiceName: practices.name,
           practicePhone: practices.phone,
           practiceTimezone: practices.timezone,
+          locationId: rooms.locationId,
         })
         .from(appointments)
         .leftJoin(
@@ -724,6 +748,14 @@ export const notificationsRouter = createRouter({
             isNull(practices.deletedAt)
           )
         )
+        .leftJoin(
+          rooms,
+          and(
+            eq(appointments.roomId, rooms.id),
+            eq(rooms.practiceId, ctx.practiceId),
+            isNull(rooms.deletedAt)
+          )
+        )
         .where(
           and(
             inArray(appointments.id, appointmentIds),
@@ -740,10 +772,18 @@ export const notificationsRouter = createRouter({
 
       let sent = 0;
       let failed = appointmentIds.length - appts.length;
-      let smsSenderPromise: Promise<{ locationId: string } | null> | null = null;
-      const getSmsSender = () => {
-        smsSenderPromise ??= activeReminderSmsSender(ctx);
-        return smsSenderPromise;
+      const smsSenderPromises = new Map<
+        string,
+        Promise<{ locationId: string } | null>
+      >();
+      const getSmsSender = (locationId: string | null) => {
+        if (!locationId) return Promise.resolve(null);
+        let promise = smsSenderPromises.get(locationId);
+        if (!promise) {
+          promise = activeReminderSmsSender(ctx, locationId);
+          smsSenderPromises.set(locationId, promise);
+        }
+        return promise;
       };
 
       for (const appt of appts) {
@@ -772,7 +812,9 @@ export const notificationsRouter = createRouter({
           });
 
         const sendEmail = async (): Promise<boolean> => {
-          const clientEmail = normalizeEmailSuppressionAddress(appt.clientEmail);
+          const clientEmail = normalizeEmailSuppressionAddress(
+            appt.clientEmail
+          );
           if (!clientEmail) return false;
           if (appt.emailSuppressionReason) return false;
           try {
@@ -802,7 +844,7 @@ export const notificationsRouter = createRouter({
         });
 
         if (channel === "sms") {
-          const smsSender = await getSmsSender();
+          const smsSender = await getSmsSender(appt.locationId);
           let result: { success: boolean; sid?: string; error?: string };
           if (smsSender) {
             try {
@@ -815,6 +857,7 @@ export const notificationsRouter = createRouter({
                 practicePhone: appt.practicePhone ?? undefined,
                 practiceId: ctx.practiceId,
                 locationId: smsSender.locationId,
+                clientId: appt.clientId!,
               });
             } catch (error) {
               result = {
@@ -860,7 +903,7 @@ export const notificationsRouter = createRouter({
       }
 
       return { sent, failed };
-  }),
+    }),
 
   getOverdueVaccinations: protectedProcedure.query(async ({ ctx }) => {
     await assertActivePractice(ctx);
@@ -912,20 +955,26 @@ export const notificationsRouter = createRouter({
       )
       .orderBy(patients.name);
 
-    const grouped = new Map<string, {
-      patientId: string;
-      patientName: string;
-      clientId: string;
-      clientFirstName: string;
-      clientLastName: string;
-      clientEmail: string | null;
-      overdueVaccines: { vaccineName: string; nextDueDate: string | null }[];
-    }>();
+    const grouped = new Map<
+      string,
+      {
+        patientId: string;
+        patientName: string;
+        clientId: string;
+        clientFirstName: string;
+        clientLastName: string;
+        clientEmail: string | null;
+        overdueVaccines: { vaccineName: string; nextDueDate: string | null }[];
+      }
+    >();
 
     for (const row of rows) {
       const existing = grouped.get(row.patientId);
       if (existing) {
-        existing.overdueVaccines.push({ vaccineName: row.vaccineName, nextDueDate: row.nextDueDate });
+        existing.overdueVaccines.push({
+          vaccineName: row.vaccineName,
+          nextDueDate: row.nextDueDate,
+        });
       } else {
         grouped.set(row.patientId, {
           patientId: row.patientId,
@@ -934,7 +983,9 @@ export const notificationsRouter = createRouter({
           clientFirstName: row.clientFirstName,
           clientLastName: row.clientLastName,
           clientEmail: row.clientEmail,
-          overdueVaccines: [{ vaccineName: row.vaccineName, nextDueDate: row.nextDueDate }],
+          overdueVaccines: [
+            { vaccineName: row.vaccineName, nextDueDate: row.nextDueDate },
+          ],
         });
       }
     }

--- a/apps/web/server/vaccination-recalls.ts
+++ b/apps/web/server/vaccination-recalls.ts
@@ -88,12 +88,7 @@ async function practiceNotificationSettings(ctx: {
       settings: practices.settings,
     })
     .from(practices)
-    .where(
-      and(
-        eq(practices.id, ctx.practiceId),
-        isNull(practices.deletedAt)
-      )
-    )
+    .where(and(eq(practices.id, ctx.practiceId), isNull(practices.deletedAt)))
     .limit(1);
   if (!practice) return null;
   return {
@@ -348,7 +343,8 @@ export async function getVaccinationRecallPreview(ctx: {
     total: result.recipients.length,
     eligible: result.recipients.filter((item) => item.status === "eligible")
       .length,
-    blocked: result.recipients.filter((item) => item.status === "blocked").length,
+    blocked: result.recipients.filter((item) => item.status === "blocked")
+      .length,
     alreadySent: result.recipients.filter(
       (item) => item.status === "already_sent"
     ).length,
@@ -370,7 +366,8 @@ export async function sendVaccinationRecallReminders(
   let sent = 0;
   let failed = 0;
   const blocked =
-    targets.length - recipients.length +
+    targets.length -
+    recipients.length +
     recipients.filter((recipient) => recipient.status === "blocked").length;
   let deduped = recipients.filter(
     (recipient) => recipient.status === "already_sent"
@@ -402,7 +399,9 @@ export async function sendVaccinationRecallReminders(
     }
 
     const sendEmail = async () => {
-      const clientEmail = normalizeEmailSuppressionAddress(recipient.clientEmail);
+      const clientEmail = normalizeEmailSuppressionAddress(
+        recipient.clientEmail
+      );
       if (!clientEmail || recipient.emailSuppressionReason || !dueDate) {
         return { success: false as const };
       }
@@ -434,6 +433,7 @@ export async function sendVaccinationRecallReminders(
           practicePhone: practice.phone ?? undefined,
           practiceId: ctx.practiceId,
           locationId: smsSender.locationId,
+          clientId: recipient.clientId,
         });
         delivered = smsResult.success;
         providerMessageId = smsResult.sid;

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -88,6 +88,9 @@ TELNYX_PUBLIC_KEY=...
 MESSAGING_REGISTRATION_ENCRYPTION_KEY=... # openssl rand -base64 32
 MESSAGING_PROVISIONING_ENABLED=false
 MESSAGING_PROVISIONING_PRACTICE_IDS= # comma-separated approved pilot practice UUIDs
+MESSAGING_SENDING_ENABLED=false
+MESSAGING_SENDING_PRACTICE_IDS= # comma-separated approved pilot practice UUIDs
+MESSAGING_SENDING_LOCATION_IDS= # comma-separated approved pilot location UUIDs
 AI_MODEL=claude-sonnet-4-6
 ANTHROPIC_API_KEY=...
 OPS_ALERT_WEBHOOK_URL=...
@@ -114,8 +117,21 @@ number orders additionally require the clinic's practice UUID in
 `MESSAGING_PROVISIONING_PRACTICE_IDS`, so a controlled pilot does not expose
 purchases to every clinic admin. New OpenVPM-created messaging profiles enforce
 a `$10.00` daily Telnyx spend limit and smart encoding; review that cap before
-expanding beyond a design-partner pilot. For a
-Twilio fallback deployment, set `MESSAGING_PROVIDER=twilio` and provide
+expanding beyond a design-partner pilot.
+
+Outbound sending has a separate, default-off launch interlock. Keep
+`MESSAGING_SENDING_ENABLED=false` and both sending allowlists empty until one
+Telnyx location has carrier-active registration, its database sender is enabled,
+and the clinic has passed pilot review. A hosted send requires the practice UUID
+in `MESSAGING_SENDING_PRACTICE_IDS` and the exact location UUID in
+`MESSAGING_SENDING_LOCATION_IDS`; the hosted pilot permits only one enabled
+location per practice. Missing, ambiguous, Twilio, inactive, or partially
+configured state makes no provider call. These three variables are hosted-only
+and do not gate intentional self-host messaging configuration. Arbitrary hosted
+test destinations remain disabled; validate through a current, consented client
+workflow after approval.
+
+For a Twilio fallback deployment, set `MESSAGING_PROVIDER=twilio` and provide
 `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER` instead of
 the Telnyx send envs.
 


### PR DESCRIPTION
## Summary
- make hosted SMS sending default-off behind separate global, practice, and location operator allowlists
- require explicit clinic, location, client, active Telnyx sender, current consent evidence, matching phone, and no suppression immediately before dispatch
- add one-location pilot enforcement, deterministic sender selection, and disable arbitrary hosted test sends
- add conservative STOP/START/HELP classification plus transactional practice-wide staff revocation
- serialize sends and revocations under one advisory-first lock order and protect against stale phone edits
- keep clinic-facing setup and status copy truthful while sending remains off

## Verification
- full suite: 300 files / 2,919 tests
- workspace type-check
- 42-page production build
- independent post-rebase safety audit: SHIP
- independent focused verification: 317 tests / 15 files
- diff, secret, PII, binary, and conflict-marker scans
- no provider calls, SMS, spend, activation, database mutation, or external contact

## Launch boundary
This is a default-off safety interlock, not authorization to enable external SMS. Keep `MESSAGING_SENDING_ENABLED=false` and both sending allowlists empty until the consent ledger, message formatter, idempotency/outcome handling, and supervised pilot approval are complete.