### PR TITLE
Add append-only SMS consent evidence

### DIFF
--- a/apps/web/app/(dashboard)/clients/[id]/edit/page.tsx
+++ b/apps/web/app/(dashboard)/clients/[id]/edit/page.tsx
@@ -111,7 +111,7 @@ function EditClientForm() {
     refetch,
   } = trpc.clients.getById.useQuery(
     { id: params.id },
-    { enabled: !!params.id }
+    { enabled: !!params.id },
   );
 
   useEffect(() => {
@@ -144,7 +144,7 @@ function EditClientForm() {
   const revokeSms = trpc.clients.revokeSms.useMutation({
     onSuccess: async ({ clientsRevoked }) => {
       toast.success(
-        `Texting revoked for this number${clientsRevoked > 1 ? ` across ${clientsRevoked} matching client records` : ""}.`
+        `Texting revoked for this number${clientsRevoked > 1 ? ` across ${clientsRevoked} matching client records` : ""}.`,
       );
       setSmsConsent(false);
       setSmsConsentTouched(false);
@@ -182,7 +182,7 @@ function EditClientForm() {
     }
     if (smsConsentTouched && smsConsent && !smsPhoneValid) {
       setError(
-        "Enter a valid mobile phone number before recording SMS consent."
+        "Enter a valid mobile phone number before recording SMS consent.",
       );
       return;
     }
@@ -213,7 +213,7 @@ function EditClientForm() {
       setSmsConsent(
         phoneNumbersMatchForConsent(client.phone, value)
           ? (client.smsConsent ?? false)
-          : false
+          : false,
       );
       setSmsConsentTouched(false);
     }
@@ -376,7 +376,7 @@ function EditClientForm() {
               setError(null);
               if (
                 window.confirm(
-                  "Stop all SMS to this phone number across the practice?"
+                  "Stop all SMS to this phone number across the practice?",
                 )
               ) {
                 revokeSms.mutate({
@@ -393,6 +393,47 @@ function EditClientForm() {
             )}
             Do not text this number
           </Button>
+        </div>
+
+        <div className="rounded-md border border-border p-3">
+          <p className="text-sm font-medium">SMS consent history</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Append-only evidence for this client. Destination-wide events may
+            affect other client records that share the same phone number.
+          </p>
+          {client.smsConsentHistory.length === 0 ? (
+            <p className="mt-3 text-xs text-muted-foreground">
+              No consent events have been recorded yet.
+            </p>
+          ) : (
+            <ol className="mt-3 space-y-2">
+              {client.smsConsentHistory.map((event) => (
+                <li
+                  key={event.id}
+                  className="rounded border border-border/70 bg-muted/30 p-2 text-xs"
+                >
+                  <p className="font-medium">
+                    {event.action === "granted"
+                      ? "Consent granted"
+                      : "Consent revoked"}
+                    {` · ${event.destinationE164}`}
+                  </p>
+                  <p className="mt-0.5 text-muted-foreground">
+                    {new Date(event.occurredAt).toLocaleString()} ·{" "}
+                    {event.source}
+                    {event.actorName
+                      ? ` · ${event.actorName}`
+                      : event.provider
+                        ? ` · ${event.provider}`
+                        : " · system"}
+                  </p>
+                  {event.detail ? (
+                    <p className="mt-1 text-muted-foreground">{event.detail}</p>
+                  ) : null}
+                </li>
+              ))}
+            </ol>
+          )}
         </div>
 
         <div>

--- a/apps/web/app/api/webhooks/telnyx/route.test.ts
+++ b/apps/web/app/api/webhooks/telnyx/route.test.ts
@@ -4,19 +4,30 @@ import { fileURLToPath } from "node:url";
 
 const INBOUND_SOURCE = readFileSync(
   fileURLToPath(
-    new URL("../../../../lib/messaging/inbound.ts", import.meta.url)
+    new URL("../../../../lib/messaging/inbound.ts", import.meta.url),
   ),
-  "utf8"
+  "utf8",
 );
 const ROUTE_SOURCE = readFileSync(
   fileURLToPath(new URL("./route.ts", import.meta.url)),
-  "utf8"
+  "utf8",
 );
 
 const mocks = vi.hoisted(() => {
   const selectResults: unknown[][] = [];
   const updateResults: unknown[][] = [];
-  const selectLimit = vi.fn(async () => selectResults.shift() ?? []);
+  const insertResults: unknown[][] = [];
+  const selectLimit = vi.fn(() => {
+    const result = selectResults.shift() ?? [];
+    const terminal = {
+      for: vi.fn(() => terminal),
+      then: (
+        resolve: (value: unknown[]) => unknown,
+        reject?: (error: unknown) => unknown,
+      ) => Promise.resolve(result).then(resolve, reject),
+    };
+    return terminal;
+  });
   const selectWhere = vi.fn((_condition: unknown) => ({ limit: selectLimit }));
   const selectInnerJoin = vi.fn(() => ({
     innerJoin: selectInnerJoin,
@@ -31,7 +42,7 @@ const mocks = vi.hoisted(() => {
   const updateReturning = vi.fn(async () =>
     updateResults.length > 0
       ? updateResults.shift()
-      : [{ id: "00000000-0000-0000-0000-000000000009" }]
+      : [{ id: "00000000-0000-0000-0000-000000000009" }],
   );
   const updateWhere = vi.fn((_condition: unknown) => ({
     returning: updateReturning,
@@ -39,7 +50,14 @@ const mocks = vi.hoisted(() => {
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
 
-  const insertConflict = vi.fn(async (_config?: unknown) => undefined);
+  const insertReturning = vi.fn(async () =>
+    insertResults.length > 0
+      ? insertResults.shift()
+      : [{ id: "00000000-0000-0000-0000-0000000000ee" }],
+  );
+  const insertConflict = vi.fn((_config?: unknown) => ({
+    returning: insertReturning,
+  }));
   const insertValues = vi.fn((_values: unknown) => ({
     onConflictDoNothing: insertConflict,
     onConflictDoUpdate: insertConflict,
@@ -61,10 +79,12 @@ const mocks = vi.hoisted(() => {
     db,
     selectResults,
     updateResults,
+    insertResults,
     selectLimit,
     selectWhere,
     selectInnerJoin,
     insertConflict,
+    insertReturning,
     insertValues,
     deleteWhere,
     updateReturning,
@@ -72,11 +92,11 @@ const mocks = vi.hoisted(() => {
     updateWhere,
     verifyTelnyxSignature: vi.fn(() => true),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn(db)
+      fn(db),
     ),
     withTenant: vi.fn(
       async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
-        fn(db)
+        fn(db),
     ),
   };
 });
@@ -104,7 +124,7 @@ const { MESSAGING_WEBHOOK_BODY_MAX_BYTES } =
 function sqlIncludesColumnParamPair(
   value: unknown,
   columnName: string,
-  paramValue: unknown
+  paramValue: unknown,
 ): boolean {
   if (!value || typeof value !== "object") {
     return false;
@@ -119,7 +139,7 @@ function sqlIncludesColumnParamPair(
     (item) =>
       !!item &&
       typeof item === "object" &&
-      (item as { name?: unknown }).name === columnName
+      (item as { name?: unknown }).name === columnName,
   );
   const hasParam = chunk.queryChunks.some((item) => {
     if (!item || typeof item !== "object") {
@@ -134,7 +154,7 @@ function sqlIncludesColumnParamPair(
   return (
     (hasColumn && hasParam) ||
     chunk.queryChunks.some((item) =>
-      sqlIncludesColumnParamPair(item, columnName, paramValue)
+      sqlIncludesColumnParamPair(item, columnName, paramValue),
     )
   );
 }
@@ -142,7 +162,7 @@ function sqlIncludesColumnParamPair(
 function sqlIncludesColumnName(
   value: unknown,
   columnName: string,
-  seen = new WeakSet<object>()
+  seen = new WeakSet<object>(),
 ): boolean {
   if (!value || typeof value !== "object") {
     return false;
@@ -154,18 +174,18 @@ function sqlIncludesColumnName(
   if (candidate.name === columnName) return true;
   if (Array.isArray(candidate.queryChunks)) {
     return candidate.queryChunks.some((item) =>
-      sqlIncludesColumnName(item, columnName, seen)
+      sqlIncludesColumnName(item, columnName, seen),
     );
   }
   return Object.values(value as Record<string, unknown>).some((item) =>
-    sqlIncludesColumnName(item, columnName, seen)
+    sqlIncludesColumnName(item, columnName, seen),
   );
 }
 
 function sqlIncludesValue(
   value: unknown,
   needle: unknown,
-  seen = new WeakSet<object>()
+  seen = new WeakSet<object>(),
 ): boolean {
   if (Object.is(value, needle)) return true;
   if (!value || typeof value !== "object") {
@@ -183,11 +203,11 @@ function sqlIncludesValue(
   }
   if (Array.isArray(candidate.queryChunks)) {
     return candidate.queryChunks.some((item) =>
-      sqlIncludesValue(item, needle, seen)
+      sqlIncludesValue(item, needle, seen),
     );
   }
   return Object.values(value as Record<string, unknown>).some((item) =>
-    sqlIncludesValue(item, needle, seen)
+    sqlIncludesValue(item, needle, seen),
   );
 }
 
@@ -230,7 +250,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     expect(response.status).toBe(200);
@@ -240,13 +260,13 @@ describe("Telnyx webhook", () => {
         status: "action_required",
         providerCampaignStatus: "REJECTED",
         lastError: "Privacy policy could not be verified",
-      })
+      }),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         registrationStatus: "action_required",
         enabled: false,
-      })
+      }),
     );
     expect(mocks.withTenant).not.toHaveBeenCalled();
   });
@@ -261,7 +281,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body: "{}",
-      })
+      }),
     );
 
     expect(response.status).toBe(413);
@@ -284,7 +304,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body: "x".repeat(MESSAGING_WEBHOOK_BODY_MAX_BYTES + 1),
-      })
+      }),
     );
 
     expect(response.status).toBe(413);
@@ -324,7 +344,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     expect(response.status).toBe(401);
@@ -363,28 +383,28 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({ ok: true });
     expect(mocks.verifyTelnyxSignature).toHaveBeenCalledWith(
       expect.objectContaining({
         publicKeyB64: "test-public-key",
-      })
+      }),
     );
     expect(mocks.withTenant).toHaveBeenCalledWith(
       mocks.db,
       "00000000-0000-0000-0000-0000000000aa",
-      expect.any(Function)
+      expect.any(Function),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith({ status: "delivered" });
     const condition = mocks.updateWhere.mock.calls[0]?.[0];
     expect(sqlIncludesColumnParamPair(condition, "channel", "sms")).toBe(true);
     expect(sqlIncludesColumnParamPair(condition, "direction", "outbound")).toBe(
-      true
+      true,
     );
     expect(sqlIncludesColumnParamPair(condition, "status", "pending")).toBe(
-      true
+      true,
     );
     expect(sqlIncludesColumnParamPair(condition, "status", "sent")).toBe(true);
     expect(sqlIncludesColumnName(condition, "deleted_at")).toBe(true);
@@ -417,19 +437,19 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({ ok: true });
     expect(mocks.withTenant).toHaveBeenCalledWith(
       mocks.db,
       "00000000-0000-0000-0000-0000000000aa",
-      expect.any(Function)
+      expect.any(Function),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith({ status: "delivered" });
     const senderCondition = mocks.selectWhere.mock.calls[0]?.[0];
     expect(sqlIncludesColumnName(senderCondition, "messaging_profile_id")).toBe(
-      true
+      true,
     );
     expect(sqlIncludesValue(senderCondition, "profile-1")).toBe(true);
   });
@@ -461,14 +481,14 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({ ok: true });
     expect(mocks.updateSet).toHaveBeenCalledWith({ status: "sent" });
     const condition = mocks.updateWhere.mock.calls[0]?.[0];
     expect(sqlIncludesColumnParamPair(condition, "status", "pending")).toBe(
-      true
+      true,
     );
     expect(sqlIncludesColumnParamPair(condition, "status", "sent")).toBe(false);
   });
@@ -482,7 +502,7 @@ describe("Telnyx webhook", () => {
           locationId: "00000000-0000-0000-0000-000000000002",
         },
       ],
-      [{ id: "00000000-0000-0000-0000-000000000003" }]
+      [{ id: "00000000-0000-0000-0000-000000000003" }],
     );
     const body = JSON.stringify({
       data: {
@@ -504,7 +524,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -515,7 +535,7 @@ describe("Telnyx webhook", () => {
     expect(mocks.withTenant).toHaveBeenCalledWith(
       mocks.db,
       "00000000-0000-0000-0000-0000000000aa",
-      expect.any(Function)
+      expect.any(Function),
     );
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -526,29 +546,29 @@ describe("Telnyx webhook", () => {
         content: "Running five minutes late",
         providerMessageId: "msg-inbound",
         dedupeKey: "telnyx:inbound:msg-inbound",
-      })
+      }),
     );
     const inserted = mocks.insertValues.mock.calls.find(
       ([value]) =>
         (value as { providerMessageId?: string }).providerMessageId ===
-        "msg-inbound"
+        "msg-inbound",
     )?.[0] as { assignedTo?: unknown };
     expect(inserted.assignedTo).toBeTruthy();
     expect(sqlIncludesColumnName(inserted.assignedTo, "assigned_to")).toBe(
-      true
+      true,
     );
     expect(sqlIncludesColumnName(inserted.assignedTo, "client_id")).toBe(true);
     expect(
       sqlIncludesValue(
         inserted.assignedTo,
-        "00000000-0000-0000-0000-0000000000aa"
-      )
+        "00000000-0000-0000-0000-0000000000aa",
+      ),
     ).toBe(true);
     expect(
       sqlIncludesValue(
         inserted.assignedTo,
-        "00000000-0000-0000-0000-000000000003"
-      )
+        "00000000-0000-0000-0000-000000000003",
+      ),
     ).toBe(true);
     expect(mocks.insertConflict).toHaveBeenCalledWith({
       target: communications.dedupeKey,
@@ -565,7 +585,7 @@ describe("Telnyx webhook", () => {
           locationId: "00000000-0000-0000-0000-000000000002",
         },
       ],
-      [{ id: "00000000-0000-0000-0000-000000000003" }]
+      [{ id: "00000000-0000-0000-0000-000000000003" }],
     );
     const body = JSON.stringify({
       data: {
@@ -588,7 +608,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -598,7 +618,7 @@ describe("Telnyx webhook", () => {
     expect(mocks.withSystem).toHaveBeenCalledTimes(3);
     const profileCondition = mocks.selectWhere.mock.calls[1]?.[0];
     expect(
-      sqlIncludesColumnName(profileCondition, "messaging_profile_id")
+      sqlIncludesColumnName(profileCondition, "messaging_profile_id"),
     ).toBe(true);
     expect(sqlIncludesValue(profileCondition, "profile-1")).toBe(true);
     expect(mocks.insertValues).toHaveBeenCalledWith(
@@ -610,7 +630,7 @@ describe("Telnyx webhook", () => {
         content: "Following up",
         providerMessageId: "msg-profile-inbound",
         dedupeKey: "telnyx:inbound:msg-profile-inbound",
-      })
+      }),
     );
   });
 
@@ -636,7 +656,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({ ok: true });
@@ -658,7 +678,7 @@ describe("Telnyx webhook", () => {
       [
         { id: "00000000-0000-0000-0000-000000000003" },
         { id: "00000000-0000-0000-0000-000000000004" },
-      ]
+      ],
     );
     const body = JSON.stringify({
       data: {
@@ -680,7 +700,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -694,12 +714,12 @@ describe("Telnyx webhook", () => {
         content: "Can you check both pets?",
         providerMessageId: "msg-ambiguous",
         dedupeKey: "telnyx:inbound:msg-ambiguous",
-      })
+      }),
     );
     expect(mocks.insertValues).not.toHaveBeenCalledWith(
       expect.objectContaining({
         clientId: expect.any(String),
-      })
+      }),
     );
   });
 
@@ -713,7 +733,7 @@ describe("Telnyx webhook", () => {
           locationId: "00000000-0000-0000-0000-000000000002",
         },
       ],
-      [{ id: clientId }]
+      [{ id: clientId }],
     );
     const body = JSON.stringify({
       data: {
@@ -735,7 +755,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -745,11 +765,24 @@ describe("Telnyx webhook", () => {
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         practiceId: "00000000-0000-0000-0000-0000000000aa",
+        clientId: null,
+        locationId: "00000000-0000-0000-0000-000000000002",
+        destinationE164: "+15555550199",
+        action: "revoked",
+        source: "inbound_opt_out:v1",
+        actorType: "client",
+        provider: "telnyx",
+        providerMessageId: "msg-stop",
+      }),
+    );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
         locationId: "00000000-0000-0000-0000-000000000002",
         phone: "+15555550199",
         reason: "stop",
         detail: 'Inbound opt-out: "STOP"',
-      })
+      }),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith({
       smsConsent: false,
@@ -768,11 +801,41 @@ describe("Telnyx webhook", () => {
         status: "delivered",
         providerMessageId: "msg-stop",
         dedupeKey: "telnyx:inbound:msg-stop",
-      })
+      }),
     );
     expect(mocks.insertConflict).toHaveBeenCalledWith({
       target: communications.dedupeKey,
     });
+  });
+
+  it("rejects inbound consent messages without a durable provider id", async () => {
+    process.env.TELNYX_PUBLIC_KEY = "test-public-key";
+    const response = await POST(
+      new Request("https://openvpm.test/api/webhooks/telnyx", {
+        method: "POST",
+        headers: {
+          "telnyx-signature-ed25519": "sig",
+          "telnyx-timestamp": "123",
+        },
+        body: JSON.stringify({
+          data: {
+            event_type: "message.received",
+            payload: {
+              from: { phone_number: "+15555550199" },
+              to: [{ phone_number: "+15555550100" }],
+              text: "STOP",
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "missing inbound message id",
+    });
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+    expect(mocks.updateSet).not.toHaveBeenCalled();
   });
 
   it("restores client SMS consent on START only when the sender phone uniquely matches a client", async () => {
@@ -785,7 +848,7 @@ describe("Telnyx webhook", () => {
           locationId: "00000000-0000-0000-0000-000000000002",
         },
       ],
-      [{ id: clientId }]
+      [{ id: clientId }],
     );
     const body = JSON.stringify({
       data: {
@@ -807,13 +870,27 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
       ok: true,
       action: "unsuppressed",
     });
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        clientId,
+        locationId: "00000000-0000-0000-0000-000000000002",
+        destinationE164: "+15555550199",
+        action: "granted",
+        source: SMS_INBOUND_OPT_IN.source,
+        disclosureVersion: SMS_INBOUND_OPT_IN.version,
+        actorType: "client",
+        provider: "telnyx",
+        providerMessageId: "msg-start",
+      }),
+    );
     expect(mocks.deleteWhere).toHaveBeenCalled();
     expect(mocks.updateSet).toHaveBeenCalledWith({
       smsConsent: true,
@@ -834,11 +911,116 @@ describe("Telnyx webhook", () => {
         status: "delivered",
         providerMessageId: "msg-start",
         dedupeKey: "telnyx:inbound:msg-start",
-      })
+      }),
     );
     expect(mocks.insertConflict).toHaveBeenCalledWith({
       target: communications.dedupeKey,
     });
+  });
+
+  it("fails the START transaction when the locked client projection is not updated", async () => {
+    process.env.TELNYX_PUBLIC_KEY = "test-public-key";
+    mocks.selectResults.push(
+      [
+        {
+          practiceId: "00000000-0000-0000-0000-0000000000aa",
+          locationId: "00000000-0000-0000-0000-000000000002",
+        },
+      ],
+      [{ id: "00000000-0000-0000-0000-000000000003" }],
+      [],
+    );
+    mocks.updateResults.push([]);
+    const body = JSON.stringify({
+      data: {
+        event_type: "message.received",
+        payload: {
+          id: "msg-start-stale-client",
+          from: { phone_number: "+15555550199" },
+          to: [{ phone_number: "+15555550100" }],
+          text: "START",
+        },
+      },
+    });
+
+    await expect(
+      POST(
+        new Request("https://openvpm.test/api/webhooks/telnyx", {
+          method: "POST",
+          headers: {
+            "telnyx-signature-ed25519": "sig",
+            "telnyx-timestamp": "123",
+          },
+          body,
+        }),
+      ),
+    ).rejects.toThrow(
+      "Inbound SMS opt-in client changed before consent could be projected",
+    );
+  });
+
+  it("does not reapply consent projection or suppression changes on provider replay", async () => {
+    process.env.TELNYX_PUBLIC_KEY = "test-public-key";
+    const clientId = "00000000-0000-0000-0000-000000000003";
+    const location = [
+      {
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        locationId: "00000000-0000-0000-0000-000000000002",
+      },
+    ];
+    mocks.selectResults.push(location, [{ id: clientId }], []);
+    mocks.insertResults.push([{ id: "00000000-0000-0000-0000-0000000000ee" }]);
+
+    const body = JSON.stringify({
+      data: {
+        event_type: "message.received",
+        payload: {
+          id: "msg-start-replay",
+          from: { phone_number: "+15555550199" },
+          to: [{ phone_number: "+15555550100" }],
+          text: "START",
+        },
+      },
+    });
+    const request = () =>
+      new Request("https://openvpm.test/api/webhooks/telnyx", {
+        method: "POST",
+        headers: {
+          "telnyx-signature-ed25519": "sig",
+          "telnyx-timestamp": "123",
+        },
+        body,
+      });
+
+    await expect((await POST(request())).json()).resolves.toEqual({
+      ok: true,
+      action: "unsuppressed",
+    });
+
+    mocks.selectResults.push(location, [{ id: clientId }], []);
+    mocks.insertResults.push([]);
+    await expect((await POST(request())).json()).resolves.toEqual({
+      ok: true,
+      action: "unsuppressed",
+    });
+
+    expect(mocks.updateSet).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteWhere).toHaveBeenCalledTimes(1);
+
+    // A historical START replay must not claim success over a later STOP.
+    mocks.selectResults.push(
+      location,
+      [{ id: clientId }],
+      [{ reason: "stop" }],
+    );
+    mocks.insertResults.push([]);
+    await expect((await POST(request())).json()).resolves.toEqual({
+      ok: true,
+      action: "suppressed",
+    });
+
+    expect(mocks.updateSet).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteWhere).toHaveBeenCalledTimes(1);
   });
 
   it("keeps consent off when START encounters a manual suppression", async () => {
@@ -852,7 +1034,7 @@ describe("Telnyx webhook", () => {
         },
       ],
       [{ id: clientId }],
-      [{ id: "00000000-0000-0000-0000-000000000099" }]
+      [{ id: "00000000-0000-0000-0000-000000000099" }],
     );
     const body = JSON.stringify({
       data: {
@@ -874,21 +1056,21 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
       ok: true,
       action: "suppressed",
     });
-    expect(mocks.deleteWhere).toHaveBeenCalled();
+    expect(mocks.deleteWhere).not.toHaveBeenCalled();
     expect(mocks.updateSet).not.toHaveBeenCalled();
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         clientId,
         subject: "SMS opt-in blocked for +15555550199",
         providerMessageId: "msg-start-manual-block",
-      })
+      }),
     );
   });
 
@@ -904,7 +1086,7 @@ describe("Telnyx webhook", () => {
       [
         { id: "00000000-0000-0000-0000-000000000003" },
         { id: "00000000-0000-0000-0000-000000000004" },
-      ]
+      ],
     );
     const body = JSON.stringify({
       data: {
@@ -926,7 +1108,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -943,12 +1125,12 @@ describe("Telnyx webhook", () => {
         content: "START",
         providerMessageId: "msg-start-ambiguous",
         dedupeKey: "telnyx:inbound:msg-start-ambiguous",
-      })
+      }),
     );
     expect(mocks.insertValues).not.toHaveBeenCalledWith(
       expect.objectContaining({
         clientId: expect.any(String),
-      })
+      }),
     );
   });
 
@@ -961,7 +1143,7 @@ describe("Telnyx webhook", () => {
           locationId: "00000000-0000-0000-0000-000000000002",
         },
       ],
-      []
+      [],
     );
     const longProviderId = `msg-${"x".repeat(220)}`;
     const body = JSON.stringify({
@@ -984,7 +1166,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -995,7 +1177,7 @@ describe("Telnyx webhook", () => {
       expect.objectContaining({
         providerMessageId: longProviderId,
         dedupeKey: expect.stringMatching(/^telnyx:inbound:[a-f0-9]{64}$/),
-      })
+      }),
     );
     const inserted = mocks.insertValues.mock.calls[0]?.[0] as {
       dedupeKey?: string;
@@ -1030,7 +1212,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({ ok: true });
@@ -1067,7 +1249,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({ ok: true });
@@ -1100,7 +1282,7 @@ describe("Telnyx webhook", () => {
           "telnyx-timestamp": "123",
         },
         body,
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({ ok: true });
@@ -1111,11 +1293,21 @@ describe("Telnyx webhook", () => {
 
   it("requires active practices when resolving inbound sender locations", () => {
     const senderLookup = INBOUND_SOURCE.match(
-      /async function findMessagingLocationMatching[\s\S]+?return matches\.length === 1 \? \(?matches\[0\] \?\? null\)? : null;/
+      /async function findMessagingLocationMatching[\s\S]+?return matches\.length === 1 \? \(?matches\[0\] \?\? null\)? : null;/,
     )?.[0];
 
     expect(senderLookup).toContain("innerJoin(");
     expect(senderLookup).toContain("practices");
     expect(senderLookup).toContain("isNull(practices.deletedAt)");
+  });
+
+  it("keeps inbound START identity stable under the recipient and client locks", () => {
+    const optIn = INBOUND_SOURCE.match(
+      /async function applyInboundSmsOptIn[\s\S]+?async function logInboundSmsCommunication/,
+    )?.[0];
+
+    expect(optIn).toMatch(/\.limit\(2\)\s*\.for\("update"\)/);
+    expect(optIn).toContain(".returning({ id: clients.id })");
+    expect(optIn).toContain("updated.length !== 1");
   });
 });

--- a/apps/web/app/api/webhooks/telnyx/route.ts
+++ b/apps/web/app/api/webhooks/telnyx/route.ts
@@ -35,7 +35,7 @@ export const dynamic = "force-dynamic";
 function payloadTooLargeResponse() {
   return NextResponse.json(
     { error: "Messaging webhook payload too large" },
-    { status: 413 }
+    { status: 413 },
   );
 }
 
@@ -57,7 +57,7 @@ function payloadMessagingProfileId(payload: {
 }
 
 function deliveryReceiptCurrentStatusCondition(
-  deliveryStatus: CommunicationDeliveryStatus
+  deliveryStatus: CommunicationDeliveryStatus,
 ) {
   if (deliveryStatus === "sent") {
     return eq(communications.status, "pending");
@@ -65,7 +65,7 @@ function deliveryReceiptCurrentStatusCondition(
 
   return or(
     eq(communications.status, "pending"),
-    eq(communications.status, "sent")
+    eq(communications.status, "sent"),
   )!;
 }
 
@@ -131,9 +131,9 @@ async function handleA2pLifecycleWebhook(opts: {
               ? eq(messagingRegistrations.providerCampaignId, campaignId)
               : eq(
                   messagingRegistrations.id,
-                  "00000000-0000-0000-0000-000000000000"
-                )
-        )
+                  "00000000-0000-0000-0000-000000000000",
+                ),
+        ),
       )
       .limit(1);
 
@@ -145,8 +145,8 @@ async function handleA2pLifecycleWebhook(opts: {
           and(
             eq(locationMessaging.provider, "telnyx"),
             eq(locationMessaging.senderE164, phoneNumber),
-            isNull(locationMessaging.deletedAt)
-          )
+            isNull(locationMessaging.deletedAt),
+          ),
         )
         .limit(1);
       if (sender) {
@@ -160,8 +160,8 @@ async function handleA2pLifecycleWebhook(opts: {
           .where(
             and(
               eq(messagingRegistrations.practiceId, sender.practiceId),
-              isNull(messagingRegistrations.deletedAt)
-            )
+              isNull(messagingRegistrations.deletedAt),
+            ),
           )
           .limit(1);
       }
@@ -171,7 +171,7 @@ async function handleA2pLifecycleWebhook(opts: {
     const next = mergeRegistrationStatus(registration.status, observed);
     const reasons = Array.isArray(opts.payload.reasons)
       ? opts.payload.reasons.filter(
-          (item): item is string => typeof item === "string"
+          (item): item is string => typeof item === "string",
         )
       : [];
     const detail =
@@ -214,8 +214,8 @@ async function handleA2pLifecycleWebhook(opts: {
         and(
           eq(locationMessaging.practiceId, registration.practiceId),
           eq(locationMessaging.provider, "telnyx"),
-          isNull(locationMessaging.deletedAt)
-        )
+          isNull(locationMessaging.deletedAt),
+        ),
       );
   });
 }
@@ -227,7 +227,7 @@ export async function POST(request: Request) {
 
   const rawBody = await readRequestTextWithLimit(
     request,
-    MESSAGING_WEBHOOK_BODY_MAX_BYTES
+    MESSAGING_WEBHOOK_BODY_MAX_BYTES,
   );
   if (!rawBody.ok) {
     return payloadTooLargeResponse();
@@ -317,10 +317,10 @@ export async function POST(request: Request) {
               eq(communications.channel, "sms"),
               eq(communications.direction, "outbound"),
               isNull(communications.deletedAt),
-              deliveryReceiptCurrentStatusCondition(deliveryStatus)
-            )
+              deliveryReceiptCurrentStatusCondition(deliveryStatus),
+            ),
           )
-          .returning({ id: communications.id })
+          .returning({ id: communications.id }),
       );
 
       // Generic Telnyx failure events do not distinguish a permanently invalid
@@ -348,6 +348,12 @@ export async function POST(request: Request) {
   if (!text) {
     return NextResponse.json({ ok: true });
   }
+  if (!providerMessageId) {
+    return NextResponse.json(
+      { error: "missing inbound message id" },
+      { status: 400 },
+    );
+  }
 
   const result = await handleInboundSmsReply({
     provider: "telnyx",
@@ -362,7 +368,7 @@ export async function POST(request: Request) {
     console.warn(
       `[telnyx-webhook] inbound to unrecognised sender ${
         toPhone ?? messagingProfileId
-      }`
+      }`,
     );
     return NextResponse.json({ ok: true });
   }

--- a/apps/web/app/api/webhooks/twilio/route.test.ts
+++ b/apps/web/app/api/webhooks/twilio/route.test.ts
@@ -3,14 +3,24 @@ import { readFileSync } from "node:fs";
 
 const ROUTE_SOURCE = readFileSync(
   new URL("./route.ts", import.meta.url),
-  "utf8"
+  "utf8",
 );
 
 const mocks = vi.hoisted(() => {
   const selectResults: unknown[][] = [];
   const updateResults: unknown[][] = [];
 
-  const selectLimit = vi.fn(async () => selectResults.shift() ?? []);
+  const selectLimit = vi.fn(() => {
+    const result = selectResults.shift() ?? [];
+    const terminal = {
+      for: vi.fn(() => terminal),
+      then: (
+        resolve: (value: unknown[]) => unknown,
+        reject?: (error: unknown) => unknown,
+      ) => Promise.resolve(result).then(resolve, reject),
+    };
+    return terminal;
+  });
   const selectWhere = vi.fn((_condition: unknown) => ({ limit: selectLimit }));
   const selectInnerJoin = vi.fn(() => ({
     innerJoin: selectInnerJoin,
@@ -25,7 +35,7 @@ const mocks = vi.hoisted(() => {
   const updateReturning = vi.fn(async () =>
     updateResults.length > 0
       ? updateResults.shift()
-      : [{ id: "00000000-0000-0000-0000-000000000009" }]
+      : [{ id: "00000000-0000-0000-0000-000000000009" }],
   );
   const updateWhere = vi.fn((_condition: unknown) => ({
     returning: updateReturning,
@@ -33,7 +43,12 @@ const mocks = vi.hoisted(() => {
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
 
-  const insertConflict = vi.fn(async (_config?: unknown) => undefined);
+  const insertReturning = vi.fn(async () => [
+    { id: "00000000-0000-0000-0000-0000000000ee" },
+  ]);
+  const insertConflict = vi.fn((_config?: unknown) => ({
+    returning: insertReturning,
+  }));
   const insertValues = vi.fn((_values: unknown) => ({
     onConflictDoNothing: insertConflict,
     onConflictDoUpdate: insertConflict,
@@ -57,17 +72,18 @@ const mocks = vi.hoisted(() => {
     updateResults,
     selectWhere,
     insertConflict,
+    insertReturning,
     insertValues,
     deleteWhere,
     updateSet,
     updateWhere,
     validateRequest: vi.fn(() => true),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn(db)
+      fn(db),
     ),
     withTenant: vi.fn(
       async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
-        fn(db)
+        fn(db),
     ),
   };
 });
@@ -108,7 +124,7 @@ function twilioRequest(params: Record<string, string>, signature = "sig") {
 function sqlIncludesColumnName(
   value: unknown,
   columnName: string,
-  seen = new WeakSet<object>()
+  seen = new WeakSet<object>(),
 ): boolean {
   if (!value || typeof value !== "object") {
     return false;
@@ -120,18 +136,18 @@ function sqlIncludesColumnName(
   if (candidate.name === columnName) return true;
   if (Array.isArray(candidate.queryChunks)) {
     return candidate.queryChunks.some((item) =>
-      sqlIncludesColumnName(item, columnName, seen)
+      sqlIncludesColumnName(item, columnName, seen),
     );
   }
   return Object.values(value as Record<string, unknown>).some((item) =>
-    sqlIncludesColumnName(item, columnName, seen)
+    sqlIncludesColumnName(item, columnName, seen),
   );
 }
 
 function sqlIncludesValue(
   value: unknown,
   needle: unknown,
-  seen = new WeakSet<object>()
+  seen = new WeakSet<object>(),
 ): boolean {
   if (Object.is(value, needle)) return true;
   if (!value || typeof value !== "object") {
@@ -149,11 +165,11 @@ function sqlIncludesValue(
   }
   if (Array.isArray(candidate.queryChunks)) {
     return candidate.queryChunks.some((item) =>
-      sqlIncludesValue(item, needle, seen)
+      sqlIncludesValue(item, needle, seen),
     );
   }
   return Object.values(value as Record<string, unknown>).some((item) =>
-    sqlIncludesValue(item, needle, seen)
+    sqlIncludesValue(item, needle, seen),
   );
 }
 
@@ -176,7 +192,7 @@ describe("Twilio webhook", () => {
           "x-twilio-signature": "sig",
         },
         body: new URLSearchParams({ From: "+15555550199" }),
-      })
+      }),
     );
 
     expect(response.status).toBe(413);
@@ -199,7 +215,7 @@ describe("Twilio webhook", () => {
           "x-twilio-signature": "sig",
         },
         body: "x".repeat(MESSAGING_WEBHOOK_BODY_MAX_BYTES + 1),
-      })
+      }),
     );
 
     expect(response.status).toBe(413);
@@ -222,7 +238,7 @@ describe("Twilio webhook", () => {
       new Request("https://openvpm.test/api/webhooks/twilio", {
         method: "POST",
         body: new URLSearchParams({ From: "+15555550199" }),
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -241,7 +257,7 @@ describe("Twilio webhook", () => {
         From: "+15555550199",
         To: "+15555550100",
         Body: "Running five minutes late",
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -262,7 +278,7 @@ describe("Twilio webhook", () => {
           locationId: "00000000-0000-0000-0000-000000000002",
         },
       ],
-      [{ id: "00000000-0000-0000-0000-000000000003" }]
+      [{ id: "00000000-0000-0000-0000-000000000003" }],
     );
 
     const response = await POST(
@@ -271,7 +287,7 @@ describe("Twilio webhook", () => {
         To: "+15555550100",
         Body: "Running five minutes late",
         MessageSid: "SM123",
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -287,12 +303,12 @@ describe("Twilio webhook", () => {
         To: "+15555550100",
         Body: "Running five minutes late",
         MessageSid: "SM123",
-      })
+      }),
     );
     expect(mocks.withTenant).toHaveBeenCalledWith(
       mocks.db,
       "00000000-0000-0000-0000-0000000000aa",
-      expect.any(Function)
+      expect.any(Function),
     );
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -303,28 +319,28 @@ describe("Twilio webhook", () => {
         content: "Running five minutes late",
         providerMessageId: "SM123",
         dedupeKey: "twilio:inbound:SM123",
-      })
+      }),
     );
     const inserted = mocks.insertValues.mock.calls.find(
       ([value]) =>
-        (value as { providerMessageId?: string }).providerMessageId === "SM123"
+        (value as { providerMessageId?: string }).providerMessageId === "SM123",
     )?.[0] as { assignedTo?: unknown };
     expect(inserted.assignedTo).toBeTruthy();
     expect(sqlIncludesColumnName(inserted.assignedTo, "assigned_to")).toBe(
-      true
+      true,
     );
     expect(sqlIncludesColumnName(inserted.assignedTo, "client_id")).toBe(true);
     expect(
       sqlIncludesValue(
         inserted.assignedTo,
-        "00000000-0000-0000-0000-0000000000aa"
-      )
+        "00000000-0000-0000-0000-0000000000aa",
+      ),
     ).toBe(true);
     expect(
       sqlIncludesValue(
         inserted.assignedTo,
-        "00000000-0000-0000-0000-000000000003"
-      )
+        "00000000-0000-0000-0000-000000000003",
+      ),
     ).toBe(true);
     expect(mocks.insertConflict).toHaveBeenCalledWith({
       target: communications.dedupeKey,
@@ -341,7 +357,7 @@ describe("Twilio webhook", () => {
           locationId: "00000000-0000-0000-0000-000000000002",
         },
       ],
-      [{ id: "00000000-0000-0000-0000-000000000003" }]
+      [{ id: "00000000-0000-0000-0000-000000000003" }],
     );
 
     const response = await POST(
@@ -351,7 +367,7 @@ describe("Twilio webhook", () => {
         Body: "Can you confirm pickup?",
         MessageSid: "SM-profile-inbound",
         MessagingServiceSid: " MG123 ",
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -361,7 +377,7 @@ describe("Twilio webhook", () => {
     expect(mocks.withSystem).toHaveBeenCalledTimes(3);
     const profileCondition = mocks.selectWhere.mock.calls[1]?.[0];
     expect(
-      sqlIncludesColumnName(profileCondition, "messaging_profile_id")
+      sqlIncludesColumnName(profileCondition, "messaging_profile_id"),
     ).toBe(true);
     expect(sqlIncludesValue(profileCondition, "MG123")).toBe(true);
     expect(mocks.insertValues).toHaveBeenCalledWith(
@@ -373,7 +389,7 @@ describe("Twilio webhook", () => {
         content: "Can you confirm pickup?",
         providerMessageId: "SM-profile-inbound",
         dedupeKey: "twilio:inbound:SM-profile-inbound",
-      })
+      }),
     );
   });
 
@@ -387,7 +403,7 @@ describe("Twilio webhook", () => {
           locationId: "00000000-0000-0000-0000-000000000002",
         },
       ],
-      [{ id: clientId }]
+      [{ id: clientId }],
     );
 
     const response = await POST(
@@ -396,7 +412,7 @@ describe("Twilio webhook", () => {
         To: "+15555550100",
         Body: "STOP",
         MessageSid: "SM-stop",
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -406,11 +422,23 @@ describe("Twilio webhook", () => {
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         practiceId: "00000000-0000-0000-0000-0000000000aa",
+        clientId: null,
+        destinationE164: "+15555550199",
+        action: "revoked",
+        source: "inbound_opt_out:v1",
+        actorType: "client",
+        provider: "twilio",
+        providerMessageId: "SM-stop",
+      }),
+    );
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
         locationId: "00000000-0000-0000-0000-000000000002",
         phone: "+15555550199",
         reason: "stop",
         detail: 'Inbound opt-out: "STOP"',
-      })
+      }),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith({
       smsConsent: false,
@@ -429,7 +457,7 @@ describe("Twilio webhook", () => {
         status: "delivered",
         providerMessageId: "SM-stop",
         dedupeKey: "twilio:inbound:SM-stop",
-      })
+      }),
     );
     expect(mocks.insertConflict).toHaveBeenCalledWith({
       target: communications.dedupeKey,
@@ -446,7 +474,7 @@ describe("Twilio webhook", () => {
           locationId: "00000000-0000-0000-0000-000000000002",
         },
       ],
-      [{ id: clientId }]
+      [{ id: clientId }],
     );
 
     const response = await POST(
@@ -455,7 +483,7 @@ describe("Twilio webhook", () => {
         To: "+15555550100",
         Body: "START",
         MessageSid: "SM-start",
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -480,11 +508,29 @@ describe("Twilio webhook", () => {
         status: "delivered",
         providerMessageId: "SM-start",
         dedupeKey: "twilio:inbound:SM-start",
-      })
+      }),
     );
     expect(mocks.insertConflict).toHaveBeenCalledWith({
       target: communications.dedupeKey,
     });
+  });
+
+  it("rejects inbound consent messages without a durable provider id", async () => {
+    process.env.TWILIO_AUTH_TOKEN = "test-token";
+    const response = await POST(
+      twilioRequest({
+        From: "+15555550199",
+        To: "+15555550100",
+        Body: "START",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "missing inbound message id",
+    });
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+    expect(mocks.updateSet).not.toHaveBeenCalled();
   });
 
   it("updates transient failed delivery callbacks without suppressing recipients", async () => {
@@ -503,7 +549,7 @@ describe("Twilio webhook", () => {
         MessageSid: "SM-failed",
         MessageStatus: "undelivered",
         ErrorCode: "30008",
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({ ok: true });
@@ -528,18 +574,18 @@ describe("Twilio webhook", () => {
         MessageSid: "SM-profile-failed",
         MessageStatus: "undelivered",
         MessagingServiceSid: "MG123",
-      })
+      }),
     );
 
     await expect(response.json()).resolves.toEqual({ ok: true });
     expect(mocks.withTenant).toHaveBeenCalledWith(
       mocks.db,
       "00000000-0000-0000-0000-0000000000aa",
-      expect.any(Function)
+      expect.any(Function),
     );
     const profileCondition = mocks.selectWhere.mock.calls[0]?.[0];
     expect(
-      sqlIncludesColumnName(profileCondition, "messaging_profile_id")
+      sqlIncludesColumnName(profileCondition, "messaging_profile_id"),
     ).toBe(true);
     expect(sqlIncludesValue(profileCondition, "MG123")).toBe(true);
     expect(mocks.updateSet).toHaveBeenCalledWith({ status: "failed" });

--- a/apps/web/app/api/webhooks/twilio/route.ts
+++ b/apps/web/app/api/webhooks/twilio/route.ts
@@ -23,7 +23,7 @@ export const dynamic = "force-dynamic";
 function payloadTooLargeResponse() {
   return NextResponse.json(
     { error: "Messaging webhook payload too large" },
-    { status: 413 }
+    { status: 413 },
   );
 }
 
@@ -36,7 +36,7 @@ function deliveryReceiptCurrentStatusCondition(deliveryStatus: DeliveryStatus) {
 
   return or(
     eq(communications.status, "pending"),
-    eq(communications.status, "sent")
+    eq(communications.status, "sent"),
   )!;
 }
 
@@ -61,14 +61,14 @@ function requestValidationUrls(request: Request): string[] {
 
 function verifyTwilioRequest(
   request: Request,
-  params: Record<string, string>
+  params: Record<string, string>,
 ): boolean {
   const authToken = envValue("TWILIO_AUTH_TOKEN");
   const signature = request.headers.get("x-twilio-signature");
   if (!authToken || !signature) return false;
 
   return requestValidationUrls(request).some((url) =>
-    Twilio.validateRequest(authToken, signature, url, params)
+    Twilio.validateRequest(authToken, signature, url, params),
   );
 }
 
@@ -79,7 +79,7 @@ export async function POST(request: Request) {
 
   const rawBody = await readRequestTextWithLimit(
     request,
-    MESSAGING_WEBHOOK_BODY_MAX_BYTES
+    MESSAGING_WEBHOOK_BODY_MAX_BYTES,
   );
   if (!rawBody.ok) {
     return payloadTooLargeResponse();
@@ -100,6 +100,12 @@ export async function POST(request: Request) {
   const messagingProfileId = nonBlankParam(params.MessagingServiceSid);
 
   if (fromPhone && toPhone && text) {
+    if (!providerMessageId) {
+      return NextResponse.json(
+        { error: "missing inbound message id" },
+        { status: 400 },
+      );
+    }
     const result = await handleInboundSmsReply({
       provider: "twilio",
       fromPhone,
@@ -110,7 +116,9 @@ export async function POST(request: Request) {
     });
 
     if (result.action === "ignored") {
-      console.warn(`[twilio-webhook] inbound to unrecognised number ${toPhone}`);
+      console.warn(
+        `[twilio-webhook] inbound to unrecognised number ${toPhone}`,
+      );
       return NextResponse.json({ ok: true });
     }
 
@@ -118,7 +126,7 @@ export async function POST(request: Request) {
   }
 
   const deliveryStatus = twilioDeliveryStatus(
-    params.MessageStatus ?? params.SmsStatus ?? null
+    params.MessageStatus ?? params.SmsStatus ?? null,
   );
   if (!deliveryStatus || !providerMessageId) {
     return NextResponse.json({ ok: true });
@@ -144,10 +152,10 @@ export async function POST(request: Request) {
           eq(communications.channel, "sms"),
           eq(communications.direction, "outbound"),
           isNull(communications.deletedAt),
-          deliveryReceiptCurrentStatusCondition(deliveryStatus)
-        )
+          deliveryReceiptCurrentStatusCondition(deliveryStatus),
+        ),
       )
-      .returning({ id: communications.id })
+      .returning({ id: communications.id }),
   );
 
   // A failed/undelivered DLR is not proof that the recipient is permanently

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -671,12 +671,12 @@ describe("committed Drizzle migrations", () => {
     expect(sql).toContain(
       "source.product_id IS NOT DISTINCT FROM NEW.product_id",
     );
-    expect(sql).toContain(
-      "source.quantity IS NOT DISTINCT FROM NEW.quantity",
-    );
+    expect(sql).toContain("source.quantity IS NOT DISTINCT FROM NEW.quantity");
     expect(sql).toContain("prescription_events_immutable");
     expect(sql).toContain("app.ledger_maintenance");
-    expect(sql).toContain("ALTER TABLE prescription_events ENABLE ROW LEVEL SECURITY");
+    expect(sql).toContain(
+      "ALTER TABLE prescription_events ENABLE ROW LEVEL SECURITY",
+    );
     expect(sql).toContain(
       "GRANT SELECT, INSERT ON prescription_events TO openpims_app",
     );
@@ -778,5 +778,59 @@ describe("committed Drizzle migrations", () => {
       'UPDATE "invoice_items" SET "taxable" = true WHERE "taxable" IS NULL',
     );
     expect(sql.match(/ALTER COLUMN "taxable" SET NOT NULL/g)).toHaveLength(2);
+  });
+
+  it("adds an immutable tenant-scoped SMS consent evidence ledger", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries?: Array<{ tag?: string }> };
+    expect(journal.entries?.map((entry) => entry.tag)).toContain(
+      "0055_flippant_silver_fox",
+    );
+
+    const sql = readRepoFile(
+      "packages/db/drizzle/0055_flippant_silver_fox.sql",
+    );
+    expect(sql).toContain('CREATE TABLE "sms_consent_events"');
+    expect(sql).toContain("sms_consent_events_client_tenant_fk");
+    expect(sql).toContain("sms_consent_events_location_tenant_fk");
+    expect(sql).toContain("sms_consent_events_actor_tenant_fk");
+    expect(
+      sql.indexOf('CREATE UNIQUE INDEX "locations_practice_id_uq"'),
+    ).toBeLessThan(sql.indexOf("sms_consent_events_location_tenant_fk"));
+    expect(sql).toContain("sms_consent_events_practice_event_key_uq");
+    expect(sql).toContain("sms_consent_events_provider_message_uq");
+    expect(sql).toContain('"provider_message_id" varchar(255)');
+    expect(sql).toContain("sms_consent_events_destination_check");
+    expect(sql).toContain("sms_consent_events_evidence_shape_check");
+    expect(sql).toContain("sms_consent_events_actor_shape_check");
+    expect(sql).toContain(
+      "\"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')",
+    );
+    expect(sql).toContain(
+      'coalesce("sms_consent_events"."provider_message_id", \'\')',
+    );
+    expect(sql).toContain("AND c.sms_consent = true");
+    expect(sql).toContain("c.sms_consent_at IS NOT NULL");
+    expect(sql).toContain("split_part(c.sms_consent_source, ':', 2)");
+    expect(sql).toContain("WITH consent_candidates AS MATERIALIZED");
+    expect(sql).toContain("'[^0-9]'");
+    expect(sql).not.toContain("'\\\\D'");
+    expect(sql).toContain("normalized_destination ~ '^\\+[1-9][0-9]{7,14}$'");
+    expect(sql).toContain("UPDATE clients c");
+    expect(sql).toContain("AND NOT EXISTS (");
+    expect(sql).not.toContain("WHERE c.sms_consent = false");
+    expect(sql).toContain("sms_consent_events_immutable");
+    expect(sql).toContain("app.ledger_maintenance");
+    expect(sql).toContain(
+      "ALTER TABLE sms_consent_events ENABLE ROW LEVEL SECURITY",
+    );
+    expect(sql).toContain(
+      "GRANT SELECT, INSERT ON sms_consent_events TO openpims_app",
+    );
+    expect(sql).toContain("REVOKE ALL ON sms_consent_events FROM anon");
+    expect(sql).toContain(
+      "REVOKE ALL ON sms_consent_events FROM authenticated",
+    );
   });
 });

--- a/apps/web/lib/__tests__/sms.test.ts
+++ b/apps/web/lib/__tests__/sms.test.ts
@@ -75,7 +75,7 @@ function hostedDispatchDb(rows: Array<unknown[] | Error>) {
       for: settle,
       then: (
         resolve: (value: unknown[]) => unknown,
-        reject?: (reason: unknown) => unknown
+        reject?: (reason: unknown) => unknown,
       ) => settle().then(resolve, reject),
     };
     return builder;
@@ -96,7 +96,7 @@ function deferred<T = void>() {
 function transport(
   sender: { messagingServiceId?: string; from?: string },
   name: "telnyx" | "twilio" | "console" = "telnyx",
-  send = mocks.providerSend
+  send = mocks.providerSend,
 ) {
   return {
     provider: { name, isConfigured: () => true, send },
@@ -130,7 +130,7 @@ afterEach(() => {
             }),
           }),
         }),
-      })
+      }),
   );
 });
 
@@ -145,7 +145,7 @@ describe("sendSms", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error:
@@ -166,7 +166,7 @@ describe("sendSms", () => {
         to: "+15555550199",
         body: "Reminder",
         practiceId: PRACTICE_ID,
-      })
+      }),
     ).resolves.toMatchObject({ success: false });
     await expect(
       sendSms({
@@ -174,7 +174,7 @@ describe("sendSms", () => {
         body: "Reminder",
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error: "Hosted SMS requires an explicit consented client.",
@@ -189,7 +189,7 @@ describe("sendSms", () => {
     mocks.billingEnforced.mockReturnValue(true);
     const twilioSend = vi.fn();
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }, "twilio", twilioSend)
+      transport({ from: "+15555550100" }, "twilio", twilioSend),
     );
 
     await expect(
@@ -199,7 +199,7 @@ describe("sendSms", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error:
@@ -213,7 +213,7 @@ describe("sendSms", () => {
     allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
     mocks.withSystem
       .mockImplementationOnce(
@@ -221,8 +221,8 @@ describe("sendSms", () => {
           fn(
             hostedDispatchDb([
               [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
-            ])
-          )
+            ]),
+          ),
       )
       .mockImplementationOnce(
         async (_db: unknown, fn: (tx: unknown) => unknown) =>
@@ -237,8 +237,8 @@ describe("sendSms", () => {
                   smsConsentDisclosure: null,
                 },
               ],
-            ])
-          )
+            ]),
+          ),
       );
 
     await expect(
@@ -248,7 +248,7 @@ describe("sendSms", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error:
@@ -262,7 +262,7 @@ describe("sendSms", () => {
     allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
     mocks.providerSend.mockResolvedValue({ success: true, id: "sms-hosted-1" });
     mocks.withSystem
@@ -271,8 +271,8 @@ describe("sendSms", () => {
           fn(
             hostedDispatchDb([
               [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
-            ])
-          )
+            ]),
+          ),
       )
       .mockImplementationOnce(
         async (_db: unknown, fn: (tx: unknown) => unknown) =>
@@ -288,8 +288,8 @@ describe("sendSms", () => {
                 },
               ],
               [],
-            ])
-          )
+            ]),
+          ),
       );
 
     await expect(
@@ -299,7 +299,7 @@ describe("sendSms", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     ).resolves.toEqual({
       success: true,
       sid: "sms-hosted-1",
@@ -312,7 +312,7 @@ describe("sendSms", () => {
     allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
     mocks.withSystem
       .mockImplementationOnce(
@@ -320,8 +320,8 @@ describe("sendSms", () => {
           fn(
             hostedDispatchDb([
               [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
-            ])
-          )
+            ]),
+          ),
       )
       .mockImplementationOnce(
         async (_db: unknown, fn: (tx: unknown) => unknown) =>
@@ -337,8 +337,8 @@ describe("sendSms", () => {
                 },
               ],
               [{ id: "suppression-1" }],
-            ])
-          )
+            ]),
+          ),
       );
 
     await expect(
@@ -348,7 +348,7 @@ describe("sendSms", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error: "Recipient has opted out of SMS (STOP).",
@@ -361,7 +361,7 @@ describe("sendSms", () => {
     allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
     mocks.withSystem
       .mockImplementationOnce(
@@ -369,8 +369,8 @@ describe("sendSms", () => {
           fn(
             hostedDispatchDb([
               [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
-            ])
-          )
+            ]),
+          ),
       )
       .mockImplementationOnce(
         async (_db: unknown, fn: (tx: unknown) => unknown) =>
@@ -386,8 +386,8 @@ describe("sendSms", () => {
                 },
               ],
               new Error("suppression database unavailable"),
-            ])
-          )
+            ]),
+          ),
       );
 
     await expect(
@@ -397,7 +397,7 @@ describe("sendSms", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error: "Could not verify SMS consent; send blocked.",
@@ -410,7 +410,7 @@ describe("sendSms", () => {
     allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
 
     const revokeReachedWrite = deferred();
@@ -436,7 +436,12 @@ describe("sendSms", () => {
     const revokeTx = {
       execute: vi.fn(acquireRecipient),
       insert: () => ({
-        values: () => ({ onConflictDoUpdate: async () => undefined }),
+        values: () => ({
+          onConflictDoNothing: () => ({
+            returning: async () => [{ id: "consent-event-1" }],
+          }),
+          onConflictDoUpdate: async () => undefined,
+        }),
       }),
       update: () => ({
         set: () => ({
@@ -457,7 +462,14 @@ describe("sendSms", () => {
           practiceId: PRACTICE_ID,
           phone: "+15555550199",
           reason: "manual",
-        }
+          evidence: {
+            source: "staff_manual_revoke:v1",
+            actorType: "staff",
+            actorUserId: "00000000-0000-0000-0000-000000000001",
+            actorName: "Test User",
+            eventKey: "staff:test-race",
+          },
+        },
       );
       state.consent = false;
       state.suppressed = true;
@@ -496,7 +508,7 @@ describe("sendSms", () => {
           for: async () => result,
           then: (
             resolve: (value: unknown[]) => unknown,
-            reject?: (reason: unknown) => unknown
+            reject?: (reason: unknown) => unknown,
           ) => Promise.resolve(result).then(resolve, reject),
         };
         return builder;
@@ -508,15 +520,15 @@ describe("sendSms", () => {
           fn(
             hostedDispatchDb([
               [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
-            ])
-          )
+            ]),
+          ),
       )
       .mockImplementationOnce(
         async (_db: unknown, fn: (tx: unknown) => unknown) => {
           const result = await fn(sendTx);
           releaseRecipient();
           return result;
-        }
+        },
       );
 
     const sendPromise = sendSms({
@@ -540,7 +552,7 @@ describe("sendSms", () => {
 
   it("requires an active practice for hosted billing entitlement checks", () => {
     expect(smsSource).toMatch(
-      /where\(\s*and\(\s*eq\(practices\.id, options\.practiceId!\),\s*isNull\(practices\.deletedAt\)\s*\)\s*\)/s
+      /where\(\s*and\(\s*eq\(practices\.id, options\.practiceId!\),\s*isNull\(practices\.deletedAt\)\s*\)\s*\)/s,
     );
     expect(smsSource).toContain("if (!practice)");
     expect(smsSource).toContain("Practice not found");
@@ -551,7 +563,7 @@ describe("sendSms", () => {
   it("meters successful real provider sends for hosted usage billing", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
     mocks.providerSend.mockResolvedValue({ success: true, id: "sms-1" });
 
@@ -560,7 +572,7 @@ describe("sendSms", () => {
         to: "+15555550199",
         body: "Reminder",
         practiceId: "00000000-0000-0000-0000-0000000000aa",
-      })
+      }),
     ).resolves.toEqual({ success: true, sid: "sms-1", error: undefined });
 
     expect(mocks.recordUsage).toHaveBeenCalledWith({
@@ -572,7 +584,7 @@ describe("sendSms", () => {
   it("normalizes recipients before suppression checks and provider sends", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
     mocks.providerSend.mockResolvedValue({ success: true, id: "sms-1" });
 
@@ -581,12 +593,12 @@ describe("sendSms", () => {
         to: " (555) 555-0199 ",
         body: "Reminder",
         practiceId: "00000000-0000-0000-0000-0000000000aa",
-      })
+      }),
     ).resolves.toEqual({ success: true, sid: "sms-1", error: undefined });
 
     expect(mocks.isSuppressed).toHaveBeenCalledWith(
       "00000000-0000-0000-0000-0000000000aa",
-      "+15555550199"
+      "+15555550199",
     );
     expect(mocks.providerSend).toHaveBeenCalledWith({
       to: "+15555550199",
@@ -601,7 +613,7 @@ describe("sendSms", () => {
         to: "12345",
         body: "Reminder",
         practiceId: "00000000-0000-0000-0000-0000000000aa",
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error:
@@ -618,7 +630,7 @@ describe("sendSms", () => {
     const usage = deferred();
     mocks.isSuppressed.mockResolvedValue(false);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
     mocks.providerSend.mockResolvedValue({ success: true, id: "sms-1" });
     mocks.recordUsage.mockReturnValueOnce(usage.promise);
@@ -647,7 +659,7 @@ describe("sendSms", () => {
   it("keeps provider message ids on appointment reminder helper results", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
     mocks.providerSend.mockResolvedValue({
       success: true,
@@ -661,7 +673,7 @@ describe("sendSms", () => {
         appointmentDate: "July 2",
         appointmentTime: "9:00 AM",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).resolves.toEqual({
       success: true,
       sid: "sms-reminder-1",
@@ -672,7 +684,7 @@ describe("sendSms", () => {
   it("keeps provider message ids on vaccination reminder helper results", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
     mocks.providerSend.mockResolvedValue({ success: true, id: "sms-vax-1" });
 
@@ -682,7 +694,7 @@ describe("sendSms", () => {
         patientName: "Miso",
         vaccineName: "Rabies",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).resolves.toEqual({
       success: true,
       sid: "sms-vax-1",
@@ -693,7 +705,7 @@ describe("sendSms", () => {
   it("does not meter failed provider sends", async () => {
     mocks.isSuppressed.mockResolvedValue(false);
     mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" })
+      transport({ from: "+15555550100" }),
     );
     mocks.providerSend.mockResolvedValue({
       success: false,
@@ -705,7 +717,7 @@ describe("sendSms", () => {
         to: "+15555550199",
         body: "Reminder",
         practiceId: "00000000-0000-0000-0000-0000000000aa",
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       sid: undefined,
@@ -730,7 +742,7 @@ describe("sendSms", () => {
         to: "+15555550199",
         body: "Reminder",
         practiceId: "00000000-0000-0000-0000-0000000000aa",
-      })
+      }),
     ).resolves.toEqual({
       success: true,
       sid: "console-1",
@@ -757,7 +769,7 @@ describe("sendSms", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error:
@@ -790,7 +802,7 @@ describe("sendSms", () => {
         to: "+15555550199",
         body: "Reminder",
         practiceId: "00000000-0000-0000-0000-0000000000aa",
-      })
+      }),
     ).resolves.toEqual({
       success: true,
       sid: "console-1",
@@ -818,7 +830,7 @@ describe("sendSms", () => {
               }),
             }),
           }),
-        })
+        }),
     );
 
     await expect(
@@ -828,7 +840,7 @@ describe("sendSms", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error: "Practice not found",
@@ -851,7 +863,7 @@ describe("sendSms", () => {
         body: "Reminder",
         practiceId: "00000000-0000-0000-0000-0000000000aa",
         locationId: "00000000-0000-0000-0000-000000000002",
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error: "No active texting sender is configured for this location.",
@@ -874,8 +886,8 @@ describe("sendSms", () => {
           from: "+15555550122",
         },
         "twilio",
-        twilioSend
-      )
+        twilioSend,
+      ),
     );
 
     await expect(
@@ -884,7 +896,7 @@ describe("sendSms", () => {
         body: "Location-bound message",
         practiceId: "00000000-0000-0000-0000-0000000000aa",
         locationId: "00000000-0000-0000-0000-000000000002",
-      })
+      }),
     ).resolves.toEqual({ success: true, sid: "SM-location", error: undefined });
 
     expect(mocks.getMessagingProvider).not.toHaveBeenCalled();

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -6,6 +6,7 @@ import {
   PRACTICE_EXPORT_SECRET_REPLACEMENTS,
   PRACTICE_EXPORT_SYSTEM_EXCLUSIONS,
   PRACTICE_EXPORT_SECTIONS,
+  prepareLegacySmsConsentRestore,
   restorePracticeData,
   sanitizePracticeExportRows,
   summarizePracticeExport,
@@ -30,7 +31,9 @@ describe("backup restore policy", () => {
 
 describe("backupKey", () => {
   it("namespaces backups per practice and date", () => {
-    expect(backupKey("prac-1", "2026-06-07")).toBe("backups/prac-1/2026-06-07.json");
+    expect(backupKey("prac-1", "2026-06-07")).toBe(
+      "backups/prac-1/2026-06-07.json",
+    );
   });
   it("keeps the practice id segment isolated", () => {
     const a = backupKey("a", "2026-06-07");
@@ -40,9 +43,9 @@ describe("backupKey", () => {
   });
 });
 
-function emptyBackup() {
+function emptyBackup(): Record<string, unknown[]> {
   return Object.fromEntries(
-    PRACTICE_EXPORT_SECTIONS.map((section) => [section, []])
+    PRACTICE_EXPORT_SECTIONS.map((section) => [section, []]),
   );
 }
 
@@ -139,6 +142,7 @@ describe("summarizePracticeExport", () => {
     expect(PRACTICE_EXPORT_SECTIONS).toContain("wellnessEnrollments");
     expect(PRACTICE_EXPORT_SECTIONS).toContain("locationMessaging");
     expect(PRACTICE_EXPORT_SECTIONS).toContain("smsSuppressions");
+    expect(PRACTICE_EXPORT_SECTIONS).toContain("smsConsentEvents");
     expect(PRACTICE_EXPORT_SECTIONS).toContain("emailSuppressions");
     expect(PRACTICE_EXPORT_SECTIONS).toContain("webhooks");
     expect(PRACTICE_EXPORT_SECTIONS).toContain("apiKeys");
@@ -155,13 +159,13 @@ describe("summarizePracticeExport", () => {
     expect(sections).not.toContain("messagingRegistrations");
     expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.usageRecords).toContain("billing");
     expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.practicePaymentAccounts).toContain(
-      "Stripe Connect"
+      "Stripe Connect",
     );
     expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.messagingRegistrations).toContain(
-      "Encrypted tax identity"
+      "Encrypted tax identity",
     );
     expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.messagingRegistrations).toContain(
-      "operational database disaster recovery"
+      "operational database disaster recovery",
     );
   });
 
@@ -198,6 +202,153 @@ describe("summarizePracticeExport", () => {
     expect(summary.missingSections).not.toContain("patientMergeEvents");
     expect(summary.counts.patientMergeEvents).toBe(0);
   });
+
+  it("allows restoring older backups that predate SMS consent events", () => {
+    const backup = emptyBackup();
+    delete (backup as Record<string, unknown>).smsConsentEvents;
+
+    const summary = summarizePracticeExport(backup);
+
+    expect(summary.missingSections).not.toContain("smsConsentEvents");
+    expect(summary.counts.smsConsentEvents).toBe(0);
+  });
+
+  it("synthesizes only truthful legacy consent and clears incomplete projections", () => {
+    const backup = emptyBackup();
+    delete (backup as Record<string, unknown>).smsConsentEvents;
+    backup.clients = [
+      {
+        id: "00000000-0000-0000-0000-000000000001",
+        practiceId: "source-practice",
+        phone: "+1 (555) 555-0100",
+        smsConsent: true,
+        smsConsentAt: "2026-08-01T12:00:00.000Z",
+        smsConsentSource: "staff_attested_form:v1",
+        smsConsentDisclosure: "Exact historical disclosure",
+      },
+      {
+        id: "00000000-0000-0000-0000-000000000002",
+        practiceId: "source-practice",
+        phone: "+05555550101",
+        smsConsent: true,
+        smsConsentAt: "2026-08-01T12:00:00.000Z",
+        smsConsentSource: "intake",
+        smsConsentDisclosure: "Incomplete historical evidence",
+      },
+    ];
+
+    const prepared = prepareLegacySmsConsentRestore(backup);
+
+    expect(prepared.clients[0]).toMatchObject({ smsConsent: true });
+    expect(prepared.smsConsentEvents).toHaveLength(1);
+    expect(prepared.smsConsentEvents[0]).toMatchObject({
+      clientId: "00000000-0000-0000-0000-000000000001",
+      destinationE164: "+15555550100",
+      action: "granted",
+      source: "staff_attested_form:v1",
+      disclosureVersion: "v1",
+      disclosure: "Exact historical disclosure",
+      actorType: "system",
+      occurredAt: "2026-08-01T12:00:00.000Z",
+    });
+    expect(prepared.clients[1]).toMatchObject({
+      smsConsent: false,
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
+    });
+  });
+
+  it("clears a modern affirmative projection without a matching destination grant", () => {
+    const backup = emptyBackup();
+    backup.clients = [
+      {
+        id: "00000000-0000-0000-0000-000000000001",
+        phone: "+15555550100",
+        smsConsent: true,
+        smsConsentAt: "2026-08-01T12:00:00.000Z",
+        smsConsentSource: "staff_attested_form:v1",
+        smsConsentDisclosure: "Exact historical disclosure",
+      },
+    ];
+
+    expect(prepareLegacySmsConsentRestore(backup).clients[0]).toMatchObject({
+      smsConsent: false,
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
+    });
+
+    backup.smsConsentEvents = [
+      {
+        id: "00000000-0000-0000-0000-000000000010",
+        clientId: "00000000-0000-0000-0000-000000000001",
+        destinationE164: "+15555550100",
+        action: "granted",
+        occurredAt: "2026-08-01T12:00:00.000Z",
+      },
+    ];
+    expect(prepareLegacySmsConsentRestore(backup).clients[0]).toMatchObject({
+      smsConsent: true,
+      phone: "+15555550100",
+    });
+
+    const destinationRevoke = {
+      id: "00000000-0000-0000-0000-000000000011",
+      clientId: "00000000-0000-0000-0000-000000000099",
+      destinationE164: "+15555550100",
+      action: "revoked",
+      occurredAt: "2026-08-01T12:00:00.000Z",
+    };
+    backup.smsConsentEvents.push(destinationRevoke);
+    expect(prepareLegacySmsConsentRestore(backup).clients[0]).toMatchObject({
+      smsConsent: false,
+      smsConsentAt: null,
+    });
+
+    destinationRevoke.occurredAt = "2026-08-02T12:00:00.000Z";
+    expect(prepareLegacySmsConsentRestore(backup).clients[0]).toMatchObject({
+      smsConsent: false,
+      smsConsentAt: null,
+    });
+  });
+
+  it("restores a truthful pre-ledger projection with its synthesized event", async () => {
+    const backup = emptyBackup();
+    delete (backup as Record<string, unknown>).smsConsentEvents;
+    backup.clients = [
+      {
+        id: "00000000-0000-0000-0000-000000000001",
+        practiceId: "source-practice",
+        phone: "+15555550100",
+        smsConsent: true,
+        smsConsentAt: "2026-08-01T12:00:00.000Z",
+        smsConsentSource: "staff_attested_form:v1",
+        smsConsentDisclosure: "Exact historical disclosure",
+      },
+    ];
+    const { db, inserted } = restoreDb();
+
+    const result = await restorePracticeData(
+      db as never,
+      "target-practice",
+      backup,
+    );
+    const restoredRows = inserted.flatMap(({ rows }) => rows);
+
+    expect(result.restored.clients).toBe(1);
+    expect(result.restored.smsConsentEvents).toBe(1);
+    expect(restoredRows).toContainEqual(
+      expect.objectContaining({
+        practiceId: "target-practice",
+        clientId: "00000000-0000-0000-0000-000000000001",
+        destinationE164: "+15555550100",
+        action: "granted",
+        actorType: "system",
+        occurredAt: new Date("2026-08-01T12:00:00.000Z"),
+      }),
+    );
+  });
 });
 
 describe("exportPracticeData query scoping", () => {
@@ -205,7 +356,7 @@ describe("exportPracticeData query scoping", () => {
 
   it("exports parent-scoped children through active tenant parents", () => {
     const helper = source.match(
-      /async function tenantParentChildRows[\s\S]+?async function restoreRows/
+      /async function tenantParentChildRows[\s\S]+?async function restoreRows/,
     )?.[0];
 
     expect(helper).toContain("inArray(parentColumn, parentIds)");
@@ -213,17 +364,29 @@ describe("exportPracticeData query scoping", () => {
     expect(helper).toContain("and ${parentTable.practiceId} = ${practiceId}");
     expect(helper).toContain("and ${parentTable.deletedAt} is null");
     expect(helper).toContain("isNull(table.deletedAt)");
-    expect(source).toContain("tenantParentChildRows(\n      db,\n      patientWeights");
-    expect(source).toContain("tenantParentChildRows(\n      db,\n      patientAllergies");
-    expect(source).toContain("tenantParentChildRows(\n      db,\n      invoiceItems");
-    expect(source).toContain("tenantParentChildRows(\n      db,\n      payments");
-    expect(source).toContain("tenantParentChildRows(\n      db,\n      invoiceAdjustments");
     expect(source).toContain(
-      "tenantParentChildRows(\n      db,\n      treatmentTemplateItems"
+      "tenantParentChildRows(\n      db,\n      patientWeights",
     );
-    expect(source).toContain("tenantParentChildRows(\n      db,\n      caseEntries");
     expect(source).toContain(
-      "tenantParentChildRows(\n      db,\n      treatmentPlanItems"
+      "tenantParentChildRows(\n      db,\n      patientAllergies",
+    );
+    expect(source).toContain(
+      "tenantParentChildRows(\n      db,\n      invoiceItems",
+    );
+    expect(source).toContain(
+      "tenantParentChildRows(\n      db,\n      payments",
+    );
+    expect(source).toContain(
+      "tenantParentChildRows(\n      db,\n      invoiceAdjustments",
+    );
+    expect(source).toContain(
+      "tenantParentChildRows(\n      db,\n      treatmentTemplateItems",
+    );
+    expect(source).toContain(
+      "tenantParentChildRows(\n      db,\n      caseEntries",
+    );
+    expect(source).toContain(
+      "tenantParentChildRows(\n      db,\n      treatmentPlanItems",
     );
   });
 
@@ -236,6 +399,25 @@ describe("exportPracticeData query scoping", () => {
     expect(source).toContain("event.targetPatientId");
     expect(source).toContain("patientMergeEvents: patientMergeRows");
   });
+
+  it("exports append-only SMS consent evidence and referenced identities", () => {
+    expect(source).toContain(
+      "allPracticeRows(db, smsConsentEvents, practiceId)",
+    );
+    expect(source).toContain(
+      "...smsConsentEventRows.map((event) => event.clientId)",
+    );
+    expect(source).toContain(
+      "...smsConsentEventRows.map((event) => event.actorUserId)",
+    );
+    expect(source).toContain(
+      "...smsConsentEventRows.map((event) => event.locationId)",
+    );
+    expect(source).toContain("smsConsentEvents: smsConsentEventRows");
+    expect(source).toContain(".onConflictDoNothing()");
+    expect(source).toContain("restored.smsConsentEvents = await restoreRows(");
+    expect(source).toContain("smsConsentRestore.smsConsentEvents");
+  });
 });
 
 describe("practice backup secret handling", () => {
@@ -247,7 +429,7 @@ describe("practice backup secret handling", () => {
           passwordHash: "real-password-hash",
           emailVerifiedAt: new Date("2026-06-01T12:00:00Z"),
         },
-      ])
+      ]),
     ).toEqual([
       {
         id: "user-1",
@@ -259,7 +441,7 @@ describe("practice backup secret handling", () => {
     expect(
       sanitizePracticeExportRows("clients", [
         { id: "client-1", accessToken: "portal-token" },
-      ])
+      ]),
     ).toEqual([{ id: "client-1", accessToken: null }]);
 
     expect(
@@ -270,7 +452,7 @@ describe("practice backup secret handling", () => {
           keyHash: "stored-api-key-hash",
           lastUsedAt: new Date("2026-06-01T12:00:00Z"),
         },
-      ])
+      ]),
     ).toEqual([
       {
         id: "api-key-1",
@@ -287,7 +469,7 @@ describe("practice backup secret handling", () => {
           secret: "stored-webhook-secret",
           active: true,
         },
-      ])
+      ]),
     ).toEqual([
       {
         id: "webhook-1",
@@ -309,7 +491,7 @@ describe("practice backup secret handling", () => {
             events: [{ apiKey: "raw-key", label: "created" }],
           },
         },
-      ])
+      ]),
     ).toEqual([
       {
         id: "audit-1",
@@ -609,9 +791,9 @@ describe("restorePracticeData", () => {
             appointmentId: "appointment-2",
           },
         ],
-      }).errors
+      }).errors,
     ).toContain(
-      "clinicalRecordCorrections[correction-1] must match its source record patientId and appointmentId exactly."
+      "clinicalRecordCorrections[correction-1] must match its source record patientId and appointmentId exactly.",
     );
 
     expect(
@@ -623,9 +805,9 @@ describe("restorePracticeData", () => {
             recordType: "lab_result",
           },
         ],
-      }).errors
+      }).errors,
     ).toContain(
-      "clinicalRecordCorrections[correction-1].recordType must be soap_note, vital_sign, or vaccination_record."
+      "clinicalRecordCorrections[correction-1].recordType must be soap_note, vital_sign, or vaccination_record.",
     );
 
     expect(
@@ -638,9 +820,9 @@ describe("restorePracticeData", () => {
             appointmentId: "appointment-2",
           },
         ],
-      }).errors
+      }).errors,
     ).toContain(
-      "clinicalRecordCorrections[correction-3] must match its source record patientId and appointmentId exactly."
+      "clinicalRecordCorrections[correction-3] must match its source record patientId and appointmentId exactly.",
     );
 
     expect(
@@ -653,9 +835,9 @@ describe("restorePracticeData", () => {
             id: "correction-4",
           },
         ],
-      }).errors
+      }).errors,
     ).toContain(
-      "clinicalRecordCorrections[correction-4] duplicates an existing correction source."
+      "clinicalRecordCorrections[correction-4] duplicates an existing correction source.",
     );
   });
 
@@ -686,7 +868,7 @@ describe("restorePracticeData", () => {
     };
 
     expect(validatePracticeExportRestore(backup).errors).toContain(
-      "soapNotes[soap-1].appointmentId must reference an appointment for the same patient."
+      "soapNotes[soap-1].appointmentId must reference an appointment for the same patient.",
     );
   });
 
@@ -700,11 +882,11 @@ describe("restorePracticeData", () => {
     const { db, inserted } = restoreDb();
 
     expect(validatePracticeExportRestore(backup).errors).toContain(
-      'appointments[appointment-1].clientId references missing clients row "other-client".'
+      'appointments[appointment-1].clientId references missing clients row "other-client".',
     );
 
     await expect(
-      restorePracticeData(db as never, "target-practice", backup)
+      restorePracticeData(db as never, "target-practice", backup),
     ).rejects.toThrow("Backup contains invalid restore data");
     expect(inserted).toEqual([]);
   });
@@ -877,7 +1059,9 @@ describe("restorePracticeData", () => {
     );
     await expect(
       restorePracticeData(db as never, "target-practice", backup),
-    ).rejects.toThrow("Backup is missing required sections: prescriptionEvents");
+    ).rejects.toThrow(
+      "Backup is missing required sections: prescriptionEvents",
+    );
     expect(inserted).toEqual([]);
   });
 
@@ -899,11 +1083,11 @@ describe("restorePracticeData", () => {
         "clients[#2].id is required.",
         "clients[#3].id must be a non-empty string.",
         "clients[#4].id must be a non-empty string.",
-      ])
+      ]),
     );
 
     await expect(
-      restorePracticeData(db as never, "target-practice", backup)
+      restorePracticeData(db as never, "target-practice", backup),
     ).rejects.toThrow("Backup contains invalid restore data");
     expect(inserted).toEqual([]);
   });
@@ -941,7 +1125,7 @@ describe("restorePracticeData", () => {
     expect(client?.createdAt).toBeInstanceOf(Date);
     expect(client?.updatedAt).toBeInstanceOf(Date);
     expect((client?.createdAt as Date).toISOString()).toBe(
-      "2026-07-01T12:00:00.000Z"
+      "2026-07-01T12:00:00.000Z",
     );
     expect(patient?.createdAt).toBeInstanceOf(Date);
     // String-mode date columns (calendar dates) stay strings.
@@ -973,7 +1157,7 @@ describe("restorePracticeData", () => {
     const result = await restorePracticeData(
       rootDb as never,
       "target-practice",
-      backup
+      backup,
     );
     const restoredRows = inserted.flatMap(({ rows }) => rows);
 
@@ -983,7 +1167,7 @@ describe("restorePracticeData", () => {
       expect.objectContaining({
         id: "client-1",
         practiceId: "target-practice",
-      })
+      }),
     );
   });
 
@@ -1042,6 +1226,25 @@ describe("restorePracticeData", () => {
       ],
       clients: [{ id: "client-1", practiceId: "source-practice" }],
       users: [{ id: "user-1", practiceId: "source-practice" }],
+      smsConsentEvents: [
+        {
+          id: "sms-consent-event-1",
+          practiceId: "source-practice",
+          clientId: "client-1",
+          locationId: "location-1",
+          destinationE164: "+15555550100",
+          action: "granted",
+          source: "staff_attested_form:v1",
+          disclosureVersion: "v1",
+          disclosure: "Exact historical disclosure",
+          actorType: "staff",
+          actorUserId: "user-1",
+          actorName: "Ada Staff",
+          eventKey: "staff:historical-1",
+          occurredAt: "2026-08-01T12:00:00.000Z",
+          createdAt: "2026-08-01T12:00:01.000Z",
+        },
+      ],
       patients: [
         {
           id: "patient-1",
@@ -1088,26 +1291,32 @@ describe("restorePracticeData", () => {
     };
     const { db, inserted } = restoreDb();
 
-    const result = await restorePracticeData(db as never, "target-practice", backup);
+    const result = await restorePracticeData(
+      db as never,
+      "target-practice",
+      backup,
+    );
     const restoredRows = inserted.flatMap(({ rows }) => rows);
 
-    expect(result.totalRows).toBe(18);
+    expect(result.totalRows).toBe(19);
     expect(restoredRows.find((row) => row.id === "location-1")).toMatchObject({
       id: "location-1",
       practiceId: "target-practice",
     });
     expect(
-      restoredRows.find((row) => row.id === "location-messaging-1")
+      restoredRows.find((row) => row.id === "location-messaging-1"),
     ).toMatchObject({
       id: "location-messaging-1",
       practiceId: "target-practice",
     });
-    expect(restoredRows.find((row) => row.id === "suppression-1")).toMatchObject({
+    expect(
+      restoredRows.find((row) => row.id === "suppression-1"),
+    ).toMatchObject({
       id: "suppression-1",
       practiceId: "target-practice",
     });
     expect(
-      restoredRows.find((row) => row.id === "email-suppression-1")
+      restoredRows.find((row) => row.id === "email-suppression-1"),
     ).toMatchObject({
       id: "email-suppression-1",
       practiceId: "target-practice",
@@ -1135,6 +1344,19 @@ describe("restorePracticeData", () => {
       practiceId: "target-practice",
       accessToken: null,
     });
+    expect(
+      restoredRows.find((row) => row.id === "sms-consent-event-1"),
+    ).toMatchObject({
+      id: "sms-consent-event-1",
+      practiceId: "target-practice",
+      clientId: "client-1",
+      locationId: "location-1",
+      destinationE164: "+15555550100",
+      disclosure: "Exact historical disclosure",
+      eventKey: "staff:historical-1",
+      occurredAt: new Date("2026-08-01T12:00:00.000Z"),
+      createdAt: new Date("2026-08-01T12:00:01.000Z"),
+    });
     expect(restoredRows.find((row) => row.id === "user-1")).toMatchObject({
       id: "user-1",
       practiceId: "target-practice",
@@ -1155,13 +1377,13 @@ describe("restorePracticeData", () => {
       practiceId: "target-practice",
     });
     expect(
-      restoredRows.find((row) => row.id === "wellness-plan-1")
+      restoredRows.find((row) => row.id === "wellness-plan-1"),
     ).toMatchObject({
       id: "wellness-plan-1",
       practiceId: "target-practice",
     });
     expect(
-      restoredRows.find((row) => row.id === "wellness-enrollment-1")
+      restoredRows.find((row) => row.id === "wellness-enrollment-1"),
     ).toMatchObject({
       id: "wellness-enrollment-1",
       practiceId: "target-practice",
@@ -1191,7 +1413,7 @@ describe("restorePracticeData", () => {
       restorePracticeData(db as never, "target-practice", {
         clients: [],
         patients: [],
-      })
+      }),
     ).rejects.toThrow("Backup is missing required sections");
   });
 });

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -1,7 +1,8 @@
 import { eq, and, isNull, inArray, sql, getTableColumns } from "drizzle-orm";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import type { Database } from "@openpims/db/client";
 import { redactSecrets } from "@/lib/audit";
+import { normalizeE164 } from "@/lib/messaging/phone";
 import {
   appointmentTypes,
   appointmentWaitlist,
@@ -40,6 +41,7 @@ import {
   recurringSeries,
   rooms,
   services,
+  smsConsentEvents,
   smsSuppressions,
   soapNotes,
   staffSchedules,
@@ -76,7 +78,8 @@ export const PRACTICE_EXPORT_SYSTEM_EXCLUSIONS = {
   rateLimitBuckets: "Transient abuse-control buckets, not clinic-owned data.",
   sessions: "Transient authentication sessions.",
   verificationTokens: "Transient authentication verification tokens.",
-  authTokens: "Expiring pre-tenant email verification and password-reset tokens.",
+  authTokens:
+    "Expiring pre-tenant email verification and password-reset tokens.",
   captureSessions:
     "Expiring QR photo-capture link tokens; restoring them would resurrect old capture URLs. The photos themselves are in the files section.",
   consentRequests:
@@ -86,11 +89,9 @@ export const PRACTICE_EXPORT_SYSTEM_EXCLUSIONS = {
 } as const;
 
 export const PRACTICE_EXPORT_SECRET_REPLACEMENTS = {
-  passwordHash:
-    "$2a$12$HNkF00edpp2mYk2gvvj8ne/PWjlXwgT5YZhAodh0/UVgTgtIPdnWS",
+  passwordHash: "$2a$12$HNkF00edpp2mYk2gvvj8ne/PWjlXwgT5YZhAodh0/UVgTgtIPdnWS",
   apiKeyPrefix: "disabled",
-  apiKeyHash:
-    "$2a$12$HNkF00edpp2mYk2gvvj8ne/PWjlXwgT5YZhAodh0/UVgTgtIPdnWS",
+  apiKeyHash: "$2a$12$HNkF00edpp2mYk2gvvj8ne/PWjlXwgT5YZhAodh0/UVgTgtIPdnWS",
   webhookSecret: "rotate-after-restore",
 } as const;
 
@@ -98,6 +99,7 @@ export const PRACTICE_EXPORT_SECTIONS = [
   "locations",
   "locationMessaging",
   "smsSuppressions",
+  "smsConsentEvents",
   "emailSuppressions",
   "webhooks",
   "apiKeys",
@@ -159,6 +161,8 @@ const PRACTICE_EXPORT_OPTIONAL_RESTORE_SECTIONS = [
   "dispenseChargeQueue",
   // Backward compatibility for backups created before durable patient lineage.
   "patientMergeEvents",
+  // Backward compatibility for backups created before SMS consent evidence.
+  "smsConsentEvents",
   "visitCloseouts",
   "clinicalRecordCorrections",
 ] as const satisfies readonly PracticeExportSection[];
@@ -184,7 +188,7 @@ function rowsFor(data: unknown, section: PracticeExportSection): Row[] {
 
 export function sanitizePracticeExportRows(
   section: PracticeExportSection,
-  rows: Row[]
+  rows: Row[],
 ): Row[] {
   return rows.map((row) => {
     switch (section) {
@@ -232,7 +236,7 @@ const MAX_RESTORE_REFERENCE_ERRORS = 25;
 function requiredRef(
   section: PracticeExportSection,
   field: string,
-  parentSection: PracticeExportSection
+  parentSection: PracticeExportSection,
 ): RestoreReferenceRule {
   return { section, field, parentSection, required: true };
 }
@@ -240,7 +244,7 @@ function requiredRef(
 function optionalRef(
   section: PracticeExportSection,
   field: string,
-  parentSection: PracticeExportSection
+  parentSection: PracticeExportSection,
 ): RestoreReferenceRule {
   return { section, field, parentSection };
 }
@@ -248,6 +252,9 @@ function optionalRef(
 const RESTORE_REFERENCE_RULES: RestoreReferenceRule[] = [
   requiredRef("locationMessaging", "locationId", "locations"),
   optionalRef("smsSuppressions", "locationId", "locations"),
+  optionalRef("smsConsentEvents", "clientId", "clients"),
+  optionalRef("smsConsentEvents", "locationId", "locations"),
+  optionalRef("smsConsentEvents", "actorUserId", "users"),
   optionalRef("users", "locationId", "locations"),
   optionalRef("rooms", "locationId", "locations"),
   requiredRef("patients", "clientId", "clients"),
@@ -311,18 +318,14 @@ const RESTORE_REFERENCE_RULES: RestoreReferenceRule[] = [
   optionalRef("vitalSigns", "appointmentId", "appointments"),
   optionalRef("vitalSigns", "recordedBy", "users"),
   requiredRef("clinicalRecordCorrections", "patientId", "patients"),
-  optionalRef(
-    "clinicalRecordCorrections",
-    "appointmentId",
-    "appointments"
-  ),
+  optionalRef("clinicalRecordCorrections", "appointmentId", "appointments"),
   requiredRef("clinicalRecordCorrections", "correctedBy", "users"),
   optionalRef("clinicalRecordCorrections", "soapNoteId", "soapNotes"),
   optionalRef("clinicalRecordCorrections", "vitalSignId", "vitalSigns"),
   optionalRef(
     "clinicalRecordCorrections",
     "vaccinationRecordId",
-    "vaccinationRecords"
+    "vaccinationRecords",
   ),
   requiredRef("cases", "patientId", "patients"),
   optionalRef("cases", "primaryVetId", "users"),
@@ -371,12 +374,14 @@ function withPracticeId(rows: Row[], practiceId: string): Row[] {
   return rows.map((row) => ({ ...row, practiceId }));
 }
 
-function countsFor(sections: Record<PracticeExportSection, unknown[]>): Record<PracticeExportSection, number> {
+function countsFor(
+  sections: Record<PracticeExportSection, unknown[]>,
+): Record<PracticeExportSection, number> {
   return Object.fromEntries(
     PRACTICE_EXPORT_SECTIONS.map((section) => [
       section,
       sections[section].length,
-    ])
+    ]),
   ) as Record<PracticeExportSection, number>;
 }
 
@@ -386,20 +391,18 @@ export function summarizePracticeExport(data: unknown): {
   totalRows: number;
 } {
   const record = isRecord(data) ? data : {};
-  const missingSections = PRACTICE_EXPORT_SECTIONS.filter(
-    (section) => {
-      if (Array.isArray(record[section])) return false;
-      const isBackwardCompatibleAbsence =
-        !Object.prototype.hasOwnProperty.call(record, section) &&
-        PRACTICE_EXPORT_OPTIONAL_RESTORE_SECTIONS.includes(section as never);
-      return !isBackwardCompatibleAbsence;
-    },
-  );
+  const missingSections = PRACTICE_EXPORT_SECTIONS.filter((section) => {
+    if (Array.isArray(record[section])) return false;
+    const isBackwardCompatibleAbsence =
+      !Object.prototype.hasOwnProperty.call(record, section) &&
+      PRACTICE_EXPORT_OPTIONAL_RESTORE_SECTIONS.includes(section as never);
+    return !isBackwardCompatibleAbsence;
+  });
   const counts = Object.fromEntries(
     PRACTICE_EXPORT_SECTIONS.map((section) => [
       section,
       rowsFor(record, section).length,
-    ])
+    ]),
   ) as Record<PracticeExportSection, number>;
 
   return {
@@ -430,7 +433,9 @@ const PATIENT_IDENTITY_SEX = new Set([
 ]);
 
 function isNullableBoundedString(value: unknown, maxLength: number): boolean {
-  return value == null || (typeof value === "string" && value.length <= maxLength);
+  return (
+    value == null || (typeof value === "string" && value.length <= maxLength)
+  );
 }
 
 function isValidCalendarDate(value: unknown): boolean {
@@ -439,7 +444,10 @@ function isValidCalendarDate(value: unknown): boolean {
     return false;
   }
   const parsed = new Date(`${value}T00:00:00.000Z`);
-  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+  return (
+    !Number.isNaN(parsed.getTime()) &&
+    parsed.toISOString().slice(0, 10) === value
+  );
 }
 
 function isValidPatientIdentitySnapshot(
@@ -482,7 +490,10 @@ function isRestoredTimestamp(value: unknown): boolean {
   );
 }
 
-function validateRestoreRows(data: unknown, pushError: (message: string) => void) {
+function validateRestoreRows(
+  data: unknown,
+  pushError: (message: string) => void,
+) {
   const record = isRecord(data) ? data : {};
 
   for (const section of PRACTICE_EXPORT_SECTIONS) {
@@ -521,7 +532,9 @@ export function validatePracticeExportRestore(data: unknown): {
       ids = new Set(
         rowsFor(data, section)
           .map((row) => row.id)
-          .filter((id): id is string => typeof id === "string" && id.length > 0)
+          .filter(
+            (id): id is string => typeof id === "string" && id.length > 0,
+          ),
       );
       parentIds.set(section, ids);
     }
@@ -543,7 +556,7 @@ export function validatePracticeExportRestore(data: unknown): {
       if (value == null || value === "") {
         if (rule.required) {
           pushError(
-            `${rule.section}[${rowLabel(row, index)}].${rule.field} is required.`
+            `${rule.section}[${rowLabel(row, index)}].${rule.field} is required.`,
           );
         }
         return;
@@ -551,14 +564,14 @@ export function validatePracticeExportRestore(data: unknown): {
 
       if (typeof value !== "string") {
         pushError(
-          `${rule.section}[${rowLabel(row, index)}].${rule.field} must be a string id.`
+          `${rule.section}[${rowLabel(row, index)}].${rule.field} must be a string id.`,
         );
         return;
       }
 
       if (!ids.has(value)) {
         pushError(
-          `${rule.section}[${rowLabel(row, index)}].${rule.field} references missing ${rule.parentSection} row "${value}".`
+          `${rule.section}[${rowLabel(row, index)}].${rule.field} references missing ${rule.parentSection} row "${value}".`,
         );
       }
     });
@@ -568,9 +581,9 @@ export function validatePracticeExportRestore(data: unknown): {
     new Map(
       rowsFor(data, section)
         .filter((row): row is Row & { id: string } =>
-          Boolean(typeof row.id === "string" && row.id.length > 0)
+          Boolean(typeof row.id === "string" && row.id.length > 0),
         )
-        .map((row) => [row.id, row])
+        .map((row) => [row.id, row]),
     );
   const appointmentRows = rowsById("appointments");
 
@@ -582,7 +595,7 @@ export function validatePracticeExportRestore(data: unknown): {
 
       if (appointment.patientId !== row.patientId) {
         pushError(
-          `${section}[${rowLabel(row, index)}].appointmentId must reference an appointment for the same patient.`
+          `${section}[${rowLabel(row, index)}].appointmentId must reference an appointment for the same patient.`,
         );
       }
     });
@@ -640,10 +653,15 @@ export function validatePracticeExportRestore(data: unknown): {
         pushError(`${label} cannot use an existing merge target as a source.`);
       }
 
-      if (typeof practiceId === "string" && typeof row.sourcePatientId === "string") {
+      if (
+        typeof practiceId === "string" &&
+        typeof row.sourcePatientId === "string"
+      ) {
         const sourceKey = `${practiceId}:${row.sourcePatientId}`;
         if (sourceKeys.has(sourceKey)) {
-          pushError(`${label}.sourcePatientId must be unique within its practice.`);
+          pushError(
+            `${label}.sourcePatientId must be unique within its practice.`,
+          );
         }
         sourceKeys.add(sourceKey);
       }
@@ -667,7 +685,9 @@ export function validatePracticeExportRestore(data: unknown): {
         row.performedByName.trim().length === 0 ||
         row.performedByName.length > 255
       ) {
-        pushError(`${label}.performedByName must be between 1 and 255 characters.`);
+        pushError(
+          `${label}.performedByName must be between 1 and 255 characters.`,
+        );
       }
       if (
         typeof row.reason !== "string" ||
@@ -684,7 +704,9 @@ export function validatePracticeExportRestore(data: unknown): {
           row.clientId,
         )
       ) {
-        pushError(`${label}.sourceSnapshot must be a valid patient identity snapshot.`);
+        pushError(
+          `${label}.sourceSnapshot must be a valid patient identity snapshot.`,
+        );
       }
       if (
         !isValidPatientIdentitySnapshot(
@@ -693,7 +715,9 @@ export function validatePracticeExportRestore(data: unknown): {
           row.clientId,
         )
       ) {
-        pushError(`${label}.targetSnapshot must be a valid patient identity snapshot.`);
+        pushError(
+          `${label}.targetSnapshot must be a valid patient identity snapshot.`,
+        );
       }
 
       if (
@@ -701,14 +725,18 @@ export function validatePracticeExportRestore(data: unknown): {
         (sourcePatient.clientId !== row.clientId ||
           sourcePatient.practiceId !== practiceId)
       ) {
-        pushError(`${label}.sourcePatientId must share its client and practice.`);
+        pushError(
+          `${label}.sourcePatientId must share its client and practice.`,
+        );
       }
       if (
         targetPatient &&
         (targetPatient.clientId !== row.clientId ||
           targetPatient.practiceId !== practiceId)
       ) {
-        pushError(`${label}.targetPatientId must share its client and practice.`);
+        pushError(
+          `${label}.targetPatientId must share its client and practice.`,
+        );
       }
       if (client && client.practiceId !== practiceId) {
         pushError(`${label}.clientId must belong to the declared practice.`);
@@ -717,7 +745,9 @@ export function validatePracticeExportRestore(data: unknown): {
         pushError(`${label}.performedBy must belong to the declared practice.`);
       }
       if (sourcePatient && !isRestoredTimestamp(sourcePatient.deletedAt)) {
-        pushError(`${label}.sourcePatientId must reference a soft-deleted source.`);
+        pushError(
+          `${label}.sourcePatientId must reference a soft-deleted source.`,
+        );
       }
       if (targetPatient && targetPatient.deletedAt != null) {
         pushError(`${label}.targetPatientId must reference an active target.`);
@@ -763,7 +793,8 @@ export function validatePracticeExportRestore(data: unknown): {
     const invoiceItemsByDispense = new Map<string, Row[]>();
     rowsFor(data, "invoiceItems").forEach((item) => {
       if (typeof item.sourceDispenseChargeId !== "string") return;
-      const rows = invoiceItemsByDispense.get(item.sourceDispenseChargeId) ?? [];
+      const rows =
+        invoiceItemsByDispense.get(item.sourceDispenseChargeId) ?? [];
       rows.push(item);
       invoiceItemsByDispense.set(item.sourceDispenseChargeId, rows);
     });
@@ -771,7 +802,7 @@ export function validatePracticeExportRestore(data: unknown): {
       const label = `dispenseChargeQueue[${rowLabel(row, index)}]`;
       const sourceItems =
         typeof row.id === "string"
-          ? invoiceItemsByDispense.get(row.id) ?? []
+          ? (invoiceItemsByDispense.get(row.id) ?? [])
           : [];
       if (
         row.status !== "pending" &&
@@ -827,7 +858,9 @@ export function validatePracticeExportRestore(data: unknown): {
         row.resolutionReason.trim().length < 5 ||
         row.resolutionReason.length > 1000
       ) {
-        pushError(`${label} waived state requires one bounded reason and no invoice.`);
+        pushError(
+          `${label} waived state requires one bounded reason and no invoice.`,
+        );
       }
     });
   }
@@ -847,34 +880,35 @@ export function validatePracticeExportRestore(data: unknown): {
         return;
       }
       if (row.vitalSignId != null) {
-        pushError(`${label}.vitalSignId must be null for recordType soap_note.`);
+        pushError(
+          `${label}.vitalSignId must be null for recordType soap_note.`,
+        );
         return;
       }
       if (row.vaccinationRecordId != null) {
         pushError(
-          `${label}.vaccinationRecordId must be null for recordType soap_note.`
+          `${label}.vaccinationRecordId must be null for recordType soap_note.`,
         );
         return;
       }
       source = soapRows.get(row.soapNoteId);
       sourceIdentity = `soap_note:${row.soapNoteId}`;
     } else if (row.recordType === "vital_sign") {
-      if (
-        typeof row.vitalSignId !== "string" ||
-        row.vitalSignId.length === 0
-      ) {
+      if (typeof row.vitalSignId !== "string" || row.vitalSignId.length === 0) {
         pushError(
-          `${label}.vitalSignId is required for recordType vital_sign.`
+          `${label}.vitalSignId is required for recordType vital_sign.`,
         );
         return;
       }
       if (row.soapNoteId != null) {
-        pushError(`${label}.soapNoteId must be null for recordType vital_sign.`);
+        pushError(
+          `${label}.soapNoteId must be null for recordType vital_sign.`,
+        );
         return;
       }
       if (row.vaccinationRecordId != null) {
         pushError(
-          `${label}.vaccinationRecordId must be null for recordType vital_sign.`
+          `${label}.vaccinationRecordId must be null for recordType vital_sign.`,
         );
         return;
       }
@@ -886,13 +920,13 @@ export function validatePracticeExportRestore(data: unknown): {
         row.vaccinationRecordId.length === 0
       ) {
         pushError(
-          `${label}.vaccinationRecordId is required for recordType vaccination_record.`
+          `${label}.vaccinationRecordId is required for recordType vaccination_record.`,
         );
         return;
       }
       if (row.soapNoteId != null || row.vitalSignId != null) {
         pushError(
-          `${label}.soapNoteId and .vitalSignId must be null for recordType vaccination_record.`
+          `${label}.soapNoteId and .vitalSignId must be null for recordType vaccination_record.`,
         );
         return;
       }
@@ -900,7 +934,7 @@ export function validatePracticeExportRestore(data: unknown): {
       sourceIdentity = `vaccination_record:${row.vaccinationRecordId}`;
     } else {
       pushError(
-        `${label}.recordType must be soap_note, vital_sign, or vaccination_record.`
+        `${label}.recordType must be soap_note, vital_sign, or vaccination_record.`,
       );
       return;
     }
@@ -919,7 +953,7 @@ export function validatePracticeExportRestore(data: unknown): {
       sourceAppointmentId !== correctionAppointmentId
     ) {
       pushError(
-        `${label} must match its source record patientId and appointmentId exactly.`
+        `${label} must match its source record patientId and appointmentId exactly.`,
       );
     }
   });
@@ -956,6 +990,155 @@ export function synthesizeLegacyPrescriptionEvents(data: unknown): Row[] {
   }));
 }
 
+/**
+ * Backups created before the consent ledger may contain only the current
+ * client projection. Preserve an affirmative value only when that legacy row
+ * itself contains complete, valid evidence; otherwise clear it fail-closed.
+ */
+export function prepareLegacySmsConsentRestore(data: unknown): {
+  clients: Row[];
+  smsConsentEvents: Row[];
+} {
+  const clientRows = rowsFor(data, "clients");
+  const backupRecord = isRecord(data) ? data : {};
+  if (Object.prototype.hasOwnProperty.call(backupRecord, "smsConsentEvents")) {
+    const eventRows = rowsFor(data, "smsConsentEvents");
+    const latestGrants = new Map<string, Row>();
+    const latestRevokes = new Map<string, Row>();
+    const occurredAtMs = (event: Row) => {
+      const value = event.occurredAt;
+      if (value instanceof Date) return value.getTime();
+      if (typeof value === "string") return new Date(value).getTime();
+      return Number.NaN;
+    };
+    const compareEvents = (left: Row, right: Row) => {
+      const leftTime = occurredAtMs(left);
+      const rightTime = occurredAtMs(right);
+      if (!Number.isFinite(leftTime) || !Number.isFinite(rightTime)) {
+        // Malformed modern evidence must never preserve an affirmative state.
+        return Number.NaN;
+      }
+      return (
+        leftTime - rightTime ||
+        String(left.id ?? "").localeCompare(String(right.id ?? ""))
+      );
+    };
+    for (const event of eventRows) {
+      if (typeof event.destinationE164 !== "string") continue;
+      if (event.action === "revoked") {
+        const prior = latestRevokes.get(event.destinationE164);
+        if (!prior || compareEvents(event, prior) > 0) {
+          latestRevokes.set(event.destinationE164, event);
+        }
+      } else if (
+        event.action === "granted" &&
+        typeof event.clientId === "string"
+      ) {
+        const key = `${event.clientId}\u0000${event.destinationE164}`;
+        const prior = latestGrants.get(key);
+        if (!prior || compareEvents(event, prior) > 0) {
+          latestGrants.set(key, event);
+        }
+      }
+    }
+    return {
+      clients: clientRows.map((client) => {
+        if (client.smsConsent !== true) return client;
+        const destination = normalizeE164(
+          typeof client.phone === "string" ? client.phone : null,
+        );
+        const matchingGrant =
+          typeof client.id === "string" && destination !== null
+            ? latestGrants.get(`${client.id}\u0000${destination}`)
+            : undefined;
+        const latestRevoke = destination
+          ? latestRevokes.get(destination)
+          : undefined;
+        const latestApplicableEventIsGrant =
+          matchingGrant !== undefined &&
+          Number.isFinite(occurredAtMs(matchingGrant)) &&
+          (!latestRevoke ||
+            (Number.isFinite(occurredAtMs(latestRevoke)) &&
+              occurredAtMs(matchingGrant) > occurredAtMs(latestRevoke)));
+        return latestApplicableEventIsGrant
+          ? client
+          : {
+              ...client,
+              smsConsent: false,
+              smsConsentAt: null,
+              smsConsentSource: null,
+              smsConsentDisclosure: null,
+            };
+      }),
+      smsConsentEvents: eventRows,
+    };
+  }
+
+  const synthesizedEvents: Row[] = [];
+  const preparedClients = clientRows.map((client) => {
+    if (client.smsConsent !== true) return client;
+
+    const destination = normalizeE164(
+      typeof client.phone === "string" ? client.phone : null,
+    );
+    const source =
+      typeof client.smsConsentSource === "string"
+        ? client.smsConsentSource.trim()
+        : "";
+    const disclosure =
+      typeof client.smsConsentDisclosure === "string"
+        ? client.smsConsentDisclosure.trim()
+        : "";
+    const disclosureVersion = source.split(":", 2)[1]?.trim() ?? "";
+    const occurredAt = client.smsConsentAt;
+    const hasTruthfulEvidence =
+      typeof client.id === "string" &&
+      destination !== null &&
+      source.length > 0 &&
+      disclosureVersion.length > 0 &&
+      disclosure.length > 0 &&
+      isRestoredTimestamp(occurredAt);
+
+    if (!hasTruthfulEvidence) {
+      return {
+        ...client,
+        smsConsent: false,
+        smsConsentAt: null,
+        smsConsentSource: null,
+        smsConsentDisclosure: null,
+      };
+    }
+
+    const eventDigest = createHash("sha256")
+      .update(client.id as string)
+      .digest("hex");
+    synthesizedEvents.push({
+      id: randomUUID(),
+      createdAt: occurredAt,
+      occurredAt,
+      practiceId: client.practiceId,
+      clientId: client.id,
+      locationId: null,
+      destinationE164: destination,
+      action: "granted",
+      source,
+      disclosureVersion,
+      disclosure,
+      detail:
+        "Restored from complete affirmative evidence in a pre-ledger backup.",
+      actorType: "system",
+      actorUserId: null,
+      actorName: null,
+      provider: null,
+      providerMessageId: null,
+      eventKey: `restore:legacy-client:${eventDigest}:affirmative-v1`,
+    });
+    return client;
+  });
+
+  return { clients: preparedClients, smsConsentEvents: synthesizedEvents };
+}
+
 async function activeRows(db: Database, table: any, practiceId: string) {
   return db
     .select()
@@ -974,7 +1157,7 @@ async function tenantParentChildRows(
   parentIds: string[],
   parentTable: any,
   parentIdColumn: any,
-  practiceId: string
+  practiceId: string,
 ) {
   if (parentIds.length === 0) return [];
   return db
@@ -990,8 +1173,8 @@ async function tenantParentChildRows(
             and ${parentTable.practiceId} = ${practiceId}
             and ${parentTable.deletedAt} is null
         )`,
-        isNull(table.deletedAt)
-      )
+        isNull(table.deletedAt),
+      ),
     );
 }
 
@@ -1002,7 +1185,9 @@ async function tenantParentChildRows(
  */
 export function coerceRowDates(table: any, rows: Row[]): Row[] {
   const dateColumns = Object.entries(getTableColumns(table))
-    .filter(([, column]) => (column as { dataType?: string }).dataType === "date")
+    .filter(
+      ([, column]) => (column as { dataType?: string }).dataType === "date",
+    )
     .map(([name]) => name);
   if (dateColumns.length === 0) return rows;
 
@@ -1024,12 +1209,12 @@ async function restoreRows(
   table: any,
   section: PracticeExportSection,
   rows: Row[],
-  opts: { practiceId?: string } = {}
+  opts: { practiceId?: string } = {},
 ): Promise<number> {
   if (rows.length === 0) return 0;
   const sanitizedRows = coerceRowDates(
     table,
-    sanitizePracticeExportRows(section, rows)
+    sanitizePracticeExportRows(section, rows),
   );
   const values = opts.practiceId
     ? withPracticeId(sanitizedRows, opts.practiceId)
@@ -1045,12 +1230,13 @@ async function restoreRows(
 export async function exportPracticeData(
   db: Database,
   practiceId: string,
-  exportedAt: string
+  exportedAt: string,
 ): Promise<PracticeExport> {
   const [
     allLocationRows,
     locationMessagingRows,
     smsSuppressionRows,
+    smsConsentEventRows,
     emailSuppressionRows,
     webhookRows,
     apiKeyRows,
@@ -1096,6 +1282,7 @@ export async function exportPracticeData(
     allPracticeRows(db, locations, practiceId),
     activeRows(db, locationMessaging, practiceId),
     activeRows(db, smsSuppressions, practiceId),
+    allPracticeRows(db, smsConsentEvents, practiceId),
     activeRows(db, emailSuppressions, practiceId),
     activeRows(db, webhooks, practiceId),
     activeRows(db, apiKeys, practiceId),
@@ -1226,6 +1413,7 @@ export async function exportPracticeData(
       ...vaccinationRows.map((vaccination) => vaccination.administeredBy),
       ...appointmentRows.map((appointment) => appointment.doctorId),
       ...patientMergeRows.map((event) => event.performedBy),
+      ...smsConsentEventRows.map((event) => event.actorUserId),
     ].filter((id): id is string => typeof id === "string"),
   );
   const userRows = allUserRows.filter(
@@ -1236,16 +1424,17 @@ export async function exportPracticeData(
       ...patientRows.map((patient) => patient.clientId),
       ...appointmentRows.map((appointment) => appointment.clientId),
       ...patientMergeRows.map((event) => event.clientId),
+      ...smsConsentEventRows.map((event) => event.clientId),
     ].filter((id): id is string => typeof id === "string"),
   );
   const clientRows = allClientRows.filter(
-    (client) =>
-      client.deletedAt == null || referencedClientIds.has(client.id),
+    (client) => client.deletedAt == null || referencedClientIds.has(client.id),
   );
   const referencedLocationIds = new Set(
     [
       ...productRows.map((product) => product.locationId),
       ...userRows.map((user) => user.locationId),
+      ...smsConsentEventRows.map((event) => event.locationId),
       ...allRoomRows.map((room) =>
         appointmentRows.some((appointment) => appointment.roomId === room.id)
           ? room.locationId
@@ -1307,7 +1496,7 @@ export async function exportPracticeData(
       patientIds,
       patients,
       patients.id,
-      practiceId
+      practiceId,
     ),
     tenantParentChildRows(
       db,
@@ -1316,7 +1505,7 @@ export async function exportPracticeData(
       patientIds,
       patients,
       patients.id,
-      practiceId
+      practiceId,
     ),
     tenantParentChildRows(
       db,
@@ -1325,7 +1514,7 @@ export async function exportPracticeData(
       invoiceIds,
       invoices,
       invoices.id,
-      practiceId
+      practiceId,
     ),
     tenantParentChildRows(
       db,
@@ -1334,7 +1523,7 @@ export async function exportPracticeData(
       invoiceIds,
       invoices,
       invoices.id,
-      practiceId
+      practiceId,
     ),
     tenantParentChildRows(
       db,
@@ -1343,7 +1532,7 @@ export async function exportPracticeData(
       invoiceIds,
       invoices,
       invoices.id,
-      practiceId
+      practiceId,
     ),
     tenantParentChildRows(
       db,
@@ -1352,7 +1541,7 @@ export async function exportPracticeData(
       treatmentTemplateIds,
       treatmentTemplates,
       treatmentTemplates.id,
-      practiceId
+      practiceId,
     ),
     tenantParentChildRows(
       db,
@@ -1361,7 +1550,7 @@ export async function exportPracticeData(
       caseIds,
       cases,
       cases.id,
-      practiceId
+      practiceId,
     ),
     tenantParentChildRows(
       db,
@@ -1370,7 +1559,7 @@ export async function exportPracticeData(
       treatmentPlanIds,
       treatmentPlans,
       treatmentPlans.id,
-      practiceId
+      practiceId,
     ),
   ]);
 
@@ -1378,6 +1567,7 @@ export async function exportPracticeData(
     locations: locationRows,
     locationMessaging: locationMessagingRows,
     smsSuppressions: smsSuppressionRows,
+    smsConsentEvents: smsConsentEventRows,
     emailSuppressions: emailSuppressionRows,
     webhooks: sanitizePracticeExportRows("webhooks", webhookRows),
     apiKeys: sanitizePracticeExportRows("apiKeys", apiKeyRows),
@@ -1447,18 +1637,21 @@ export async function exportPracticeData(
 async function restorePracticeDataRows(
   db: Database,
   practiceId: string,
-  data: unknown
-): Promise<{ restored: Record<PracticeExportSection, number>; totalRows: number }> {
+  data: unknown,
+): Promise<{
+  restored: Record<PracticeExportSection, number>;
+  totalRows: number;
+}> {
   const summary = summarizePracticeExport(data);
   if (summary.missingSections.length > 0) {
     throw new Error(
-      `Backup is missing required sections: ${summary.missingSections.join(", ")}`
+      `Backup is missing required sections: ${summary.missingSections.join(", ")}`,
     );
   }
   const validation = validatePracticeExportRestore(data);
   if (!validation.valid) {
     throw new Error(
-      `Backup contains invalid restore data: ${validation.errors.join("; ")}`
+      `Backup contains invalid restore data: ${validation.errors.join("; ")}`,
     );
   }
   const backupRecord = isRecord(data) ? data : {};
@@ -1467,15 +1660,33 @@ async function restorePracticeDataRows(
     "dispenseChargeQueue",
   );
   const dispenseChargeRestoreRows = rowsFor(data, "dispenseChargeQueue");
+  const smsConsentRestore = prepareLegacySmsConsentRestore(data);
 
   const restored = {} as Record<PracticeExportSection, number>;
-  const restorePracticeRows = async (section: PracticeExportSection, table: any) => {
-    restored[section] = await restoreRows(db, table, section, rowsFor(data, section), {
-      practiceId,
-    });
+  const restorePracticeRows = async (
+    section: PracticeExportSection,
+    table: any,
+  ) => {
+    restored[section] = await restoreRows(
+      db,
+      table,
+      section,
+      rowsFor(data, section),
+      {
+        practiceId,
+      },
+    );
   };
-  const restoreChildRows = async (section: PracticeExportSection, table: any) => {
-    restored[section] = await restoreRows(db, table, section, rowsFor(data, section));
+  const restoreChildRows = async (
+    section: PracticeExportSection,
+    table: any,
+  ) => {
+    restored[section] = await restoreRows(
+      db,
+      table,
+      section,
+      rowsFor(data, section),
+    );
   };
 
   await restorePracticeRows("locations", locations);
@@ -1489,7 +1700,20 @@ async function restorePracticeDataRows(
   await restorePracticeRows("appointmentTypes", appointmentTypes);
   await restorePracticeRows("rooms", rooms);
   await restorePracticeRows("recurringSeries", recurringSeries);
-  await restorePracticeRows("clients", clients);
+  restored.clients = await restoreRows(
+    db,
+    clients,
+    "clients",
+    smsConsentRestore.clients,
+    { practiceId },
+  );
+  restored.smsConsentEvents = await restoreRows(
+    db,
+    smsConsentEvents,
+    "smsConsentEvents",
+    smsConsentRestore.smsConsentEvents,
+    { practiceId },
+  );
   await restorePracticeRows("patients", patients);
   await restorePracticeRows("patientMergeEvents", patientMergeEvents);
   await restorePracticeRows("insurancePolicies", insurancePolicies);
@@ -1531,7 +1755,7 @@ async function restorePracticeDataRows(
   await restorePracticeRows("vitalSigns", vitalSigns);
   await restorePracticeRows(
     "clinicalRecordCorrections",
-    clinicalRecordCorrections
+    clinicalRecordCorrections,
   );
   await restorePracticeRows("cases", cases);
   await restoreChildRows("caseEntries", caseEntries);
@@ -1602,16 +1826,13 @@ async function restorePracticeDataRows(
           resolvedBy:
             typeof row.resolvedBy === "string" ? row.resolvedBy : null,
           resolvedByName:
-            typeof row.resolvedByName === "string"
-              ? row.resolvedByName
-              : null,
+            typeof row.resolvedByName === "string" ? row.resolvedByName : null,
           resolvedAt: row.resolvedAt instanceof Date ? row.resolvedAt : null,
           resolutionReason:
             typeof row.resolutionReason === "string"
               ? row.resolutionReason
               : null,
-          updatedAt:
-            row.updatedAt instanceof Date ? row.updatedAt : new Date(),
+          updatedAt: row.updatedAt instanceof Date ? row.updatedAt : new Date(),
         })
         .where(
           and(
@@ -1635,23 +1856,28 @@ async function restorePracticeDataRows(
 export async function restorePracticeData(
   db: Database,
   practiceId: string,
-  data: unknown
-): Promise<{ restored: Record<PracticeExportSection, number>; totalRows: number }> {
-  const transaction = (db as unknown as {
-    transaction?: (
-      fn: (tx: unknown) => Promise<{
+  data: unknown,
+): Promise<{
+  restored: Record<PracticeExportSection, number>;
+  totalRows: number;
+}> {
+  const transaction = (
+    db as unknown as {
+      transaction?: (
+        fn: (tx: unknown) => Promise<{
+          restored: Record<PracticeExportSection, number>;
+          totalRows: number;
+        }>,
+      ) => Promise<{
         restored: Record<PracticeExportSection, number>;
         totalRows: number;
-      }>
-    ) => Promise<{
-      restored: Record<PracticeExportSection, number>;
-      totalRows: number;
-    }>;
-  }).transaction;
+      }>;
+    }
+  ).transaction;
 
   if (typeof transaction === "function") {
     return transaction.call(db, (tx) =>
-      restorePracticeDataRows(tx as Database, practiceId, data)
+      restorePracticeDataRows(tx as Database, practiceId, data),
     );
   }
 

--- a/apps/web/lib/messaging/__tests__/consent-events.test.ts
+++ b/apps/web/lib/messaging/__tests__/consent-events.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  appendRequiredSmsConsentEventInTransaction,
+  appendSmsConsentEventInTransaction,
+  inboundSmsConsentEventKey,
+  SMS_CONSENT_EVENT_DETAIL_MAX_LENGTH,
+} from "../consent-events";
+
+describe("SMS consent event evidence", () => {
+  it("uses deterministic bounded keys for provider webhook replay", () => {
+    expect(inboundSmsConsentEventKey("telnyx", "message-1", "revoked")).toBe(
+      "inbound:telnyx:message-1:revoked",
+    );
+
+    const longId = `message-${"x".repeat(240)}`;
+    const first = inboundSmsConsentEventKey("twilio", longId, "granted");
+    const second = inboundSmsConsentEventKey("twilio", longId, "granted");
+    expect(first).toBe(second);
+    expect(first.length).toBeLessThanOrEqual(200);
+  });
+
+  it("returns false when an exact event was already appended", async () => {
+    const returning = vi.fn(async () => []);
+    const onConflictDoNothing = vi.fn(() => ({ returning }));
+    const values = vi.fn(() => ({ onConflictDoNothing }));
+    const insert = vi.fn(() => ({ values }));
+
+    await expect(
+      appendSmsConsentEventInTransaction({ insert } as never, {
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        destinationE164: "+15555550123",
+        action: "revoked",
+        source: "inbound_opt_out:v1",
+        actorType: "client",
+        provider: "telnyx",
+        providerMessageId: "message-1",
+        eventKey: "inbound:telnyx:message-1:revoked",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("fails a required staff event so its transaction cannot commit unaudited", async () => {
+    const returning = vi.fn(async () => []);
+    const onConflictDoNothing = vi.fn(() => ({ returning }));
+    const values = vi.fn(() => ({ onConflictDoNothing }));
+    const insert = vi.fn(() => ({ values }));
+
+    await expect(
+      appendRequiredSmsConsentEventInTransaction({ insert } as never, {
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        destinationE164: "+15555550123",
+        action: "granted",
+        source: "staff_attested_form:v1",
+        disclosureVersion: "v1",
+        disclosure: "Exact disclosure",
+        actorType: "staff",
+        actorUserId: "00000000-0000-0000-0000-000000000001",
+        actorName: "Test User",
+        eventKey: "staff:collision",
+      }),
+    ).rejects.toThrow("SMS consent evidence event could not be appended");
+  });
+
+  it("persists normalized evidence snapshots without caller-owned updates", async () => {
+    const returning = vi.fn(async () => [{ id: "event-1" }]);
+    const onConflictDoNothing = vi.fn(() => ({ returning }));
+    const values = vi.fn(() => ({ onConflictDoNothing }));
+    const insert = vi.fn(() => ({ values }));
+
+    await expect(
+      appendSmsConsentEventInTransaction({ insert } as never, {
+        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        clientId: "00000000-0000-0000-0000-000000000003",
+        destinationE164: "+15555550123",
+        action: "granted",
+        source: "staff_attested_form:v1",
+        disclosureVersion: "v1",
+        disclosure: "Exact disclosure",
+        actorType: "staff",
+        actorUserId: "00000000-0000-0000-0000-000000000001",
+        actorName: "Test User",
+        eventKey: "staff:event-1",
+      }),
+    ).resolves.toBe(true);
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationE164: "+15555550123",
+        action: "granted",
+        disclosure: "Exact disclosure",
+        occurredAt: expect.any(Date),
+      }),
+    );
+  });
+
+  it("bounds free-form detail before it reaches the database constraint", async () => {
+    const returning = vi.fn(async () => [{ id: "event-1" }]);
+    const onConflictDoNothing = vi.fn(() => ({ returning }));
+    const values = vi.fn(() => ({ onConflictDoNothing }));
+    const insert = vi.fn(() => ({ values }));
+
+    await appendSmsConsentEventInTransaction({ insert } as never, {
+      practiceId: "00000000-0000-0000-0000-0000000000aa",
+      destinationE164: "+15555550123",
+      action: "revoked",
+      source: "inbound_opt_out:v1",
+      detail: "x".repeat(SMS_CONSENT_EVENT_DETAIL_MAX_LENGTH + 500),
+      actorType: "client",
+      provider: "telnyx",
+      providerMessageId: "message-long",
+      eventKey: "inbound:telnyx:message-long:revoked",
+    });
+
+    expect(values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: "x".repeat(SMS_CONSENT_EVENT_DETAIL_MAX_LENGTH),
+      }),
+    );
+  });
+});

--- a/apps/web/lib/messaging/__tests__/phone.test.ts
+++ b/apps/web/lib/messaging/__tests__/phone.test.ts
@@ -22,6 +22,11 @@ describe("normalizeE164", () => {
     expect(normalizeE164("+44 20 7946 0958")).toBe("+442079460958");
   });
 
+  it("rejects plus-prefixed numbers with an invalid zero country code", () => {
+    expect(normalizeE164("+05555550123")).toBeNull();
+    expect(normalizeE164("+0 555 555 0123")).toBeNull();
+  });
+
   it("returns null for empty / nullish input", () => {
     expect(normalizeE164("")).toBeNull();
     expect(normalizeE164(null)).toBeNull();

--- a/apps/web/lib/messaging/__tests__/suppression.test.ts
+++ b/apps/web/lib/messaging/__tests__/suppression.test.ts
@@ -2,9 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { smsSuppressions } from "@openpims/db";
 
 const mocks = vi.hoisted(() => {
-  const deleteWhere = vi.fn(async (_condition: unknown) => undefined);
-  const deleteFrom = vi.fn(() => ({ where: deleteWhere }));
-  const insertConflict = vi.fn(async () => undefined);
+  const insertReturning = vi.fn(async () => [{ id: "event-1" }]);
+  const insertConflict = vi.fn(() => ({ returning: insertReturning }));
   const insertValues = vi.fn(() => ({
     onConflictDoNothing: insertConflict,
     onConflictDoUpdate: insertConflict,
@@ -16,21 +15,20 @@ const mocks = vi.hoisted(() => {
   const update = vi.fn(() => ({ set: updateSet }));
   const execute = vi.fn(async () => undefined);
   const tx = {
-    delete: deleteFrom,
     insert,
     update,
     execute,
   };
   return {
     tx,
-    deleteWhere,
     insertValues,
     insertConflict,
+    insertReturning,
     updateSet,
     updateWhere,
     execute,
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn(tx)
+      fn(tx),
     ),
   };
 });
@@ -43,48 +41,10 @@ vi.mock("@/lib/tenant-db", () => ({
   withSystem: mocks.withSystem,
 }));
 
-const { addSuppression, removeSuppression, revokeSmsConsentByPhone } =
+const { addSuppression, revokeSmsConsentByPhone } =
   await import("../suppression");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
-
-function sqlIncludesColumnParamPair(
-  value: unknown,
-  columnName: string,
-  paramValue: unknown
-): boolean {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-
-  const chunk = value as { name?: unknown; queryChunks?: unknown[] };
-  if (!Array.isArray(chunk.queryChunks)) {
-    return false;
-  }
-
-  const hasColumn = chunk.queryChunks.some(
-    (item) =>
-      !!item &&
-      typeof item === "object" &&
-      (item as { name?: unknown }).name === columnName
-  );
-  const hasParam = chunk.queryChunks.some((item) => {
-    if (!item || typeof item !== "object") {
-      return false;
-    }
-    const candidate = item as { value?: unknown };
-    return Object.prototype.hasOwnProperty.call(candidate, "value")
-      ? Object.is(candidate.value, paramValue)
-      : false;
-  });
-
-  return (
-    (hasColumn && hasParam) ||
-    chunk.queryChunks.some((item) =>
-      sqlIncludesColumnParamPair(item, columnName, paramValue)
-    )
-  );
-}
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -107,16 +67,9 @@ describe("SMS suppression helpers", () => {
         phone: "+15555550100",
         reason: "bounce",
         detail: "Delivery failed",
-      })
+      }),
     );
     expect(mocks.insertConflict).toHaveBeenCalled();
-  });
-
-  it("removes only stop suppressions when a recipient texts start", async () => {
-    await removeSuppression(PRACTICE_ID, "(555) 555-0100");
-
-    const condition = mocks.deleteWhere.mock.calls[0]?.[0];
-    expect(sqlIncludesColumnParamPair(condition, "reason", "stop")).toBe(true);
   });
 
   it("writes one practice-wide manual suppression and clears every duplicate consent", async () => {
@@ -126,7 +79,14 @@ describe("SMS suppression helpers", () => {
         phone: "(555) 555-0100",
         reason: "manual",
         detail: "Staff request",
-      })
+        evidence: {
+          source: "staff_manual_revoke:v1",
+          actorType: "staff",
+          actorUserId: "00000000-0000-0000-0000-000000000001",
+          actorName: "Test User",
+          eventKey: "staff:test-manual",
+        },
+      }),
     ).resolves.toEqual({ phone: "+15555550100", clientsRevoked: 2 });
 
     expect(mocks.execute).toHaveBeenCalledOnce();
@@ -143,7 +103,7 @@ describe("SMS suppression helpers", () => {
           reason: "manual",
           deletedAt: null,
         }),
-      })
+      }),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith({
       smsConsent: false,
@@ -153,6 +113,27 @@ describe("SMS suppression helpers", () => {
     });
   });
 
+  it("rolls back a staff revocation when its immutable event is not inserted", async () => {
+    mocks.insertReturning.mockResolvedValueOnce([]);
+
+    await expect(
+      revokeSmsConsentByPhone({
+        practiceId: PRACTICE_ID,
+        phone: "+15555550100",
+        reason: "manual",
+        evidence: {
+          source: "staff_manual_revoke:v1",
+          actorType: "staff",
+          actorUserId: "00000000-0000-0000-0000-000000000001",
+          actorName: "Test User",
+          eventKey: "staff:duplicate",
+        },
+      }),
+    ).rejects.toThrow("SMS consent revocation evidence could not be appended");
+
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+  });
+
   it("does not let a later carrier STOP downgrade a staff suppression", async () => {
     await revokeSmsConsentByPhone({
       practiceId: PRACTICE_ID,
@@ -160,6 +141,13 @@ describe("SMS suppression helpers", () => {
       locationId: "00000000-0000-0000-0000-000000000002",
       reason: "stop",
       detail: "STOP",
+      evidence: {
+        source: "inbound_opt_out:v1",
+        actorType: "client",
+        provider: "telnyx",
+        providerMessageId: "message-1",
+        eventKey: "inbound:telnyx:message-1:revoked",
+      },
     });
 
     expect(mocks.insertConflict).toHaveBeenCalledWith(
@@ -170,7 +158,7 @@ describe("SMS suppression helpers", () => {
           detail: smsSuppressions.detail,
           deletedAt: null,
         }),
-      })
+      }),
     );
   });
 });

--- a/apps/web/lib/messaging/consent-events.ts
+++ b/apps/web/lib/messaging/consent-events.ts
@@ -1,0 +1,97 @@
+import { createHash, randomUUID } from "node:crypto";
+import { smsConsentEvents } from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+
+type SmsConsentEventDatabase = Pick<Database, "insert">;
+
+export const SMS_CONSENT_EVENT_DETAIL_MAX_LENGTH = 2000;
+
+export type SmsConsentEventEvidence = {
+  practiceId: string;
+  clientId?: string | null;
+  locationId?: string | null;
+  destinationE164: string;
+  action: "granted" | "revoked";
+  source: string;
+  disclosureVersion?: string | null;
+  disclosure?: string | null;
+  detail?: string | null;
+  actorType: "staff" | "client" | "system";
+  actorUserId?: string | null;
+  actorName?: string | null;
+  provider?: "telnyx" | "twilio" | null;
+  providerMessageId?: string | null;
+  eventKey: string;
+  occurredAt?: Date;
+};
+
+export function staffSmsConsentEventKey(): string {
+  return `staff:${randomUUID()}`;
+}
+
+export function inboundSmsConsentEventKey(
+  provider: "telnyx" | "twilio",
+  providerMessageId: string,
+  action: "granted" | "revoked",
+): string {
+  const raw = `inbound:${provider}:${providerMessageId}:${action}`;
+  if (raw.length <= 200) return raw;
+  return `inbound:${provider}:${action}:${createHash("sha256")
+    .update(providerMessageId)
+    .digest("hex")}`;
+}
+
+/**
+ * Append consent evidence inside the caller's projection/suppression
+ * transaction. A false result means this exact event was already applied (for
+ * example, a carrier replay) and callers must not repeat its state mutation.
+ */
+export async function appendSmsConsentEventInTransaction(
+  tx: SmsConsentEventDatabase,
+  evidence: SmsConsentEventEvidence,
+): Promise<boolean> {
+  const inserted = await tx
+    .insert(smsConsentEvents)
+    .values({
+      practiceId: evidence.practiceId,
+      clientId: evidence.clientId ?? null,
+      locationId: evidence.locationId ?? null,
+      destinationE164: evidence.destinationE164,
+      action: evidence.action,
+      source: evidence.source,
+      disclosureVersion: evidence.disclosureVersion ?? null,
+      disclosure: evidence.disclosure ?? null,
+      detail:
+        evidence.detail == null
+          ? null
+          : evidence.detail.slice(0, SMS_CONSENT_EVENT_DETAIL_MAX_LENGTH),
+      actorType: evidence.actorType,
+      actorUserId: evidence.actorUserId ?? null,
+      actorName: evidence.actorName ?? null,
+      provider: evidence.provider ?? null,
+      providerMessageId: evidence.providerMessageId ?? null,
+      eventKey: evidence.eventKey,
+      occurredAt: evidence.occurredAt ?? new Date(),
+    })
+    .onConflictDoNothing({
+      target: [smsConsentEvents.practiceId, smsConsentEvents.eventKey],
+    })
+    .returning({ id: smsConsentEvents.id });
+
+  return inserted.length === 1;
+}
+
+/**
+ * Staff-originated projection changes are not replayable. Require their
+ * evidence row to be inserted so a vanishingly unlikely event-key collision
+ * rolls the entire transaction back instead of leaving an unaudited state.
+ */
+export async function appendRequiredSmsConsentEventInTransaction(
+  tx: SmsConsentEventDatabase,
+  evidence: SmsConsentEventEvidence,
+): Promise<void> {
+  const inserted = await appendSmsConsentEventInTransaction(tx, evidence);
+  if (!inserted) {
+    throw new Error("SMS consent evidence event could not be appended");
+  }
+}

--- a/apps/web/lib/messaging/inbound.ts
+++ b/apps/web/lib/messaging/inbound.ts
@@ -7,15 +7,19 @@ import {
   locationMessaging,
   locations,
   practices,
+  smsSuppressions,
 } from "@openpims/db";
 import { withSystem, withTenant } from "@/lib/tenant-db";
 import { normalizeE164 } from "./phone";
 import {
-  isSuppressed,
-  removeSuppression,
+  acquireSmsRecipientLockInTransaction,
   revokeSmsConsentByPhone,
 } from "./suppression";
 import { inboundSmsOptInEvidence, SMS_INBOUND_OPT_IN } from "./consent";
+import {
+  appendSmsConsentEventInTransaction,
+  inboundSmsConsentEventKey,
+} from "./consent-events";
 import { latestAssignedToForClient } from "@/lib/communications/assignment";
 
 export type InboundSmsProvider = "telnyx" | "twilio";
@@ -75,7 +79,7 @@ export function classifyInboundSms(text: string): InboundSmsClassification {
 
 export function inboundSmsDedupeKey(
   provider: InboundSmsProvider,
-  providerMessageId: string | null
+  providerMessageId: string | null,
 ): string | undefined {
   if (!providerMessageId) return undefined;
   const prefix = `${provider}:inbound:`;
@@ -100,13 +104,13 @@ function normalizedClientPhoneCondition(e164: string): SQL | null {
       : fullDigits;
   return or(
     sql`regexp_replace(${clients.phone}, '\D', '', 'g') = ${fullDigits}`,
-    sql`regexp_replace(${clients.phone}, '\D', '', 'g') = ${nationalDigits}`
+    sql`regexp_replace(${clients.phone}, '\D', '', 'g') = ${nationalDigits}`,
   )!;
 }
 
 async function findMessagingLocationMatching(
   provider: InboundSmsProvider,
-  matchCondition: SQL
+  matchCondition: SQL,
 ): Promise<{ practiceId: string; locationId: string } | null> {
   const matches = await withSystem(db, (tx) =>
     tx
@@ -120,15 +124,15 @@ async function findMessagingLocationMatching(
         and(
           eq(locations.id, locationMessaging.locationId),
           eq(locations.practiceId, locationMessaging.practiceId),
-          isNull(locations.deletedAt)
-        )
+          isNull(locations.deletedAt),
+        ),
       )
       .innerJoin(
         practices,
         and(
           eq(practices.id, locationMessaging.practiceId),
-          isNull(practices.deletedAt)
-        )
+          isNull(practices.deletedAt),
+        ),
       )
       .where(
         and(
@@ -136,23 +140,23 @@ async function findMessagingLocationMatching(
           eq(locationMessaging.provider, provider),
           isNull(locationMessaging.deletedAt),
           eq(locations.practiceId, locationMessaging.practiceId),
-          isNull(locations.deletedAt)
-        )
+          isNull(locations.deletedAt),
+        ),
       )
-      .limit(2)
+      .limit(2),
   );
   return matches.length === 1 ? (matches[0] ?? null) : null;
 }
 
 export async function findMessagingLocationBySender(
   senderE164: string,
-  provider: InboundSmsProvider
+  provider: InboundSmsProvider,
 ): Promise<{ practiceId: string; locationId: string } | null> {
   const sender = normalizeE164(senderE164);
   if (!sender) return null;
   return findMessagingLocationMatching(
     provider,
-    sql`trim(${locationMessaging.senderE164}) = ${sender}`
+    sql`trim(${locationMessaging.senderE164}) = ${sender}`,
   );
 }
 
@@ -167,7 +171,7 @@ export async function findMessagingLocationForWebhook(opts: {
   if (sender) {
     const loc = await findMessagingLocationMatching(
       opts.provider,
-      sql`trim(${locationMessaging.senderE164}) = ${sender}`
+      sql`trim(${locationMessaging.senderE164}) = ${sender}`,
     );
     if (loc) return loc;
   }
@@ -175,14 +179,14 @@ export async function findMessagingLocationForWebhook(opts: {
   if (!messagingProfileId) return null;
   return findMessagingLocationMatching(
     opts.provider,
-    sql`trim(${locationMessaging.messagingProfileId}) = ${messagingProfileId}`
+    sql`trim(${locationMessaging.messagingProfileId}) = ${messagingProfileId}`,
   );
 }
 
 /** Best-effort: find the only active client in the practice matching this phone. */
 export async function findClientIdByPhone(
   practiceId: string,
-  e164: string
+  e164: string,
 ): Promise<string | null> {
   const phoneCondition = normalizedClientPhoneCondition(e164);
   if (!phoneCondition) return null;
@@ -194,71 +198,128 @@ export async function findClientIdByPhone(
         and(
           eq(clients.practiceId, practiceId),
           isNull(clients.deletedAt),
-          phoneCondition
-        )
+          phoneCondition,
+        ),
       )
-      .limit(2)
+      .limit(2),
   );
   return matches.length === 1 ? (matches[0]?.id ?? null) : null;
 }
 
-/** Flip a client's SMS consent flag after carrier opt-out / opt-in callbacks. */
-export async function setClientSmsConsentByPhone(
-  practiceId: string,
-  e164: string,
-  consent: boolean,
-  matchedClientId?: string | null,
-  optInKeyword?: string
-): Promise<void> {
-  const phoneCondition = normalizedClientPhoneCondition(e164);
-  if (!phoneCondition) return;
+async function applyInboundSmsOptIn(opts: {
+  practiceId: string;
+  locationId: string;
+  provider: InboundSmsProvider;
+  providerMessageId: string;
+  phone: string;
+  keyword: string;
+}): Promise<{ clientId: string | null; remainsSuppressed: boolean }> {
+  const destination = normalizeE164(opts.phone);
+  const phoneCondition = normalizedClientPhoneCondition(opts.phone);
+  if (!destination || !phoneCondition) {
+    return { clientId: null, remainsSuppressed: true };
+  }
 
-  if (consent) {
-    const clientId =
-      matchedClientId === undefined
-        ? await findClientIdByPhone(practiceId, e164)
-        : matchedClientId;
-    if (!clientId) return;
+  return withSystem(db, async (tx) => {
+    await acquireSmsRecipientLockInTransaction(
+      tx,
+      opts.practiceId,
+      destination,
+    );
 
-    await withSystem(db, (tx) =>
-      tx
+    const matches = await tx
+      .select({ id: clients.id })
+      .from(clients)
+      .where(
+        and(
+          eq(clients.practiceId, opts.practiceId),
+          isNull(clients.deletedAt),
+          phoneCondition,
+        ),
+      )
+      .limit(2)
+      .for("update");
+    const clientId = matches.length === 1 ? (matches[0]?.id ?? null) : null;
+
+    const [suppression] = await tx
+      .select({ reason: smsSuppressions.reason })
+      .from(smsSuppressions)
+      .where(
+        and(
+          eq(smsSuppressions.practiceId, opts.practiceId),
+          eq(smsSuppressions.phone, destination),
+        ),
+      )
+      .limit(1);
+    if (suppression && suppression.reason !== "stop") {
+      return { clientId, remainsSuppressed: true };
+    }
+
+    const disclosure = inboundSmsOptInEvidence(opts.keyword);
+    const eventInserted = await appendSmsConsentEventInTransaction(tx, {
+      practiceId: opts.practiceId,
+      clientId,
+      locationId: opts.locationId,
+      destinationE164: destination,
+      action: "granted",
+      source: SMS_INBOUND_OPT_IN.source,
+      disclosureVersion: SMS_INBOUND_OPT_IN.version,
+      disclosure,
+      detail: `Inbound opt-in keyword: "${opts.keyword}"`,
+      actorType: "client",
+      provider: opts.provider,
+      providerMessageId: opts.providerMessageId,
+      eventKey: inboundSmsConsentEventKey(
+        opts.provider,
+        opts.providerMessageId,
+        "granted",
+      ),
+    });
+
+    if (!eventInserted) {
+      // A replay must report the state that is still current. In particular,
+      // START(event A) -> STOP(event B) -> replay START(A) must not claim the
+      // later STOP was removed when the idempotent event insert was skipped.
+      return { clientId, remainsSuppressed: Boolean(suppression) };
+    }
+
+    await tx
+      .delete(smsSuppressions)
+      .where(
+        and(
+          eq(smsSuppressions.practiceId, opts.practiceId),
+          eq(smsSuppressions.phone, destination),
+          eq(smsSuppressions.reason, "stop"),
+        ),
+      );
+
+    if (clientId) {
+      const updated = await tx
         .update(clients)
         .set({
           smsConsent: true,
           smsConsentAt: new Date(),
           smsConsentSource: SMS_INBOUND_OPT_IN.source,
-          smsConsentDisclosure: inboundSmsOptInEvidence(
-            optInKeyword ?? "START"
-          ),
+          smsConsentDisclosure: disclosure,
         })
         .where(
           and(
             eq(clients.id, clientId),
-            eq(clients.practiceId, practiceId),
-            isNull(clients.deletedAt)
-          )
+            eq(clients.practiceId, opts.practiceId),
+            isNull(clients.deletedAt),
+            phoneCondition,
+          ),
         )
-    );
-    return;
-  }
+        .returning({ id: clients.id });
+      if (updated.length !== 1) {
+        throw new Error(
+          "Inbound SMS opt-in client changed before consent could be projected",
+        );
+      }
+    }
 
-  await withSystem(db, (tx) =>
-    tx
-      .update(clients)
-      .set({
-        smsConsent: false,
-        smsConsentAt: null,
-        smsConsentSource: null,
-        smsConsentDisclosure: null,
-      })
-      .where(
-        and(
-          eq(clients.practiceId, practiceId),
-          isNull(clients.deletedAt),
-          phoneCondition
-        )
-      )
-  );
+    return { clientId, remainsSuppressed: false };
+  });
 }
 
 async function logInboundSmsCommunication(opts: {
@@ -287,12 +348,12 @@ async function logInboundSmsCommunication(opts: {
           ? {
               assignedTo: latestAssignedToForClient(
                 opts.practiceId,
-                opts.clientId
+                opts.clientId,
               ),
             }
           : {}),
       })
-      .onConflictDoNothing({ target: communications.dedupeKey })
+      .onConflictDoNothing({ target: communications.dedupeKey }),
   );
 }
 
@@ -320,15 +381,38 @@ export async function handleInboundSmsReply(opts: {
 
   const classification = classifyInboundSms(text);
   const keyword = normalizedKeyword(text);
-  const clientId = await findClientIdByPhone(loc.practiceId, fromPhone);
   if (classification === "stop") {
+    const providerMessageId = opts.providerMessageId;
+    if (!providerMessageId) {
+      // Consent state changes require a durable provider identity. Without one,
+      // a replay cannot be distinguished from a later legitimate decision.
+      return { ok: true, action: "ignored" };
+    }
     await revokeSmsConsentByPhone({
       practiceId: loc.practiceId,
       locationId: loc.locationId,
       phone: fromPhone,
       reason: "stop",
       detail: `Inbound opt-out: "${text}"`,
+      evidence: {
+        // STOP is a destination-wide instruction. Do not bind immutable
+        // evidence to a client selected before the recipient lock: the phone
+        // can move concurrently, and duplicate clients are all revoked.
+        clientId: null,
+        locationId: loc.locationId,
+        source: "inbound_opt_out:v1",
+        detail: `Inbound opt-out: "${text}"`,
+        actorType: "client",
+        provider: opts.provider,
+        providerMessageId,
+        eventKey: inboundSmsConsentEventKey(
+          opts.provider,
+          providerMessageId,
+          "revoked",
+        ),
+      },
     });
+    const clientId = await findClientIdByPhone(loc.practiceId, fromPhone);
     await logInboundSmsCommunication({
       practiceId: loc.practiceId,
       clientId,
@@ -342,22 +426,25 @@ export async function handleInboundSmsReply(opts: {
   }
 
   if (classification === "start") {
-    await removeSuppression(loc.practiceId, fromPhone);
-    // START can remove only a carrier STOP. A manual, complaint, or bounce
-    // suppression remains authoritative and must not silently restore consent.
-    const remainsSuppressed = await isSuppressed(loc.practiceId, fromPhone);
-    if (!remainsSuppressed) {
-      await setClientSmsConsentByPhone(
-        loc.practiceId,
-        fromPhone,
-        true,
-        clientId,
-        keyword
-      );
+    const providerMessageId = opts.providerMessageId;
+    if (!providerMessageId) {
+      return { ok: true, action: "ignored" };
     }
+    // START can remove only a carrier STOP. The event, suppression removal,
+    // and (only for a unique client match) current projection change commit
+    // together. Manual, complaint, and bounce suppressions remain authoritative.
+    const optIn = await applyInboundSmsOptIn({
+      practiceId: loc.practiceId,
+      locationId: loc.locationId,
+      provider: opts.provider,
+      providerMessageId,
+      phone: fromPhone,
+      keyword,
+    });
+    const remainsSuppressed = optIn.remainsSuppressed;
     await logInboundSmsCommunication({
       practiceId: loc.practiceId,
-      clientId,
+      clientId: optIn.clientId,
       provider: opts.provider,
       fromPhone,
       text,
@@ -371,6 +458,8 @@ export async function handleInboundSmsReply(opts: {
       action: remainsSuppressed ? "suppressed" : "unsuppressed",
     };
   }
+
+  const clientId = await findClientIdByPhone(loc.practiceId, fromPhone);
 
   if (classification === "help") {
     // Carriers commonly generate their own HELP response. Log one staff-visible

--- a/apps/web/lib/messaging/index.ts
+++ b/apps/web/lib/messaging/index.ts
@@ -19,7 +19,6 @@ export { normalizeE164 } from "./phone";
 export {
   isSuppressed,
   addSuppression,
-  removeSuppression,
   acquireSmsRecipientLockInTransaction,
   revokeSmsConsentAfterRecipientLockInTransaction,
   revokeSmsConsentByPhone,
@@ -107,8 +106,8 @@ export async function resolveMessagingTransport(opts: {
             and(
               eq(locations.id, locationMessaging.locationId),
               eq(locations.practiceId, opts.practiceId!),
-              isNull(locations.deletedAt)
-            )
+              isNull(locations.deletedAt),
+            ),
           )
           .where(
             opts.hosted
@@ -119,7 +118,7 @@ export async function resolveMessagingTransport(opts: {
                   isNull(locations.deletedAt),
                   eq(locationMessaging.enabled, true),
                   eq(locationMessaging.registrationStatus, "active"),
-                  hasNonBlankMessagingSender()
+                  hasNonBlankMessagingSender(),
                 )
               : and(
                   eq(locationMessaging.locationId, opts.locationId!),
@@ -129,10 +128,10 @@ export async function resolveMessagingTransport(opts: {
                   isNull(locations.deletedAt),
                   eq(locationMessaging.enabled, true),
                   eq(locationMessaging.registrationStatus, "active"),
-                  hasNonBlankMessagingSender()
-                )
+                  hasNonBlankMessagingSender(),
+                ),
           )
-          .limit(opts.hosted ? 2 : 1)
+          .limit(opts.hosted ? 2 : 1),
       );
       // Hosted rollout is deliberately one location per practice. More than
       // one active/enabled sender is ambiguous and must never become “first row

--- a/apps/web/lib/messaging/phone.ts
+++ b/apps/web/lib/messaging/phone.ts
@@ -11,7 +11,7 @@ export function normalizeE164(raw: string | null | undefined): string | null {
   const digits = trimmed.replace(/\D/g, "");
   if (!digits) return null;
   if (hasPlus) {
-    return digits.length >= 8 && digits.length <= 15 ? `+${digits}` : null;
+    return /^[1-9][0-9]{7,14}$/.test(digits) ? `+${digits}` : null;
   }
   if (digits.length === 10) return `+1${digits}`; // US/CA national
   if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;

--- a/apps/web/lib/messaging/suppression.ts
+++ b/apps/web/lib/messaging/suppression.ts
@@ -4,22 +4,30 @@ import type { Database } from "@openpims/db/client";
 import { clients, smsSuppressions } from "@openpims/db";
 import { withSystem } from "@/lib/tenant-db";
 import { normalizeE164 } from "./phone";
+import {
+  appendSmsConsentEventInTransaction,
+  type SmsConsentEventEvidence,
+} from "./consent-events";
 
 export type SuppressionReason = "stop" | "manual" | "bounce" | "complaint";
 type SmsRevocationDatabase = Pick<Database, "execute" | "insert" | "update">;
 type SmsRecipientLockDatabase = Pick<Database, "execute">;
+type SmsRevocationEvidence = Omit<
+  SmsConsentEventEvidence,
+  "practiceId" | "destinationE164" | "action"
+>;
 
 export async function acquireSmsRecipientLockInTransaction(
   tx: SmsRecipientLockDatabase,
   practiceId: string,
-  phone: string
+  phone: string,
 ): Promise<string> {
   const e164 = normalizeE164(phone);
   if (!e164) {
     throw new Error("A valid SMS phone number is required for revocation.");
   }
   await tx.execute(
-    sql`select pg_advisory_xact_lock(hashtextextended(${`sms:${practiceId}:${e164}`}, 0))`
+    sql`select pg_advisory_xact_lock(hashtextextended(${`sms:${practiceId}:${e164}`}, 0))`,
   );
   return e164;
 }
@@ -31,7 +39,7 @@ export async function acquireSmsRecipientLockInTransaction(
  */
 export async function isSuppressed(
   practiceId: string,
-  phone: string
+  phone: string,
 ): Promise<boolean> {
   const e164 = normalizeE164(phone);
   if (!e164) return false;
@@ -42,10 +50,10 @@ export async function isSuppressed(
       .where(
         and(
           eq(smsSuppressions.practiceId, practiceId),
-          eq(smsSuppressions.phone, e164)
-        )
+          eq(smsSuppressions.phone, e164),
+        ),
       )
-      .limit(1)
+      .limit(1),
   );
   return Boolean(row);
 }
@@ -75,7 +83,7 @@ export async function addSuppression(opts: {
       })
       .onConflictDoNothing({
         target: [smsSuppressions.practiceId, smsSuppressions.phone],
-      })
+      }),
   );
 }
 
@@ -92,13 +100,28 @@ async function revokeSmsConsentAfterLock(
     locationId?: string;
     reason: "stop" | "manual";
     detail?: string;
-  }
+    evidence: SmsRevocationEvidence;
+  },
 ): Promise<{ phone: string; clientsRevoked: number }> {
   const fullDigits = e164.replace(/\D/g, "");
   const nationalDigits =
     e164.startsWith("+1") && fullDigits.length === 11
       ? fullDigits.slice(1)
       : fullDigits;
+
+  const eventInserted = await appendSmsConsentEventInTransaction(tx, {
+    ...opts.evidence,
+    practiceId: opts.practiceId,
+    destinationE164: e164,
+    action: "revoked",
+    detail: opts.evidence.detail ?? opts.detail,
+  });
+  if (!eventInserted) {
+    if (opts.evidence.actorType !== "client") {
+      throw new Error("SMS consent revocation evidence could not be appended");
+    }
+    return { phone: e164, clientsRevoked: 0 };
+  }
 
   await tx
     .insert(smsSuppressions)
@@ -140,9 +163,9 @@ async function revokeSmsConsentAfterLock(
         isNull(clients.deletedAt),
         or(
           sql`regexp_replace(${clients.phone}, '\D', '', 'g') = ${fullDigits}`,
-          sql`regexp_replace(${clients.phone}, '\D', '', 'g') = ${nationalDigits}`
-        )
-      )
+          sql`regexp_replace(${clients.phone}, '\D', '', 'g') = ${nationalDigits}`,
+        ),
+      ),
     )
     .returning({ id: clients.id });
 
@@ -163,7 +186,8 @@ export async function revokeSmsConsentAfterRecipientLockInTransaction(
     locationId?: string;
     reason: "stop" | "manual";
     detail?: string;
-  }
+    evidence: SmsRevocationEvidence;
+  },
 ): Promise<{ phone: string; clientsRevoked: number }> {
   const e164 = normalizeE164(opts.phone);
   if (!e164) {
@@ -180,12 +204,13 @@ export async function revokeSmsConsentByPhoneInTransaction(
     locationId?: string;
     reason: "stop" | "manual";
     detail?: string;
-  }
+    evidence: SmsRevocationEvidence;
+  },
 ): Promise<{ phone: string; clientsRevoked: number }> {
   const e164 = await acquireSmsRecipientLockInTransaction(
     tx,
     opts.practiceId,
-    opts.phone
+    opts.phone,
   );
   return revokeSmsConsentAfterLock(tx, e164, opts);
 }
@@ -196,6 +221,7 @@ export async function revokeSmsConsentByPhone(opts: {
   locationId?: string;
   reason: "stop" | "manual";
   detail?: string;
+  evidence: SmsRevocationEvidence;
 }): Promise<{ phone: string; clientsRevoked: number }> {
   return withSystem(db, (tx) => revokeSmsConsentByPhoneInTransaction(tx, opts));
 }
@@ -204,21 +230,3 @@ export async function revokeSmsConsentByPhone(opts: {
  * Remove carrier STOP suppression after an explicit opt-in keyword. Manual,
  * bounce, and complaint suppressions remain as staff/provider safety gates.
  */
-export async function removeSuppression(
-  practiceId: string,
-  phone: string
-): Promise<void> {
-  const e164 = normalizeE164(phone);
-  if (!e164) return;
-  await withSystem(db, (tx) =>
-    tx
-      .delete(smsSuppressions)
-      .where(
-        and(
-          eq(smsSuppressions.practiceId, practiceId),
-          eq(smsSuppressions.phone, e164),
-          eq(smsSuppressions.reason, "stop")
-        )
-      )
-  );
-}

--- a/apps/web/server/__tests__/clients-safety.test.ts
+++ b/apps/web/server/__tests__/clients-safety.test.ts
@@ -19,7 +19,7 @@ const { LIST_OFFSET_MAX } = await import("../routers/pagination");
 const { SMS_CONSENT_DISCLOSURE } = await import("@/lib/messaging/consent");
 const CLIENTS_SOURCE = readFileSync(
   new URL("../routers/clients.ts", import.meta.url),
-  "utf8"
+  "utf8",
 );
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
@@ -46,13 +46,13 @@ function callerWithDb(db: Record<string, unknown>, role = "admin") {
 function objectContainsText(
   value: unknown,
   needle: string,
-  seen = new WeakSet<object>()
+  seen = new WeakSet<object>(),
 ): boolean {
   if (typeof value === "string") return value.includes(needle);
   if (!value || typeof value !== "object" || seen.has(value)) return false;
   seen.add(value);
   return Object.values(value as Record<string, unknown>).some((item) =>
-    objectContainsText(item, needle, seen)
+    objectContainsText(item, needle, seen),
   );
 }
 
@@ -77,15 +77,18 @@ function createDb(opts?: {
       offset: vi.fn(async () => result),
       then: (
         resolve: (value: unknown[]) => unknown,
-        reject?: (error: unknown) => unknown
+        reject?: (error: unknown) => unknown,
       ) => Promise.resolve(result).then(resolve, reject),
     };
     return builder;
   });
-  const insertReturning = vi.fn(async () => opts?.insertedRows ?? []);
+  const insertReturning = vi.fn(
+    async () => opts?.insertedRows ?? [{ id: "consent-event-1" }],
+  );
   const insertConflict = vi.fn(async () => undefined);
   const insertValues = vi.fn(() => ({
     returning: insertReturning,
+    onConflictDoNothing: vi.fn(() => ({ returning: insertReturning })),
     onConflictDoUpdate: insertConflict,
   }));
   const insert = vi.fn(() => ({ values: insertValues }));
@@ -122,16 +125,16 @@ describe("clients mutation safety", () => {
       viewer.create({
         firstName: "Ada",
         lastName: "Lovelace",
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     await expect(
       viewer.update({
         id: CLIENT_ID,
         firstName: "Ada",
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     await expect(
-      viewer.rotatePortalAccessToken({ id: CLIENT_ID })
+      viewer.rotatePortalAccessToken({ id: CLIENT_ID }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
     expect(insertValues).not.toHaveBeenCalled();
@@ -146,17 +149,17 @@ describe("clients mutation safety", () => {
       callerWithDb(writableDb, "front_desk").create({
         firstName: "Ada",
         lastName: "Lovelace",
-      })
+      }),
     ).resolves.toMatchObject({ id: CLIENT_ID });
   });
 
   it("returns the practice timezone with client list results", () => {
     expect(CLIENTS_SOURCE).toContain("practices,");
     expect(CLIENTS_SOURCE).toContain(
-      ".select({ timezone: practices.timezone })"
+      ".select({ timezone: practices.timezone })",
     );
     expect(CLIENTS_SOURCE).toContain(
-      "timezone: practiceResult[0].timezone ?? null"
+      "timezone: practiceResult[0].timezone ?? null",
     );
     expect(CLIENTS_SOURCE).toContain("if (!practiceResult[0])");
     expect(CLIENTS_SOURCE).toContain('message: "Practice not found"');
@@ -179,7 +182,7 @@ describe("clients mutation safety", () => {
     });
 
     await expect(
-      callerWithDb(db, "admin").list({ limit: 25, offset: 0 })
+      callerWithDb(db, "admin").list({ limit: 25, offset: 0 }),
     ).resolves.toMatchObject({
       items: [
         {
@@ -200,7 +203,7 @@ describe("clients mutation safety", () => {
     });
 
     await expect(
-      callerWithDb(db, "admin").list({ limit: 25, offset: 0 })
+      callerWithDb(db, "admin").list({ limit: 25, offset: 0 }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -219,7 +222,7 @@ describe("clients mutation safety", () => {
     });
 
     await expect(
-      callerWithDb(db, "viewer").getById({ id: CLIENT_ID })
+      callerWithDb(db, "viewer").getById({ id: CLIENT_ID }),
     ).resolves.toMatchObject({
       id: CLIENT_ID,
       accessToken: null,
@@ -231,7 +234,7 @@ describe("clients mutation safety", () => {
     });
 
     await expect(
-      callerWithDb(writableDb, "front_desk").getById({ id: CLIENT_ID })
+      callerWithDb(writableDb, "front_desk").getById({ id: CLIENT_ID }),
     ).resolves.toMatchObject({
       id: CLIENT_ID,
       accessToken: "private-portal-token",
@@ -243,7 +246,7 @@ describe("clients mutation safety", () => {
     const { db, select, insertValues, updateSet } = createDb();
 
     await expect(
-      callerWithDb(db).list({ limit: 1.5, offset: 0 } as never)
+      callerWithDb(db).list({ limit: 1.5, offset: 0 } as never),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -251,18 +254,18 @@ describe("clients mutation safety", () => {
         search: "s".repeat(101),
         limit: 25,
         offset: 0,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).list({
         limit: 25,
         offset: LIST_OFFSET_MAX + 1,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
-      callerWithDb(db).search({ query: "   " })
+      callerWithDb(db).search({ query: "   " }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -270,14 +273,14 @@ describe("clients mutation safety", () => {
         firstName: "Ada",
         lastName: "Lovelace",
         email: "not-an-email",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).create({
         firstName: "A".repeat(129),
         lastName: "Lovelace",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -285,21 +288,21 @@ describe("clients mutation safety", () => {
         firstName: "Ada",
         lastName: "Lovelace",
         address: "a".repeat(501),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).update({
         id: CLIENT_ID,
         phone: "1".repeat(33),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).update({
         id: CLIENT_ID,
         notes: "n".repeat(2001),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -333,7 +336,7 @@ describe("clients mutation safety", () => {
         state: " Middlesex ",
         zip: " SW1 ",
         notes: " Prefers email. ",
-      })
+      }),
     ).resolves.toMatchObject({ id: CLIENT_ID, accessToken: "private-token" });
 
     expect(insertValues).toHaveBeenCalledWith(
@@ -349,7 +352,7 @@ describe("clients mutation safety", () => {
         notes: "Prefers email.",
         practiceId: PRACTICE_ID,
         accessToken: expect.any(String),
-      })
+      }),
     );
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
       PRACTICE_ID,
@@ -361,7 +364,7 @@ describe("clients mutation safety", () => {
         email: "ada@example.com",
         phone: "+15555550123",
         source: "dashboard",
-      }
+      },
     );
   });
 
@@ -391,10 +394,23 @@ describe("clients mutation safety", () => {
         smsConsentAt: expect.any(Date),
         smsConsentSource: SMS_CONSENT_DISCLOSURE.source,
         smsConsentDisclosure: SMS_CONSENT_DISCLOSURE.snapshot,
-      })
+      }),
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        practiceId: PRACTICE_ID,
+        clientId: CLIENT_ID,
+        destinationE164: "+15555550123",
+        action: "granted",
+        source: SMS_CONSENT_DISCLOSURE.source,
+        disclosureVersion: SMS_CONSENT_DISCLOSURE.version,
+        disclosure: SMS_CONSENT_DISCLOSURE.snapshot,
+        actorType: "staff",
+        actorUserId: USER_ID,
+      }),
     );
     expect(SMS_CONSENT_DISCLOSURE.source).toContain(
-      SMS_CONSENT_DISCLOSURE.version
+      SMS_CONSENT_DISCLOSURE.version,
     );
   });
 
@@ -407,7 +423,7 @@ describe("clients mutation safety", () => {
         lastName: "Lovelace",
         phone: "12345",
         smsConsent: true,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "A valid mobile phone number is required for SMS consent",
@@ -424,7 +440,7 @@ describe("clients mutation safety", () => {
       callerWithDb(db).create({
         firstName: "Ada",
         lastName: "Lovelace",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -445,7 +461,7 @@ describe("clients mutation safety", () => {
         firstName: " Ada ",
         address: "   ",
         notes: " Prefers morning appointments. ",
-      })
+      }),
     ).resolves.toMatchObject({ id: CLIENT_ID, firstName: "Ada" });
 
     expect(updateSet).toHaveBeenCalledWith({
@@ -457,7 +473,10 @@ describe("clients mutation safety", () => {
 
   it("preserves consent evidence across formatting-only phone edits", async () => {
     const { db, updateSet } = createDb({
-      selectResults: [[{ id: CLIENT_ID, phone: "+15555550123" }]],
+      selectResults: [
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
+      ],
       updatedRows: [{ id: CLIENT_ID, phone: "(555) 555-0123" }],
     });
 
@@ -472,8 +491,11 @@ describe("clients mutation safety", () => {
   });
 
   it("clears consent evidence when the normalized phone destination changes", async () => {
-    const { db, updateSet } = createDb({
-      selectResults: [[{ id: CLIENT_ID, phone: "+15555550123" }]],
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
+      ],
       updatedRows: [{ id: CLIENT_ID, phone: "+15555550999" }],
     });
 
@@ -489,11 +511,25 @@ describe("clients mutation safety", () => {
       smsConsentSource: null,
       smsConsentDisclosure: null,
     });
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: CLIENT_ID,
+        destinationE164: "+15555550123",
+        action: "revoked",
+        source: "phone_change:v1",
+        actorType: "staff",
+        actorUserId: USER_ID,
+      }),
+    );
   });
 
   it("stores fresh current evidence when a phone edit explicitly re-consents", async () => {
-    const { db, updateSet } = createDb({
-      selectResults: [[{ id: CLIENT_ID, phone: "+15555550123" }]],
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
+        [],
+      ],
       updatedRows: [{ id: CLIENT_ID, phone: "+15555550999" }],
     });
 
@@ -510,25 +546,56 @@ describe("clients mutation safety", () => {
       smsConsentSource: SMS_CONSENT_DISCLOSURE.source,
       smsConsentDisclosure: SMS_CONSENT_DISCLOSURE.snapshot,
     });
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: CLIENT_ID,
+        destinationE164: "+15555550999",
+        action: "granted",
+        source: SMS_CONSENT_DISCLOSURE.source,
+        disclosureVersion: SMS_CONSENT_DISCLOSURE.version,
+        actorType: "staff",
+        actorUserId: USER_ID,
+      }),
+    );
   });
 
   it("does not let ordinary re-consent bypass a manual suppression", async () => {
     const { db, updateSet } = createDb({
       selectResults: [
-        [{ id: CLIENT_ID, phone: "+15555550123" }],
-        [{ id: "suppression-1" }],
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
+        [{ id: "suppression-1", reason: "manual" }],
       ],
       updatedRows: [{ id: CLIENT_ID }],
     });
 
     await expect(
-      callerWithDb(db).update({ id: CLIENT_ID, smsConsent: true })
+      callerWithDb(db).update({ id: CLIENT_ID, smsConsent: true }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining(
-        "manually placed on the do-not-text list"
+        "manually placed on the do-not-text list",
       ),
     });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("requires an inbound START before staff can restore a carrier STOP", async () => {
+    const { db, insertValues, updateSet } = createDb({
+      selectResults: [
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: false }],
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: false }],
+        [{ id: "suppression-1", reason: "stop" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db).update({ id: CLIENT_ID, smsConsent: true }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("reply START"),
+    });
+    expect(insertValues).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
   });
 
@@ -545,17 +612,27 @@ describe("clients mutation safety", () => {
       callerWithDb(db, "front_desk").revokeSms({
         id: CLIENT_ID,
         expectedPhone: "+15555550123",
-      })
+      }),
     ).resolves.toEqual({
       phone: "+15555550123",
       clientsRevoked: 2,
     });
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
+        clientId: CLIENT_ID,
+        destinationE164: "+15555550123",
+        action: "revoked",
+        source: "staff_manual_revoke:v1",
+        actorType: "staff",
+        actorUserId: USER_ID,
+      }),
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
         practiceId: PRACTICE_ID,
         phone: "+15555550123",
         reason: "manual",
-      })
+      }),
     );
     expect(updateSet).toHaveBeenCalledWith({
       smsConsent: false,
@@ -575,7 +652,7 @@ describe("clients mutation safety", () => {
       callerWithDb(db, "front_desk").revokeSms({
         id: CLIENT_ID,
         expectedPhone: "+15555550123",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message: expect.stringContaining("no longer matches"),
@@ -595,7 +672,7 @@ describe("clients mutation safety", () => {
       callerWithDb(db, "front_desk").revokeSms({
         id: CLIENT_ID,
         expectedPhone: "+15555550123",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message: expect.stringContaining("changed while revoking"),
@@ -609,8 +686,8 @@ describe("clients mutation safety", () => {
   it("clears prior evidence when staff explicitly withdraws SMS consent", async () => {
     const { db, updateSet, lockEvents } = createDb({
       selectResults: [
-        [{ phone: "+15555550123" }],
-        [{ id: CLIENT_ID, phone: "+15555550123" }],
+        [{ phone: "+15555550123", smsConsent: true }],
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
       ],
       updatedRows: [{ id: CLIENT_ID, smsConsent: false }],
     });
@@ -629,11 +706,26 @@ describe("clients mutation safety", () => {
     expect(lockEvents.slice(0, 2)).toEqual(["advisory", "row:update"]);
   });
 
+  it("does not withdraw consent when the immutable revoke event conflicts", async () => {
+    const { db, updateSet } = createDb({
+      selectResults: [
+        [{ phone: "+15555550123", smsConsent: true }],
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
+      ],
+      insertedRows: [],
+    });
+
+    await expect(
+      callerWithDb(db).update({ id: CLIENT_ID, smsConsent: false }),
+    ).rejects.toThrow("SMS consent revocation evidence could not be appended");
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
   it("withdraws from the persisted phone rather than an unsaved replacement", async () => {
     const { db, insertValues, updateSet } = createDb({
       selectResults: [
-        [{ phone: "+15555550123" }],
-        [{ id: CLIENT_ID, phone: "+15555550123" }],
+        [{ phone: "+15555550123", smsConsent: true }],
+        [{ id: CLIENT_ID, phone: "+15555550123", smsConsent: true }],
       ],
       updatedRows: [{ id: CLIENT_ID, smsConsent: false }],
     });
@@ -645,10 +737,10 @@ describe("clients mutation safety", () => {
     });
 
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ phone: "+15555550123", reason: "manual" })
+      expect.objectContaining({ phone: "+15555550123", reason: "manual" }),
     );
     expect(insertValues).not.toHaveBeenCalledWith(
-      expect.objectContaining({ phone: "+15555550999" })
+      expect.objectContaining({ phone: "+15555550999" }),
     );
     expect(updateSet).toHaveBeenCalledWith({
       phone: "+15555550999",
@@ -662,16 +754,16 @@ describe("clients mutation safety", () => {
   it("rechecks the withdrawal phone after the recipient lock", async () => {
     const { db, insertValues, updateSet, lockEvents } = createDb({
       selectResults: [
-        [{ phone: "+15555550123" }],
-        [{ id: CLIENT_ID, phone: "+15555550999" }],
+        [{ phone: "+15555550123", smsConsent: true }],
+        [{ id: CLIENT_ID, phone: "+15555550999", smsConsent: true }],
       ],
     });
 
     await expect(
-      callerWithDb(db).update({ id: CLIENT_ID, smsConsent: false })
+      callerWithDb(db).update({ id: CLIENT_ID, smsConsent: false }),
     ).rejects.toMatchObject({
       code: "CONFLICT",
-      message: expect.stringContaining("changed while withdrawing"),
+      message: expect.stringContaining("changed while saving"),
     });
 
     expect(lockEvents).toEqual(["advisory", "row:update"]);
@@ -686,7 +778,7 @@ describe("clients mutation safety", () => {
       callerWithDb(db).update({
         id: CLIENT_ID,
         firstName: "Ada",
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).toHaveBeenCalledWith({ firstName: "Ada" });
@@ -696,7 +788,7 @@ describe("clients mutation safety", () => {
     const { db, updateSet } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).delete({ id: CLIENT_ID })
+      callerWithDb(db).delete({ id: CLIENT_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -708,7 +800,7 @@ describe("clients mutation safety", () => {
     });
 
     await expect(
-      callerWithDb(db).delete({ id: CLIENT_ID })
+      callerWithDb(db).delete({ id: CLIENT_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -720,7 +812,7 @@ describe("clients mutation safety", () => {
     });
 
     await expect(
-      callerWithDb(db).delete({ id: CLIENT_ID })
+      callerWithDb(db).delete({ id: CLIENT_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -732,7 +824,7 @@ describe("clients mutation safety", () => {
     });
 
     await expect(
-      callerWithDb(db).delete({ id: CLIENT_ID })
+      callerWithDb(db).delete({ id: CLIENT_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -744,7 +836,7 @@ describe("clients mutation safety", () => {
     });
 
     await expect(
-      callerWithDb(db).delete({ id: CLIENT_ID })
+      callerWithDb(db).delete({ id: CLIENT_ID }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -772,23 +864,23 @@ describe("clients delete dependency safety", () => {
     expect(CLIENTS_SOURCE).toContain("${practices.deletedAt} is null");
     expect(
       CLIENTS_SOURCE.match(/activePracticePredicate\(ctx\.practiceId\)/g)
-        ?.length ?? 0
+        ?.length ?? 0,
     ).toBeGreaterThanOrEqual(10);
     expect(CLIENTS_SOURCE).toContain("await assertActivePractice(ctx)");
     expect(CLIENTS_SOURCE).toMatch(
-      /eq\(clients\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(clients\.deletedAt\)/
+      /eq\(clients\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(clients\.deletedAt\)/,
     );
     expect(CLIENTS_SOURCE).toMatch(
-      /eq\(patients\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(patients\.deletedAt\)/
+      /eq\(patients\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(patients\.deletedAt\)/,
     );
     expect(CLIENTS_SOURCE).toMatch(
-      /eq\(invoices\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(invoices\.deletedAt\)/
+      /eq\(invoices\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(invoices\.deletedAt\)/,
     );
   });
 
   it("keeps client delete dependency checks tenant-scoped", () => {
     const deleteBlock = CLIENTS_SOURCE.match(
-      /delete: protectedProcedure[\s\S]+?\n\s*\}\),\n\}\);/
+      /delete: protectedProcedure[\s\S]+?\n\s*\}\),\n\}\);/,
     )?.[0];
 
     expect(deleteBlock).toContain("await ctx.db.transaction");
@@ -799,20 +891,20 @@ describe("clients delete dependency safety", () => {
     expect(deleteBlock).toContain("eq(patients.practiceId, ctx.practiceId)");
     expect(deleteBlock).toContain("eq(appointments.clientId, input.id)");
     expect(deleteBlock).toContain(
-      "eq(appointments.practiceId, ctx.practiceId)"
+      "eq(appointments.practiceId, ctx.practiceId)",
     );
     expect(deleteBlock).toContain(
-      "inArray(appointments.status, activeSchedulingStatuses)"
+      "inArray(appointments.status, activeSchedulingStatuses)",
     );
     expect(deleteBlock).toContain("eq(appointmentWaitlist.clientId, input.id)");
     expect(deleteBlock).toContain(
-      "eq(appointmentWaitlist.practiceId, ctx.practiceId)"
+      "eq(appointmentWaitlist.practiceId, ctx.practiceId)",
     );
     expect(deleteBlock).toContain('eq(appointmentWaitlist.status, "waiting")');
     expect(deleteBlock).toContain("eq(invoices.clientId, input.id)");
     expect(deleteBlock).toContain("eq(invoices.practiceId, ctx.practiceId)");
     expect(deleteBlock).toContain(
-      "inArray(invoices.status, unresolvedInvoiceStatuses)"
+      "inArray(invoices.status, unresolvedInvoiceStatuses)",
     );
   });
 });

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -1561,7 +1561,7 @@ describe("messaging location sender join scoping", () => {
         )}\\),\\s*(?:activePracticePredicate\\(${practiceExpr.replace(
           ".",
           "\\."
-        )}\\),\\s*)?isNull\\(locations\\.deletedAt\\)\\s*\\)\\s*\\)`,
+        )}\\),\\s*)?isNull\\(locations\\.deletedAt\\)\\s*,?\\s*\\)\\s*,?\\s*\\)`,
         "s"
       )
     );
@@ -1676,7 +1676,7 @@ describe("messaging location sender join scoping", () => {
 
     expect(source).toContain("if (!opts.practiceId) return undefined");
     expect(source).toMatch(
-      /innerJoin\(\s*locations,\s*and\(\s*eq\(locations\.id, locationMessaging\.locationId\),\s*eq\(locations\.practiceId, opts\.practiceId!\),\s*isNull\(locations\.deletedAt\)\s*\)\s*\)/s
+      /innerJoin\(\s*locations,\s*and\(\s*eq\(locations\.id, locationMessaging\.locationId\),\s*eq\(locations\.practiceId, opts\.practiceId!\),\s*isNull\(locations\.deletedAt\)\s*,?\s*\)\s*,?\s*\)/s
     );
     expect(source).toContain(
       "eq(locationMessaging.practiceId, opts.practiceId!)"

--- a/apps/web/server/routers/clients.ts
+++ b/apps/web/server/routers/clients.ts
@@ -9,6 +9,7 @@ import {
   invoices,
   patients,
   practices,
+  smsConsentEvents,
   smsSuppressions,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
@@ -34,6 +35,10 @@ import {
   acquireSmsRecipientLockInTransaction,
   revokeSmsConsentAfterRecipientLockInTransaction,
 } from "@/lib/messaging/suppression";
+import {
+  appendRequiredSmsConsentEventInTransaction,
+  staffSmsConsentEventKey,
+} from "@/lib/messaging/consent-events";
 
 const clientNameInput = z.string().trim().min(1).max(CLIENT_NAME_MAX_LENGTH);
 const clientEmailInput = z
@@ -84,7 +89,7 @@ const activeSchedulingStatuses = [
 ] as const;
 const unresolvedInvoiceStatuses = ["draft", "sent", "overdue"] as const;
 const clientManagerProcedure = protectedProcedure.use(
-  requireRole("admin", "veterinarian", "technician", "front_desk")
+  requireRole("admin", "veterinarian", "technician", "front_desk"),
 );
 type ClientsContext = {
   db: Pick<Database, "select">;
@@ -124,6 +129,28 @@ function canReadPortalAccessTokenRole(role?: string | null): boolean {
   );
 }
 
+function smsSuppressionConsentError(reason: string): TRPCError {
+  if (reason === "manual") {
+    return new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "This number was manually placed on the do-not-text list. A staff member must review it before any future opt-in.",
+    });
+  }
+  if (reason === "stop") {
+    return new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "This number previously opted out by text. The client must reply START from that phone before SMS consent can be restored.",
+    });
+  }
+  return new TRPCError({
+    code: "PRECONDITION_FAILED",
+    message:
+      "This number is blocked from texting after a delivery or complaint event. Review the suppression before recording consent.",
+  });
+}
+
 function redactClientPortalAccessToken<
   T extends { accessToken: string | null },
 >(client: T): Omit<T, "accessToken"> & { accessToken: null } {
@@ -137,7 +164,7 @@ export const clientsRouter = createRouter({
         search: clientSearchInput,
         limit: z.number().int().min(1).max(100).default(25),
         offset: listOffsetInput,
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const conditions = [
@@ -153,11 +180,11 @@ export const clientsRouter = createRouter({
             ilike(clients.lastName, `%${input.search}%`),
             ilike(
               sql`concat_ws(' ', ${clients.firstName}, ${clients.lastName})`,
-              `%${input.search}%`
+              `%${input.search}%`,
             ),
             ilike(clients.email, `%${input.search}%`),
-            ilike(clients.phone, `%${input.search}%`)
-          )!
+            ilike(clients.phone, `%${input.search}%`),
+          )!,
         );
       }
 
@@ -177,7 +204,7 @@ export const clientsRouter = createRouter({
           .select({ timezone: practices.timezone })
           .from(practices)
           .where(
-            and(eq(practices.id, ctx.practiceId), isNull(practices.deletedAt))
+            and(eq(practices.id, ctx.practiceId), isNull(practices.deletedAt)),
           )
           .limit(1),
       ]);
@@ -218,12 +245,12 @@ export const clientsRouter = createRouter({
               ilike(clients.lastName, `%${input.query}%`),
               ilike(
                 sql`concat_ws(' ', ${clients.firstName}, ${clients.lastName})`,
-                `%${input.query}%`
+                `%${input.query}%`,
               ),
               ilike(clients.email, `%${input.query}%`),
-              ilike(clients.phone, `%${input.query}%`)
-            )
-          )
+              ilike(clients.phone, `%${input.query}%`),
+            ),
+          ),
         )
         .limit(10);
     }),
@@ -239,8 +266,8 @@ export const clientsRouter = createRouter({
             eq(clients.id, input.id),
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -256,9 +283,38 @@ export const clientsRouter = createRouter({
             eq(patients.clientId, input.id),
             eq(patients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(patients.deletedAt)
-          )
+            isNull(patients.deletedAt),
+          ),
         );
+
+      const normalizedClientPhone = normalizeE164(client.phone);
+      const smsConsentHistory = await ctx.db
+        .select({
+          id: smsConsentEvents.id,
+          action: smsConsentEvents.action,
+          destinationE164: smsConsentEvents.destinationE164,
+          source: smsConsentEvents.source,
+          detail: smsConsentEvents.detail,
+          actorType: smsConsentEvents.actorType,
+          actorName: smsConsentEvents.actorName,
+          provider: smsConsentEvents.provider,
+          occurredAt: smsConsentEvents.occurredAt,
+        })
+        .from(smsConsentEvents)
+        .where(
+          and(
+            eq(smsConsentEvents.practiceId, ctx.practiceId),
+            normalizedClientPhone
+              ? or(
+                  eq(smsConsentEvents.clientId, input.id),
+                  eq(smsConsentEvents.destinationE164, normalizedClientPhone),
+                )
+              : eq(smsConsentEvents.clientId, input.id),
+            activePracticePredicate(ctx.practiceId),
+          ),
+        )
+        .orderBy(desc(smsConsentEvents.occurredAt), desc(smsConsentEvents.id))
+        .limit(50);
 
       const safeClient = canReadPortalAccessTokenRole(ctx.user.role)
         ? client
@@ -267,6 +323,7 @@ export const clientsRouter = createRouter({
       return {
         ...safeClient,
         patients: clientPatients,
+        smsConsentHistory,
       };
     }),
 
@@ -283,7 +340,7 @@ export const clientsRouter = createRouter({
         zip: optionalClientString(CLIENT_ZIP_MAX_LENGTH),
         notes: clientNotesInput,
         smsConsent: z.boolean().optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const { smsConsent, ...rest } = input;
@@ -296,26 +353,6 @@ export const clientsRouter = createRouter({
 
       await assertActivePractice(ctx);
       const normalizedPhone = normalizeE164(rest.phone);
-      if (smsConsent && normalizedPhone) {
-        const [manualSuppression] = await ctx.db
-          .select({ id: smsSuppressions.id })
-          .from(smsSuppressions)
-          .where(
-            and(
-              eq(smsSuppressions.practiceId, ctx.practiceId),
-              eq(smsSuppressions.phone, normalizedPhone),
-              eq(smsSuppressions.reason, "manual")
-            )
-          )
-          .limit(1);
-        if (manualSuppression) {
-          throw new TRPCError({
-            code: "PRECONDITION_FAILED",
-            message:
-              "This number was manually placed on the do-not-text list. A staff member must review it before any future opt-in.",
-          });
-        }
-      }
       const consent = smsConsent
         ? {
             smsConsent: true,
@@ -324,24 +361,73 @@ export const clientsRouter = createRouter({
             smsConsentDisclosure: SMS_CONSENT_DISCLOSURE.snapshot,
           }
         : {};
-      const [client] = await ctx.db
-        .insert(clients)
-        .values({
-          ...rest,
-          ...consent,
-          practiceId: ctx.practiceId,
-          accessToken: generatePortalAccessToken(),
-        })
-        .returning();
+      const client = await ctx.db.transaction(async (tx) => {
+        if (smsConsent && normalizedPhone) {
+          await acquireSmsRecipientLockInTransaction(
+            tx,
+            ctx.practiceId,
+            normalizedPhone,
+          );
+          const [suppression] = await tx
+            .select({ reason: smsSuppressions.reason })
+            .from(smsSuppressions)
+            .where(
+              and(
+                eq(smsSuppressions.practiceId, ctx.practiceId),
+                eq(smsSuppressions.phone, normalizedPhone),
+              ),
+            )
+            .limit(1);
+          if (suppression) {
+            throw smsSuppressionConsentError(suppression.reason);
+          }
+        }
+
+        const [created] = await tx
+          .insert(clients)
+          .values({
+            ...rest,
+            ...consent,
+            practiceId: ctx.practiceId,
+            accessToken: generatePortalAccessToken(),
+          })
+          .returning();
+        if (!created) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Client could not be created",
+          });
+        }
+
+        if (smsConsent && normalizedPhone) {
+          await appendRequiredSmsConsentEventInTransaction(tx, {
+            practiceId: ctx.practiceId,
+            clientId: created.id,
+            destinationE164: normalizedPhone,
+            action: "granted",
+            source: SMS_CONSENT_DISCLOSURE.source,
+            disclosureVersion: SMS_CONSENT_DISCLOSURE.version,
+            disclosure: SMS_CONSENT_DISCLOSURE.snapshot,
+            detail:
+              "Staff recorded affirmative consent while creating the client.",
+            actorType: "staff",
+            actorUserId: ctx.user.id,
+            actorName: ctx.user.name,
+            eventKey: staffSmsConsentEventKey(),
+          });
+        }
+
+        return created;
+      });
       await dispatchWebhookEvent(ctx.practiceId, "client.created", {
-        id: client!.id,
-        firstName: client!.firstName,
-        lastName: client!.lastName,
-        email: client!.email,
-        phone: client!.phone,
+        id: client.id,
+        firstName: client.firstName,
+        lastName: client.lastName,
+        email: client.email,
+        phone: client.phone,
         source: "dashboard",
       });
-      return client!;
+      return client;
     }),
 
   update: clientManagerProcedure
@@ -358,49 +444,16 @@ export const clientsRouter = createRouter({
         zip: optionalClientString(CLIENT_ZIP_MAX_LENGTH),
         notes: clientNotesInput,
         smsConsent: z.boolean().optional(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       return ctx.db.transaction(async (tx) => {
         const phoneWasProvided = Object.prototype.hasOwnProperty.call(
           input,
-          "phone"
+          "phone",
         );
         const { id, smsConsent, phone, ...rest } = input;
         const data: Record<string, unknown> = { ...rest };
-        let withdrawalPhoneSnapshot: string | null | undefined;
-
-        if (smsConsent === false) {
-          // Read without a row lock only to derive the recipient advisory key.
-          // Hosted sends use advisory -> row, so every revocation must follow
-          // that same order. The locked row is rechecked below before writes.
-          const [prelockClient] = await tx
-            .select({ phone: clients.phone })
-            .from(clients)
-            .where(
-              and(
-                eq(clients.id, id),
-                eq(clients.practiceId, ctx.practiceId),
-                activePracticePredicate(ctx.practiceId),
-                isNull(clients.deletedAt)
-              )
-            )
-            .limit(1);
-          if (!prelockClient) {
-            throw new TRPCError({
-              code: "NOT_FOUND",
-              message: "Client not found",
-            });
-          }
-          withdrawalPhoneSnapshot = normalizeE164(prelockClient.phone);
-          if (withdrawalPhoneSnapshot) {
-            await acquireSmsRecipientLockInTransaction(
-              tx,
-              ctx.practiceId,
-              withdrawalPhoneSnapshot
-            );
-          }
-        }
 
         if (phoneWasProvided) {
           // Drizzle ignores undefined values. Use null so an explicitly cleared
@@ -409,20 +462,73 @@ export const clientsRouter = createRouter({
         }
 
         if (phoneWasProvided || smsConsent !== undefined) {
-          // Keep the consent decision and destination update under one row lock.
-          // Without the surrounding transaction, FOR UPDATE would release before
-          // the write and a concurrent phone edit could attach consent to the
-          // wrong destination.
-          const [existingClient] = await tx
-            .select({ id: clients.id, phone: clients.phone })
+          // Read without a row lock only to derive recipient advisory keys.
+          // Hosted sends use advisory -> client row, so consent transitions use
+          // the same order and then revalidate the row after acquiring locks.
+          const [prelockClient] = await tx
+            .select({
+              phone: clients.phone,
+              smsConsent: clients.smsConsent,
+            })
             .from(clients)
             .where(
               and(
                 eq(clients.id, id),
                 eq(clients.practiceId, ctx.practiceId),
                 activePracticePredicate(ctx.practiceId),
-                isNull(clients.deletedAt)
-              )
+                isNull(clients.deletedAt),
+              ),
+            )
+            .limit(1);
+          if (!prelockClient) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Client not found",
+            });
+          }
+
+          const prelockNextPhone = phoneWasProvided
+            ? phone
+            : prelockClient.phone;
+          const prelockPhoneChanged = !phoneNumbersMatchForConsent(
+            prelockClient.phone,
+            prelockNextPhone,
+          );
+          const oldDestination = normalizeE164(prelockClient.phone);
+          const newDestination = normalizeE164(prelockNextPhone);
+          const lockDestinations = new Set<string>();
+          if (
+            oldDestination &&
+            (smsConsent === false ||
+              (prelockClient.smsConsent && prelockPhoneChanged))
+          ) {
+            lockDestinations.add(oldDestination);
+          }
+          if (smsConsent === true && newDestination) {
+            lockDestinations.add(newDestination);
+          }
+          for (const destination of [...lockDestinations].sort()) {
+            await acquireSmsRecipientLockInTransaction(
+              tx,
+              ctx.practiceId,
+              destination,
+            );
+          }
+
+          const [existingClient] = await tx
+            .select({
+              id: clients.id,
+              phone: clients.phone,
+              smsConsent: clients.smsConsent,
+            })
+            .from(clients)
+            .where(
+              and(
+                eq(clients.id, id),
+                eq(clients.practiceId, ctx.practiceId),
+                activePracticePredicate(ctx.practiceId),
+                isNull(clients.deletedAt),
+              ),
             )
             .limit(1)
             .for("update");
@@ -435,20 +541,23 @@ export const clientsRouter = createRouter({
           }
 
           if (
-            smsConsent === false &&
-            normalizeE164(existingClient.phone) !== withdrawalPhoneSnapshot
+            !phoneNumbersMatchForConsent(
+              existingClient.phone,
+              prelockClient.phone,
+            ) ||
+            existingClient.smsConsent !== prelockClient.smsConsent
           ) {
             throw new TRPCError({
               code: "CONFLICT",
               message:
-                "Client phone changed while withdrawing SMS consent. Refresh and try again.",
+                "Client SMS consent or phone changed while saving. Refresh and try again.",
             });
           }
 
           const nextPhone = phoneWasProvided ? phone : existingClient.phone;
           const phoneChanged = !phoneNumbersMatchForConsent(
             existingClient.phone,
-            nextPhone
+            nextPhone,
           );
 
           if (smsConsent === true) {
@@ -461,24 +570,51 @@ export const clientsRouter = createRouter({
               });
             }
 
-            const [manualSuppression] = await tx
-              .select({ id: smsSuppressions.id })
+            const [suppression] = await tx
+              .select({ reason: smsSuppressions.reason })
               .from(smsSuppressions)
               .where(
                 and(
                   eq(smsSuppressions.practiceId, ctx.practiceId),
                   eq(smsSuppressions.phone, normalizedNextPhone),
-                  eq(smsSuppressions.reason, "manual")
-                )
+                ),
               )
               .limit(1);
-            if (manualSuppression) {
-              throw new TRPCError({
-                code: "PRECONDITION_FAILED",
-                message:
-                  "This number was manually placed on the do-not-text list. A staff member must review it before any future opt-in.",
+            if (suppression) {
+              throw smsSuppressionConsentError(suppression.reason);
+            }
+
+            if (phoneChanged && existingClient.smsConsent && oldDestination) {
+              await appendRequiredSmsConsentEventInTransaction(tx, {
+                practiceId: ctx.practiceId,
+                clientId: id,
+                destinationE164: oldDestination,
+                action: "revoked",
+                source: "phone_change:v1",
+                detail:
+                  "Prior SMS consent was invalidated because the client destination changed.",
+                actorType: "staff",
+                actorUserId: ctx.user.id,
+                actorName: ctx.user.name,
+                eventKey: staffSmsConsentEventKey(),
               });
             }
+
+            await appendRequiredSmsConsentEventInTransaction(tx, {
+              practiceId: ctx.practiceId,
+              clientId: id,
+              destinationE164: normalizedNextPhone,
+              action: "granted",
+              source: SMS_CONSENT_DISCLOSURE.source,
+              disclosureVersion: SMS_CONSENT_DISCLOSURE.version,
+              disclosure: SMS_CONSENT_DISCLOSURE.snapshot,
+              detail:
+                "Staff recorded affirmative consent on the client record.",
+              actorType: "staff",
+              actorUserId: ctx.user.id,
+              actorName: ctx.user.name,
+              eventKey: staffSmsConsentEventKey(),
+            });
 
             // A true value is an explicit staff attestation under the current,
             // server-owned disclosure. Unrelated edits omit this field entirely.
@@ -488,14 +624,37 @@ export const clientsRouter = createRouter({
             data.smsConsentDisclosure = SMS_CONSENT_DISCLOSURE.snapshot;
           } else if (phoneChanged || smsConsent === false) {
             if (smsConsent === false) {
-              if (withdrawalPhoneSnapshot) {
+              if (oldDestination) {
                 await revokeSmsConsentAfterRecipientLockInTransaction(tx, {
                   practiceId: ctx.practiceId,
-                  phone: withdrawalPhoneSnapshot,
+                  phone: oldDestination,
                   reason: "manual",
                   detail: `Staff revoked SMS consent from client ${id}.`,
+                  evidence: {
+                    clientId: id,
+                    source: "staff_manual_revoke:v1",
+                    detail: "Staff explicitly withdrew SMS consent.",
+                    actorType: "staff",
+                    actorUserId: ctx.user.id,
+                    actorName: ctx.user.name,
+                    eventKey: staffSmsConsentEventKey(),
+                  },
                 });
               }
+            } else if (existingClient.smsConsent && oldDestination) {
+              await appendRequiredSmsConsentEventInTransaction(tx, {
+                practiceId: ctx.practiceId,
+                clientId: id,
+                destinationE164: oldDestination,
+                action: "revoked",
+                source: "phone_change:v1",
+                detail:
+                  "Prior SMS consent was invalidated because the client destination changed.",
+                actorType: "staff",
+                actorUserId: ctx.user.id,
+                actorName: ctx.user.name,
+                eventKey: staffSmsConsentEventKey(),
+              });
             }
             // Consent belongs to one destination. Changing that destination (or
             // explicitly withdrawing consent) invalidates all prior evidence.
@@ -514,8 +673,8 @@ export const clientsRouter = createRouter({
               eq(clients.id, id),
               eq(clients.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(clients.deletedAt)
-            )
+              isNull(clients.deletedAt),
+            ),
           )
           .returning();
         if (!client) {
@@ -534,7 +693,7 @@ export const clientsRouter = createRouter({
       z.object({
         id: z.string().uuid(),
         expectedPhone: normalizedClientPhoneInput,
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       return ctx.db.transaction(async (tx) => {
@@ -546,8 +705,8 @@ export const clientsRouter = createRouter({
               eq(clients.id, input.id),
               eq(clients.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(clients.deletedAt)
-            )
+              isNull(clients.deletedAt),
+            ),
           )
           .limit(1);
         if (!prelockClient) {
@@ -575,7 +734,7 @@ export const clientsRouter = createRouter({
           await acquireSmsRecipientLockInTransaction(
             tx,
             ctx.practiceId,
-            prelockPhone
+            prelockPhone,
           );
           const [lockedClient] = await tx
             .select({ phone: clients.phone })
@@ -585,8 +744,8 @@ export const clientsRouter = createRouter({
                 eq(clients.id, input.id),
                 eq(clients.practiceId, ctx.practiceId),
                 activePracticePredicate(ctx.practiceId),
-                isNull(clients.deletedAt)
-              )
+                isNull(clients.deletedAt),
+              ),
             )
             .limit(1)
             .for("update");
@@ -608,6 +767,15 @@ export const clientsRouter = createRouter({
             phone: prelockPhone,
             reason: "manual",
             detail: `Staff revoked SMS consent from client ${input.id}.`,
+            evidence: {
+              clientId: input.id,
+              source: "staff_manual_revoke:v1",
+              detail: "Staff explicitly withdrew SMS consent practice-wide.",
+              actorType: "staff",
+              actorUserId: ctx.user.id,
+              actorName: ctx.user.name,
+              eventKey: staffSmsConsentEventKey(),
+            },
           });
         } catch (error) {
           if (error instanceof TRPCError) throw error;
@@ -632,8 +800,8 @@ export const clientsRouter = createRouter({
             eq(clients.id, input.id),
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .returning({
           id: clients.id,
@@ -660,8 +828,8 @@ export const clientsRouter = createRouter({
               eq(clients.id, input.id),
               eq(clients.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(clients.deletedAt)
-            )
+              isNull(clients.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -680,8 +848,8 @@ export const clientsRouter = createRouter({
               eq(patients.clientId, input.id),
               eq(patients.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(patients.deletedAt)
-            )
+              isNull(patients.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -701,8 +869,8 @@ export const clientsRouter = createRouter({
               eq(appointments.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               isNull(appointments.deletedAt),
-              inArray(appointments.status, activeSchedulingStatuses)
-            )
+              inArray(appointments.status, activeSchedulingStatuses),
+            ),
           )
           .limit(1);
 
@@ -723,8 +891,8 @@ export const clientsRouter = createRouter({
               eq(appointmentWaitlist.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               eq(appointmentWaitlist.status, "waiting"),
-              isNull(appointmentWaitlist.deletedAt)
-            )
+              isNull(appointmentWaitlist.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -745,8 +913,8 @@ export const clientsRouter = createRouter({
               eq(invoices.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               isNull(invoices.deletedAt),
-              inArray(invoices.status, unresolvedInvoiceStatuses)
-            )
+              inArray(invoices.status, unresolvedInvoiceStatuses),
+            ),
           )
           .limit(1);
 
@@ -766,8 +934,8 @@ export const clientsRouter = createRouter({
               eq(clients.id, input.id),
               eq(clients.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(clients.deletedAt)
-            )
+              isNull(clients.deletedAt),
+            ),
           )
           .returning({ id: clients.id });
         if (!client) {

--- a/packages/db/drizzle/0055_flippant_silver_fox.sql
+++ b/packages/db/drizzle/0055_flippant_silver_fox.sql
@@ -1,0 +1,197 @@
+CREATE TYPE "public"."sms_consent_action" AS ENUM('granted', 'revoked');--> statement-breakpoint
+CREATE TYPE "public"."sms_consent_actor_type" AS ENUM('staff', 'client', 'system');--> statement-breakpoint
+CREATE TABLE "sms_consent_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"occurred_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"practice_id" uuid NOT NULL,
+	"client_id" uuid,
+	"location_id" uuid,
+	"destination_e164" varchar(16) NOT NULL,
+	"action" "sms_consent_action" NOT NULL,
+	"source" varchar(64) NOT NULL,
+	"disclosure_version" varchar(32),
+	"disclosure" text,
+	"detail" text,
+	"actor_type" "sms_consent_actor_type" NOT NULL,
+	"actor_user_id" uuid,
+	"actor_name" varchar(255),
+	"provider" varchar(16),
+	"provider_message_id" varchar(255),
+	"event_key" varchar(200) NOT NULL,
+	CONSTRAINT "sms_consent_events_destination_check" CHECK ("sms_consent_events"."destination_e164" ~ '^\+[1-9][0-9]{7,14}$'),
+	CONSTRAINT "sms_consent_events_source_check" CHECK (length(btrim("sms_consent_events"."source")) between 1 and 64),
+	CONSTRAINT "sms_consent_events_event_key_check" CHECK (length(btrim("sms_consent_events"."event_key")) between 1 and 200),
+	CONSTRAINT "sms_consent_events_detail_check" CHECK ("sms_consent_events"."detail" is null or length("sms_consent_events"."detail") <= 2000),
+	CONSTRAINT "sms_consent_events_evidence_shape_check" CHECK ((
+          "sms_consent_events"."action" = 'granted'
+          and length(btrim(coalesce("sms_consent_events"."disclosure_version", ''))) > 0
+          and length(btrim(coalesce("sms_consent_events"."disclosure", ''))) > 0
+        ) or (
+          "sms_consent_events"."action" = 'revoked'
+          and "sms_consent_events"."disclosure_version" is null
+          and "sms_consent_events"."disclosure" is null
+        )),
+	CONSTRAINT "sms_consent_events_actor_shape_check" CHECK ((
+          "sms_consent_events"."actor_type" = 'staff'
+          and "sms_consent_events"."actor_user_id" is not null
+          and length(btrim(coalesce("sms_consent_events"."actor_name", ''))) > 0
+          and "sms_consent_events"."provider" is null
+          and "sms_consent_events"."provider_message_id" is null
+        ) or (
+          "sms_consent_events"."actor_type" = 'client'
+          and "sms_consent_events"."actor_user_id" is null
+          and "sms_consent_events"."actor_name" is null
+          and "sms_consent_events"."provider" in ('telnyx', 'twilio')
+          and length(btrim(coalesce("sms_consent_events"."provider_message_id", ''))) > 0
+        ) or (
+          "sms_consent_events"."actor_type" = 'system'
+          and "sms_consent_events"."actor_user_id" is null
+          and "sms_consent_events"."actor_name" is null
+          and "sms_consent_events"."provider" is null
+          and "sms_consent_events"."provider_message_id" is null
+        ))
+);
+--> statement-breakpoint
+ALTER TABLE "sms_consent_events" ADD CONSTRAINT "sms_consent_events_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_consent_events" ADD CONSTRAINT "sms_consent_events_client_id_clients_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."clients"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_consent_events" ADD CONSTRAINT "sms_consent_events_location_id_locations_id_fk" FOREIGN KEY ("location_id") REFERENCES "public"."locations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_consent_events" ADD CONSTRAINT "sms_consent_events_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_consent_events" ADD CONSTRAINT "sms_consent_events_client_tenant_fk" FOREIGN KEY ("practice_id","client_id") REFERENCES "public"."clients"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "locations_practice_id_uq" ON "locations" USING btree ("practice_id","id");--> statement-breakpoint
+ALTER TABLE "sms_consent_events" ADD CONSTRAINT "sms_consent_events_location_tenant_fk" FOREIGN KEY ("practice_id","location_id") REFERENCES "public"."locations"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_consent_events" ADD CONSTRAINT "sms_consent_events_actor_tenant_fk" FOREIGN KEY ("practice_id","actor_user_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_consent_events_practice_event_key_uq" ON "sms_consent_events" USING btree ("practice_id","event_key");--> statement-breakpoint
+CREATE INDEX "sms_consent_events_client_history_idx" ON "sms_consent_events" USING btree ("practice_id","client_id","occurred_at","id");--> statement-breakpoint
+CREATE INDEX "sms_consent_events_destination_history_idx" ON "sms_consent_events" USING btree ("practice_id","destination_e164","occurred_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_consent_events_provider_message_uq" ON "sms_consent_events" USING btree ("practice_id","provider","provider_message_id") WHERE "sms_consent_events"."provider" is not null and "sms_consent_events"."provider_message_id" is not null;--> statement-breakpoint
+WITH consent_candidates AS MATERIALIZED (
+	SELECT
+		c.*,
+		regexp_replace(coalesce(c.phone, ''), '[^0-9]', '', 'g') AS phone_digits
+	FROM clients c
+	WHERE c.deleted_at IS NULL
+		AND c.sms_consent = true
+		AND c.sms_consent_at IS NOT NULL
+		AND length(btrim(coalesce(c.sms_consent_source, ''))) > 0
+		AND length(btrim(split_part(c.sms_consent_source, ':', 2))) > 0
+		AND length(btrim(coalesce(c.sms_consent_disclosure, ''))) > 0
+),
+normalized_candidates AS (
+	SELECT
+		c.*,
+		CASE
+			WHEN left(btrim(c.phone), 1) = '+'
+				THEN '+' || c.phone_digits
+			WHEN length(c.phone_digits) = 10
+				THEN '+1' || c.phone_digits
+			WHEN length(c.phone_digits) = 11
+				AND left(c.phone_digits, 1) = '1'
+				THEN '+' || c.phone_digits
+		END AS normalized_destination
+	FROM consent_candidates c
+),
+valid_affirmative AS (
+	SELECT *
+	FROM normalized_candidates
+	WHERE normalized_destination ~ '^\+[1-9][0-9]{7,14}$'
+)
+INSERT INTO sms_consent_events (
+	id,
+	created_at,
+	occurred_at,
+	practice_id,
+	client_id,
+	destination_e164,
+	action,
+	source,
+	disclosure_version,
+	disclosure,
+	detail,
+	actor_type,
+	event_key
+)
+SELECT
+	gen_random_uuid(),
+	now(),
+	c.sms_consent_at,
+	c.practice_id,
+	c.id,
+	c.normalized_destination,
+	'granted'::sms_consent_action,
+	c.sms_consent_source,
+	split_part(c.sms_consent_source, ':', 2),
+	c.sms_consent_disclosure,
+	'Backfilled from the existing affirmative client consent projection.',
+	'system'::sms_consent_actor_type,
+	'backfill:client:' || c.id::text || ':affirmative-v1'
+FROM valid_affirmative c;--> statement-breakpoint
+UPDATE clients c
+SET
+	sms_consent = false,
+	sms_consent_at = null,
+	sms_consent_source = null,
+	sms_consent_disclosure = null
+WHERE c.sms_consent = true
+	AND NOT EXISTS (
+		SELECT 1
+		FROM sms_consent_events event
+		WHERE event.practice_id = c.practice_id
+			AND event.client_id = c.id
+			AND event.action = 'granted'
+	);--> statement-breakpoint
+CREATE FUNCTION reject_sms_consent_event_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+	IF coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+		AND current_user = (
+			SELECT pg_catalog.pg_get_userbyid(class.relowner)
+			FROM pg_catalog.pg_class class
+			JOIN pg_catalog.pg_namespace namespace
+				ON namespace.oid = class.relnamespace
+			WHERE namespace.nspname = 'public'
+				AND class.relname = 'sms_consent_events'
+		)
+	THEN
+		IF TG_OP = 'DELETE' THEN
+			RETURN OLD;
+		END IF;
+		RETURN NEW;
+	END IF;
+
+	RAISE EXCEPTION USING
+		ERRCODE = '55000',
+		MESSAGE = 'SMS consent events are append-only and cannot be updated or deleted.';
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER sms_consent_events_immutable
+	BEFORE UPDATE OR DELETE ON sms_consent_events
+	FOR EACH ROW
+	EXECUTE FUNCTION reject_sms_consent_event_mutation();--> statement-breakpoint
+ALTER TABLE sms_consent_events ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY tenant_isolation ON sms_consent_events
+	USING (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	)
+	WITH CHECK (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	);--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'openpims_app') THEN
+		REVOKE ALL ON sms_consent_events FROM openpims_app;
+		GRANT SELECT, INSERT ON sms_consent_events TO openpims_app;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+		REVOKE ALL ON sms_consent_events FROM anon;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+		REVOKE ALL ON sms_consent_events FROM authenticated;
+	END IF;
+END
+$$;

--- a/packages/db/drizzle/meta/0055_snapshot.json
+++ b/packages/db/drizzle/meta/0055_snapshot.json
@@ -1,0 +1,15682 @@
+{
+  "id": "57afe1b0-faf6-4d90-9d56-7f42bbf59e36",
+  "prevId": "472b4c86-8952-4efa-93b7-33ad6d010e89",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "performed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "practice_id",
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n      )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": [
+        "entered_in_error"
+      ]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign",
+        "vaccination_record"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invoiced",
+        "waived"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": [
+        "staff",
+        "client",
+        "system"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": [
+        "unresolved",
+        "charged",
+        "no_charge",
+        "voided"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1786250872372,
       "tag": "0054_ambitious_ultimatum",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1786256547912,
+      "tag": "0055_flippant_silver_fox",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -18,6 +18,7 @@ const TABLES = [
   "api_keys",
   "treatment_template_items",
   "treatment_templates",
+  "sms_consent_events",
   "patient_merge_events",
   "dispense_charge_queue",
   "invoice_items",

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -55,7 +55,7 @@ DECLARE
     'capture_sessions','cases','clients','clinical_notes','clinical_record_corrections','communications','consent_forms','consent_requests','controlled_substance_log','dispense_charge_queue','email_suppressions',
     'files','insurance_claims','insurance_policies','invoices','lab_results','location_messaging','messaging_registrations','migration_runs',
     'locations','patient_merge_events','patients','practice_payment_accounts','prescription_events','prescriptions','problem_list','procedures','products','purchase_orders',
-    'recurring_series','rooms','services','sms_suppressions','soap_notes','staff_schedules','suppliers',
+    'recurring_series','rooms','services','sms_consent_events','sms_suppressions','soap_notes','staff_schedules','suppliers',
     'treatment_plans','treatment_templates','usage_records','users','vaccination_records',
     'visit_closeouts','visit_work_items','vital_signs','webhooks','wellness_enrollments','wellness_plans'
   ];
@@ -87,6 +87,11 @@ GRANT SELECT, INSERT ON prescription_events TO openpims_app;
 -- can create and read attributed events but cannot rewrite or remove lineage.
 REVOKE ALL ON patient_merge_events FROM openpims_app;
 GRANT SELECT, INSERT ON patient_merge_events TO openpims_app;
+
+-- SMS consent events are an append-only compliance ledger. The current client
+-- consent projection may change; its evidence history may only be appended.
+REVOKE ALL ON sms_consent_events FROM openpims_app;
+GRANT SELECT, INSERT ON sms_consent_events TO openpims_app;
 
 -- Dispense charge snapshots are durable revenue work. The app may advance or
 -- reopen their attributed workflow status, while database triggers prevent

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -21,6 +21,7 @@ export * from "./wellness";
 export * from "./usage";
 export * from "./auth-tokens";
 export * from "./messaging";
+export * from "./sms-consent-events";
 export * from "./demo-access";
 export * from "./booking";
 export * from "./funnel-events";

--- a/packages/db/schema/practices.ts
+++ b/packages/db/schema/practices.ts
@@ -56,22 +56,22 @@ export const practices = pgTable(
     billingTrialIdx: index("practices_billing_trial_idx").on(
       table.billingStatus,
       table.trialEndsAt,
-      table.deletedAt
+      table.deletedAt,
     ),
     stripeCustomerIdx: index("practices_stripe_customer_idx").on(
       table.stripeCustomerId,
-      table.deletedAt
+      table.deletedAt,
     ),
     stripeSubscriptionIdx: index("practices_stripe_subscription_idx").on(
       table.stripeSubscriptionId,
-      table.deletedAt
+      table.deletedAt,
     ),
     // Unique token lookup for the unauthenticated ICS feed route. Postgres
     // treats NULLs as distinct, so practices without a feed are unaffected.
     calendarFeedTokenUq: uniqueIndex("practices_calendar_feed_token_uq").on(
-      table.calendarFeedToken
+      table.calendarFeedToken,
     ),
-  })
+  }),
 );
 
 export const locations = pgTable(
@@ -87,15 +87,19 @@ export const locations = pgTable(
     isPrimary: boolean("is_primary").notNull().default(false),
   },
   (table) => ({
+    practiceIdUq: uniqueIndex("locations_practice_id_uq").on(
+      table.practiceId,
+      table.id,
+    ),
     practiceIdx: index("locations_practice_idx").on(
       table.practiceId,
-      table.deletedAt
+      table.deletedAt,
     ),
     primaryIdx: index("locations_primary_idx").on(
       table.practiceId,
-      table.isPrimary
+      table.isPrimary,
     ),
-  })
+  }),
 );
 
 export const practicesRelations = relations(practices, ({ many }) => ({

--- a/packages/db/schema/sms-consent-events.ts
+++ b/packages/db/schema/sms-consent-events.ts
@@ -1,0 +1,171 @@
+import { relations, sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  pgEnum,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+  text,
+} from "drizzle-orm/pg-core";
+import { clients } from "./clients";
+import { locations, practices } from "./practices";
+import { users } from "./users";
+
+export const smsConsentActionEnum = pgEnum("sms_consent_action", [
+  "granted",
+  "revoked",
+]);
+
+export const smsConsentActorTypeEnum = pgEnum("sms_consent_actor_type", [
+  "staff",
+  "client",
+  "system",
+]);
+
+/**
+ * Immutable evidence for every SMS consent grant and revocation. The clients
+ * row remains the fast current-state projection; this table preserves what
+ * happened, for which normalized destination, under which disclosure, and who
+ * initiated it. `eventKey` makes provider webhook replay and migration backfill
+ * idempotent without conflating distinct staff decisions.
+ */
+export const smsConsentEvents = pgTable(
+  "sms_consent_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    occurredAt: timestamp("occurred_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    clientId: uuid("client_id").references(() => clients.id),
+    locationId: uuid("location_id").references(() => locations.id),
+    destinationE164: varchar("destination_e164", { length: 16 }).notNull(),
+    action: smsConsentActionEnum("action").notNull(),
+    source: varchar("source", { length: 64 }).notNull(),
+    disclosureVersion: varchar("disclosure_version", { length: 32 }),
+    disclosure: text("disclosure"),
+    detail: text("detail"),
+    actorType: smsConsentActorTypeEnum("actor_type").notNull(),
+    actorUserId: uuid("actor_user_id").references(() => users.id),
+    actorName: varchar("actor_name", { length: 255 }),
+    provider: varchar("provider", { length: 16 }),
+    providerMessageId: varchar("provider_message_id", { length: 255 }),
+    eventKey: varchar("event_key", { length: 200 }).notNull(),
+  },
+  (table) => ({
+    eventKeyUq: uniqueIndex("sms_consent_events_practice_event_key_uq").on(
+      table.practiceId,
+      table.eventKey,
+    ),
+    clientHistoryIdx: index("sms_consent_events_client_history_idx").on(
+      table.practiceId,
+      table.clientId,
+      table.occurredAt,
+      table.id,
+    ),
+    destinationHistoryIdx: index(
+      "sms_consent_events_destination_history_idx",
+    ).on(table.practiceId, table.destinationE164, table.occurredAt, table.id),
+    providerMessageUq: uniqueIndex("sms_consent_events_provider_message_uq")
+      .on(table.practiceId, table.provider, table.providerMessageId)
+      .where(
+        sql`${table.provider} is not null and ${table.providerMessageId} is not null`,
+      ),
+    clientTenantFk: foreignKey({
+      columns: [table.practiceId, table.clientId],
+      foreignColumns: [clients.practiceId, clients.id],
+      name: "sms_consent_events_client_tenant_fk",
+    }),
+    locationTenantFk: foreignKey({
+      columns: [table.practiceId, table.locationId],
+      foreignColumns: [locations.practiceId, locations.id],
+      name: "sms_consent_events_location_tenant_fk",
+    }),
+    actorTenantFk: foreignKey({
+      columns: [table.practiceId, table.actorUserId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "sms_consent_events_actor_tenant_fk",
+    }),
+    destinationCheck: check(
+      "sms_consent_events_destination_check",
+      sql`${table.destinationE164} ~ '^\\+[1-9][0-9]{7,14}$'`,
+    ),
+    sourceCheck: check(
+      "sms_consent_events_source_check",
+      sql`length(btrim(${table.source})) between 1 and 64`,
+    ),
+    eventKeyCheck: check(
+      "sms_consent_events_event_key_check",
+      sql`length(btrim(${table.eventKey})) between 1 and 200`,
+    ),
+    detailCheck: check(
+      "sms_consent_events_detail_check",
+      sql`${table.detail} is null or length(${table.detail}) <= 2000`,
+    ),
+    evidenceShapeCheck: check(
+      "sms_consent_events_evidence_shape_check",
+      sql`(
+          ${table.action} = 'granted'
+          and length(btrim(coalesce(${table.disclosureVersion}, ''))) > 0
+          and length(btrim(coalesce(${table.disclosure}, ''))) > 0
+        ) or (
+          ${table.action} = 'revoked'
+          and ${table.disclosureVersion} is null
+          and ${table.disclosure} is null
+        )`,
+    ),
+    actorShapeCheck: check(
+      "sms_consent_events_actor_shape_check",
+      sql`(
+          ${table.actorType} = 'staff'
+          and ${table.actorUserId} is not null
+          and length(btrim(coalesce(${table.actorName}, ''))) > 0
+          and ${table.provider} is null
+          and ${table.providerMessageId} is null
+        ) or (
+          ${table.actorType} = 'client'
+          and ${table.actorUserId} is null
+          and ${table.actorName} is null
+          and ${table.provider} in ('telnyx', 'twilio')
+          and length(btrim(coalesce(${table.providerMessageId}, ''))) > 0
+        ) or (
+          ${table.actorType} = 'system'
+          and ${table.actorUserId} is null
+          and ${table.actorName} is null
+          and ${table.provider} is null
+          and ${table.providerMessageId} is null
+        )`,
+    ),
+  }),
+);
+
+export const smsConsentEventsRelations = relations(
+  smsConsentEvents,
+  ({ one }) => ({
+    practice: one(practices, {
+      fields: [smsConsentEvents.practiceId],
+      references: [practices.id],
+    }),
+    client: one(clients, {
+      fields: [smsConsentEvents.clientId],
+      references: [clients.id],
+    }),
+    location: one(locations, {
+      fields: [smsConsentEvents.locationId],
+      references: [locations.id],
+    }),
+    actor: one(users, {
+      fields: [smsConsentEvents.actorUserId],
+      references: [users.id],
+    }),
+  }),
+);

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -64,6 +64,8 @@ const aPrescriptionEvent = randomUUID();
 const bPrescriptionEvent = randomUUID();
 const aDispenseCharge = randomUUID();
 const bDispenseCharge = randomUUID();
+const aSmsConsentEvent = randomUUID();
+const bSmsConsentEvent = randomUUID();
 const funnelEventId = randomUUID();
 let failures = 0;
 
@@ -86,6 +88,11 @@ try {
   await owner`insert into users (id, email, password_hash, name, role, practice_id) values
     (${aUser}, ${`rls-${aUser}@example.com`}, 'not-a-real-hash', 'RLS Admin A', 'admin', ${aId}),
     (${bUser}, ${`rls-${bUser}@example.com`}, 'not-a-real-hash', 'RLS Admin B', 'admin', ${bId})`;
+  await owner`insert into sms_consent_events
+    (id, practice_id, client_id, destination_e164, action, source, detail, actor_type, event_key)
+    values
+    (${aSmsConsentEvent}, ${aId}, ${aClient}, '+15555550101', 'revoked', 'rls_test:v1', 'Tenant A event', 'system', ${`rls:${aSmsConsentEvent}`}),
+    (${bSmsConsentEvent}, ${bId}, ${bClient}, '+15555550102', 'revoked', 'rls_test:v1', 'Tenant B event', 'system', ${`rls:${bSmsConsentEvent}`})`;
   await owner`insert into patients (id, practice_id, client_id, name, species)
     select ${aPatient}, ${aId}, id, 'RLS Pet A', 'canine'
     from clients where practice_id = ${aId}`;
@@ -164,6 +171,60 @@ try {
   check(
     "tenant A sees only A's clients",
     aRows.length === 1 && aRows[0]!.practice_id === aId,
+  );
+
+  const aSmsConsentEvents = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id, practice_id from sms_consent_events where id in (${aSmsConsentEvent}, ${bSmsConsentEvent})`;
+  });
+  check(
+    "tenant A sees only A's SMS consent events",
+    aSmsConsentEvents.length === 1 &&
+      aSmsConsentEvents[0]!.id === aSmsConsentEvent,
+  );
+
+  let smsConsentUpdateBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`update sms_consent_events set detail = 'tampered' where id = ${aSmsConsentEvent}`;
+    });
+  } catch {
+    smsConsentUpdateBlocked = true;
+  }
+  check(
+    "application role cannot rewrite SMS consent history",
+    smsConsentUpdateBlocked,
+  );
+
+  let smsConsentDeleteBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`delete from sms_consent_events where id = ${aSmsConsentEvent}`;
+    });
+  } catch {
+    smsConsentDeleteBlocked = true;
+  }
+  check(
+    "application role cannot delete SMS consent history",
+    smsConsentDeleteBlocked,
+  );
+
+  let crossTenantSmsConsentInsertBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into sms_consent_events
+        (practice_id, client_id, destination_e164, action, source, actor_type, event_key)
+        values (${bId}, ${bClient}, '+15555550102', 'revoked', 'rls_cross_tenant:v1', 'system', ${`rls:cross:${randomUUID()}`})`;
+    });
+  } catch {
+    crossTenantSmsConsentInsertBlocked = true;
+  }
+  check(
+    "cross-tenant SMS consent INSERT is blocked",
+    crossTenantSmsConsentInsertBlocked,
   );
 
   const aPrescriptionEvents = await appTransaction(async (tx) => {
@@ -538,6 +599,7 @@ try {
   await owner.begin(async (tx) => {
     const cleanup = tx as unknown as typeof owner;
     await cleanup`select set_config('app.ledger_maintenance', 'on', true)`;
+    await cleanup`delete from sms_consent_events where id in (${aSmsConsentEvent}, ${bSmsConsentEvent})`;
     await cleanup`delete from patient_merge_events where id in (${aPatientMergeEvent}, ${bPatientMergeEvent})`;
     await cleanup`delete from dispense_charge_queue where id in (${aDispenseCharge}, ${bDispenseCharge})`;
     await cleanup`delete from invoice_adjustments where invoice_id in (${aInvoice}, ${bInvoice})`;


### PR DESCRIPTION
## Summary
- add an immutable, tenant-scoped SMS consent and revocation ledger with RLS and database constraints
- update staff grant, withdrawal, phone-change, inbound STOP, and inbound START paths transactionally
- preserve replay and race safety with recipient and client row locks
- backfill only truthful consent evidence and clear unsupported projections fail-closed
- include consent history in clinic UI and preserve it through safe backup and restore

## Safety
- hosted SMS sending remains default-off and this change performs no provider activation or external sends
- STOP evidence is destination-wide; START requires a durable provider identity and a stable unique client match
- legacy and modern restore paths refuse affirmative consent without supporting evidence

## Verification
- 301 test files / 2,935 tests passed
- web and database typechecks passed
- production build passed with 42 pages
- schema generation reported no drift
- two independent audits returned SHIP

## Operational gate
CI migration and RLS checks against disposable PostgreSQL must pass before merge.