### PR TITLE
Harden durable SMS dispatch and recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ EMAIL_FROM=
 # "twilio" (fallback). Leave unset to auto-pick whichever is configured (Telnyx
 # preferred), or fall back to console logging in local dev.
 MESSAGING_PROVIDER=
+# Self-hosted Telnyx/Twilio only: exact clinic identity approved on the active
+# carrier campaign. Hosted deployments use the active provider-matching
+# messaging_registrations row instead. Console-only local testing safely falls
+# back to the practice name.
+MESSAGING_REGISTERED_DISPLAY_NAME=
 
 # Telnyx (recommended SMS provider). Clinic sends use the per-location profile
 # and number created during texting setup. The global profile/from values below

--- a/apps/web/app/(dashboard)/inbox/page.tsx
+++ b/apps/web/app/(dashboard)/inbox/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import {
@@ -130,7 +130,7 @@ function formatInboxDate(date: Date, timeZone?: string | null): string {
 
 function relativeTime(
   date: Date | string | null,
-  timeZone?: string | null
+  timeZone?: string | null,
 ): string {
   if (!date) return "";
   const now = new Date();
@@ -143,10 +143,10 @@ function relativeTime(
   const diffHr = Math.floor(diffMin / 60);
   if (diffHr < 24) return `${diffHr}h ago`;
   const todayDay = dateInputDayNumber(
-    formatDateInputForTimeZone(now, timeZone)
+    formatDateInputForTimeZone(now, timeZone),
   );
   const messageDay = dateInputDayNumber(
-    formatDateInputForTimeZone(d, timeZone)
+    formatDateInputForTimeZone(d, timeZone),
   );
   const diffDay =
     todayDay !== null && messageDay !== null
@@ -211,18 +211,17 @@ export default function InboxPage() {
     error: inboxError,
   } = trpc.communications.listConversations.useQuery(
     { inboxFilter: filter, limit: 50, offset: 0 },
-    { refetchInterval: 30000 }
+    { refetchInterval: 30000 },
   );
 
   const {
     data: timeline,
     isLoading: timelineLoading,
     error: timelineError,
-  } =
-    trpc.communications.getByClient.useQuery(
-      { clientId: selectedClientId! },
-      { enabled: !!selectedClientId }
-    );
+  } = trpc.communications.getByClient.useQuery(
+    { clientId: selectedClientId! },
+    { enabled: !!selectedClientId },
+  );
 
   const {
     data: searchResults,
@@ -230,7 +229,7 @@ export default function InboxPage() {
     error: searchError,
   } = trpc.clients.search.useQuery(
     { query: trimmedNewClientSearch },
-    { enabled: canSearchNewClients }
+    { enabled: canSearchNewClients },
   );
 
   const {
@@ -239,7 +238,7 @@ export default function InboxPage() {
     error: linkClientError,
   } = trpc.clients.search.useQuery(
     { query: trimmedLinkClientSearch },
-    { enabled: Boolean(selectedUnmatched && canSearchLinkClients) }
+    { enabled: Boolean(selectedUnmatched && canSearchLinkClients) },
   );
 
   const {
@@ -259,11 +258,9 @@ export default function InboxPage() {
     (Boolean(messagingStatusError) || !messagingStatus);
   const smsComposeBlocked =
     composeChannel === "sms" && smsSummary?.smsComposeEnabled !== true;
-  const showSmsBanner = Boolean(
-    smsSummary?.showBanner && !smsBannerDismissed
-  );
+  const showSmsBanner = Boolean(smsSummary?.showBanner && !smsBannerDismissed);
   const showSmsStatusError = Boolean(
-    smsStatusUnavailable && !smsBannerDismissed
+    smsStatusUnavailable && !smsBannerDismissed,
   );
   const currentUserId = session?.user?.id;
   const canMutateInbox = canMutateInboxRole(session?.user?.role);
@@ -302,8 +299,13 @@ export default function InboxPage() {
     }
   }, [inboxSettingsError, inboxSettingsMissing]);
 
+  const smsComposeRequest = useRef<{
+    fingerprint: string;
+    requestId: string;
+  } | null>(null);
   const createMutation = trpc.communications.create.useMutation({
     onSuccess: () => {
+      smsComposeRequest.current = null;
       toast.success("Message sent");
       utils.communications.listConversations.invalidate();
       if (selectedClientId) {
@@ -315,6 +317,9 @@ export default function InboxPage() {
       setComposeSubject("");
     },
     onError: (err) => {
+      if (err.data?.code === "BAD_REQUEST") {
+        smsComposeRequest.current = null;
+      }
       toast.error(err.message);
       utils.communications.listConversations.invalidate();
       if (selectedClientId) {
@@ -332,7 +337,7 @@ export default function InboxPage() {
         ? "portal"
         : "email";
   const composeContentMaxLength = communicationContentMaxLength(
-    composeDeliveryChannel
+    composeDeliveryChannel,
   );
   const composeContentInvalid =
     composeContent.length > 0 &&
@@ -398,7 +403,7 @@ export default function InboxPage() {
     if (!commsData?.items) return [];
     return (commsData.items as InboxListItem[]).map((item) => {
       const unreadCount = Number(
-        item.unreadCount ?? (isUnreadInboxMessage(item) ? 1 : 0)
+        item.unreadCount ?? (isUnreadInboxMessage(item) ? 1 : 0),
       );
       if (!item.clientId) {
         return {
@@ -429,9 +434,9 @@ export default function InboxPage() {
     () =>
       conversationGroups.find(
         (group) =>
-          group.kind === "client" && group.clientId === selectedClientId
+          group.kind === "client" && group.clientId === selectedClientId,
       ),
-    [conversationGroups, selectedClientId]
+    [conversationGroups, selectedClientId],
   );
   const assignmentSource = selectedGroup?.latest ?? timeline?.[0];
   const assignedTo = assignmentSource?.assignedTo ?? null;
@@ -443,16 +448,16 @@ export default function InboxPage() {
       : `Assigned to ${assignedToName ?? "staff"}`
     : "Unassigned";
   const SelectedUnmatchedIcon = selectedUnmatched
-    ? channelIcons[selectedUnmatched.channel as Channel] ?? MessageSquare
+    ? (channelIcons[selectedUnmatched.channel as Channel] ?? MessageSquare)
     : MessageSquare;
   const selectedUnmatchedChannel = selectedUnmatched
-    ? channelLabels[selectedUnmatched.channel as Channel] ?? "Message"
+    ? (channelLabels[selectedUnmatched.channel as Channel] ?? "Message")
     : "Message";
 
   function handleSelectClient(
     clientId: string,
     clientName: string,
-    unreadCount = 0
+    unreadCount = 0,
   ) {
     setSelectedClientId(clientId);
     setSelectedClientName(clientName);
@@ -482,25 +487,38 @@ export default function InboxPage() {
       toast.error(
         smsStatusUnavailable
           ? "Unable to check texting setup"
-          : smsSummary?.title ?? "Checking texting setup"
+          : (smsSummary?.title ?? "Checking texting setup"),
       );
       return;
     }
     if (!canSendCompose) return;
+    const trimmedContent = composeContent.trim();
+    const trimmedSubject = composeSubject.trim();
+    let requestId: string | undefined;
+    if (composeChannel === "sms") {
+      const fingerprint = `${selectedClientId}\u0000${trimmedContent}`;
+      if (smsComposeRequest.current?.fingerprint !== fingerprint) {
+        smsComposeRequest.current = {
+          fingerprint,
+          requestId: crypto.randomUUID(),
+        };
+      }
+      requestId = smsComposeRequest.current.requestId;
+    }
     createMutation.mutate({
       clientId: selectedClientId,
       channel: composeChannel,
       direction: "outbound",
       subject:
-        composeChannel === "email"
-          ? composeSubject.trim() || undefined
-          : undefined,
-      content: composeContent.trim(),
+        composeChannel === "email" ? trimmedSubject || undefined : undefined,
+      content: trimmedContent,
+      ...(requestId ? { requestId } : {}),
     });
   }
 
   function handleNewMessage() {
     if (!canMutateInbox) return;
+    smsComposeRequest.current = null;
     setNewMessageMode(true);
     setSelectedClientId(null);
     setSelectedClientName("");
@@ -535,7 +553,7 @@ export default function InboxPage() {
           setSelectedClientName(clientName);
           setLinkClientSearch("");
         },
-      }
+      },
     );
   }
 
@@ -551,9 +569,7 @@ export default function InboxPage() {
       <div className="flex items-center justify-between mb-4">
         <div>
           <h2 className="font-heading text-xl font-semibold">Inbox</h2>
-          <p className="text-sm text-muted-foreground">
-            Client communications
-          </p>
+          <p className="text-sm text-muted-foreground">Client communications</p>
         </div>
         {canMutateInbox ? (
           <Button onClick={handleNewMessage} className="gap-2">
@@ -653,7 +669,7 @@ export default function InboxPage() {
             "w-full flex-col border-border shrink-0 md:flex md:w-80 md:border-r",
             selectedClientId || selectedUnmatched || newMessageMode
               ? "hidden"
-              : "flex"
+              : "flex",
           )}
         >
           {/* Filter tabs */}
@@ -666,7 +682,7 @@ export default function InboxPage() {
                   "flex-1 px-3 py-2.5 text-sm font-medium transition-colors",
                   filter === tab.key
                     ? "border-b-2 border-primary text-primary"
-                    : "text-muted-foreground hover:text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
                 )}
               >
                 {tab.label}
@@ -715,15 +731,13 @@ export default function InboxPage() {
                         ? handleSelectClient(
                             group.clientId,
                             group.clientName,
-                            group.unreadCount
+                            group.unreadCount,
                           )
                         : handleSelectUnmatched(group.latest)
                     }
                     className={cn(
                       "w-full text-left px-4 py-3 border-b border-border transition-colors",
-                      isSelected
-                        ? "bg-accent"
-                        : "hover:bg-accent/50"
+                      isSelected ? "bg-accent" : "hover:bg-accent/50",
                     )}
                   >
                     <div className="flex items-start gap-3">
@@ -741,7 +755,7 @@ export default function InboxPage() {
                           <span
                             className={cn(
                               "text-sm truncate",
-                              isUnread ? "font-semibold" : "font-medium"
+                              isUnread ? "font-semibold" : "font-medium",
                             )}
                           >
                             {group.clientName}
@@ -751,7 +765,7 @@ export default function InboxPage() {
                             <span className="text-xs">
                               {relativeTime(
                                 group.latest.createdAt,
-                                inboxTimeZone
+                                inboxTimeZone,
                               )}
                             </span>
                           </div>
@@ -789,7 +803,7 @@ export default function InboxPage() {
             "flex-1 flex-col min-w-0 md:flex",
             selectedClientId || selectedUnmatched || newMessageMode
               ? "flex"
-              : "hidden"
+              : "hidden",
           )}
         >
           {(selectedClientId || selectedUnmatched || newMessageMode) && (
@@ -840,7 +854,7 @@ export default function InboxPage() {
                       onClick={() =>
                         handleSelectClient(
                           client.id,
-                          `${client.firstName} ${client.lastName}`
+                          `${client.firstName} ${client.lastName}`,
                         )
                       }
                       className="w-full text-left px-3 py-2 rounded-md hover:bg-accent transition-colors"
@@ -918,7 +932,7 @@ export default function InboxPage() {
                       <span className="text-[10px]">
                         {relativeTime(
                           selectedUnmatched.createdAt,
-                          inboxTimeZone
+                          inboxTimeZone,
                         )}
                       </span>
                       {selectedUnmatched.status ? (
@@ -978,7 +992,9 @@ export default function InboxPage() {
                                 {client.firstName} {client.lastName}
                               </div>
                               <div className="truncate text-xs text-muted-foreground">
-                                {client.email || client.phone || "No contact info"}
+                                {client.email ||
+                                  client.phone ||
+                                  "No contact info"}
                               </div>
                             </div>
                             <UserPlus className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -1071,7 +1087,7 @@ export default function InboxPage() {
                         key={msg.id}
                         className={cn(
                           "flex gap-2",
-                          isOutbound ? "justify-end" : "justify-start"
+                          isOutbound ? "justify-end" : "justify-start",
                         )}
                       >
                         <div
@@ -1079,7 +1095,7 @@ export default function InboxPage() {
                             "max-w-[70%] rounded-lg px-3 py-2",
                             isOutbound
                               ? "bg-primary text-primary-foreground"
-                              : "bg-muted"
+                              : "bg-muted",
                           )}
                         >
                           {/* Direction + channel */}
@@ -1088,7 +1104,7 @@ export default function InboxPage() {
                               "flex items-center gap-1.5 mb-1",
                               isOutbound
                                 ? "text-primary-foreground/70"
-                                : "text-muted-foreground"
+                                : "text-muted-foreground",
                             )}
                           >
                             {isOutbound ? (
@@ -1108,7 +1124,7 @@ export default function InboxPage() {
                                 "text-xs font-semibold mb-0.5",
                                 isOutbound
                                   ? "text-primary-foreground/90"
-                                  : "text-foreground"
+                                  : "text-foreground",
                               )}
                             >
                               {msg.subject}
@@ -1124,7 +1140,7 @@ export default function InboxPage() {
                               "flex items-center gap-1 mt-1",
                               isOutbound
                                 ? "text-primary-foreground/50"
-                                : "text-muted-foreground"
+                                : "text-muted-foreground",
                             )}
                           >
                             <Clock className="h-2.5 w-2.5" />

--- a/apps/web/app/api-docs/page.tsx
+++ b/apps/web/app/api-docs/page.tsx
@@ -82,7 +82,8 @@ const sections: Section[] = [
       {
         name: "clients.search",
         method: "GET",
-        description: "Quick search clients by name, email, or phone. Returns up to 10 results.",
+        description:
+          "Quick search clients by name, email, or phone. Returns up to 10 results.",
         input: `{ query: string }`,
         response: `Client[]`,
       },
@@ -181,7 +182,8 @@ const sections: Section[] = [
       {
         name: "patients.getById",
         method: "GET",
-        description: "Get full patient details including weights, allergies, and owner info.",
+        description:
+          "Get full patient details including weights, allergies, and owner info.",
         input: `{ id: string }`,
         response: `{
   ...Patient,
@@ -564,7 +566,8 @@ const sections: Section[] = [
       {
         name: "billing.createCardPaymentCheckout",
         method: "POST",
-        description: "Create a Stripe Checkout link for the remaining adjusted invoice balance.",
+        description:
+          "Create a Stripe Checkout link for the remaining adjusted invoice balance.",
         input: `{ invoiceId: string }`,
         response: `{ url: string }`,
       },
@@ -723,7 +726,8 @@ const sections: Section[] = [
       {
         name: "portal.createMessage",
         method: "POST",
-        description: "Send a portal message from the client into the shared inbox.",
+        description:
+          "Send a portal message from the client into the shared inbox.",
         input: `{
   token: string,
   content: string
@@ -734,7 +738,8 @@ const sections: Section[] = [
       {
         name: "portal.markMessagesRead",
         method: "POST",
-        description: "Mark outbound clinic portal messages as read after the client opens the thread.",
+        description:
+          "Mark outbound clinic portal messages as read after the client opens the thread.",
         input: `{ token: string }`,
         response: `{ success: true, updated: number }`,
         auth: "Portal token",
@@ -762,7 +767,8 @@ const sections: Section[] = [
       {
         name: "portal.requestAppointment",
         method: "POST",
-        description: "Submit an appointment request from the portal using an exact requested time.",
+        description:
+          "Submit an appointment request from the portal using an exact requested time.",
         input: `{
   token: string,
   patientId: string,
@@ -1267,7 +1273,8 @@ const sections: Section[] = [
       {
         name: "communications.markClientRead",
         method: "POST",
-        description: "Mark unread inbound messages for a client thread as read.",
+        description:
+          "Mark unread inbound messages for a client thread as read.",
         input: `{ clientId: string }`,
         response: `{ ok: true, updated: number }`,
       },
@@ -1316,7 +1323,8 @@ const sections: Section[] = [
   direction: "inbound" | "outbound",
   subject?: string,
   content: string,
-  status?: "pending" | "sent" | "delivered" | "read" | "failed"
+  status?: "pending" | "sent" | "delivered" | "read" | "failed",
+  requestId?: string // Required UUID for outbound SMS; reuse for retries of the same send.
 }`,
         response: `Communication`,
       },
@@ -1604,9 +1612,7 @@ function verifySignature(
 
           {/* Footer */}
           <footer className="mt-16 border-t border-slate-200 pt-6 text-center text-sm text-slate-500 dark:border-slate-700">
-            <p>
-              OpenVPM &mdash; Open-source veterinary practice management.
-            </p>
+            <p>OpenVPM &mdash; Open-source veterinary practice management.</p>
             <p className="mt-1">
               API questions? Check the{" "}
               <a

--- a/apps/web/app/api/cron/reminders/route.test.ts
+++ b/apps/web/app/api/cron/reminders/route.test.ts
@@ -5,12 +5,21 @@ const mocks = vi.hoisted(() => {
   const selectResults: unknown[][] = [];
   const select = vi.fn(() => {
     const result = selectResults.shift() ?? [];
-    const afterWhere = {
-      limit: vi.fn(async () => result),
-      orderBy: vi.fn(async () => result),
+    const afterWhere: {
+      limit: ReturnType<typeof vi.fn>;
+      orderBy: ReturnType<typeof vi.fn>;
+      for: ReturnType<typeof vi.fn>;
       then: (
         resolve: (value: unknown[]) => unknown,
-        reject?: (error: unknown) => unknown
+        reject?: (error: unknown) => unknown,
+      ) => Promise<unknown>;
+    } = {
+      limit: vi.fn(async () => result),
+      orderBy: vi.fn(async () => result),
+      for: vi.fn(() => afterWhere),
+      then: (
+        resolve: (value: unknown[]) => unknown,
+        reject?: (error: unknown) => unknown,
       ) => Promise.resolve(result).then(resolve, reject),
     };
     const builder = {
@@ -26,7 +35,7 @@ const mocks = vi.hoisted(() => {
 
   const claimResults: unknown[][] = [];
   const insertReturning = vi.fn(
-    async () => claimResults.shift() ?? [{ id: "comm-1" }]
+    async () => claimResults.shift() ?? [{ id: "comm-1" }],
   );
   const insertOnConflict = vi.fn(() => ({ returning: insertReturning }));
   const insertValues = vi.fn(() => ({ onConflictDoNothing: insertOnConflict }));
@@ -36,7 +45,7 @@ const mocks = vi.hoisted(() => {
   const update = vi.fn(() => ({ set: updateSet }));
   const deleteResults: unknown[][] = [];
   const deleteReturning = vi.fn(
-    async () => deleteResults.shift() ?? [{ id: "old-claim" }]
+    async () => deleteResults.shift() ?? [{ id: "old-claim" }],
   );
   const deleteWhere = vi.fn(() => ({ returning: deleteReturning }));
   const deleteRows = vi.fn(() => ({ where: deleteWhere }));
@@ -60,11 +69,11 @@ const mocks = vi.hoisted(() => {
     alertOps: vi.fn(async () => undefined),
     cronAuthError: vi.fn(() => null),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn(db)
+      fn(db),
     ),
     withTenant: vi.fn(
       async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
-        fn(db)
+        fn(db),
     ),
   };
 });
@@ -150,7 +159,7 @@ describe("appointment reminder cron", () => {
     mocks.selectResults.push([]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -173,7 +182,7 @@ describe("appointment reminder cron", () => {
     ]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -187,13 +196,13 @@ describe("appointment reminder cron", () => {
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
     expect(mocks.insertValues).not.toHaveBeenCalled();
     expect(consoleLog).toHaveBeenCalledWith(
-      "Cron reminders completed: 0 sent, 0 failed, 0 deferred (quiet hours), 0 deduped, 1 suppressed (1 demo, 0 reserved address) out of 1 total"
+      "Cron reminders completed: 0 sent, 0 failed, 0 deferred (quiet hours), 0 deduped, 1 suppressed (1 demo, 0 reserved address) out of 1 total",
     );
     expect(consoleLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("Miso")
+      expect.stringContaining("Miso"),
     );
     expect(consoleLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("lovelacevet.com")
+      expect.stringContaining("lovelacevet.com"),
     );
   });
 
@@ -205,7 +214,7 @@ describe("appointment reminder cron", () => {
     ]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -219,7 +228,7 @@ describe("appointment reminder cron", () => {
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
     expect(mocks.insertValues).not.toHaveBeenCalled();
     expect(consoleLog).toHaveBeenCalledWith(
-      "Cron reminders completed: 0 sent, 0 failed, 0 deferred (quiet hours), 0 deduped, 1 suppressed (0 demo, 1 reserved address) out of 1 total"
+      "Cron reminders completed: 0 sent, 0 failed, 0 deferred (quiet hours), 0 deduped, 1 suppressed (0 demo, 1 reserved address) out of 1 total",
     );
   });
 
@@ -236,11 +245,11 @@ describe("appointment reminder cron", () => {
           locationId: LOCATION_ID,
         }),
       ],
-      [{ locationId: LOCATION_ID }]
+      [{ locationId: LOCATION_ID }],
     );
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -258,7 +267,7 @@ describe("appointment reminder cron", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     );
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -267,7 +276,7 @@ describe("appointment reminder cron", () => {
         channel: "sms",
         status: "pending",
         dedupeKey: `reminder:appointment:${APPOINTMENT_ID}:2026-07-02T16:00:00.000Z`,
-      })
+      }),
     );
     expect(mocks.insertOnConflict).toHaveBeenCalled();
     expect(mocks.updateSet).toHaveBeenCalledWith(
@@ -275,7 +284,7 @@ describe("appointment reminder cron", () => {
         channel: "sms",
         status: "sent",
         providerMessageId: "sms-cron-1",
-      })
+      }),
     );
   });
 
@@ -286,11 +295,11 @@ describe("appointment reminder cron", () => {
     });
     mocks.selectResults.push(
       [appointment({ clientEmail: " Ada@LovelaceVet.COM " })],
-      []
+      [],
     );
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -302,7 +311,7 @@ describe("appointment reminder cron", () => {
     });
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
     expect(mocks.sendAppointmentReminder).toHaveBeenCalledWith(
-      expect.objectContaining({ to: "ada@lovelacevet.com" })
+      expect.objectContaining({ to: "ada@lovelacevet.com" }),
     );
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -310,14 +319,14 @@ describe("appointment reminder cron", () => {
         clientId: CLIENT_ID,
         channel: "sms",
         status: "pending",
-      })
+      }),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "email",
         status: "sent",
         providerMessageId: "email-cron-1",
-      })
+      }),
     );
   });
 
@@ -334,7 +343,7 @@ describe("appointment reminder cron", () => {
     ]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -346,7 +355,7 @@ describe("appointment reminder cron", () => {
     });
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
     expect(mocks.sendAppointmentReminder).toHaveBeenCalledWith(
-      expect.objectContaining({ to: "ada@lovelacevet.com" })
+      expect.objectContaining({ to: "ada@lovelacevet.com" }),
     );
     expect(mocks.insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -354,14 +363,14 @@ describe("appointment reminder cron", () => {
         clientId: CLIENT_ID,
         channel: "email",
         status: "pending",
-      })
+      }),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "email",
         status: "sent",
         providerMessageId: "email-cron-2",
-      })
+      }),
     );
   });
 
@@ -375,7 +384,7 @@ describe("appointment reminder cron", () => {
     ]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -401,7 +410,7 @@ describe("appointment reminder cron", () => {
     ]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -418,16 +427,16 @@ describe("appointment reminder cron", () => {
         clientId: CLIENT_ID,
         channel: "email",
         status: "pending",
-      })
+      }),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "email",
         status: "failed",
         content: expect.stringContaining(
-          "Client email is suppressed after a delivery bounce"
+          "Client email is suppressed after a delivery bounce",
         ),
-      })
+      }),
     );
   });
 
@@ -435,7 +444,7 @@ describe("appointment reminder cron", () => {
     mocks.selectResults.push([appointment({ clientEmail: null })], []);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -453,13 +462,13 @@ describe("appointment reminder cron", () => {
         clientId: CLIENT_ID,
         channel: "sms",
         status: "pending",
-      })
+      }),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "sms",
         status: "failed",
-      })
+      }),
     );
   });
 
@@ -468,7 +477,7 @@ describe("appointment reminder cron", () => {
     mocks.claimResults.push([]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -492,12 +501,12 @@ describe("appointment reminder cron", () => {
           status: "pending",
           createdAt: new Date("2026-07-01T15:45:00Z"),
         },
-      ]
+      ],
     );
     mocks.claimResults.push([]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -512,7 +521,7 @@ describe("appointment reminder cron", () => {
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
   });
 
-  it("retries failed scheduled reminder claims", async () => {
+  it("keeps failed scheduled reminder claims deduped for operator review", async () => {
     mocks.selectResults.push(
       [appointment({ preferredContactMethod: "email" })],
       [
@@ -521,33 +530,28 @@ describe("appointment reminder cron", () => {
           status: "failed",
           createdAt: new Date("2026-07-01T15:55:00Z"),
         },
-      ]
+      ],
     );
     mocks.claimResults.push([]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
-      sent: 1,
+      sent: 0,
       failed: 0,
       skipped: 0,
-      deduped: 0,
+      deduped: 1,
       suppressed: 0,
     });
-    expect(mocks.deleteRows).toHaveBeenCalledOnce();
-    expect(mocks.insertReturning).toHaveBeenCalledTimes(2);
-    expect(mocks.sendAppointmentReminder).toHaveBeenCalledOnce();
-    expect(mocks.updateSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channel: "email",
-        status: "sent",
-      })
-    );
+    expect(mocks.deleteRows).not.toHaveBeenCalled();
+    expect(mocks.insertReturning).toHaveBeenCalledOnce();
+    expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
+    expect(mocks.updateSet).not.toHaveBeenCalled();
   });
 
-  it("reclaims stale pending scheduled reminder claims", async () => {
+  it("keeps stale pending scheduled reminder claims deduped", async () => {
     mocks.selectResults.push(
       [appointment({ preferredContactMethod: "email" })],
       [
@@ -556,24 +560,65 @@ describe("appointment reminder cron", () => {
           status: "pending",
           createdAt: new Date("2026-07-01T15:00:00Z"),
         },
-      ]
+      ],
     );
     mocks.claimResults.push([]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
-      sent: 1,
+      sent: 0,
       failed: 0,
+      skipped: 0,
+      deduped: 1,
+      suppressed: 0,
+    });
+    expect(mocks.deleteRows).not.toHaveBeenCalled();
+    expect(mocks.insertReturning).toHaveBeenCalledOnce();
+    expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
+  });
+
+  it("never projects an accepted SMS as failed when status persistence errors", async () => {
+    mocks.selectResults.push(
+      [appointment({ locationId: LOCATION_ID })],
+      [{ locationId: LOCATION_ID }],
+    );
+    mocks.sendAppointmentReminderSms.mockResolvedValueOnce({
+      success: true,
+      outcome: "accepted",
+      sid: "sms-accepted-1",
+      attemptId: "attempt-accepted-1",
+      replayed: false,
+    });
+    mocks.updateWhere.mockRejectedValueOnce(
+      new Error("projection unavailable"),
+    );
+
+    const response = await GET(
+      new Request("https://openvpm.test/api/cron/reminders"),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      sent: 0,
+      failed: 1,
       skipped: 0,
       deduped: 0,
       suppressed: 0,
     });
-    expect(mocks.deleteRows).toHaveBeenCalledOnce();
-    expect(mocks.insertReturning).toHaveBeenCalledTimes(2);
-    expect(mocks.sendAppointmentReminder).toHaveBeenCalledOnce();
+    expect(mocks.sendAppointmentReminderSms).toHaveBeenCalledOnce();
+    expect(mocks.updateSet).toHaveBeenCalledTimes(1);
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "sms", status: "sent" }),
+    );
+    expect(mocks.updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "failed" }),
+    );
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Accepted or ambiguous SMS reminder projection failed",
+      expect.stringContaining("attempt=attempt-accepted-1"),
+    );
   });
 
   it("marks claimed email reminders failed when the email provider rejects the send", async () => {
@@ -587,7 +632,7 @@ describe("appointment reminder cron", () => {
     ]);
 
     const response = await GET(
-      new Request("https://openvpm.test/api/cron/reminders")
+      new Request("https://openvpm.test/api/cron/reminders"),
     );
 
     await expect(response.json()).resolves.toEqual({
@@ -602,13 +647,13 @@ describe("appointment reminder cron", () => {
       expect.objectContaining({
         appointmentDate: "Thursday, July 2, 2026",
         appointmentTime: "9:00 AM",
-      })
+      }),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "email",
         status: "failed",
-      })
+      }),
     );
   });
 });
@@ -621,35 +666,35 @@ describe("appointment reminder cron query scoping", () => {
       new RegExp(
         `leftJoin\\(\\s*${table},\\s*and\\(\\s*eq\\(${foreignKey.replace(
           ".",
-          "\\."
-        )}, ${table}\\.id\\),\\s*eq\\(${table}\\.practiceId, appointments\\.practiceId\\),\\s*isNull\\(${table}\\.deletedAt\\)\\s*\\)\\s*\\)`,
-        "s"
-      )
+          "\\.",
+        )}, ${table}\\.id\\),\\s*eq\\(${table}\\.practiceId, appointments\\.practiceId\\),\\s*isNull\\(${table}\\.deletedAt\\),?\\s*\\),?\\s*\\)`,
+        "s",
+      ),
     );
   }
 
   it("keeps reminder sweep joins scoped to active appointment practices", () => {
     expect(source).toMatch(
-      /leftJoin\(\s*patients,\s*and\(\s*eq\(appointments\.patientId, patients\.id\),\s*eq\(patients\.clientId, appointments\.clientId\),\s*eq\(patients\.practiceId, appointments\.practiceId\),\s*isNull\(patients\.deletedAt\)\s*\)\s*\)/s
+      /leftJoin\(\s*patients,\s*and\(\s*eq\(appointments\.patientId, patients\.id\),\s*eq\(patients\.clientId, appointments\.clientId\),\s*eq\(patients\.practiceId, appointments\.practiceId\),\s*isNull\(patients\.deletedAt\),?\s*\),?\s*\)/s,
     );
     expectScopedJoin("clients", "appointments.clientId");
     expectScopedJoin("users", "appointments.doctorId");
     expectScopedJoin("rooms", "appointments.roomId");
     expect(source).toMatch(
-      /innerJoin\(\s*practices,\s*and\(\s*eq\(appointments\.practiceId, practices\.id\),\s*isNull\(practices\.deletedAt\)\s*\)\s*\)/s
+      /innerJoin\(\s*practices,\s*and\(\s*eq\(appointments\.practiceId, practices\.id\),\s*isNull\(practices\.deletedAt\),?\s*\),?\s*\)/s,
     );
     expect(source).toContain('eq(appointments.status, "confirmed")');
     expect(source).not.toContain(
-      'inArray(appointments.status, ["scheduled", "confirmed"])'
+      'inArray(appointments.status, ["scheduled", "confirmed"])',
     );
   });
 
   it("matches provider suppressions against trimmed normalized client emails", () => {
     expect(source).toContain(
-      "sql`${emailSuppressions.email} = lower(trim(${clients.email}))`"
+      "sql`${emailSuppressions.email} = lower(trim(${clients.email}))`",
     );
     expect(source).not.toContain(
-      "sql`${emailSuppressions.email} = lower(${clients.email})`"
+      "sql`${emailSuppressions.email} = lower(${clients.email})`",
     );
   });
 
@@ -665,17 +710,14 @@ describe("appointment reminder cron query scoping", () => {
     expect(source).toContain("const normalizedTimeZone = timeZone?.trim()");
     expect(source).toContain("timeZone: normalizedTimeZone");
     expect(source).toContain(
-      "formatAppointmentReminderDateTime(startDate, appt.practiceTimezone)"
+      "formatAppointmentReminderDateTime(startDate, appt.practiceTimezone)",
     );
     expect(source).not.toContain('startDate.toLocaleTimeString("en-US", {');
   });
 
-  it("reclaims failed or stale reminder claims with scoped predicates", () => {
-    expect(source).toContain("const REMINDER_PENDING_RECLAIM_MS");
-    expect(source).toContain('existing.status === "failed"');
-    expect(source).toContain("lte(communications.createdAt, staleBefore)");
-    expect(source).toContain("eq(communications.practiceId, opts.practiceId)");
-    expect(source).toContain("eq(communications.dedupeKey, opts.dedupeKey)");
-    expect(source).toContain("isNull(communications.deletedAt)");
+  it("never auto-reclaims failed or pending reminder claims", () => {
+    expect(source).toContain("claimAppointmentReminderCommunication");
+    expect(source).not.toContain("REMINDER_PENDING_RECLAIM_MS");
+    expect(source).not.toContain("delete(communications)");
   });
 });

--- a/apps/web/app/api/cron/reminders/route.ts
+++ b/apps/web/app/api/cron/reminders/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { eq, and, isNull, gte, lte, sql } from "drizzle-orm";
+import { eq, and, isNull, gte, lte, or, sql } from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import {
   appointments,
@@ -26,13 +26,17 @@ import {
   normalizeEmailSuppressionAddress,
 } from "@/lib/email-suppression";
 import { automatedAppointmentReminderSuppressionReason } from "@/lib/automated-reminder-policy";
+import {
+  appointmentReminderDedupeKey,
+  appointmentReminderSmsIdempotencyKey,
+  claimAppointmentReminderCommunication,
+} from "@/lib/messaging/appointment-reminder";
 
 type ReminderChannel = "sms" | "email";
-const REMINDER_PENDING_RECLAIM_MS = 30 * 60 * 1000;
 
 function formatAppointmentReminderDateTime(
   startTime: Date,
-  timeZone?: string | null
+  timeZone?: string | null,
 ): { appointmentDate: string; appointmentTime: string } {
   const normalizedTimeZone = timeZone?.trim();
   const dateOptions: Intl.DateTimeFormatOptions = {
@@ -69,101 +73,25 @@ function formatAppointmentReminderDateTime(
   };
 }
 
-function appointmentReminderDedupeKey(appt: {
-  id: string;
-  startTime: Date | string;
-}): string {
-  return `reminder:appointment:${appt.id}:${new Date(appt.startTime).toISOString()}`;
-}
-
 async function claimReminderCommunication(opts: {
   practiceId: string;
+  appointmentId: string;
   clientId: string;
   channel: ReminderChannel;
   patientName: string | null;
   startTime: Date;
   dedupeKey: string;
 }): Promise<string | null> {
-  const claimed = await insertReminderCommunicationClaim(opts);
-  if (claimed) return claimed;
-
-  const [existing] = await withTenant(db, opts.practiceId, (tx) =>
-    tx
-      .select({
-        id: communications.id,
-        status: communications.status,
-        createdAt: communications.createdAt,
-      })
-      .from(communications)
-      .where(
-        and(
-          eq(communications.practiceId, opts.practiceId),
-          eq(communications.dedupeKey, opts.dedupeKey),
-          isNull(communications.deletedAt)
-        )
-      )
-      .limit(1)
+  return withTenant(db, opts.practiceId, (tx) =>
+    claimAppointmentReminderCommunication(tx, {
+      practiceId: opts.practiceId,
+      appointmentId: opts.appointmentId,
+      clientId: opts.clientId,
+      channel: opts.channel,
+      patientName: opts.patientName,
+      startTime: opts.startTime,
+    }),
   );
-
-  if (!existing) return null;
-  if (existing.status !== "failed" && existing.status !== "pending") {
-    return null;
-  }
-
-  const staleBefore = new Date(Date.now() - REMINDER_PENDING_RECLAIM_MS);
-  const canReclaim =
-    existing.status === "failed" ||
-    new Date(existing.createdAt).getTime() <= staleBefore.getTime();
-  if (!canReclaim) return null;
-
-  const [deleted] = await withTenant(db, opts.practiceId, (tx) =>
-    tx
-      .delete(communications)
-      .where(
-        and(
-          eq(communications.practiceId, opts.practiceId),
-          eq(communications.dedupeKey, opts.dedupeKey),
-          existing.status === "failed"
-            ? eq(communications.status, "failed")
-            : and(
-                eq(communications.status, "pending"),
-                lte(communications.createdAt, staleBefore)
-              ),
-          isNull(communications.deletedAt)
-        )
-      )
-      .returning({ id: communications.id })
-  );
-  if (!deleted) return null;
-
-  return insertReminderCommunicationClaim(opts);
-}
-
-async function insertReminderCommunicationClaim(opts: {
-  practiceId: string;
-  clientId: string;
-  channel: ReminderChannel;
-  patientName: string | null;
-  startTime: Date;
-  dedupeKey: string;
-}): Promise<string | null> {
-  const [row] = await withTenant(db, opts.practiceId, (tx) =>
-    tx
-      .insert(communications)
-      .values({
-        practiceId: opts.practiceId,
-        clientId: opts.clientId,
-        channel: opts.channel,
-        direction: "outbound",
-        subject: "Appointment Reminder",
-        content: `Automated appointment reminder pending for ${opts.patientName ?? "Unknown"} on ${opts.startTime.toISOString()}`,
-        status: "pending",
-        dedupeKey: opts.dedupeKey,
-      })
-      .onConflictDoNothing({ target: communications.dedupeKey })
-      .returning({ id: communications.id })
-  );
-  return row?.id ?? null;
 }
 
 async function recordReminderOutcome(opts: {
@@ -183,7 +111,22 @@ async function recordReminderOutcome(opts: {
         content: opts.content,
         providerMessageId: opts.providerMessageId,
       })
-      .where(eq(communications.id, opts.communicationId))
+      .where(
+        and(
+          eq(communications.id, opts.communicationId),
+          eq(communications.practiceId, opts.practiceId),
+          or(
+            eq(communications.status, "pending"),
+            and(
+              eq(communications.status, "sent"),
+              opts.providerMessageId
+                ? eq(communications.providerMessageId, opts.providerMessageId)
+                : undefined,
+            ),
+          ),
+          isNull(communications.deletedAt),
+        ),
+      ),
   );
 }
 
@@ -235,47 +178,47 @@ export async function GET(request: Request) {
             eq(appointments.patientId, patients.id),
             eq(patients.clientId, appointments.clientId),
             eq(patients.practiceId, appointments.practiceId),
-            isNull(patients.deletedAt)
-          )
+            isNull(patients.deletedAt),
+          ),
         )
         .leftJoin(
           clients,
           and(
             eq(appointments.clientId, clients.id),
             eq(clients.practiceId, appointments.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .leftJoin(
           emailSuppressions,
           and(
             eq(emailSuppressions.practiceId, appointments.practiceId),
             sql`${emailSuppressions.email} = lower(trim(${clients.email}))`,
-            isNull(emailSuppressions.deletedAt)
-          )
+            isNull(emailSuppressions.deletedAt),
+          ),
         )
         .leftJoin(
           users,
           and(
             eq(appointments.doctorId, users.id),
             eq(users.practiceId, appointments.practiceId),
-            isNull(users.deletedAt)
-          )
+            isNull(users.deletedAt),
+          ),
         )
         .innerJoin(
           practices,
           and(
             eq(appointments.practiceId, practices.id),
-            isNull(practices.deletedAt)
-          )
+            isNull(practices.deletedAt),
+          ),
         )
         .leftJoin(
           rooms,
           and(
             eq(appointments.roomId, rooms.id),
             eq(rooms.practiceId, appointments.practiceId),
-            isNull(rooms.deletedAt)
-          )
+            isNull(rooms.deletedAt),
+          ),
         )
         .where(
           and(
@@ -286,10 +229,10 @@ export async function GET(request: Request) {
             isNull(clients.deletedAt),
             gte(appointments.startTime, now),
             lte(appointments.startTime, in24h),
-            eq(appointments.status, "confirmed")
-          )
+            eq(appointments.status, "confirmed"),
+          ),
         )
-        .orderBy(appointments.startTime)
+        .orderBy(appointments.startTime),
     );
 
     let sent = 0;
@@ -303,7 +246,7 @@ export async function GET(request: Request) {
 
     const activeSenderLocation = async (
       practiceId: string,
-      preferredLocationId?: string
+      preferredLocationId?: string,
     ): Promise<string | null> => {
       const cacheKey = `${practiceId}:${preferredLocationId ?? "*"}`;
       if (senderLocationCache.has(cacheKey)) {
@@ -320,8 +263,8 @@ export async function GET(request: Request) {
               and(
                 eq(locations.id, locationMessaging.locationId),
                 eq(locations.practiceId, practiceId),
-                isNull(locations.deletedAt)
-              )
+                isNull(locations.deletedAt),
+              ),
             )
             .where(
               and(
@@ -332,10 +275,10 @@ export async function GET(request: Request) {
                 isNull(locations.deletedAt),
                 eq(locationMessaging.enabled, true),
                 eq(locationMessaging.registrationStatus, "active"),
-                hasNonBlankMessagingSender()
-              )
+                hasNonBlankMessagingSender(),
+              ),
             )
-            .limit(2)
+            .limit(2),
         );
         return senders.length === 1 ? senders[0]!.locationId : null;
       };
@@ -375,7 +318,7 @@ export async function GET(request: Request) {
       // Email reminder + communications log (the existing path, reused as the
       // fallback whenever SMS isn't chosen or a send is blocked).
       const emailReminder = async (
-        communicationId: string
+        communicationId: string,
       ): Promise<boolean> => {
         const clientEmail = normalizeEmailSuppressionAddress(appt.clientEmail);
         if (!clientEmail) return false;
@@ -385,7 +328,7 @@ export async function GET(request: Request) {
             communicationId,
             channel: "email",
             content: `Automated appointment reminder blocked for ${appt.patientName} on ${appt.startTime.toISOString()}: ${emailSuppressionSendBlockMessage(
-              appt.emailSuppressionReason
+              appt.emailSuppressionReason,
             )}`,
             status: "failed",
           });
@@ -431,6 +374,8 @@ export async function GET(request: Request) {
 
       let claimedCommunicationId: string | null = null;
       let claimedChannel: ReminderChannel = "email";
+      let preservePendingSmsOutcome = false;
+      let smsAttemptId: string | undefined;
       try {
         const channel = pickReminderChannel({
           preferredContactMethod: appt.preferredContactMethod,
@@ -459,6 +404,7 @@ export async function GET(request: Request) {
         claimedChannel = initialChannel;
         const communicationId = await claimReminderCommunication({
           practiceId: appt.practiceId,
+          appointmentId: appt.id,
           clientId: appt.clientId,
           channel: initialChannel,
           patientName: appt.patientName,
@@ -474,10 +420,20 @@ export async function GET(request: Request) {
         if (channel === "sms") {
           const senderLocationId = await activeSenderLocation(
             appt.practiceId,
-            appt.locationId ?? undefined
+            appt.locationId ?? undefined,
           );
-          const result = senderLocationId
-            ? await sendAppointmentReminderSms({
+          let result:
+            | Awaited<ReturnType<typeof sendAppointmentReminderSms>>
+            | {
+                success: false;
+                outcome: "definite_failure" | "outcome_unknown";
+                replayed: false;
+                error: string;
+              };
+          if (senderLocationId) {
+            preservePendingSmsOutcome = true;
+            try {
+              result = await sendAppointmentReminderSms({
                 to: appt.clientPhone!,
                 patientName: appt.patientName ?? "Unknown",
                 appointmentDate,
@@ -487,12 +443,32 @@ export async function GET(request: Request) {
                 practiceId: appt.practiceId,
                 locationId: senderLocationId,
                 clientId: appt.clientId,
-              })
-            : {
+                communicationId,
+                source: "appointment_reminder",
+                sourceId: dedupeKey,
+                idempotencyKey: appointmentReminderSmsIdempotencyKey(appt),
+              });
+              smsAttemptId = result.attemptId;
+            } catch (error) {
+              result = {
                 success: false,
+                outcome: "outcome_unknown",
+                replayed: false,
                 error:
-                  "Set up an active texting number before sending SMS reminders",
+                  error instanceof Error
+                    ? error.message
+                    : "SMS dispatch ended without a known outcome",
               };
+            }
+          } else {
+            result = {
+              success: false,
+              outcome: "definite_failure",
+              replayed: false,
+              error:
+                "Set up an active texting number before sending SMS reminders",
+            };
+          }
           if (result.success) {
             await recordReminderOutcome({
               practiceId: appt.practiceId,
@@ -502,19 +478,27 @@ export async function GET(request: Request) {
               status: "sent",
               providerMessageId: result.sid,
             });
+            preservePendingSmsOutcome = false;
             sent++;
-          } else if (await emailReminder(communicationId)) {
-            // SMS blocked (e.g. opted out) — fall back to email.
-            sent++;
-          } else {
-            await recordReminderOutcome({
-              practiceId: appt.practiceId,
-              communicationId,
-              channel: "sms",
-              content: `Automated SMS appointment reminder failed for ${appt.patientName} on ${appt.startTime.toISOString()}: ${result.error ?? "unknown error"}`,
-              status: "failed",
-            });
+          } else if (result.outcome === "outcome_unknown") {
+            // Keep the communication pending and its dedupe claim intact. A
+            // later provider event/operator reconciliation projects the result.
             failed++;
+          } else {
+            preservePendingSmsOutcome = false;
+            if (await emailReminder(communicationId)) {
+              // SMS blocked (e.g. opted out) — fall back to email.
+              sent++;
+            } else {
+              await recordReminderOutcome({
+                practiceId: appt.practiceId,
+                communicationId,
+                channel: "sms",
+                content: `Automated SMS appointment reminder failed for ${appt.patientName} on ${appt.startTime.toISOString()}: ${result.error ?? "unknown error"}`,
+                status: "failed",
+              });
+              failed++;
+            }
           }
         } else if (channel === "email") {
           if (await emailReminder(communicationId)) {
@@ -526,7 +510,12 @@ export async function GET(request: Request) {
           failed++;
         }
       } catch (error) {
-        if (claimedCommunicationId) {
+        if (claimedCommunicationId && preservePendingSmsOutcome) {
+          await alertOps(
+            "Accepted or ambiguous SMS reminder projection failed",
+            `practice=${appt.practiceId} communication=${claimedCommunicationId} attempt=${smsAttemptId ?? "unknown"} source=appointment_reminder`,
+          ).catch(() => undefined);
+        } else if (claimedCommunicationId) {
           await recordReminderOutcome({
             practiceId: appt.practiceId,
             communicationId: claimedCommunicationId,
@@ -539,7 +528,7 @@ export async function GET(request: Request) {
         }
         console.error(
           `Failed to send reminder for appointment ${appt.id}:`,
-          error
+          error,
         );
         failed++;
       }
@@ -547,13 +536,13 @@ export async function GET(request: Request) {
 
     const eligible = upcomingAppointments.length - suppressed;
     console.log(
-      `Cron reminders completed: ${sent} sent, ${failed} failed, ${skipped} deferred (quiet hours), ${deduped} deduped, ${suppressed} suppressed (${suppressedDemo} demo, ${suppressedReservedAddress} reserved address) out of ${upcomingAppointments.length} total`
+      `Cron reminders completed: ${sent} sent, ${failed} failed, ${skipped} deferred (quiet hours), ${deduped} deduped, ${suppressed} suppressed (${suppressedDemo} demo, ${suppressedReservedAddress} reserved address) out of ${upcomingAppointments.length} total`,
     );
 
     if (failed > 0) {
       void alertOps(
         "Appointment reminders had failures",
-        `${failed} of ${eligible} eligible reminders failed to send (${sent} sent, ${skipped} deferred, ${deduped} deduped, ${suppressed} suppressed).`
+        `${failed} of ${eligible} eligible reminders failed to send (${sent} sent, ${skipped} deferred, ${deduped} deduped, ${suppressed} suppressed).`,
       );
     }
 
@@ -586,7 +575,7 @@ export async function GET(request: Request) {
     });
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/apps/web/components/settings/messaging-tab.tsx
+++ b/apps/web/components/settings/messaging-tab.tsx
@@ -390,7 +390,11 @@ function ConfiguredLocation({
             variant="outline"
             disabled={!canSendTest || testSend.isPending}
             onClick={() =>
-              testSend.mutate({ locationId: loc.locationId, to: testTo.trim() })
+              testSend.mutate({
+                locationId: loc.locationId,
+                to: testTo.trim(),
+                requestId: crypto.randomUUID(),
+              })
             }
           >
             {testSend.isPending ? (

--- a/apps/web/lib/__tests__/api-docs.test.ts
+++ b/apps/web/lib/__tests__/api-docs.test.ts
@@ -5,11 +5,9 @@ describe("API reference docs", () => {
   it("documents the README API surface without overstating REST coverage", () => {
     const source = readFileSync("../../README.md", "utf8");
 
+    expect(source).toContain("tRPC dashboard API + versioned `/api/v1` REST");
     expect(source).toContain(
-      'tRPC dashboard API + versioned `/api/v1` REST'
-    );
-    expect(source).toContain(
-      "External integrations use the scoped, API-key authenticated `/api/v1` REST surface"
+      "External integrations use the scoped, API-key authenticated `/api/v1` REST surface",
     );
     expect(source).toContain("Versioned `/api/v1` REST API");
     expect(source).toContain("read clients/patients/appointments");
@@ -18,34 +16,40 @@ describe("API reference docs", () => {
     expect(source).toContain("GOOGLE_GENERATIVE_AI_API_KEY");
     expect(source).toContain("/api/v1/agent");
     expect(source).toContain(
-      "external integrations use scoped `/api/v1` REST endpoints and signed webhooks"
+      "external integrations use scoped `/api/v1` REST endpoints and signed webhooks",
     );
     expect(source).not.toContain("REST via trpc-openapi");
     expect(source).not.toContain("trpc-openapi");
     expect(source).not.toContain("OpenAPI/Swagger");
     expect(source).not.toContain(
-      "Every feature accessible via a documented REST + WebSocket API"
+      "Every feature accessible via a documented REST + WebSocket API",
     );
     expect(source).not.toContain(
-      "Every action the UI performs goes through the same API available to third-party integrations"
+      "Every action the UI performs goes through the same API available to third-party integrations",
     );
     expect(source).not.toContain(
-      "Every endpoint includes Zod validation, role-based access control, and is also available as a standard REST endpoint"
+      "Every endpoint includes Zod validation, role-based access control, and is also available as a standard REST endpoint",
     );
   });
 
   it("keeps README feature claims aligned with shipped workflows", () => {
     const source = readFileSync("../../README.md", "utf8");
 
-    expect(source).toContain("Supplier contact management for reorder workflows");
+    expect(source).toContain(
+      "Supplier contact management for reorder workflows",
+    );
     expect(source).toContain("Treatment templates can populate draft invoices");
     expect(source).toContain("inbound portal requests");
-    expect(source).toContain("Vaccination reminders and wellness billing workflows");
+    expect(source).toContain(
+      "Vaccination reminders and wellness billing workflows",
+    );
     expect(source).toContain("Full communication log on every client record");
     expect(source).toContain("pay online when Stripe checkout is configured");
-    expect(source).toContain("broader campaign APIs tracked as explicit roadmap work");
+    expect(source).toContain(
+      "broader campaign APIs tracked as explicit roadmap work",
+    );
     expect(source).not.toContain(
-      "charges auto-populate as services are administered"
+      "charges auto-populate as services are administered",
     );
     expect(source).not.toContain("Vaccination and wellness reminders");
     expect(source).not.toContain("Purchase order generation");
@@ -55,10 +59,10 @@ describe("API reference docs", () => {
     expect(source).not.toContain("submit prescription refill requests");
     expect(source).not.toContain("message the clinic securely");
     expect(source).not.toContain(
-      "process refill requests, and complete forms via the API"
+      "process refill requests, and complete forms via the API",
     );
     expect(source).not.toContain(
-      "differential diagnosis, voice agent booking, and automated form completion"
+      "differential diagnosis, voice agent booking, and automated form completion",
     );
   });
 
@@ -77,15 +81,17 @@ describe("API reference docs", () => {
   it("keeps the standalone REST API README aligned with current v1 writes", () => {
     const source = readFileSync("../../docs/api/README.md", "utf8");
 
-    expect(source).toContain("| `appointments:read` | List/read appointments |");
+    expect(source).toContain(
+      "| `appointments:read` | List/read appointments |",
+    );
     expect(source).toContain("### `GET /api/v1/appointments`");
     expect(source).toContain("Scope `appointments:read`");
     expect(source).toContain("optional `client_id`,\n`patient_id`, `status`");
     expect(source).toContain(
-      "valid ISO dates (`YYYY-MM-DD`) or timezone-qualified ISO"
+      "valid ISO dates (`YYYY-MM-DD`) or timezone-qualified ISO",
     );
     expect(source).toContain(
-      "`start_time`/`end_time` are required timezone-qualified ISO-8601 timestamps"
+      "`start_time`/`end_time` are required timezone-qualified ISO-8601 timestamps",
     );
     expect(source).toContain("Date-only filters are interpreted");
     expect(source).toContain("23:59:59.999Z");
@@ -93,35 +99,35 @@ describe("API reference docs", () => {
     expect(source).toContain("| `records:write` |");
     expect(source).toContain("| `agent:write` |");
     expect(source).toContain(
-      "API key creation rejects `agent:write` unless the key also includes `agent:run`"
+      "API key creation rejects `agent:write` unless the key also includes `agent:run`",
     );
     expect(source).toContain("### `POST /api/v1/soap-notes`");
     expect(source).toContain("Scope `records:write`");
     expect(source).toContain("`soap_note.created` webhook");
     expect(source).toContain("active in-exam appointment");
     expect(source).toContain(
-      "`instruction` must contain non-whitespace text and is trimmed"
+      "`instruction` must contain non-whitespace text and is trimmed",
     );
     expect(source).toContain("also require `agent:write`");
     expect(source).toContain(
-      "the key must also carry that tool's resource scope"
+      "the key must also carry that tool's resource scope",
     );
     expect(source).toContain(
-      "`GOOGLE_API_KEY` or legacy\n`GOOGLE_GENERATIVE_AI_API_KEY` for Gemini"
+      "`GOOGLE_API_KEY` or legacy\n`GOOGLE_GENERATIVE_AI_API_KEY` for Gemini",
     );
     expect(source).not.toContain(
-      "Returns `503` if the server has no\n`ANTHROPIC_API_KEY` configured"
+      "Returns `503` if the server has no\n`ANTHROPIC_API_KEY` configured",
     );
   });
 
   it("documents both dashboard tRPC and API-key REST surfaces", () => {
     const source = readFileSync("app/api-docs/page.tsx", "utf8");
 
-    expect(source).toContain("id: \"apiKeys\"");
+    expect(source).toContain('id: "apiKeys"');
     expect(source).toContain(
-      "The agent:write scope must be paired with agent:run or *."
+      "The agent:write scope must be paired with agent:run or *.",
     );
-    expect(source).toContain("id: \"restApi\"");
+    expect(source).toContain('id: "restApi"');
     expect(source).toContain("POST /api/v1/agent");
     expect(source).toContain("POST /api/v1/soap-notes");
     expect(source).toContain("Authorization: Bearer <api-key>");
@@ -132,21 +138,21 @@ describe("API reference docs", () => {
     expect(source).toContain("from=YYYY-MM-DD-or-ISO-timestamp");
     expect(source).toContain("Date-only filters use UTC day bounds");
     expect(source).toContain(
-      "start_time: string, // timezone-qualified ISO timestamp"
+      "start_time: string, // timezone-qualified ISO timestamp",
     );
     expect(source).toContain(
-      "end_time: string,   // timezone-qualified ISO timestamp"
+      "end_time: string,   // timezone-qualified ISO timestamp",
     );
     expect(source).toContain("API key: appointments:read");
     expect(source).toContain("API key: agent:run");
     expect(source).toContain(
-      "agent:write plus resource write scopes when allow_writes=true"
+      "agent:write plus resource write scopes when allow_writes=true",
     );
     expect(source).toContain(
-      "Write-enabled runs require agent:write plus each write tool's resource scope"
+      "Write-enabled runs require agent:write plus each write tool's resource scope",
     );
     expect(source).toContain(
-      "Instruction text is trimmed and must be nonblank"
+      "Instruction text is trimmed and must be nonblank",
     );
     expect(source).toContain("/api/trpc/ + /api/v1/");
     expect(source).not.toContain("All endpoints are available via tRPC");
@@ -157,11 +163,11 @@ describe("API reference docs", () => {
     const source = readFileSync("app/api-docs/page.tsx", "utf8");
     const appointmentSection = source.slice(
       source.indexOf('id: "appointments"'),
-      source.indexOf('id: "records"')
+      source.indexOf('id: "records"'),
     );
 
     expect(appointmentSection).toContain(
-      'status: "scheduled" | "confirmed" | "checked_in" | "in_exam" | "checked_out" | "no_show" | "cancelled"'
+      'status: "scheduled" | "confirmed" | "checked_in" | "in_exam" | "checked_out" | "no_show" | "cancelled"',
     );
     expect(appointmentSection).not.toContain('"in_progress"');
     expect(appointmentSection).not.toContain('"completed"');
@@ -171,17 +177,17 @@ describe("API reference docs", () => {
     const source = readFileSync("app/api-docs/page.tsx", "utf8");
     const billingSection = source.slice(
       source.indexOf('id: "billing"'),
-      source.indexOf('id: "inventory"')
+      source.indexOf('id: "inventory"'),
     );
 
     expect(billingSection).toContain(
-      "Paid is derived from recorded payments or adjustments and cannot be set directly."
+      "Paid is derived from recorded payments or adjustments and cannot be set directly.",
     );
     expect(billingSection).toContain(
-      'status: "draft" | "sent" | "overdue" | "void"'
+      'status: "draft" | "sent" | "overdue" | "void"',
     );
     expect(billingSection).not.toContain(
-      'status: "draft" | "sent" | "paid" | "overdue" | "void"'
+      'status: "draft" | "sent" | "paid" | "overdue" | "void"',
     );
   });
 
@@ -189,11 +195,11 @@ describe("API reference docs", () => {
     const source = readFileSync("app/api-docs/page.tsx", "utf8");
     const inventorySection = source.slice(
       source.indexOf('id: "inventory"'),
-      source.indexOf('id: "communications"')
+      source.indexOf('id: "communications"'),
     );
 
     expect(inventorySection).toContain(
-      'alert?: "all" | "attention" | "low_stock" | "expired" | "expiring_soon"'
+      'alert?: "all" | "attention" | "low_stock" | "expired" | "expiring_soon"',
     );
     expect(inventorySection).toContain("stockQuantity?: number");
     expect(inventorySection).toContain("reorderPoint?: number");
@@ -203,10 +209,10 @@ describe("API reference docs", () => {
     expect(inventorySection).toContain("reason: string");
     const inventoryUpdateSection = inventorySection.slice(
       inventorySection.indexOf('name: "inventory.update"'),
-      inventorySection.indexOf('name: "inventory.adjustStock"')
+      inventorySection.indexOf('name: "inventory.adjustStock"'),
     );
     expect(inventoryUpdateSection).toContain(
-      "Use inventory.adjustStock for stock quantity changes"
+      "Use inventory.adjustStock for stock quantity changes",
     );
     expect(inventoryUpdateSection).not.toContain("stockQuantity?: number");
     expect(inventorySection).not.toContain("lowStock?: boolean");
@@ -221,27 +227,28 @@ describe("API reference docs", () => {
     const source = readFileSync("app/api-docs/page.tsx", "utf8");
 
     expect(source).toContain('name: "communications.listConversations"');
+    expect(source).toContain("with unread counts derived server-side");
     expect(source).toContain(
-      "with unread counts derived server-side"
+      "The sent inbox filter includes sent, delivered, and read outbound messages.",
     );
     expect(source).toContain(
-      "The sent inbox filter includes sent, delivered, and read outbound messages."
-    );
-    expect(source).toContain(
-      "The sent inbox filter includes sent, delivered, and read outbound conversations."
+      "The sent inbox filter includes sent, delivered, and read outbound conversations.",
     );
 
     const updateStatusSection = source.slice(
       source.indexOf('name: "communications.updateStatus"'),
-      source.indexOf("];", source.indexOf('name: "communications.updateStatus"'))
+      source.indexOf(
+        "];",
+        source.indexOf('name: "communications.updateStatus"'),
+      ),
     );
 
     expect(updateStatusSection).toContain('status: "read"');
     expect(updateStatusSection).toContain(
-      "Delivery lifecycle statuses are managed by send and provider webhook handlers."
+      "Delivery lifecycle statuses are managed by send and provider webhook handlers.",
     );
     expect(updateStatusSection).not.toContain(
-      'status: "pending" | "sent" | "delivered" | "read" | "failed"'
+      'status: "pending" | "sent" | "delivered" | "read" | "failed"',
     );
   });
 
@@ -251,34 +258,38 @@ describe("API reference docs", () => {
       source.indexOf('name: "communications.create"'),
       source.indexOf(
         'name: "communications.updateStatus"',
-        source.indexOf('name: "communications.create"')
-      )
+        source.indexOf('name: "communications.create"'),
+      ),
     );
 
     expect(createSection).toContain("Send outbound SMS/email from the inbox");
     expect(createSection).toContain(
-      "send/log internal portal communications visible in the client portal"
+      "send/log internal portal communications visible in the client portal",
     );
-    expect(createSection).not.toContain("Outbound portal delivery is not available");
+    expect(createSection).not.toContain(
+      "Outbound portal delivery is not available",
+    );
     expect(createSection).not.toContain("portal may only be logged inbound");
     expect(createSection).not.toContain('description: "Log a communication."');
+    expect(createSection).toContain("Required UUID for outbound SMS");
+    expect(createSection).toContain("reuse for retries of the same send");
   });
 
   it("documents portal message read and reply endpoints", () => {
     const source = readFileSync("app/api-docs/page.tsx", "utf8");
     const portalSection = source.slice(
       source.indexOf('id: "portal"'),
-      source.indexOf('id: "apiKeys"')
+      source.indexOf('id: "apiKeys"'),
     );
 
     expect(portalSection).toContain('name: "portal.getMessages"');
     expect(portalSection).toContain('name: "portal.createMessage"');
     expect(portalSection).toContain('name: "portal.markMessagesRead"');
     expect(portalSection).toContain(
-      "Send a portal message from the client into the shared inbox."
+      "Send a portal message from the client into the shared inbox.",
     );
     expect(portalSection).toContain(
-      "Mark outbound clinic portal messages as read after the client opens the thread."
+      "Mark outbound clinic portal messages as read after the client opens the thread.",
     );
   });
 
@@ -288,8 +299,8 @@ describe("API reference docs", () => {
       source.indexOf('name: "communications.assignClient"'),
       source.indexOf(
         'name: "communications.linkCommunicationToClient"',
-        source.indexOf('name: "communications.assignClient"')
-      )
+        source.indexOf('name: "communications.assignClient"'),
+      ),
     );
 
     expect(assignSection).toContain("expectedAssignedTo: string | null");

--- a/apps/web/lib/__tests__/inbox-ui-states.test.ts
+++ b/apps/web/lib/__tests__/inbox-ui-states.test.ts
@@ -20,65 +20,77 @@ describe("inbox UI states", () => {
   it("keeps viewer access read-only for inbox writes", () => {
     expect(source).toContain('import { useSession } from "next-auth/react"');
     expect(source).toContain("const { data: session } = useSession()");
-    expect(source).toContain("function canMutateInboxRole(role?: string | null): boolean");
+    expect(source).toContain(
+      "function canMutateInboxRole(role?: string | null): boolean",
+    );
     expect(source).toContain('role === "admin"');
     expect(source).toContain('role === "veterinarian"');
     expect(source).toContain('role === "technician"');
     expect(source).toContain('role === "front_desk"');
     expect(source).toContain(
-      "const canMutateInbox = canMutateInboxRole(session?.user?.role)"
+      "const canMutateInbox = canMutateInboxRole(session?.user?.role)",
     );
     expect(source).not.toContain('session?.user?.role !== "viewer"');
     expect(source).toContain("if (unreadCount > 0 && canMutateInbox)");
-    expect(source).toContain("if (isUnreadInboxMessage(item) && canMutateInbox)");
-    expect(source).toContain("canMutateInbox &&\n    Boolean(selectedClientId)");
+    expect(source).toContain(
+      "if (isUnreadInboxMessage(item) && canMutateInbox)",
+    );
+    expect(source).toContain(
+      "canMutateInbox &&\n    Boolean(selectedClientId)",
+    );
     expect(source).toContain("if (!canMutateInbox) return;");
-    expect(source).toContain("if (!canMutateInbox || !selectedClientId) return;");
-    expect(source).toContain("if (!canMutateInbox || !selectedUnmatched) return;");
+    expect(source).toContain(
+      "if (!canMutateInbox || !selectedClientId) return;",
+    );
+    expect(source).toContain(
+      "if (!canMutateInbox || !selectedUnmatched) return;",
+    );
     expect(source).toContain("{canMutateInbox ? (");
     expect(source).toContain("{newMessageMode && canMutateInbox ? (");
-    expect(source).toContain('No client communications to review yet.');
+    expect(source).toContain("No client communications to review yet.");
     expect(source).toContain("canMutateInbox\n                    ? {");
     expect(source).toContain("Viewer access cannot link inbox messages.");
 
     expect(routerSource).toContain("const inboxStaffProcedure =");
     expect(routerSource).toContain(
-      'requireRole("admin", "veterinarian", "technician", "front_desk")'
+      'requireRole("admin", "veterinarian", "technician", "front_desk")',
     );
     expect(routerSource).toContain("markClientRead: inboxStaffProcedure");
     expect(routerSource).toContain("assignClient: inboxStaffProcedure");
-    expect(routerSource).toContain("linkCommunicationToClient: inboxStaffProcedure");
+    expect(routerSource).toContain(
+      "linkCommunicationToClient: inboxStaffProcedure",
+    );
     expect(routerSource).toContain("create: inboxStaffProcedure");
     expect(routerSource).toContain("updateStatus: inboxStaffProcedure");
   });
 
   it("renders inbox timestamps from the practice timezone contract", () => {
     expect(source).toContain(
-      'import { formatDateInputForTimeZone } from "@/lib/date-input"'
+      'import { formatDateInputForTimeZone } from "@/lib/date-input"',
     );
     expect(source).toContain(
-      "function relativeTime(\n  date: Date | string | null,\n  timeZone?: string | null"
+      "function relativeTime(\n  date: Date | string | null,\n  timeZone?: string | null",
     );
     expect(source).toContain(
-      "const {\n    data: inboxSettings,\n    isLoading: inboxSettingsLoading,\n    error: inboxSettingsError,\n  } = trpc.communications.settings.useQuery"
+      "const {\n    data: inboxSettings,\n    isLoading: inboxSettingsLoading,\n    error: inboxSettingsError,\n  } = trpc.communications.settings.useQuery",
     );
     expect(source).toContain("const verifiedInboxSettings =");
     expect(source).toContain(
-      "const inboxTimeZone = verifiedInboxSettings\n    ? verifiedInboxSettings.timezone\n    : null"
+      "const inboxTimeZone = verifiedInboxSettings\n    ? verifiedInboxSettings.timezone\n    : null",
     );
     expect(source).toContain(
-      "const inboxListLoading = inboxSettingsLoading || isLoading"
+      "const inboxListLoading = inboxSettingsLoading || isLoading",
     );
     expect(source).toContain(
-      "const timelineDisplayLoading = inboxSettingsLoading || timelineLoading"
+      "const timelineDisplayLoading = inboxSettingsLoading || timelineLoading",
     );
     expect(source).toContain("formatDateInputForTimeZone(now, timeZone)");
     expect(source).toContain("formatDateInputForTimeZone(d, timeZone)");
     expect(source).toContain(
-      "relativeTime(\n                                group.latest.createdAt,\n                                inboxTimeZone"
+      "relativeTime(\n                                group.latest.createdAt,\n                                inboxTimeZone",
     );
     expect(source).toContain(
-      "relativeTime(\n                          selectedUnmatched.createdAt,\n                          inboxTimeZone"
+      "relativeTime(\n                          selectedUnmatched.createdAt,\n                          inboxTimeZone",
     );
     expect(source).toContain("relativeTime(msg.createdAt, inboxTimeZone)");
     expect(source).not.toContain("inboxSettings?.timezone");
@@ -92,11 +104,15 @@ describe("inbox UI states", () => {
     expect(isClientSearchInputValid("A".repeat(101))).toBe(false);
 
     expect(source).toContain(
-      'import { EmptyState } from "@/components/common/empty-state"'
+      'import { EmptyState } from "@/components/common/empty-state"',
     );
     expect(source).toContain('from "@/lib/clients/policy"');
-    expect(source).toContain("const canSearchNewClients = isClientSearchInputValid(newClientSearch)");
-    expect(source).toContain("const canSearchLinkClients = isClientSearchInputValid(linkClientSearch)");
+    expect(source).toContain(
+      "const canSearchNewClients = isClientSearchInputValid(newClientSearch)",
+    );
+    expect(source).toContain(
+      "const canSearchLinkClients = isClientSearchInputValid(linkClientSearch)",
+    );
     expect(source).toContain("maxLength={CLIENT_SEARCH_MAX_LENGTH}");
     expect(source).toContain("error: inboxError");
     expect(source).toContain("error: timelineError");
@@ -111,41 +127,47 @@ describe("inbox UI states", () => {
     expect(source).toContain("const searchMissing =");
     expect(source).toContain("const linkClientMissing =");
     expect(source).toContain(
-      "if (inboxSettingsError || inboxSettingsMissing) {\n      setSelectedUnmatched(null);"
+      "if (inboxSettingsError || inboxSettingsMissing) {\n      setSelectedUnmatched(null);",
     );
     expect(source).toContain("{inboxListError || inboxListMissing ? (");
     expect(source).toContain("{searchError || searchMissing ? (");
     expect(source).toContain("{linkClientError || linkClientMissing ? (");
-    expect(source).toContain("{timelineDisplayError || timelineDisplayMissing ? (");
+    expect(source).toContain(
+      "{timelineDisplayError || timelineDisplayMissing ? (",
+    );
     expect(source).toContain("Unable to load inbox messages. Please retry.");
-    expect(source).toContain("Unable to load conversation messages. Please retry.");
+    expect(source).toContain(
+      "Unable to load conversation messages. Please retry.",
+    );
     expect(source).toContain("Unable to search clients. Please retry.");
     expect(source.indexOf("inboxListError || inboxListMissing")).toBeLessThan(
-      source.indexOf('title="No messages yet"')
+      source.indexOf('title="No messages yet"'),
     );
     expect(source.indexOf("searchError || searchMissing")).toBeLessThan(
-      source.indexOf('title="No clients found"')
+      source.indexOf('title="No clients found"'),
     );
-    expect(source.indexOf("timelineDisplayError || timelineDisplayMissing")).toBeLessThan(
-      source.indexOf('title="No messages with this client yet"')
-    );
+    expect(
+      source.indexOf("timelineDisplayError || timelineDisplayMissing"),
+    ).toBeLessThan(source.indexOf('title="No messages with this client yet"'));
   });
 
   it("surfaces SMS setup status failures before hiding the inbox setup prompt", () => {
     expect(source).toContain("error: messagingStatusError");
     expect(source).toContain("refetch: refetchMessagingStatus");
     expect(source).toContain("const smsStatusUnavailable =");
-    expect(source).toContain("Boolean(messagingStatusError) || !messagingStatus");
+    expect(source).toContain(
+      "Boolean(messagingStatusError) || !messagingStatus",
+    );
     expect(source).toContain("const showSmsStatusError = Boolean(");
     expect(source).toContain("Unable to check texting setup");
     expect(source).toContain("SMS status unavailable");
     expect(source).toContain("onClick={() => void refetchMessagingStatus()}");
     expect(source).toContain('aria-label="Dismiss SMS status warning"');
     expect(source.indexOf("{showSmsStatusError ? (")).toBeLessThan(
-      source.indexOf(") : showSmsBanner && smsSummary ? (")
+      source.indexOf(") : showSmsBanner && smsSummary ? ("),
     );
     expect(source).toContain(
-      "Unable to check texting setup. Retry from the inbox banner"
+      "Unable to check texting setup. Retry from the inbox banner",
     );
   });
 
@@ -153,30 +175,32 @@ describe("inbox UI states", () => {
     expect(routerSource).toContain("listConversations: protectedProcedure");
     expect(routerSource).toContain("row_number() over");
     expect(routerSource).toContain(
-      "partition by coalesce(c.client_id::text, c.id::text)"
+      "partition by coalesce(c.client_id::text, c.id::text)",
     );
     expect(routerSource).toContain("count(*) filter (");
     expect(routerSource).toContain("unreadCount: dbNumber(unreadCount)");
 
+    expect(source).toContain("trpc.communications.listConversations.useQuery");
     expect(source).toContain(
-      "trpc.communications.listConversations.useQuery"
+      "utils.communications.listConversations.invalidate()",
     );
-    expect(source).toContain("utils.communications.listConversations.invalidate()");
-    expect(source).toContain("item.unreadCount ?? (isUnreadInboxMessage(item) ? 1 : 0)");
+    expect(source).toContain(
+      "item.unreadCount ?? (isUnreadInboxMessage(item) ? 1 : 0)",
+    );
     expect(source).not.toContain("const map = new Map");
   });
 
   it("keeps assignment controls anchored to the server conversation summary", () => {
     expect(source).toContain(
-      "const assignmentSource = selectedGroup?.latest ?? timeline?.[0]"
+      "const assignmentSource = selectedGroup?.latest ?? timeline?.[0]",
     );
     expect(source).not.toContain(
-      "const assignmentSource = timeline?.[0] ?? selectedGroup?.latest"
+      "const assignmentSource = timeline?.[0] ?? selectedGroup?.latest",
     );
     expect(source).toContain("expectedAssignedTo: assignedTo");
     expect(routerSource).toContain("isNotNull(communications.assignedTo)");
     expect(routerSource).toContain(
-      "orderBy(desc(communications.createdAt), desc(communications.id))"
+      "orderBy(desc(communications.createdAt), desc(communications.id))",
     );
   });
 
@@ -193,13 +217,13 @@ describe("inbox UI states", () => {
     expect(COMMUNICATION_CONTENT_MAX_LENGTH).toBe(5000);
     expect(SMS_COMMUNICATION_CONTENT_MAX_LENGTH).toBe(1600);
     expect(communicationContentMaxLength("email")).toBe(
-      COMMUNICATION_CONTENT_MAX_LENGTH
+      COMMUNICATION_CONTENT_MAX_LENGTH,
     );
     expect(communicationContentMaxLength("portal")).toBe(
-      COMMUNICATION_CONTENT_MAX_LENGTH
+      COMMUNICATION_CONTENT_MAX_LENGTH,
     );
     expect(communicationContentMaxLength("sms")).toBe(
-      SMS_COMMUNICATION_CONTENT_MAX_LENGTH
+      SMS_COMMUNICATION_CONTENT_MAX_LENGTH,
     );
     expect(isCommunicationSubjectValid("A".repeat(255))).toBe(true);
     expect(isCommunicationSubjectValid("A".repeat(256))).toBe(false);
@@ -210,52 +234,73 @@ describe("inbox UI states", () => {
 
     expect(routerSource).toContain('from "@/lib/communications/policy"');
     expect(routerSource).toContain(
-      "subject: z.string().trim().max(COMMUNICATION_SUBJECT_MAX_LENGTH).optional()"
+      "subject: z.string().trim().max(COMMUNICATION_SUBJECT_MAX_LENGTH).optional()",
     );
     expect(routerSource).toContain("COMMUNICATION_CONTENT_MAX_LENGTH");
     expect(routerSource).toContain("SMS_COMMUNICATION_CONTENT_MAX_LENGTH");
 
     expect(source).toContain('from "@/lib/communications/policy"');
     expect(source).toContain(
-      'import { communicationStatusLabel } from "@/lib/communications/status"'
+      'import { communicationStatusLabel } from "@/lib/communications/status"',
     );
     expect(source).toContain(
-      "const composeContentMaxLength = communicationContentMaxLength("
+      "const composeContentMaxLength = communicationContentMaxLength(",
     );
     expect(source).toContain('<option value="portal">Portal</option>');
-    expect(source).toContain("composeChannel === \"portal\"");
+    expect(source).toContain('composeChannel === "portal"');
     expect(source).toContain(
-      "isCommunicationContentValid(composeContent, composeDeliveryChannel)"
+      "isCommunicationContentValid(composeContent, composeDeliveryChannel)",
     );
     expect(source).toContain("isCommunicationSubjectValid(composeSubject)");
     expect(source).toContain("maxLength={COMMUNICATION_SUBJECT_MAX_LENGTH}");
     expect(source).toContain("maxLength={composeContentMaxLength}");
     expect(source).toContain("disabled={!canSendCompose}");
     expect(source).toContain(
-      'subject:\n        composeChannel === "email"\n          ? composeSubject.trim() || undefined\n          : undefined'
+      'subject:\n        composeChannel === "email" ? trimmedSubject || undefined : undefined',
     );
-    expect(source).toContain("content: composeContent.trim()");
-    expect(source).toContain("const statusLabel = communicationStatusLabel(msg)");
+    expect(source).toContain("content: trimmedContent");
+    expect(source).toContain(
+      "const statusLabel = communicationStatusLabel(msg)",
+    );
     expect(source).toContain("{statusLabel ? (");
     expect(source).not.toContain("{msg.status && (");
   });
 
+  it("keeps one client request ID across retries of the same SMS", () => {
+    expect(source).toContain("const smsComposeRequest = useRef<");
+    expect(source).toContain("requestId: crypto.randomUUID()");
+    expect(source).toContain(
+      "if (smsComposeRequest.current?.fingerprint !== fingerprint)",
+    );
+    expect(source).toContain("requestId = smsComposeRequest.current.requestId");
+    expect(source).toContain("...(requestId ? { requestId } : {})");
+    expect(source).toContain("smsComposeRequest.current = null");
+    expect(routerSource).toContain(
+      "SMS request ID was already used for different message data.",
+    );
+    expect(routerSource).toContain(
+      "`sms:inbox:${ctx.practiceId}:${input.requestId!}`",
+    );
+  });
+
   it("sets accurate expectations for outbound email replies", () => {
     expect(source).toContain(
-      "Outbound email is logged here. Replies go to the practice"
+      "Outbound email is logged here. Replies go to the practice",
     );
     expect(source).toContain(
-      "inbound email replies are not\n                    imported into OpenVPM yet"
+      "inbound email replies are not\n                    imported into OpenVPM yet",
     );
     expect(source.indexOf('composeChannel === "email"')).toBeLessThan(
-      source.indexOf("smsComposeBlocked && smsSummary")
+      source.indexOf("smsComposeBlocked && smsSummary"),
     );
   });
 
   it("collapses the two-pane layout on phones: list or thread, with a back button", () => {
     // Below md, an open conversation replaces the list instead of squeezing
     // beside it; the back button restores the list.
-    expect(source).toContain('selectedClientId || selectedUnmatched || newMessageMode');
+    expect(source).toContain(
+      "selectedClientId || selectedUnmatched || newMessageMode",
+    );
     expect(source).toContain('"hidden"');
     expect(source).toContain("md:w-80 md:border-r");
     expect(source).toContain("Back to conversations");

--- a/apps/web/lib/__tests__/sms.test.ts
+++ b/apps/web/lib/__tests__/sms.test.ts
@@ -1,77 +1,247 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { readFileSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getTableName } from "drizzle-orm";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { smsSendAttempts } from "@openpims/db";
 
-const mocks = vi.hoisted(() => {
-  const providerSend = vi.fn();
-  return {
-    getMessagingProvider: vi.fn(() => ({
-      name: "telnyx",
-      isConfigured: () => true,
-      send: providerSend,
-    })),
-    providerSend,
-    resolveMessagingTransport: vi.fn(),
-    isSuppressed: vi.fn(),
-    recordUsage: vi.fn(),
-    billingEnforced: vi.fn(() => false),
-    hasHostedFullAccess: vi.fn(() => true),
-    withSystem: vi.fn(),
-  };
-});
-
-vi.mock("@openpims/db/client", () => ({
-  db: {},
+const mocks = vi.hoisted(() => ({
+  tx: {} as Record<string, unknown>,
+  providerSend: vi.fn(),
+  resolveMessagingTransport: vi.fn(),
+  getMessagingProvider: vi.fn(),
+  billingEnforced: vi.fn(() => false),
+  hasHostedFullAccess: vi.fn(() => true),
+  recordUsage: vi.fn(async () => undefined),
+  withSystem: vi.fn(),
+  acquireSmsRecipientLockInTransaction: vi.fn(async () => undefined),
+  alertOps: vi.fn(async () => undefined),
 }));
 
-vi.mock("@/lib/tenant-db", () => ({
-  withSystem: mocks.withSystem,
-}));
-
+vi.mock("@openpims/db/client", () => ({ db: {} }));
+vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
 vi.mock("@/lib/billing/plans", () => ({
   billingEnforced: mocks.billingEnforced,
   hasHostedFullAccess: mocks.hasHostedFullAccess,
 }));
-
-vi.mock("@/lib/billing/usage", () => ({
-  recordUsage: mocks.recordUsage,
-}));
-
+vi.mock("@/lib/billing/usage", () => ({ recordUsage: mocks.recordUsage }));
+vi.mock("@/lib/alerts", () => ({ alertOps: mocks.alertOps }));
 vi.mock("@/lib/messaging", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/messaging")>();
   return {
     ...actual,
-    getMessagingProvider: mocks.getMessagingProvider,
     resolveMessagingTransport: mocks.resolveMessagingTransport,
-    isSuppressed: mocks.isSuppressed,
+    getMessagingProvider: mocks.getMessagingProvider,
+    acquireSmsRecipientLockInTransaction:
+      mocks.acquireSmsRecipientLockInTransaction,
   };
 });
 
-const { sendAppointmentReminderSms, sendSms, sendVaccinationReminderSms } =
+const {
+  classifySmsAttemptForOps,
+  prepareCampaignSmsBody,
+  reconcileSmsSendAttempt,
+  resendSmsAttempt,
+  sendSms,
+  SMS_COMPLIANCE_FOOTER,
+} = await import("../sms-dispatch");
+const { sendAppointmentReminderSms, sendVaccinationReminderSms } =
   await import("../sms");
 const { revokeSmsConsentByPhoneInTransaction } =
   await import("@/lib/messaging/suppression");
-const smsSource = readFileSync(new URL("../sms.ts", import.meta.url), "utf8");
-const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
-const LOCATION_ID = "00000000-0000-0000-0000-000000000002";
-const CLIENT_ID = "00000000-0000-0000-0000-000000000003";
 
-function allowHostedPilot() {
-  vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
-  vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", PRACTICE_ID);
-  vi.stubEnv("MESSAGING_SENDING_LOCATION_IDS", LOCATION_ID);
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const CLIENT_ID = "00000000-0000-0000-0000-0000000000bb";
+const LOCATION_ID = "00000000-0000-0000-0000-0000000000cc";
+const COMMUNICATION_ID = "00000000-0000-0000-0000-0000000000dd";
+const ACTOR_ID = "00000000-0000-0000-0000-0000000000ee";
+
+type Attempt = Record<string, unknown> & {
+  id: string;
+  createdAt: Date;
+  practiceId: string;
+  idempotencyKey: string;
+  resendOfAttemptId: string | null;
+};
+type AttemptEvent = Record<string, unknown> & {
+  id: string;
+  createdAt: Date;
+  practiceId: string;
+  attemptId: string;
+  kind: "provider_result" | "reconciliation";
+  outcome: "accepted" | "definite_failure" | "outcome_unknown";
+  providerMessageId: string | null;
+  detail: string | null;
+  eventKey: string;
+};
+
+function sqlIncludesColumnParamPair(
+  value: unknown,
+  columnName: string,
+  paramValue: unknown,
+): boolean {
+  if (!value || typeof value !== "object") return false;
+  const chunk = value as { name?: unknown; queryChunks?: unknown[] };
+  if (!Array.isArray(chunk.queryChunks)) return false;
+  const hasColumn = chunk.queryChunks.some(
+    (item) =>
+      !!item &&
+      typeof item === "object" &&
+      (item as { name?: unknown }).name === columnName,
+  );
+  const hasParam = chunk.queryChunks.some((item) => {
+    if (!item || typeof item !== "object") return false;
+    const candidate = item as { value?: unknown };
+    return Object.prototype.hasOwnProperty.call(candidate, "value")
+      ? Object.is(candidate.value, paramValue)
+      : false;
+  });
+  return (
+    (hasColumn && hasParam) ||
+    chunk.queryChunks.some((item) =>
+      sqlIncludesColumnParamPair(item, columnName, paramValue),
+    )
+  );
 }
 
-function hostedDispatchDb(rows: Array<unknown[] | Error>) {
-  const select = vi.fn(() => {
-    const result = rows.shift() ?? [];
-    const settle = () =>
-      result instanceof Error
-        ? Promise.reject(result)
-        : Promise.resolve(result);
+function sqlIncludesColumn(value: unknown, columnName: string): boolean {
+  if (!value || typeof value !== "object") return false;
+  const chunk = value as { name?: unknown; queryChunks?: unknown[] };
+  if (chunk.name === columnName) return true;
+  return (
+    Array.isArray(chunk.queryChunks) &&
+    chunk.queryChunks.some((item) => sqlIncludesColumn(item, columnName))
+  );
+}
+
+function createLedgerDb() {
+  const attempts: Attempt[] = [];
+  const events: AttemptEvent[] = [];
+  const updates: Array<Record<string, unknown>> = [];
+  const registrations: Array<Record<string, unknown>> = [];
+  const locationMessagingRows: Array<Record<string, unknown>> = [
+    {
+      provider: "telnyx",
+      messagingServiceId: null,
+      senderE164: "+15555550100",
+      enabled: true,
+      registrationStatus: "active",
+      a2pCampaignId: "campaign-1",
+      a2pBrandId: "brand-1",
+    },
+  ];
+  const practiceRows: Array<Record<string, unknown>> = [
+    {
+      name: "Neighborhood Veterinary",
+      tier: "cloud",
+      billingStatus: "active",
+      trialEndsAt: null,
+    },
+  ];
+  const clientRows: Array<Record<string, unknown>> = [
+    {
+      phone: "+15555550199",
+      smsConsent: true,
+      smsConsentAt: new Date("2026-08-01T00:00:00Z"),
+      smsConsentSource: "staff_attested_form:v1",
+      smsConsentDisclosure: "Disclosure",
+    },
+  ];
+  const suppressionRows: Array<Record<string, unknown>> = [];
+  const communicationRows: Array<Record<string, unknown>> = [
+    { id: COMMUNICATION_ID, status: "pending" },
+  ];
+  const communicationProjection = { available: true };
+  const throwOnSelect = new Map<string, Error>();
+  const selectedTables: string[] = [];
+  let id = 0;
+
+  const rowsFor = (
+    table: unknown,
+    fields?: Record<string, unknown>,
+    condition?: unknown,
+  ) => {
+    const name = getTableName(table as never);
+    selectedTables.push(name);
+    const selectedError = throwOnSelect.get(name);
+    if (selectedError) throw selectedError;
+    if (name === "messaging_registrations") return registrations;
+    if (name === "location_messaging") return locationMessagingRows;
+    if (name === "practices") return practiceRows;
+    if (name === "sms_suppressions") return suppressionRows;
+    if (name === "users") {
+      return [{ id: ACTOR_ID, name: "Operator", email: "ops@openvpm.com" }];
+    }
+    if (name === "communications") return communicationRows;
+    if (name === "sms_send_attempts") {
+      if (fields && Object.keys(fields).length === 1 && "id" in fields) {
+        const current = attempts.at(-1)?.id;
+        return attempts.filter((attempt) => {
+          if (attempt.id === current) return false;
+          const attemptEvents = events.filter(
+            (event) => event.attemptId === attempt.id,
+          );
+          const effective =
+            [...attemptEvents]
+              .reverse()
+              .find((event) => event.kind === "reconciliation") ??
+            [...attemptEvents]
+              .reverse()
+              .find((event) => event.kind === "provider_result");
+          return !effective || effective.outcome === "outcome_unknown";
+        });
+      }
+      const specificallyMatched = attempts.filter(
+        (attempt) =>
+          sqlIncludesColumnParamPair(condition, "id", attempt.id) ||
+          sqlIncludesColumnParamPair(
+            condition,
+            "idempotency_key",
+            attempt.idempotencyKey,
+          ) ||
+          (attempt.resendOfAttemptId !== null &&
+            sqlIncludesColumnParamPair(
+              condition,
+              "resend_of_attempt_id",
+              attempt.resendOfAttemptId,
+            )),
+      );
+      if (specificallyMatched.length > 0) return specificallyMatched;
+      if (
+        sqlIncludesColumn(condition, "id") ||
+        sqlIncludesColumn(condition, "idempotency_key") ||
+        sqlIncludesColumn(condition, "resend_of_attempt_id")
+      ) {
+        return [];
+      }
+      return attempts;
+    }
+    if (name === "sms_send_attempt_events") {
+      const matched = events.filter((event) =>
+        sqlIncludesColumnParamPair(condition, "attempt_id", event.attemptId),
+      );
+      return [
+        ...(sqlIncludesColumn(condition, "attempt_id") ? matched : events),
+      ].reverse();
+    }
+    if (name === "clients") return clientRows;
+    return [];
+  };
+
+  const select = vi.fn((fields?: Record<string, unknown>) => {
+    let table: unknown;
+    let condition: unknown;
+    const settle = () => Promise.resolve(rowsFor(table, fields, condition));
+    const limited = () => Object.assign(settle(), { for: settle });
     const builder = {
-      from: () => builder,
-      where: () => builder,
-      limit: () => builder,
+      from(value: unknown) {
+        table = value;
+        return builder;
+      },
+      where(value: unknown) {
+        condition = value;
+        return builder;
+      },
+      orderBy: () => builder,
+      limit: limited,
       for: settle,
       then: (
         resolve: (value: unknown[]) => unknown,
@@ -80,17 +250,130 @@ function hostedDispatchDb(rows: Array<unknown[] | Error>) {
     };
     return builder;
   });
-  return { execute: vi.fn(async () => undefined), select };
+
+  const insert = vi.fn((table: unknown) => ({
+    values(values: Record<string, unknown>) {
+      let committed: Record<string, unknown> | undefined;
+      const commit = () => {
+        if (committed) return committed;
+        const name = getTableName(table as never);
+        if (name === "sms_send_attempts") {
+          const duplicate = attempts.find(
+            (attempt) =>
+              attempt.practiceId === values.practiceId &&
+              (attempt.idempotencyKey === values.idempotencyKey ||
+                (values.resendOfAttemptId &&
+                  attempt.resendOfAttemptId === values.resendOfAttemptId)),
+          );
+          if (duplicate) return undefined;
+          committed = {
+            ...values,
+            id: `00000000-0000-0000-0000-${String(++id).padStart(12, "0")}`,
+            createdAt: new Date(),
+            clientId: values.clientId ?? null,
+            locationId: values.locationId ?? null,
+            communicationId: values.communicationId ?? null,
+            resendOfAttemptId: values.resendOfAttemptId ?? null,
+            requestedByActorType: values.requestedByActorType ?? null,
+            requestedByUserId: values.requestedByUserId ?? null,
+            requestedByIdentity: values.requestedByIdentity ?? null,
+            requestedByName: values.requestedByName ?? null,
+            senderMessagingServiceId: values.senderMessagingServiceId ?? null,
+            senderE164: values.senderE164 ?? null,
+          };
+          attempts.push(committed as Attempt);
+          return committed;
+        }
+        if (name === "sms_send_attempt_events") {
+          const duplicate = events.find(
+            (event) =>
+              event.practiceId === values.practiceId &&
+              event.eventKey === values.eventKey,
+          );
+          if (duplicate) return undefined;
+          committed = {
+            ...values,
+            id: `10000000-0000-0000-0000-${String(++id).padStart(12, "0")}`,
+            createdAt: new Date(),
+            providerMessageId: values.providerMessageId ?? null,
+            detail: values.detail ?? null,
+          };
+          events.push(committed as AttemptEvent);
+          return committed;
+        }
+        return undefined;
+      };
+      const chain = {
+        onConflictDoNothing: () => chain,
+        returning: async () => {
+          const row = commit();
+          return row ? [row] : [];
+        },
+        then: (
+          resolve: (value: unknown) => unknown,
+          reject?: (reason: unknown) => unknown,
+        ) => Promise.resolve(commit()).then(resolve, reject),
+      };
+      return chain;
+    },
+  }));
+
+  const update = vi.fn(() => ({
+    set(values: Record<string, unknown>) {
+      updates.push(values);
+      const chain = {
+        where: () => chain,
+        returning: async () =>
+          communicationProjection.available ? [{ id: COMMUNICATION_ID }] : [],
+        then: (resolve: (value: unknown) => unknown) =>
+          Promise.resolve(undefined).then(resolve),
+      };
+      return chain;
+    },
+  }));
+
+  const tx = { execute: vi.fn(async () => undefined), select, insert, update };
+  return {
+    tx,
+    attempts,
+    events,
+    updates,
+    registrations,
+    locationMessagingRows,
+    practiceRows,
+    clientRows,
+    suppressionRows,
+    communicationRows,
+    communicationProjection,
+    throwOnSelect,
+    selectedTables,
+  };
 }
 
-function deferred<T = void>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
+function sendOptions(overrides: Record<string, unknown> = {}) {
+  return {
+    to: "+15555550199",
+    body: "Miso's prescription is ready for pickup.",
+    practiceId: PRACTICE_ID,
+    locationId: LOCATION_ID,
+    clientId: CLIENT_ID,
+    communicationId: COMMUNICATION_ID,
+    source: "inbox",
+    sourceId: COMMUNICATION_ID,
+    idempotencyKey: `sms:inbox:${COMMUNICATION_ID}`,
+    ...overrides,
+  };
+}
+
+function allowHostedPilot() {
+  vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+  vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", PRACTICE_ID);
+  vi.stubEnv("MESSAGING_SENDING_LOCATION_IDS", LOCATION_ID);
+  state().registrations.push({
+    displayName: "Neighborhood Veterinary",
+    providerCampaignId: "campaign-1",
+    providerBrandId: "brand-1",
   });
-  return { promise, resolve, reject };
 }
 
 function transport(
@@ -104,9 +387,26 @@ function transport(
   };
 }
 
-afterEach(() => {
-  vi.unstubAllEnvs();
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
   vi.clearAllMocks();
+  const state = createLedgerDb();
+  mocks.tx = state.tx;
+  mocks.withSystem.mockImplementation(
+    async (_db: unknown, fn: (tx: unknown) => unknown) => fn(mocks.tx),
+  );
+  mocks.resolveMessagingTransport.mockResolvedValue(
+    transport({ from: "+15555550100" }),
+  );
   mocks.getMessagingProvider.mockReturnValue({
     name: "telnyx",
     isConfigured: () => true,
@@ -114,44 +414,122 @@ afterEach(() => {
   });
   mocks.billingEnforced.mockReturnValue(false);
   mocks.hasHostedFullAccess.mockReturnValue(true);
-  mocks.withSystem.mockImplementation(
-    async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn({
-        select: () => ({
-          from: () => ({
-            where: () => ({
-              limit: async () => [
-                {
-                  tier: "cloud",
-                  billingStatus: "active",
-                  trialEndsAt: null,
-                },
-              ],
-            }),
-          }),
-        }),
-      }),
-  );
+  mocks.providerSend.mockResolvedValue({
+    status: "accepted",
+    id: "msg-default",
+  });
+  mocks.recordUsage.mockResolvedValue(undefined);
+  mocks.acquireSmsRecipientLockInTransaction.mockResolvedValue(undefined);
+  vi.stubEnv("MESSAGING_REGISTERED_DISPLAY_NAME", "Neighborhood Veterinary");
+  (globalThis as Record<string, unknown>).__smsLedgerState = state;
 });
 
-describe("sendSms", () => {
-  it("keeps hosted SMS default-off before any DB, transport, or provider work", async () => {
+afterEach(() => {
+  vi.unstubAllEnvs();
+  delete (globalThis as Record<string, unknown>).__smsLedgerState;
+});
+
+function state() {
+  return (globalThis as Record<string, unknown>).__smsLedgerState as ReturnType<
+    typeof createLedgerDb
+  >;
+}
+
+describe("campaign-consistent SMS copy", () => {
+  it("uses one registered-name prefix and one canonical STOP/HELP footer", () => {
+    expect(
+      prepareCampaignSmsBody({
+        registeredDisplayName: "Neighborhood Veterinary",
+        content: "Neighborhood Veterinary: Miso is ready.",
+      }),
+    ).toEqual({
+      success: true,
+      body: `Neighborhood Veterinary: Miso is ready. ${SMS_COMPLIANCE_FOOTER}`,
+    });
+  });
+
+  it("rejects embedded compliance copy and validates the final 1600 characters", () => {
+    expect(
+      prepareCampaignSmsBody({
+        registeredDisplayName: "Clinic",
+        content: "Reply STOP to opt out.",
+      }),
+    ).toMatchObject({ success: false });
+    expect(
+      prepareCampaignSmsBody({
+        registeredDisplayName: "Clinic",
+        content: "x".repeat(1600),
+      }),
+    ).toMatchObject({ success: false });
+  });
+});
+
+describe("operator queue classification", () => {
+  const stale = new Date("2026-08-09T00:00:00Z");
+  const now = new Date("2026-08-09T01:00:00Z");
+  const event = (
+    kind: "provider_result" | "reconciliation",
+    outcome: "accepted" | "definite_failure" | "outcome_unknown",
+  ) => ({ kind, outcome, providerMessageId: null, detail: null });
+
+  it("queues stale missing and unknown outcomes but not fresh or resolved attempts", () => {
+    expect(
+      classifySmsAttemptForOps({ createdAt: stale, events: [], now }),
+    ).toBe("missing_provider_result");
+    expect(
+      classifySmsAttemptForOps({
+        createdAt: stale,
+        events: [event("provider_result", "outcome_unknown")],
+        now,
+      }),
+    ).toBe("outcome_unknown");
+    expect(
+      classifySmsAttemptForOps({
+        createdAt: stale,
+        events: [
+          event("reconciliation", "definite_failure"),
+          event("provider_result", "outcome_unknown"),
+        ],
+        now,
+      }),
+    ).toBeNull();
+    expect(
+      classifySmsAttemptForOps({
+        createdAt: new Date("2026-08-09T00:55:00Z"),
+        events: [],
+        now,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("independent ledger reservation", () => {
+  it("retains scalar and tenant FKs to a durably precommitted communication", () => {
+    const communicationForeignKeys = getTableConfig(smsSendAttempts)
+      .foreignKeys.filter((foreignKey) =>
+        foreignKey
+          .reference()
+          .columns.some((column) => column.name === "communication_id"),
+      )
+      .map((foreignKey) => foreignKey.getName());
+
+    expect(communicationForeignKeys).toEqual(
+      expect.arrayContaining([
+        "sms_send_attempts_communication_id_communications_id_fk",
+        "sms_send_attempts_communication_tenant_fk",
+      ]),
+    );
+  });
+});
+
+describe("durable SMS dispatch", () => {
+  it("keeps hosted sending default-off before DB or provider work", async () => {
     mocks.billingEnforced.mockReturnValue(true);
 
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Reminder",
-        practiceId: PRACTICE_ID,
-        locationId: LOCATION_ID,
-        clientId: CLIENT_ID,
-      }),
-    ).resolves.toEqual({
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
       success: false,
-      error:
-        "Texting is not enabled for this clinic pilot. Contact OpenVPM support.",
+      outcome: "definite_failure",
     });
-
     expect(mocks.withSystem).not.toHaveBeenCalled();
     expect(mocks.resolveMessagingTransport).not.toHaveBeenCalled();
     expect(mocks.providerSend).not.toHaveBeenCalled();
@@ -175,16 +553,16 @@ describe("sendSms", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
       }),
-    ).resolves.toEqual({
+    ).resolves.toMatchObject({
       success: false,
       error: "Hosted SMS requires an explicit consented client.",
     });
 
-    expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.resolveMessagingTransport).not.toHaveBeenCalled();
     expect(mocks.providerSend).not.toHaveBeenCalled();
   });
 
-  it("rejects non-Telnyx hosted transports before provider dispatch", async () => {
+  it("rejects non-Telnyx and console hosted transports before dispatch", async () => {
     allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
     const twilioSend = vi.fn();
@@ -192,65 +570,47 @@ describe("sendSms", () => {
       transport({ from: "+15555550100" }, "twilio", twilioSend),
     );
 
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Reminder",
-        practiceId: PRACTICE_ID,
-        locationId: LOCATION_ID,
-        clientId: CLIENT_ID,
-      }),
-    ).resolves.toEqual({
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
       success: false,
       error:
         "Hosted texting is available only through the approved Telnyx pilot.",
     });
     expect(twilioSend).not.toHaveBeenCalled();
-    expect(mocks.providerSend).not.toHaveBeenCalled();
+
+    const consoleSend = vi.fn();
+    mocks.resolveMessagingTransport.mockResolvedValue(
+      transport({}, "console", consoleSend),
+    );
+    await expect(
+      sendSms(
+        sendOptions({
+          idempotencyKey: "sms:inbox:hosted-console",
+          sourceId: "hosted-console",
+        }),
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      error:
+        "Hosted texting is available only through the approved Telnyx pilot.",
+    });
+    expect(consoleSend).not.toHaveBeenCalled();
+    expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
 
-  it("rechecks current consent and phone after sender resolution before hosted dispatch", async () => {
+  it("rechecks current consent and phone after sender resolution", async () => {
     allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
-    );
-    mocks.withSystem
-      .mockImplementationOnce(
-        async (_db: unknown, fn: (tx: unknown) => unknown) =>
-          fn(
-            hostedDispatchDb([
-              [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
-            ]),
-          ),
-      )
-      .mockImplementationOnce(
-        async (_db: unknown, fn: (tx: unknown) => unknown) =>
-          fn(
-            hostedDispatchDb([
-              [
-                {
-                  phone: "+15555550199",
-                  smsConsent: false,
-                  smsConsentAt: null,
-                  smsConsentSource: null,
-                  smsConsentDisclosure: null,
-                },
-              ],
-            ]),
-          ),
-      );
+    state().clientRows.splice(0, 1, {
+      phone: "+15555550198",
+      smsConsent: false,
+      smsConsentAt: null,
+      smsConsentSource: null,
+      smsConsentDisclosure: null,
+    });
 
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Stale automation snapshot",
-        practiceId: PRACTICE_ID,
-        locationId: LOCATION_ID,
-        clientId: CLIENT_ID,
-      }),
-    ).resolves.toEqual({
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
       success: false,
+      outcome: "definite_failure",
       error:
         "Client SMS consent or phone changed before sending; delivery was blocked.",
     });
@@ -258,180 +618,196 @@ describe("sendSms", () => {
     expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
 
-  it("dispatches an allowlisted Telnyx hosted send only after current consent and suppression checks", async () => {
+  it("dispatches hosted SMS only after JIT consent and suppression checks", async () => {
     allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
-    );
-    mocks.providerSend.mockResolvedValue({ success: true, id: "sms-hosted-1" });
-    mocks.withSystem
-      .mockImplementationOnce(
-        async (_db: unknown, fn: (tx: unknown) => unknown) =>
-          fn(
-            hostedDispatchDb([
-              [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
-            ]),
-          ),
-      )
-      .mockImplementationOnce(
-        async (_db: unknown, fn: (tx: unknown) => unknown) =>
-          fn(
-            hostedDispatchDb([
-              [
-                {
-                  phone: "(555) 555-0199",
-                  smsConsent: true,
-                  smsConsentAt: new Date("2026-08-01T00:00:00Z"),
-                  smsConsentSource: "staff_attested_form:v1",
-                  smsConsentDisclosure: "Disclosure",
-                },
-              ],
-              [],
-            ]),
-          ),
-      );
+    state().clientRows[0]!.phone = "(555) 555-0199";
+    mocks.providerSend.mockResolvedValue({
+      status: "accepted",
+      id: "sms-hosted-1",
+    });
 
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Reminder",
-        practiceId: PRACTICE_ID,
-        locationId: LOCATION_ID,
-        clientId: CLIENT_ID,
-      }),
-    ).resolves.toEqual({
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
       success: true,
+      outcome: "accepted",
       sid: "sms-hosted-1",
-      error: undefined,
     });
     expect(mocks.providerSend).toHaveBeenCalledOnce();
+    expect(state().selectedTables).toContain("clients");
+    expect(state().selectedTables).toContain("sms_suppressions");
   });
 
-  it("blocks a hosted send when the JIT suppression check finds the recipient", async () => {
+  it("persists accepted outcome and linked communication projection together", async () => {
+    mocks.providerSend.mockResolvedValue({
+      status: "accepted",
+      id: "sms-atomic-1",
+    });
+
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: true,
+      outcome: "accepted",
+      sid: "sms-atomic-1",
+    });
+    expect(state().events.at(-1)).toMatchObject({
+      kind: "provider_result",
+      outcome: "accepted",
+      providerMessageId: "sms-atomic-1",
+    });
+    expect(state().updates).toContainEqual({
+      status: "sent",
+      providerMessageId: "sms-atomic-1",
+    });
+  });
+
+  it("returns unknown and alerts if an accepted outcome cannot project", async () => {
+    state().communicationProjection.available = false;
+    mocks.providerSend.mockResolvedValue({
+      status: "accepted",
+      id: "sms-unprojected-1",
+    });
+
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: false,
+      outcome: "outcome_unknown",
+      error: expect.stringContaining("could not be persisted"),
+    });
+    expect(mocks.providerSend).toHaveBeenCalledOnce();
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "SMS provider outcome requires reconciliation",
+      expect.stringContaining(`communication=${COMMUNICATION_ID}`),
+    );
+  });
+
+  it("rechecks active location sender and carrier campaign at dispatch", async () => {
     allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
-    );
-    mocks.withSystem
-      .mockImplementationOnce(
-        async (_db: unknown, fn: (tx: unknown) => unknown) =>
-          fn(
-            hostedDispatchDb([
-              [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
-            ]),
-          ),
-      )
-      .mockImplementationOnce(
-        async (_db: unknown, fn: (tx: unknown) => unknown) =>
-          fn(
-            hostedDispatchDb([
-              [
-                {
-                  phone: "+15555550199",
-                  smsConsent: true,
-                  smsConsentAt: new Date("2026-08-01T00:00:00Z"),
-                  smsConsentSource: "staff_attested_form:v1",
-                  smsConsentDisclosure: "Disclosure",
-                },
-              ],
-              [{ id: "suppression-1" }],
-            ]),
-          ),
-      );
+    state().locationMessagingRows[0]!.enabled = false;
 
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Reminder",
-        practiceId: PRACTICE_ID,
-        locationId: LOCATION_ID,
-        clientId: CLIENT_ID,
-      }),
-    ).resolves.toEqual({
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
       success: false,
+      outcome: "definite_failure",
+      error: expect.stringContaining("sender changed or became inactive"),
+    });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+
+    const nextState = createLedgerDb();
+    nextState.registrations.push({
+      displayName: "Neighborhood Veterinary",
+      providerCampaignId: null,
+      providerBrandId: "brand-1",
+    });
+    mocks.tx = nextState.tx;
+    mocks.withSystem.mockImplementation(
+      async (_db: unknown, fn: (tx: unknown) => unknown) => fn(mocks.tx),
+    );
+    (globalThis as Record<string, unknown>).__smsLedgerState = nextState;
+    await expect(
+      sendSms(
+        sendOptions({
+          idempotencyKey: "sms:inbox:inactive-campaign",
+          sourceId: "inactive-campaign",
+        }),
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      error: expect.stringContaining("carrier campaign changed"),
+    });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+
+    const mismatchedState = createLedgerDb();
+    mismatchedState.registrations.push({
+      displayName: "Neighborhood Veterinary",
+      providerCampaignId: "campaign-2",
+      providerBrandId: "brand-1",
+    });
+    mocks.tx = mismatchedState.tx;
+    mocks.withSystem.mockImplementation(
+      async (_db: unknown, fn: (tx: unknown) => unknown) => fn(mocks.tx),
+    );
+    (globalThis as Record<string, unknown>).__smsLedgerState = mismatchedState;
+    await expect(
+      sendSms(
+        sendOptions({
+          idempotencyKey: "sms:inbox:mismatched-campaign",
+          sourceId: "mismatched-campaign",
+        }),
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      error: expect.stringContaining("carrier campaign changed"),
+    });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+  });
+
+  it("blocks JIT suppression and fails closed if that query errors", async () => {
+    allowHostedPilot();
+    mocks.billingEnforced.mockReturnValue(true);
+    state().suppressionRows.push({ id: "suppression-1" });
+
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
       error: "Recipient has opted out of SMS (STOP).",
     });
     expect(mocks.providerSend).not.toHaveBeenCalled();
-    expect(mocks.recordUsage).not.toHaveBeenCalled();
-  });
 
-  it("fails closed with zero provider calls when the JIT suppression query errors", async () => {
-    allowHostedPilot();
-    mocks.billingEnforced.mockReturnValue(true);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
+    const nextState = createLedgerDb();
+    nextState.registrations.push({
+      displayName: "Neighborhood Veterinary",
+      providerCampaignId: "campaign-1",
+      providerBrandId: "brand-1",
+    });
+    nextState.throwOnSelect.set(
+      "sms_suppressions",
+      new Error("suppression database unavailable"),
     );
-    mocks.withSystem
-      .mockImplementationOnce(
-        async (_db: unknown, fn: (tx: unknown) => unknown) =>
-          fn(
-            hostedDispatchDb([
-              [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
-            ]),
-          ),
-      )
-      .mockImplementationOnce(
-        async (_db: unknown, fn: (tx: unknown) => unknown) =>
-          fn(
-            hostedDispatchDb([
-              [
-                {
-                  phone: "+15555550199",
-                  smsConsent: true,
-                  smsConsentAt: new Date("2026-08-01T00:00:00Z"),
-                  smsConsentSource: "staff_attested_form:v1",
-                  smsConsentDisclosure: "Disclosure",
-                },
-              ],
-              new Error("suppression database unavailable"),
-            ]),
-          ),
-      );
+    mocks.tx = nextState.tx;
+    mocks.withSystem.mockImplementation(
+      async (_db: unknown, fn: (tx: unknown) => unknown) => fn(mocks.tx),
+    );
+    (globalThis as Record<string, unknown>).__smsLedgerState = nextState;
 
     await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Reminder",
-        practiceId: PRACTICE_ID,
-        locationId: LOCATION_ID,
-        clientId: CLIENT_ID,
-      }),
-    ).resolves.toEqual({
+      sendSms(
+        sendOptions({
+          idempotencyKey: "sms:inbox:suppression-error",
+          sourceId: "suppression-error",
+        }),
+      ),
+    ).resolves.toMatchObject({
       success: false,
-      error: "Could not verify SMS consent; send blocked.",
+      outcome: "outcome_unknown",
+      error: expect.stringContaining("could not be persisted"),
     });
     expect(mocks.providerSend).not.toHaveBeenCalled();
     expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
 
-  it("serializes revocation ahead of hosted dispatch without a lock-order rollback", async () => {
+  it("serializes STOP revocation ahead of the hosted consent recheck", async () => {
     allowHostedPilot();
     mocks.billingEnforced.mockReturnValue(true);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
-    );
 
     const revokeReachedWrite = deferred();
     const allowRevokeCommit = deferred();
     const sendWaitingForRecipient = deferred();
     let recipientLocked = false;
     const recipientWaiters: Array<() => void> = [];
-    const acquireRecipient = async () => {
+    const acquireRecipient = async (): Promise<undefined> => {
       if (!recipientLocked) {
         recipientLocked = true;
-        return;
+        return undefined;
       }
       sendWaitingForRecipient.resolve();
       await new Promise<void>((resolve) => recipientWaiters.push(resolve));
       recipientLocked = true;
+      return undefined;
     };
     const releaseRecipient = () => {
       recipientLocked = false;
       recipientWaiters.shift()?.();
     };
-    const state = { consent: true, suppressed: false };
 
     const revokeTx = {
       execute: vi.fn(acquireRecipient),
@@ -465,79 +841,29 @@ describe("sendSms", () => {
           evidence: {
             source: "staff_manual_revoke:v1",
             actorType: "staff",
-            actorUserId: "00000000-0000-0000-0000-000000000001",
-            actorName: "Test User",
+            actorUserId: ACTOR_ID,
+            actorName: "Operator",
             eventKey: "staff:test-race",
           },
         },
       );
-      state.consent = false;
-      state.suppressed = true;
+      state().clientRows.splice(0, 1, {
+        phone: "+15555550199",
+        smsConsent: false,
+        smsConsentAt: null,
+        smsConsentSource: null,
+        smsConsentDisclosure: null,
+      });
+      state().suppressionRows.push({ id: "suppression-1" });
       releaseRecipient();
       return result;
     })();
     await revokeReachedWrite.promise;
+    mocks.acquireSmsRecipientLockInTransaction.mockImplementation(
+      acquireRecipient,
+    );
 
-    let sendSelectCount = 0;
-    const sendTx = {
-      execute: vi.fn(acquireRecipient),
-      select: () => {
-        sendSelectCount += 1;
-        const result =
-          sendSelectCount === 1
-            ? [
-                {
-                  phone: "+15555550199",
-                  smsConsent: state.consent,
-                  smsConsentAt: state.consent
-                    ? new Date("2026-08-01T00:00:00Z")
-                    : null,
-                  smsConsentSource: state.consent
-                    ? "staff_attested_form:v1"
-                    : null,
-                  smsConsentDisclosure: state.consent ? "Disclosure" : null,
-                },
-              ]
-            : state.suppressed
-              ? [{ id: "suppression-1" }]
-              : [];
-        const builder = {
-          from: () => builder,
-          where: () => builder,
-          limit: () => builder,
-          for: async () => result,
-          then: (
-            resolve: (value: unknown[]) => unknown,
-            reject?: (reason: unknown) => unknown,
-          ) => Promise.resolve(result).then(resolve, reject),
-        };
-        return builder;
-      },
-    };
-    mocks.withSystem
-      .mockImplementationOnce(
-        async (_db: unknown, fn: (tx: unknown) => unknown) =>
-          fn(
-            hostedDispatchDb([
-              [{ tier: "cloud", billingStatus: "active", trialEndsAt: null }],
-            ]),
-          ),
-      )
-      .mockImplementationOnce(
-        async (_db: unknown, fn: (tx: unknown) => unknown) => {
-          const result = await fn(sendTx);
-          releaseRecipient();
-          return result;
-        },
-      );
-
-    const sendPromise = sendSms({
-      to: "+15555550199",
-      body: "Must wait for revocation",
-      practiceId: PRACTICE_ID,
-      locationId: LOCATION_ID,
-      clientId: CLIENT_ID,
-    });
+    const sendPromise = sendSms(sendOptions());
     await sendWaitingForRecipient.promise;
     expect(mocks.providerSend).not.toHaveBeenCalled();
 
@@ -546,246 +872,187 @@ describe("sendSms", () => {
       phone: "+15555550199",
       clientsRevoked: 1,
     });
-    await expect(sendPromise).resolves.toMatchObject({ success: false });
+    await expect(sendPromise).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+    });
     expect(mocks.providerSend).not.toHaveBeenCalled();
   });
 
-  it("requires an active practice for hosted billing entitlement checks", () => {
-    expect(smsSource).toMatch(
-      /where\(\s*and\(\s*eq\(practices\.id, options\.practiceId!\),\s*isNull\(practices\.deletedAt\)\s*\)\s*\)/s,
-    );
-    expect(smsSource).toContain("if (!practice)");
-    expect(smsSource).toContain("Practice not found");
-    expect(smsSource).toContain("practice.tier");
-    expect(smsSource).not.toContain("practice?.tier");
-  });
+  it("fails closed when hosted practice entitlement is missing or inactive", async () => {
+    allowHostedPilot();
+    mocks.billingEnforced.mockReturnValue(true);
+    state().practiceRows.splice(0);
 
-  it("meters successful real provider sends for hosted usage billing", async () => {
-    mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
-    );
-    mocks.providerSend.mockResolvedValue({ success: true, id: "sms-1" });
-
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Reminder",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-      }),
-    ).resolves.toEqual({ success: true, sid: "sms-1", error: undefined });
-
-    expect(mocks.recordUsage).toHaveBeenCalledWith({
-      practiceId: "00000000-0000-0000-0000-0000000000aa",
-      kind: "sms",
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      error: "Practice not found",
     });
-  });
+    expect(mocks.hasHostedFullAccess).not.toHaveBeenCalled();
+    expect(mocks.providerSend).not.toHaveBeenCalled();
 
-  it("normalizes recipients before suppression checks and provider sends", async () => {
-    mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
+    const nextState = createLedgerDb();
+    nextState.registrations.push({
+      displayName: "Neighborhood Veterinary",
+      providerCampaignId: "campaign-1",
+      providerBrandId: "brand-1",
+    });
+    mocks.tx = nextState.tx;
+    mocks.withSystem.mockImplementation(
+      async (_db: unknown, fn: (tx: unknown) => unknown) => fn(mocks.tx),
     );
-    mocks.providerSend.mockResolvedValue({ success: true, id: "sms-1" });
+    (globalThis as Record<string, unknown>).__smsLedgerState = nextState;
+    mocks.hasHostedFullAccess.mockReturnValue(false);
 
     await expect(
-      sendSms({
-        to: " (555) 555-0199 ",
-        body: "Reminder",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-      }),
-    ).resolves.toEqual({ success: true, sid: "sms-1", error: undefined });
+      sendSms(
+        sendOptions({
+          idempotencyKey: "sms:inbox:inactive-practice",
+          sourceId: "inactive-practice",
+        }),
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      error: expect.stringContaining("read-only"),
+    });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+  });
 
-    expect(mocks.isSuppressed).toHaveBeenCalledWith(
-      "00000000-0000-0000-0000-0000000000aa",
-      "+15555550199",
-    );
+  it("normalizes recipients and rejects invalid phones before any work", async () => {
+    mocks.providerSend.mockResolvedValue({ status: "accepted", id: "sms-1" });
+
+    await expect(
+      sendSms(sendOptions({ to: " (555) 555-0199 " })),
+    ).resolves.toMatchObject({ success: true, sid: "sms-1" });
     expect(mocks.providerSend).toHaveBeenCalledWith({
       to: "+15555550199",
-      body: "Reminder",
+      body: `Neighborhood Veterinary: Miso's prescription is ready for pickup. ${SMS_COMPLIANCE_FOOTER}`,
       sender: { from: "+15555550100" },
     });
-  });
 
-  it("fails closed before provider work when the recipient phone is invalid", async () => {
-    await expect(
-      sendSms({
-        to: "12345",
-        body: "Reminder",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-      }),
-    ).resolves.toEqual({
+    vi.clearAllMocks();
+    await expect(sendSms(sendOptions({ to: "12345" }))).resolves.toMatchObject({
       success: false,
       error:
         "SMS recipient phone number must be a valid E.164 or US/CA number.",
     });
-
-    expect(mocks.isSuppressed).not.toHaveBeenCalled();
     expect(mocks.resolveMessagingTransport).not.toHaveBeenCalled();
+    expect(mocks.withSystem).not.toHaveBeenCalled();
     expect(mocks.providerSend).not.toHaveBeenCalled();
     expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
 
-  it("waits for hosted usage recording before returning a successful real send", async () => {
-    const usage = deferred();
-    mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
-    );
-    mocks.providerSend.mockResolvedValue({ success: true, id: "sms-1" });
+  it("meters only accepted real sends and awaits metering", async () => {
+    const usage = deferred<undefined>();
+    mocks.providerSend.mockResolvedValue({ status: "accepted", id: "sms-1" });
     mocks.recordUsage.mockReturnValueOnce(usage.promise);
-
     let settled = false;
-    const sendPromise = sendSms({
-      to: "+15555550199",
-      body: "Reminder",
-      practiceId: "00000000-0000-0000-0000-0000000000aa",
-    }).then((result) => {
+    const sendPromise = sendSms(sendOptions()).then((result) => {
       settled = true;
       return result;
     });
 
-    await Promise.resolve();
+    await vi.waitFor(() => expect(mocks.recordUsage).toHaveBeenCalledOnce());
     expect(settled).toBe(false);
-
-    usage.resolve();
-    await expect(sendPromise).resolves.toEqual({
+    usage.resolve(undefined);
+    await expect(sendPromise).resolves.toMatchObject({
       success: true,
       sid: "sms-1",
-      error: undefined,
     });
-  });
-
-  it("keeps provider message ids on appointment reminder helper results", async () => {
-    mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
-    );
-    mocks.providerSend.mockResolvedValue({
-      success: true,
-      id: "sms-reminder-1",
-    });
-
-    await expect(
-      sendAppointmentReminderSms({
-        to: "+15555550199",
-        patientName: "Miso",
-        appointmentDate: "July 2",
-        appointmentTime: "9:00 AM",
-        practiceName: "Neighborhood Veterinary",
-      }),
-    ).resolves.toEqual({
-      success: true,
-      sid: "sms-reminder-1",
-      error: undefined,
-    });
-  });
-
-  it("keeps provider message ids on vaccination reminder helper results", async () => {
-    mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
-    );
-    mocks.providerSend.mockResolvedValue({ success: true, id: "sms-vax-1" });
-
-    await expect(
-      sendVaccinationReminderSms({
-        to: "+15555550199",
-        patientName: "Miso",
-        vaccineName: "Rabies",
-        practiceName: "Neighborhood Veterinary",
-      }),
-    ).resolves.toEqual({
-      success: true,
-      sid: "sms-vax-1",
-      error: undefined,
-    });
-  });
-
-  it("does not meter failed provider sends", async () => {
-    mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveMessagingTransport.mockResolvedValue(
-      transport({ from: "+15555550100" }),
-    );
-    mocks.providerSend.mockResolvedValue({
-      success: false,
-      error: "Provider rejected",
-    });
-
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Reminder",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-      }),
-    ).resolves.toEqual({
-      success: false,
-      sid: undefined,
-      error: "Provider rejected",
-    });
-
-    expect(mocks.recordUsage).not.toHaveBeenCalled();
-  });
-
-  it("does not meter console fallback sends", async () => {
-    mocks.getMessagingProvider.mockReturnValue({
-      name: "console",
-      isConfigured: () => true,
-      send: mocks.providerSend,
-    });
-    mocks.isSuppressed.mockResolvedValue(false);
-    mocks.resolveMessagingTransport.mockResolvedValue(transport({}, "console"));
-    mocks.providerSend.mockResolvedValue({ success: true, id: "console-1" });
-
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Reminder",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-      }),
-    ).resolves.toEqual({
-      success: true,
-      sid: "console-1",
-      error: undefined,
-    });
-
-    expect(mocks.recordUsage).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when hosted sending would use the console fallback", async () => {
-    allowHostedPilot();
-    mocks.billingEnforced.mockReturnValue(true);
-    mocks.getMessagingProvider.mockReturnValue({
-      name: "console",
-      isConfigured: () => true,
-      send: mocks.providerSend,
-    });
-    mocks.resolveMessagingTransport.mockResolvedValue(transport({}, "console"));
-
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Reminder",
-        practiceId: PRACTICE_ID,
-        locationId: LOCATION_ID,
-        clientId: CLIENT_ID,
-      }),
-    ).resolves.toEqual({
-      success: false,
-      error:
-        "Hosted texting is available only through the approved Telnyx pilot.",
-    });
-
-    expect(mocks.resolveMessagingTransport).toHaveBeenCalledWith({
+    expect(mocks.recordUsage).toHaveBeenCalledWith({
       practiceId: PRACTICE_ID,
-      locationId: LOCATION_ID,
-      hosted: true,
+      kind: "sms",
     });
-    expect(mocks.providerSend).not.toHaveBeenCalled();
+  });
+
+  it("never turns accepted-send metering failure into a retry signal", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.providerSend.mockResolvedValue({ status: "accepted", id: "sms-1" });
+    mocks.recordUsage.mockRejectedValueOnce(new Error("meter unavailable"));
+
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: true,
+      outcome: "accepted",
+      sid: "sms-1",
+    });
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: true,
+      outcome: "accepted",
+      sid: "sms-1",
+      replayed: true,
+    });
+    expect(mocks.providerSend).toHaveBeenCalledOnce();
+    expect(mocks.recordUsage).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[messaging] accepted SMS usage metering failed",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("does not meter definite failures, unknown outcomes, or console sends", async () => {
+    mocks.providerSend.mockResolvedValueOnce({
+      status: "definite_failure",
+      error: "Provider rejected",
+    });
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+    });
+    expect(mocks.recordUsage).not.toHaveBeenCalled();
+
+    const nextState = createLedgerDb();
+    mocks.tx = nextState.tx;
+    mocks.withSystem.mockImplementation(
+      async (_db: unknown, fn: (tx: unknown) => unknown) => fn(mocks.tx),
+    );
+    (globalThis as Record<string, unknown>).__smsLedgerState = nextState;
+    mocks.providerSend.mockResolvedValueOnce({
+      status: "outcome_unknown",
+      error: "Provider timed out",
+    });
+    await expect(
+      sendSms(
+        sendOptions({
+          idempotencyKey: "sms:inbox:unknown-meter",
+          sourceId: "unknown-meter",
+        }),
+      ),
+    ).resolves.toMatchObject({ outcome: "outcome_unknown" });
+    expect(mocks.recordUsage).not.toHaveBeenCalled();
+
+    const consoleState = createLedgerDb();
+    mocks.tx = consoleState.tx;
+    mocks.withSystem.mockImplementation(
+      async (_db: unknown, fn: (tx: unknown) => unknown) => fn(mocks.tx),
+    );
+    (globalThis as Record<string, unknown>).__smsLedgerState = consoleState;
+    mocks.getMessagingProvider.mockReturnValue({
+      name: "console",
+      isConfigured: () => true,
+      send: mocks.providerSend,
+    });
+    mocks.resolveMessagingTransport.mockResolvedValue(transport({}, "console"));
+    mocks.providerSend.mockResolvedValueOnce({
+      status: "accepted",
+      id: "console-1",
+    });
+    await expect(
+      sendSms({
+        to: "+15555550199",
+        body: "Console reminder",
+        practiceId: PRACTICE_ID,
+        idempotencyKey: "sms:console:1",
+      }),
+    ).resolves.toMatchObject({ success: true, sid: "console-1" });
     expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
 
-  it("allows the safe console provider for hosted demo mode with padded env values", async () => {
+  it("allows safe console sending in hosted demo mode", async () => {
     vi.stubEnv("NEXT_PUBLIC_DEMO_MODE", " true ");
     mocks.billingEnforced.mockReturnValue(true);
     mocks.getMessagingProvider.mockReturnValue({
@@ -793,121 +1060,560 @@ describe("sendSms", () => {
       isConfigured: () => true,
       send: mocks.providerSend,
     });
-    mocks.isSuppressed.mockResolvedValue(false);
     mocks.resolveMessagingTransport.mockResolvedValue(transport({}, "console"));
-    mocks.providerSend.mockResolvedValue({ success: true, id: "console-1" });
+    mocks.providerSend.mockResolvedValue({
+      status: "accepted",
+      id: "console-demo-1",
+    });
 
     await expect(
       sendSms({
         to: "+15555550199",
-        body: "Reminder",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
+        body: "Demo reminder",
+        practiceId: PRACTICE_ID,
+        idempotencyKey: "sms:demo:1",
       }),
-    ).resolves.toEqual({
-      success: true,
-      sid: "console-1",
-      error: undefined,
-    });
-
+    ).resolves.toMatchObject({ success: true, sid: "console-demo-1" });
     expect(mocks.providerSend).toHaveBeenCalledWith({
       to: "+15555550199",
-      body: "Reminder",
+      body: `Neighborhood Veterinary: Demo reminder ${SMS_COMPLIANCE_FOOTER}`,
       sender: {},
     });
     expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
 
-  it("fails closed when hosted SMS practice entitlement lookup is stale", async () => {
-    allowHostedPilot();
-    mocks.billingEnforced.mockReturnValue(true);
-    mocks.withSystem.mockImplementationOnce(
-      async (_db: unknown, fn: (tx: unknown) => unknown) =>
-        fn({
-          select: () => ({
-            from: () => ({
-              where: () => ({
-                limit: async () => [],
-              }),
-            }),
-          }),
-        }),
-    );
-
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Reminder",
-        practiceId: PRACTICE_ID,
-        locationId: LOCATION_ID,
-        clientId: CLIENT_ID,
-      }),
-    ).resolves.toEqual({
-      success: false,
-      error: "Practice not found",
-    });
-
-    expect(mocks.hasHostedFullAccess).not.toHaveBeenCalled();
-    expect(mocks.isSuppressed).not.toHaveBeenCalled();
-    expect(mocks.resolveMessagingTransport).not.toHaveBeenCalled();
-    expect(mocks.providerSend).not.toHaveBeenCalled();
-    expect(mocks.recordUsage).not.toHaveBeenCalled();
-  });
-
-  it("fails closed for explicit locations without an active sender", async () => {
-    mocks.isSuppressed.mockResolvedValue(false);
+  it("fails closed for an explicit location without an active sender", async () => {
     mocks.resolveMessagingTransport.mockResolvedValue(undefined);
 
-    await expect(
-      sendSms({
-        to: "+15555550100",
-        body: "Reminder",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-        locationId: "00000000-0000-0000-0000-000000000002",
-      }),
-    ).resolves.toEqual({
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
       success: false,
       error: "No active texting sender is configured for this location.",
     });
-
     expect(mocks.getMessagingProvider).not.toHaveBeenCalled();
+    expect(mocks.withSystem).not.toHaveBeenCalled();
     expect(mocks.providerSend).not.toHaveBeenCalled();
-    expect(mocks.recordUsage).not.toHaveBeenCalled();
   });
 
-  it("dispatches an explicit location through its persisted provider, not the global provider", async () => {
-    const twilioSend = vi
-      .fn()
-      .mockResolvedValue({ success: true, id: "SM-location" });
-    mocks.isSuppressed.mockResolvedValue(false);
+  it("classifies escaped pre-reservation setup errors as definite failures", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.resolveMessagingTransport.mockRejectedValue(
+      new Error("sender lookup unavailable"),
+    );
+
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      error: "SMS could not be prepared; send blocked.",
+    });
+    expect(state().attempts).toHaveLength(0);
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("dispatches explicit locations through their persisted provider and sender", async () => {
+    const twilioSend = vi.fn().mockResolvedValue({
+      status: "accepted",
+      id: "SM-location",
+    });
     mocks.resolveMessagingTransport.mockResolvedValue(
       transport(
-        {
-          messagingServiceId: "MG-location",
-          from: "+15555550122",
-        },
+        { messagingServiceId: "MG-location", from: "+15555550122" },
         "twilio",
         twilioSend,
       ),
     );
+    state().locationMessagingRows.splice(0, 1, {
+      provider: "twilio",
+      messagingServiceId: "MG-location",
+      senderE164: "+15555550122",
+      enabled: true,
+      registrationStatus: "active",
+    });
 
-    await expect(
-      sendSms({
-        to: "+15555550199",
-        body: "Location-bound message",
-        practiceId: "00000000-0000-0000-0000-0000000000aa",
-        locationId: "00000000-0000-0000-0000-000000000002",
-      }),
-    ).resolves.toEqual({ success: true, sid: "SM-location", error: undefined });
-
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: true,
+      sid: "SM-location",
+    });
     expect(mocks.getMessagingProvider).not.toHaveBeenCalled();
     expect(mocks.providerSend).not.toHaveBeenCalled();
     expect(twilioSend).toHaveBeenCalledWith({
       to: "+15555550199",
-      body: "Location-bound message",
+      body: `Neighborhood Veterinary: Miso's prescription is ready for pickup. ${SMS_COMPLIANCE_FOOTER}`,
       sender: {
         messagingServiceId: "MG-location",
         from: "+15555550122",
       },
     });
+  });
+
+  it("preserves provider ids and canonical bodies through reminder helpers", async () => {
+    mocks.providerSend
+      .mockResolvedValueOnce({ status: "accepted", id: "sms-reminder-1" })
+      .mockResolvedValueOnce({ status: "accepted", id: "sms-vax-1" });
+
+    await expect(
+      sendAppointmentReminderSms({
+        to: "+15555550199",
+        patientName: "Miso",
+        appointmentDate: "August 12",
+        appointmentTime: "9:00 AM",
+        practiceName: "Stale Caller Name",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
+        idempotencyKey: "sms:appointment:1",
+      }),
+    ).resolves.toMatchObject({ success: true, sid: "sms-reminder-1" });
+    await expect(
+      sendVaccinationReminderSms({
+        to: "+15555550199",
+        patientName: "Miso",
+        vaccineName: "Rabies",
+        practiceName: "Stale Caller Name",
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        clientId: CLIENT_ID,
+        idempotencyKey: "sms:vaccination:1",
+      }),
+    ).resolves.toMatchObject({ success: true, sid: "sms-vax-1" });
+
+    expect(mocks.providerSend).toHaveBeenNthCalledWith(1, {
+      to: "+15555550199",
+      body: `Neighborhood Veterinary: Reminder: Miso has an appointment on August 12 at 9:00 AM. Contact us to reschedule. ${SMS_COMPLIANCE_FOOTER}`,
+      sender: { from: "+15555550100" },
+    });
+    expect(mocks.providerSend).toHaveBeenNthCalledWith(2, {
+      to: "+15555550199",
+      body: `Neighborhood Veterinary: Miso is due for their Rabies vaccination. Contact us to schedule. ${SMS_COMPLIANCE_FOOTER}`,
+      sender: { from: "+15555550100" },
+    });
+  });
+
+  it("allows only the reservation winner to call the provider", async () => {
+    let resolveProvider!: (value: { status: "accepted"; id: string }) => void;
+    mocks.providerSend.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveProvider = resolve;
+      }),
+    );
+
+    const first = sendSms(sendOptions());
+    await vi.waitFor(() => expect(mocks.providerSend).toHaveBeenCalledOnce());
+    const second = await sendSms(sendOptions());
+
+    expect(second).toMatchObject({
+      success: false,
+      outcome: "outcome_unknown",
+      replayed: true,
+    });
+    expect(mocks.providerSend).toHaveBeenCalledOnce();
+
+    resolveProvider({ status: "accepted", id: "msg-1" });
+    await expect(first).resolves.toMatchObject({
+      success: true,
+      outcome: "accepted",
+      sid: "msg-1",
+    });
+    expect(state().attempts).toHaveLength(1);
+    expect(state().events).toHaveLength(1);
+  });
+
+  it("persists missing provider ids as unknown and never retries them", async () => {
+    mocks.providerSend.mockResolvedValue({ status: "accepted", id: "   " });
+
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: false,
+      outcome: "outcome_unknown",
+    });
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: false,
+      outcome: "outcome_unknown",
+      replayed: true,
+    });
+    expect(mocks.providerSend).toHaveBeenCalledOnce();
+    expect(mocks.alertOps).toHaveBeenCalledOnce();
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "SMS provider outcome requires reconciliation",
+      `practice=${PRACTICE_ID} attempt=${state().attempts[0]!.id} communication=${COMMUNICATION_ID} source=inbox`,
+    );
+    expect(JSON.stringify(mocks.alertOps.mock.calls)).not.toContain(
+      "+15555550199",
+    );
+    expect(JSON.stringify(mocks.alertOps.mock.calls)).not.toContain(
+      "prescription",
+    );
+  });
+
+  it("blocks an idempotency replay onto a different communication", async () => {
+    mocks.providerSend.mockResolvedValue({ status: "accepted", id: "msg-1" });
+    await expect(sendSms(sendOptions())).resolves.toMatchObject({
+      success: true,
+      sid: "msg-1",
+    });
+
+    await expect(
+      sendSms(
+        sendOptions({
+          communicationId: "00000000-0000-0000-0000-0000000000de",
+        }),
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      replayed: true,
+      error: expect.stringContaining("different dispatch data"),
+    });
+    expect(mocks.providerSend).toHaveBeenCalledOnce();
+  });
+
+  it("blocks a fresh communication from bypassing recent ambiguity", async () => {
+    mocks.providerSend.mockResolvedValueOnce({
+      status: "outcome_unknown",
+      error: "gateway timed out",
+    });
+    await sendSms(sendOptions());
+
+    await expect(
+      sendSms(
+        sendOptions({
+          communicationId: "00000000-0000-0000-0000-0000000000de",
+          sourceId: "00000000-0000-0000-0000-0000000000de",
+          idempotencyKey: "sms:inbox:00000000-0000-0000-0000-0000000000de",
+        }),
+      ),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      error: expect.stringContaining("unresolved provider outcome"),
+    });
+    expect(mocks.providerSend).toHaveBeenCalledOnce();
+  });
+
+  it("reconciles only stale ambiguous attempts without a provider call", async () => {
+    const ledger = state();
+    ledger.attempts.push({
+      ...sendOptions(),
+      id: "00000000-0000-0000-0000-000000000001",
+      createdAt: new Date(Date.now() - 20 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      idempotencyKey: "sms:ambiguous:1",
+      resendOfAttemptId: null,
+    });
+    ledger.events.push({
+      id: "10000000-0000-0000-0000-000000000001",
+      createdAt: new Date(Date.now() - 19 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      attemptId: ledger.attempts[0]!.id,
+      kind: "provider_result",
+      outcome: "outcome_unknown",
+      providerMessageId: null,
+      detail: "timeout",
+      eventKey: "provider-result:1",
+    });
+
+    await expect(
+      reconcileSmsSendAttempt({
+        practiceId: PRACTICE_ID,
+        attemptId: ledger.attempts[0]!.id,
+        outcome: "accepted",
+        providerMessageId: "msg-reconciled",
+        detail: "Confirmed in provider console.",
+        actorType: "platform_operator",
+        actorUserId: ACTOR_ID,
+        actorIdentity: "ops@openvpm.com",
+        actorName: "OpenVPM Ops",
+        reconciliationKey: "operator-reconciliation:1",
+      }),
+    ).resolves.toMatchObject({ success: true, sid: "msg-reconciled" });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+    expect(ledger.events.at(-1)).toMatchObject({
+      kind: "reconciliation",
+      actorType: "platform_operator",
+      actorIdentity: "ops@openvpm.com",
+    });
+  });
+
+  it("keeps reconciliation durable and alerts when communication projection misses", async () => {
+    const ledger = state();
+    ledger.communicationProjection.available = false;
+    ledger.attempts.push({
+      ...sendOptions(),
+      id: "00000000-0000-0000-0000-000000000011",
+      createdAt: new Date(Date.now() - 20 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      idempotencyKey: "sms:ambiguous:projection-miss",
+      resendOfAttemptId: null,
+    });
+    ledger.events.push({
+      id: "10000000-0000-0000-0000-000000000011",
+      createdAt: new Date(Date.now() - 19 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      attemptId: ledger.attempts[0]!.id,
+      kind: "provider_result",
+      outcome: "outcome_unknown",
+      providerMessageId: null,
+      detail: "timeout",
+      eventKey: "provider-result:projection-miss",
+    });
+
+    await expect(
+      reconcileSmsSendAttempt({
+        practiceId: PRACTICE_ID,
+        attemptId: ledger.attempts[0]!.id,
+        outcome: "definite_failure",
+        detail: "Provider confirmed rejection.",
+        actorType: "platform_operator",
+        actorUserId: ACTOR_ID,
+        actorIdentity: "ops@openvpm.com",
+        actorName: "OpenVPM Ops",
+        reconciliationKey: "operator-reconciliation:projection-miss",
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+    });
+    expect(ledger.events.at(-1)).toMatchObject({ kind: "reconciliation" });
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "SMS reconciliation projection requires review",
+      expect.stringContaining(`communication=${COMMUNICATION_ID}`),
+    );
+  });
+
+  it("projects an accepted explicit resend onto its communication", async () => {
+    const ledger = state();
+    ledger.communicationRows[0]!.status = "failed";
+    ledger.attempts.push({
+      ...sendOptions(),
+      id: "00000000-0000-0000-0000-000000000002",
+      createdAt: new Date(Date.now() - 60 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      idempotencyKey: "sms:failed:1",
+      resendOfAttemptId: null,
+      destinationE164: "+15555550199",
+      registeredDisplayName: "Neighborhood Veterinary",
+      provider: "telnyx",
+      senderE164: "+15555550100",
+      senderMessagingServiceId: null,
+      clientId: CLIENT_ID,
+      locationId: LOCATION_ID,
+      communicationId: COMMUNICATION_ID,
+      body: `Neighborhood Veterinary: Ready. ${SMS_COMPLIANCE_FOOTER}`,
+    });
+    ledger.events.push({
+      id: "10000000-0000-0000-0000-000000000002",
+      createdAt: new Date(Date.now() - 59 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      attemptId: ledger.attempts[0]!.id,
+      kind: "provider_result",
+      outcome: "definite_failure",
+      providerMessageId: null,
+      detail: "rejected",
+      eventKey: "provider-result:2",
+    });
+    mocks.providerSend.mockResolvedValue({
+      status: "accepted",
+      id: "msg-resend",
+    });
+
+    await expect(
+      resendSmsAttempt({
+        practiceId: PRACTICE_ID,
+        attemptId: ledger.attempts[0]!.id,
+        idempotencyKey: "sms:operator-resend:1",
+        actorType: "platform_operator",
+        actorUserId: ACTOR_ID,
+        actorIdentity: "ops@openvpm.com",
+        actorName: "OpenVPM Ops",
+      }),
+    ).resolves.toMatchObject({ success: true, sid: "msg-resend" });
+    expect(ledger.attempts[1]).toMatchObject({
+      resendOfAttemptId: ledger.attempts[0]!.id,
+      requestedByActorType: "platform_operator",
+      requestedByIdentity: "ops@openvpm.com",
+    });
+    expect(ledger.updates).toContainEqual({
+      status: "sent",
+      providerMessageId: "msg-resend",
+    });
+  });
+
+  it("blocks explicit resend after a linked email fallback was delivered", async () => {
+    const ledger = state();
+    ledger.communicationRows[0]!.status = "sent";
+    ledger.attempts.push({
+      ...sendOptions(),
+      id: "00000000-0000-0000-0000-000000000012",
+      createdAt: new Date(Date.now() - 60 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      idempotencyKey: "sms:failed:fallback-delivered",
+      resendOfAttemptId: null,
+      destinationE164: "+15555550199",
+      registeredDisplayName: "Neighborhood Veterinary",
+      provider: "telnyx",
+      senderE164: "+15555550100",
+      senderMessagingServiceId: null,
+      clientId: CLIENT_ID,
+      locationId: LOCATION_ID,
+      communicationId: COMMUNICATION_ID,
+      body: `Neighborhood Veterinary: Ready. ${SMS_COMPLIANCE_FOOTER}`,
+    });
+    ledger.events.push({
+      id: "10000000-0000-0000-0000-000000000012",
+      createdAt: new Date(Date.now() - 59 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      attemptId: ledger.attempts[0]!.id,
+      kind: "provider_result",
+      outcome: "definite_failure",
+      providerMessageId: null,
+      detail: "rejected",
+      eventKey: "provider-result:fallback-delivered",
+    });
+
+    await expect(
+      resendSmsAttempt({
+        practiceId: PRACTICE_ID,
+        attemptId: ledger.attempts[0]!.id,
+        idempotencyKey: "sms:operator-resend:fallback-delivered",
+        actorType: "platform_operator",
+        actorUserId: ACTOR_ID,
+        actorIdentity: "ops@openvpm.com",
+        actorName: "OpenVPM Ops",
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      error: expect.stringContaining("must be definitively failed"),
+    });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+  });
+
+  it("rechecks and locks failed communication state at resend dispatch", async () => {
+    const ledger = state();
+    ledger.communicationRows[0]!.status = "failed";
+    ledger.attempts.push({
+      ...sendOptions(),
+      id: "00000000-0000-0000-0000-000000000013",
+      createdAt: new Date(Date.now() - 60 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      idempotencyKey: "sms:failed:fallback-race",
+      resendOfAttemptId: null,
+      destinationE164: "+15555550199",
+      registeredDisplayName: "Neighborhood Veterinary",
+      provider: "telnyx",
+      senderE164: "+15555550100",
+      senderMessagingServiceId: null,
+      clientId: CLIENT_ID,
+      locationId: LOCATION_ID,
+      communicationId: COMMUNICATION_ID,
+      body: `Neighborhood Veterinary: Ready. ${SMS_COMPLIANCE_FOOTER}`,
+    });
+    ledger.events.push({
+      id: "10000000-0000-0000-0000-000000000013",
+      createdAt: new Date(Date.now() - 59 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      attemptId: ledger.attempts[0]!.id,
+      kind: "provider_result",
+      outcome: "definite_failure",
+      providerMessageId: null,
+      detail: "rejected",
+      eventKey: "provider-result:fallback-race",
+    });
+    mocks.resolveMessagingTransport.mockImplementation(async () => {
+      // Simulate an email fallback becoming terminal after the eligibility
+      // read but before the child attempt reaches its provider boundary.
+      ledger.communicationRows[0]!.status = "sent";
+      return transport({ from: "+15555550100" });
+    });
+
+    await expect(
+      resendSmsAttempt({
+        practiceId: PRACTICE_ID,
+        attemptId: ledger.attempts[0]!.id,
+        idempotencyKey: "sms:operator-resend:fallback-race",
+        actorType: "platform_operator",
+        actorUserId: ACTOR_ID,
+        actorIdentity: "ops@openvpm.com",
+        actorName: "OpenVPM Ops",
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      error: expect.stringContaining("no longer failed"),
+    });
+    expect(mocks.providerSend).not.toHaveBeenCalled();
+  });
+
+  it("allows only one child attempt and provider call for concurrent resend keys", async () => {
+    const ledger = state();
+    ledger.communicationRows[0]!.status = "failed";
+    const originalAttemptId = "00000000-0000-0000-0000-000000000003";
+    ledger.attempts.push({
+      ...sendOptions(),
+      id: originalAttemptId,
+      createdAt: new Date(Date.now() - 60 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      idempotencyKey: "sms:failed:concurrent",
+      resendOfAttemptId: null,
+      destinationE164: "+15555550199",
+      registeredDisplayName: "Neighborhood Veterinary",
+      provider: "telnyx",
+      senderE164: "+15555550100",
+      senderMessagingServiceId: null,
+      clientId: CLIENT_ID,
+      locationId: LOCATION_ID,
+      communicationId: COMMUNICATION_ID,
+      body: `Neighborhood Veterinary: Ready. ${SMS_COMPLIANCE_FOOTER}`,
+    });
+    ledger.events.push({
+      id: "10000000-0000-0000-0000-000000000003",
+      createdAt: new Date(Date.now() - 59 * 60 * 1000),
+      practiceId: PRACTICE_ID,
+      attemptId: originalAttemptId,
+      kind: "provider_result",
+      outcome: "definite_failure",
+      providerMessageId: null,
+      detail: "rejected",
+      eventKey: "provider-result:3",
+    });
+    const provider = deferred<{ status: "accepted"; id: string }>();
+    mocks.providerSend.mockReturnValueOnce(provider.promise);
+    const resendOptions = {
+      practiceId: PRACTICE_ID,
+      attemptId: originalAttemptId,
+      actorType: "platform_operator" as const,
+      actorUserId: ACTOR_ID,
+      actorIdentity: "ops@openvpm.com",
+      actorName: "OpenVPM Ops",
+    };
+
+    const first = resendSmsAttempt({
+      ...resendOptions,
+      idempotencyKey: "sms:operator-resend:concurrent:a",
+    });
+    await vi.waitFor(() => expect(mocks.providerSend).toHaveBeenCalledOnce());
+    const second = await resendSmsAttempt({
+      ...resendOptions,
+      idempotencyKey: "sms:operator-resend:concurrent:b",
+    });
+
+    expect(second).toMatchObject({
+      success: false,
+      outcome: "outcome_unknown",
+      replayed: true,
+    });
+    expect(ledger.attempts.filter((row) => row.resendOfAttemptId)).toHaveLength(
+      1,
+    );
+    expect(mocks.providerSend).toHaveBeenCalledOnce();
+
+    provider.resolve({ status: "accepted", id: "msg-one-child" });
+    await expect(first).resolves.toMatchObject({
+      success: true,
+      sid: "msg-one-child",
+    });
+    expect(mocks.providerSend).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -42,6 +42,8 @@ import {
   rooms,
   services,
   smsConsentEvents,
+  smsSendAttemptEvents,
+  smsSendAttempts,
   smsSuppressions,
   soapNotes,
   staffSchedules,
@@ -102,6 +104,8 @@ export const PRACTICE_EXPORT_SECTIONS = [
   "locationMessaging",
   "smsSuppressions",
   "smsConsentEvents",
+  "smsSendAttempts",
+  "smsSendAttemptEvents",
   "emailSuppressions",
   "webhooks",
   "apiKeys",
@@ -165,6 +169,8 @@ const PRACTICE_EXPORT_OPTIONAL_RESTORE_SECTIONS = [
   "patientMergeEvents",
   // Backward compatibility for backups created before SMS consent evidence.
   "smsConsentEvents",
+  "smsSendAttempts",
+  "smsSendAttemptEvents",
   "visitCloseouts",
   "clinicalRecordCorrections",
 ] as const satisfies readonly PracticeExportSection[];
@@ -257,6 +263,13 @@ const RESTORE_REFERENCE_RULES: RestoreReferenceRule[] = [
   optionalRef("smsConsentEvents", "clientId", "clients"),
   optionalRef("smsConsentEvents", "locationId", "locations"),
   optionalRef("smsConsentEvents", "actorUserId", "users"),
+  optionalRef("smsSendAttempts", "clientId", "clients"),
+  optionalRef("smsSendAttempts", "locationId", "locations"),
+  optionalRef("smsSendAttempts", "communicationId", "communications"),
+  optionalRef("smsSendAttempts", "requestedByUserId", "users"),
+  optionalRef("smsSendAttempts", "resendOfAttemptId", "smsSendAttempts"),
+  requiredRef("smsSendAttemptEvents", "attemptId", "smsSendAttempts"),
+  optionalRef("smsSendAttemptEvents", "actorUserId", "users"),
   optionalRef("users", "locationId", "locations"),
   optionalRef("rooms", "locationId", "locations"),
   requiredRef("patients", "clientId", "clients"),
@@ -1239,6 +1252,8 @@ export async function exportPracticeData(
     locationMessagingRows,
     smsSuppressionRows,
     smsConsentEventRows,
+    smsSendAttemptRows,
+    smsSendAttemptEventRows,
     emailSuppressionRows,
     webhookRows,
     apiKeyRows,
@@ -1279,12 +1294,14 @@ export async function exportPracticeData(
     visitCloseoutRows,
     fileRows,
     controlledSubstanceRows,
-    communicationRows,
+    allCommunicationRows,
   ] = await Promise.all([
     allPracticeRows(db, locations, practiceId),
     activeRows(db, locationMessaging, practiceId),
     activeRows(db, smsSuppressions, practiceId),
     allPracticeRows(db, smsConsentEvents, practiceId),
+    allPracticeRows(db, smsSendAttempts, practiceId),
+    allPracticeRows(db, smsSendAttemptEvents, practiceId),
     activeRows(db, emailSuppressions, practiceId),
     activeRows(db, webhooks, practiceId),
     activeRows(db, apiKeys, practiceId),
@@ -1325,7 +1342,7 @@ export async function exportPracticeData(
     activeRows(db, visitCloseouts, practiceId),
     activeRows(db, files, practiceId),
     activeRows(db, controlledSubstanceLog, practiceId),
-    activeRows(db, communications, practiceId),
+    allPracticeRows(db, communications, practiceId),
   ]);
 
   const referencedPrescriptionIds = new Set(
@@ -1416,6 +1433,8 @@ export async function exportPracticeData(
       ...appointmentRows.map((appointment) => appointment.doctorId),
       ...patientMergeRows.map((event) => event.performedBy),
       ...smsConsentEventRows.map((event) => event.actorUserId),
+      ...smsSendAttemptRows.map((attempt) => attempt.requestedByUserId),
+      ...smsSendAttemptEventRows.map((event) => event.actorUserId),
     ].filter((id): id is string => typeof id === "string"),
   );
   const userRows = allUserRows.filter(
@@ -1427,6 +1446,7 @@ export async function exportPracticeData(
       ...appointmentRows.map((appointment) => appointment.clientId),
       ...patientMergeRows.map((event) => event.clientId),
       ...smsConsentEventRows.map((event) => event.clientId),
+      ...smsSendAttemptRows.map((attempt) => attempt.clientId),
     ].filter((id): id is string => typeof id === "string"),
   );
   const clientRows = allClientRows.filter(
@@ -1437,6 +1457,7 @@ export async function exportPracticeData(
       ...productRows.map((product) => product.locationId),
       ...userRows.map((user) => user.locationId),
       ...smsConsentEventRows.map((event) => event.locationId),
+      ...smsSendAttemptRows.map((attempt) => attempt.locationId),
       ...allRoomRows.map((room) =>
         appointmentRows.some((appointment) => appointment.roomId === room.id)
           ? room.locationId
@@ -1464,6 +1485,16 @@ export async function exportPracticeData(
   );
   const roomRows = allRoomRows.filter(
     (room) => room.deletedAt == null || referencedRoomIds.has(room.id),
+  );
+  const referencedCommunicationIds = new Set(
+    smsSendAttemptRows
+      .map((attempt) => attempt.communicationId)
+      .filter((id): id is string => typeof id === "string"),
+  );
+  const communicationRows = allCommunicationRows.filter(
+    (communication) =>
+      communication.deletedAt == null ||
+      referencedCommunicationIds.has(communication.id),
   );
   const referencedRecurringSeriesIds = new Set(
     appointmentRows
@@ -1570,6 +1601,8 @@ export async function exportPracticeData(
     locationMessaging: locationMessagingRows,
     smsSuppressions: smsSuppressionRows,
     smsConsentEvents: smsConsentEventRows,
+    smsSendAttempts: smsSendAttemptRows,
+    smsSendAttemptEvents: smsSendAttemptEventRows,
     emailSuppressions: emailSuppressionRows,
     webhooks: sanitizePracticeExportRows("webhooks", webhookRows),
     apiKeys: sanitizePracticeExportRows("apiKeys", apiKeyRows),
@@ -1848,6 +1881,8 @@ async function restorePracticeDataRows(
   await restorePracticeRows("files", files);
   await restorePracticeRows("controlledSubstanceLog", controlledSubstanceLog);
   await restorePracticeRows("communications", communications);
+  await restorePracticeRows("smsSendAttempts", smsSendAttempts);
+  await restorePracticeRows("smsSendAttemptEvents", smsSendAttemptEvents);
 
   return {
     restored,

--- a/apps/web/lib/messaging/__tests__/console.test.ts
+++ b/apps/web/lib/messaging/__tests__/console.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { consoleProvider } from "../console";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("console messaging provider", () => {
+  it("returns a unique accepted id for every local send", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const input = {
+      to: "+15555550199",
+      body: "Local test",
+      sender: {},
+    };
+
+    const first = await consoleProvider.send(input);
+    const second = await consoleProvider.send(input);
+
+    expect(first).toMatchObject({ status: "accepted" });
+    expect(second).toMatchObject({ status: "accepted" });
+    expect(first.status === "accepted" && first.id).toMatch(
+      /^dev-console:[0-9a-f-]{36}$/,
+    );
+    expect(second.status === "accepted" && second.id).not.toBe(
+      first.status === "accepted" ? first.id : undefined,
+    );
+  });
+});

--- a/apps/web/lib/messaging/__tests__/durable-sms-communication.test.ts
+++ b/apps/web/lib/messaging/__tests__/durable-sms-communication.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  recoverStaleUnreservedSmsCommunication,
+  STALE_SMS_COMMUNICATION_CLAIM_MS,
+} from "../durable-sms-communication";
+
+const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
+const COMMUNICATION_ID = "00000000-0000-0000-0000-000000000003";
+
+function dbWithSelectResults(results: unknown[][]) {
+  const select = vi.fn(() => {
+    const result = results.shift() ?? [];
+    const builder = {
+      from: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      for: vi.fn(() => builder),
+      limit: vi.fn(async () => result),
+    };
+    return builder;
+  });
+  return { select };
+}
+
+describe("stale durable SMS communication recovery", () => {
+  it("reuses a stale pending communication only when no attempt exists", async () => {
+    const db = dbWithSelectResults([[{ id: COMMUNICATION_ID }], []]);
+
+    await expect(
+      recoverStaleUnreservedSmsCommunication(db as never, {
+        practiceId: PRACTICE_ID,
+        dedupeKey: "reminder:appointment:one",
+        now: new Date("2026-08-09T01:00:00Z"),
+      }),
+    ).resolves.toBe(COMMUNICATION_ID);
+    expect(db.select).toHaveBeenCalledTimes(2);
+  });
+
+  it("never reuses a communication linked to any send attempt", async () => {
+    const db = dbWithSelectResults([
+      [{ id: COMMUNICATION_ID }],
+      [{ id: "00000000-0000-0000-0000-000000000004" }],
+    ]);
+
+    await expect(
+      recoverStaleUnreservedSmsCommunication(db as never, {
+        practiceId: PRACTICE_ID,
+        dedupeKey: "reminder:appointment:two",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("uses a fifteen-minute minimum stale window", () => {
+    expect(STALE_SMS_COMMUNICATION_CLAIM_MS).toBe(15 * 60 * 1000);
+  });
+});

--- a/apps/web/lib/messaging/__tests__/telnyx.test.ts
+++ b/apps/web/lib/messaging/__tests__/telnyx.test.ts
@@ -23,7 +23,7 @@ describe("telnyxProvider", () => {
         sender: { messagingServiceId: "mp-1" },
       })
     ).resolves.toEqual({
-      success: false,
+      status: "definite_failure",
       error: "Telnyx is not configured (TELNYX_API_KEY missing).",
     });
     expect(fetchMock).not.toHaveBeenCalled();
@@ -45,7 +45,7 @@ describe("telnyxProvider", () => {
         body: "Reminder",
         sender: { messagingServiceId: " mp-1 " },
       })
-    ).resolves.toEqual({ success: true, id: "msg-1" });
+    ).resolves.toEqual({ status: "accepted", id: "msg-1" });
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.telnyx.com/v2/messages",
@@ -88,8 +88,64 @@ describe("telnyxProvider", () => {
     await vi.advanceTimersByTimeAsync(TELNYX_API_TIMEOUT_MS);
 
     await expect(result).resolves.toEqual({
-      success: false,
+      status: "outcome_unknown",
       error: "aborted",
     });
+  });
+
+  it.each([408, 429, 500, 503])(
+    "treats HTTP %s as outcome unknown",
+    async (status) => {
+      vi.stubEnv("TELNYX_API_KEY", "KEY123");
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response("transient", { status })),
+      );
+
+      await expect(
+        telnyxProvider.send({
+          to: "+15555550199",
+          body: "Reminder",
+          sender: { from: "+15555550100" },
+        }),
+      ).resolves.toMatchObject({ status: "outcome_unknown" });
+    },
+  );
+
+  it("treats a non-transient 4xx rejection as definite failure", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("invalid destination", { status: 400 })),
+    );
+
+    await expect(
+      telnyxProvider.send({
+        to: "+15555550199",
+        body: "Reminder",
+        sender: { from: "+15555550100" },
+      }),
+    ).resolves.toMatchObject({ status: "definite_failure" });
+  });
+
+  it("treats 2xx without a provider id as outcome unknown", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ data: {} }), {
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+
+    await expect(
+      telnyxProvider.send({
+        to: "+15555550199",
+        body: "Reminder",
+        sender: { from: "+15555550100" },
+      }),
+    ).resolves.toMatchObject({ status: "outcome_unknown" });
   });
 });

--- a/apps/web/lib/messaging/__tests__/twilio.test.ts
+++ b/apps/web/lib/messaging/__tests__/twilio.test.ts
@@ -1,8 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ create: vi.fn() }));
+
+vi.mock("twilio", () => ({
+  default: () => ({ messages: { create: mocks.create } }),
+}));
+
 import { twilioProvider } from "../twilio";
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  mocks.create.mockReset();
 });
 
 describe("twilioProvider", () => {
@@ -16,10 +24,51 @@ describe("twilioProvider", () => {
         to: "+15555550199",
         body: "Reminder",
         sender: { messagingServiceId: "MG123" },
-      })
+      }),
     ).resolves.toEqual({
-      success: false,
+      status: "definite_failure",
       error: "Twilio is not configured.",
     });
   });
+
+  it("classifies known non-transient 4xx rejections as definite failures", async () => {
+    vi.stubEnv("TWILIO_ACCOUNT_SID", "AC123");
+    vi.stubEnv("TWILIO_AUTH_TOKEN", "token");
+    mocks.create.mockRejectedValue(
+      Object.assign(new Error("invalid destination"), { status: 400 }),
+    );
+
+    await expect(
+      twilioProvider.send({
+        to: "+15555550199",
+        body: "Reminder",
+        sender: { messagingServiceId: "MG123" },
+      }),
+    ).resolves.toEqual({
+      status: "definite_failure",
+      error: "invalid destination",
+    });
+  });
+
+  it.each([408, 429, 500])(
+    "keeps Twilio HTTP %s failures outcome-unknown",
+    async (status) => {
+      vi.stubEnv("TWILIO_ACCOUNT_SID", "AC123");
+      vi.stubEnv("TWILIO_AUTH_TOKEN", "token");
+      mocks.create.mockRejectedValue(
+        Object.assign(new Error("uncertain request"), { status }),
+      );
+
+      await expect(
+        twilioProvider.send({
+          to: "+15555550199",
+          body: "Reminder",
+          sender: { messagingServiceId: "MG123" },
+        }),
+      ).resolves.toEqual({
+        status: "outcome_unknown",
+        error: "uncertain request",
+      });
+    },
+  );
 });

--- a/apps/web/lib/messaging/appointment-reminder.ts
+++ b/apps/web/lib/messaging/appointment-reminder.ts
@@ -1,0 +1,61 @@
+import type { Database } from "@openpims/db/client";
+import { communications } from "@openpims/db";
+import { recoverStaleUnreservedSmsCommunication } from "@/lib/messaging/durable-sms-communication";
+
+export function appointmentReminderDedupeKey(appointment: {
+  id: string;
+  startTime: Date | string;
+}): string {
+  return `reminder:appointment:${appointment.id}:${new Date(
+    appointment.startTime,
+  ).toISOString()}`;
+}
+
+export function appointmentReminderSmsIdempotencyKey(appointment: {
+  id: string;
+  startTime: Date | string;
+}): string {
+  return `sms:${appointmentReminderDedupeKey(appointment)}`;
+}
+
+/**
+ * Shared cross-path claim. Pending and failed rows are intentionally not
+ * reclaimed automatically: either can represent a provider-ambiguous SMS.
+ */
+export async function claimAppointmentReminderCommunication(
+  db: Pick<Database, "insert" | "select">,
+  options: {
+    practiceId: string;
+    appointmentId: string;
+    clientId: string;
+    channel: "sms" | "email";
+    patientName: string | null;
+    startTime: Date;
+  },
+): Promise<string | null> {
+  const dedupeKey = appointmentReminderDedupeKey({
+    id: options.appointmentId,
+    startTime: options.startTime,
+  });
+  const [row] = await db
+    .insert(communications)
+    .values({
+      practiceId: options.practiceId,
+      clientId: options.clientId,
+      channel: options.channel,
+      direction: "outbound",
+      subject: "Appointment Reminder",
+      content: `Appointment reminder pending for ${options.patientName ?? "Unknown"} on ${options.startTime.toISOString()}`,
+      status: "pending",
+      dedupeKey,
+    })
+    .onConflictDoNothing({ target: communications.dedupeKey })
+    .returning({ id: communications.id });
+  if (row) return row.id;
+  if (options.channel !== "sms") return null;
+
+  return recoverStaleUnreservedSmsCommunication(db, {
+    practiceId: options.practiceId,
+    dedupeKey,
+  });
+}

--- a/apps/web/lib/messaging/console.ts
+++ b/apps/web/lib/messaging/console.ts
@@ -1,4 +1,9 @@
-import type { MessagingProvider, SendMessageInput, SendMessageResult } from "./types";
+import type {
+  MessagingProvider,
+  SendMessageInput,
+  SendMessageResult,
+} from "./types";
+import { randomUUID } from "node:crypto";
 
 /**
  * Dev/CI fallback: logs the message instead of sending when no real provider is
@@ -11,13 +16,22 @@ export const consoleProvider: MessagingProvider = {
     return true;
   },
 
-  async send({ to, body, sender }: SendMessageInput): Promise<SendMessageResult> {
+  async send({
+    to,
+    body,
+    sender,
+  }: SendMessageInput): Promise<SendMessageResult> {
     console.log("──────────────────────────────────────────");
     console.log("[SMS] No messaging provider configured – logging to console");
-    console.log(`  From: ${sender.messagingServiceId ?? sender.from ?? "(unset)"}`);
+    console.log(
+      `  From: ${sender.messagingServiceId ?? sender.from ?? "(unset)"}`,
+    );
     console.log(`  To:   ${to}`);
     console.log(`  Body: ${body}`);
     console.log("──────────────────────────────────────────");
-    return { success: true, id: "dev-console" };
+    // The immutable send ledger enforces provider-message uniqueness within a
+    // practice, so local sends need the same one-message/one-id property as a
+    // real carrier response.
+    return { status: "accepted", id: `dev-console:${randomUUID()}` };
   },
 };

--- a/apps/web/lib/messaging/durable-sms-communication.ts
+++ b/apps/web/lib/messaging/durable-sms-communication.ts
@@ -1,0 +1,72 @@
+import { db } from "@openpims/db/client";
+import type { Database } from "@openpims/db/client";
+import { and, eq, isNull, lte } from "drizzle-orm";
+import { communications, smsSendAttempts } from "@openpims/db";
+import { withTenant } from "@/lib/tenant-db";
+
+export const STALE_SMS_COMMUNICATION_CLAIM_MS = 15 * 60 * 1000;
+
+/**
+ * SMS communication claims and projections must commit outside a tRPC caller's
+ * surrounding transaction. The immutable attempt ledger foreign-keys the
+ * communication snapshot and reserves in its own transaction before provider
+ * dispatch, so the parent row must already be visible and durable.
+ */
+export function withDurableSmsCommunication<T>(
+  practiceId: string,
+  fn: (tx: Database) => Promise<T>,
+): Promise<T> {
+  return withTenant(db, practiceId, fn);
+}
+
+/**
+ * Recover only the narrow crash seam where a pending SMS communication claim
+ * committed but the process died before reserving an immutable send attempt.
+ *
+ * The parent row is locked before checking for an attempt. A concurrent
+ * attempt reservation must acquire an FK key lock, so it cannot race this
+ * decision. Any attempt at all means the provider may have been called and
+ * permanently blocks automatic recovery here.
+ */
+export async function recoverStaleUnreservedSmsCommunication(
+  tx: Pick<Database, "select">,
+  options: {
+    practiceId: string;
+    dedupeKey: string;
+    now?: Date;
+  },
+): Promise<string | null> {
+  const cutoff = new Date(
+    (options.now ?? new Date()).getTime() - STALE_SMS_COMMUNICATION_CLAIM_MS,
+  );
+  const [communication] = await tx
+    .select({ id: communications.id })
+    .from(communications)
+    .where(
+      and(
+        eq(communications.practiceId, options.practiceId),
+        eq(communications.dedupeKey, options.dedupeKey),
+        eq(communications.channel, "sms"),
+        eq(communications.direction, "outbound"),
+        eq(communications.status, "pending"),
+        lte(communications.createdAt, cutoff),
+        isNull(communications.deletedAt),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  if (!communication) return null;
+
+  const [attempt] = await tx
+    .select({ id: smsSendAttempts.id })
+    .from(smsSendAttempts)
+    .where(
+      and(
+        eq(smsSendAttempts.practiceId, options.practiceId),
+        eq(smsSendAttempts.communicationId, communication.id),
+      ),
+    )
+    .limit(1);
+
+  return attempt ? null : communication.id;
+}

--- a/apps/web/lib/messaging/telnyx.ts
+++ b/apps/web/lib/messaging/telnyx.ts
@@ -30,7 +30,10 @@ export const telnyxProvider: MessagingProvider = {
   async send({ to, body, sender }: SendMessageInput): Promise<SendMessageResult> {
     const key = apiKey();
     if (!key) {
-      return { success: false, error: "Telnyx is not configured (TELNYX_API_KEY missing)." };
+      return {
+        status: "definite_failure",
+        error: "Telnyx is not configured (TELNYX_API_KEY missing).",
+      };
     }
 
     const configuredSender = cleanSender(sender);
@@ -41,7 +44,7 @@ export const telnyxProvider: MessagingProvider = {
       payload.from = configuredSender.from;
     } else {
       return {
-        success: false,
+        status: "definite_failure",
         error: "No Telnyx sender (messaging profile or from-number) configured.",
       };
     }
@@ -57,16 +60,27 @@ export const telnyxProvider: MessagingProvider = {
       });
       if (!res.ok) {
         const detail = await res.text().catch(() => "");
+        const status =
+          res.status === 408 || res.status === 429 || res.status >= 500
+            ? "outcome_unknown"
+            : "definite_failure";
         return {
-          success: false,
+          status,
           error: `Telnyx send failed (${res.status}): ${detail.slice(0, 300)}`,
         };
       }
       const json = (await res.json()) as { data?: { id?: string } };
-      return { success: true, id: json.data?.id };
+      const id = json.data?.id?.trim();
+      return id
+        ? { status: "accepted", id }
+        : {
+            status: "outcome_unknown",
+            error:
+              "Telnyx accepted the request but returned no provider message id.",
+          };
     } catch (err) {
       return {
-        success: false,
+        status: "outcome_unknown",
         error: err instanceof Error ? err.message : "Unknown Telnyx error",
       };
     }

--- a/apps/web/lib/messaging/twilio.ts
+++ b/apps/web/lib/messaging/twilio.ts
@@ -10,6 +10,24 @@ import { cleanSender, envValue } from "./env";
 // dev / CI), mirroring the prior lib/sms.ts behaviour.
 let twilioClient: Twilio.Twilio | null = null;
 
+function twilioFailure(err: unknown): SendMessageResult {
+  const status =
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    typeof err.status === "number"
+      ? err.status
+      : undefined;
+  const error = err instanceof Error ? err.message : "Unknown Twilio error";
+  return status !== undefined &&
+    status >= 400 &&
+    status < 500 &&
+    status !== 408 &&
+    status !== 429
+    ? { status: "definite_failure", error }
+    : { status: "outcome_unknown", error };
+}
+
 function getClient(): Twilio.Twilio | null {
   if (twilioClient) return twilioClient;
   const sid = envValue("TWILIO_ACCOUNT_SID");
@@ -27,19 +45,26 @@ export const twilioProvider: MessagingProvider = {
   name: "twilio",
 
   isConfigured(): boolean {
-    return Boolean(envValue("TWILIO_ACCOUNT_SID") && envValue("TWILIO_AUTH_TOKEN"));
+    return Boolean(
+      envValue("TWILIO_ACCOUNT_SID") && envValue("TWILIO_AUTH_TOKEN"),
+    );
   },
 
-  async send({ to, body, sender }: SendMessageInput): Promise<SendMessageResult> {
+  async send({
+    to,
+    body,
+    sender,
+  }: SendMessageInput): Promise<SendMessageResult> {
     const client = getClient();
     if (!client) {
-      return { success: false, error: "Twilio is not configured." };
+      return { status: "definite_failure", error: "Twilio is not configured." };
     }
     const configuredSender = cleanSender(sender);
     if (!configuredSender.messagingServiceId && !configuredSender.from) {
       return {
-        success: false,
-        error: "No Twilio sender (Messaging Service SID or from-number) configured.",
+        status: "definite_failure",
+        error:
+          "No Twilio sender (Messaging Service SID or from-number) configured.",
       };
     }
     try {
@@ -50,12 +75,16 @@ export const twilioProvider: MessagingProvider = {
           ? { messagingServiceSid: configuredSender.messagingServiceId }
           : { from: configuredSender.from }),
       });
-      return { success: true, id: message.sid };
+      const id = message.sid?.trim();
+      return id
+        ? { status: "accepted", id }
+        : {
+            status: "outcome_unknown",
+            error:
+              "Twilio accepted the request but returned no provider message id.",
+          };
     } catch (err) {
-      return {
-        success: false,
-        error: err instanceof Error ? err.message : "Unknown Twilio error",
-      };
+      return twilioFailure(err);
     }
   },
 };

--- a/apps/web/lib/messaging/types.ts
+++ b/apps/web/lib/messaging/types.ts
@@ -29,12 +29,14 @@ export interface SendMessageInput {
   sender: MessagingSender;
 }
 
-export interface SendMessageResult {
-  success: boolean;
-  /** Provider message id (Telnyx message id / Twilio SID) on success. */
-  id?: string;
-  error?: string;
-}
+export type SendMessageResult =
+  | {
+      status: "accepted";
+      /** A provider acceptance without a durable, nonblank id is ambiguous. */
+      id: string;
+    }
+  | { status: "definite_failure"; error: string }
+  | { status: "outcome_unknown"; error: string };
 
 export interface MessagingProvider {
   readonly name: MessagingProviderName;

--- a/apps/web/lib/sms-dispatch.ts
+++ b/apps/web/lib/sms-dispatch.ts
@@ -1,0 +1,1444 @@
+import { createHash } from "node:crypto";
+import { and, desc, eq, gte, isNull, ne, sql } from "drizzle-orm";
+import { db } from "@openpims/db/client";
+import type { Database } from "@openpims/db/client";
+import {
+  clients,
+  communications,
+  locationMessaging,
+  messagingRegistrations,
+  practices,
+  smsSendAttemptEvents,
+  smsSendAttempts,
+  smsSuppressions,
+  users,
+} from "@openpims/db";
+import { recordUsage } from "@/lib/billing/usage";
+import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
+import { envFlagEnabled } from "@/lib/env-bool";
+import {
+  acquireSmsRecipientLockInTransaction,
+  getMessagingProvider,
+  normalizeE164,
+  resolveMessagingTransport,
+} from "@/lib/messaging";
+import type {
+  MessagingProvider,
+  MessagingSender,
+  SendMessageResult,
+} from "@/lib/messaging/types";
+import {
+  hostedMessagingLaunchBlockMessage,
+  hostedMessagingLaunchDecision,
+} from "@/lib/messaging/launch-gate";
+import { withSystem } from "@/lib/tenant-db";
+import { envValue } from "@/lib/messaging/env";
+import { alertOps } from "@/lib/alerts";
+
+export const SMS_COMPLIANCE_FOOTER = "Reply STOP to opt out or HELP for help.";
+export const SMS_MAX_BODY_LENGTH = 1600;
+export const SMS_AMBIGUITY_LOOKBACK_MS = 30 * 24 * 60 * 60 * 1000;
+export const SMS_RECONCILIATION_STALE_MS = 15 * 60 * 1000;
+
+const EMBEDDED_COMPLIANCE_COPY =
+  /\breply\s+(?:stop|help)\b|\bstop\s+to\s+opt\s*out\b|\bhelp\s+for\s+help\b/i;
+
+export type SmsDispatchOutcome =
+  | "accepted"
+  | "definite_failure"
+  | "outcome_unknown";
+
+export type SmsDispatchResult =
+  | {
+      success: true;
+      outcome: "accepted";
+      sid: string;
+      attemptId: string;
+      replayed: boolean;
+      error?: undefined;
+    }
+  | {
+      success: false;
+      outcome: "definite_failure" | "outcome_unknown";
+      sid?: undefined;
+      attemptId?: string;
+      replayed: boolean;
+      error: string;
+    };
+
+export type SmsSendOptions = {
+  to: string;
+  /** Message content only. Clinic identity and compliance footer are canonical. */
+  body: string;
+  practiceId: string;
+  locationId?: string;
+  clientId?: string;
+  communicationId?: string;
+  source?: string;
+  sourceId?: string;
+  idempotencyKey?: string;
+};
+
+type AttemptRow = typeof smsSendAttempts.$inferSelect;
+type AttemptEventRow = typeof smsSendAttemptEvents.$inferSelect;
+
+type PreparedDispatch = {
+  to: string;
+  body: string;
+  registeredDisplayName: string;
+  practiceId: string;
+  locationId?: string;
+  clientId?: string;
+  communicationId?: string;
+  source: string;
+  sourceId: string;
+  idempotencyKey: string;
+  resendOfAttemptId?: string;
+  expectedProvider: MessagingProvider["name"];
+  requestedBy?: {
+    actorType: "clinic_user" | "platform_operator";
+    actorUserId?: string;
+    identity: string;
+    name: string;
+  };
+};
+
+function boundedDetail(detail: string): string {
+  return detail.slice(0, 2000);
+}
+
+function failure(
+  error: string,
+  opts: {
+    outcome?: "definite_failure" | "outcome_unknown";
+    attemptId?: string;
+    replayed?: boolean;
+  } = {},
+): SmsDispatchResult {
+  return {
+    success: false,
+    outcome: opts.outcome ?? "definite_failure",
+    attemptId: opts.attemptId,
+    replayed: opts.replayed ?? false,
+    error,
+  };
+}
+
+function accepted(
+  attemptId: string,
+  sid: string,
+  replayed: boolean,
+): SmsDispatchResult {
+  return {
+    success: true,
+    outcome: "accepted",
+    sid,
+    attemptId,
+    replayed,
+  };
+}
+
+export function prepareCampaignSmsBody(input: {
+  registeredDisplayName: string;
+  content: string;
+}): { success: true; body: string } | { success: false; error: string } {
+  const displayName = input.registeredDisplayName.trim();
+  let content = input.content.trim();
+  if (!displayName) {
+    return {
+      success: false,
+      error: "Registered clinic display name is blank.",
+    };
+  }
+  if (!content) {
+    return { success: false, error: "SMS message content cannot be blank." };
+  }
+  if (EMBEDDED_COMPLIANCE_COPY.test(content)) {
+    return {
+      success: false,
+      error:
+        "Do not add STOP or HELP instructions; OpenVPM adds the registered compliance footer automatically.",
+    };
+  }
+  const repeatedPrefix = `${displayName}:`;
+  if (
+    content.toLocaleLowerCase().startsWith(repeatedPrefix.toLocaleLowerCase())
+  ) {
+    content = content.slice(repeatedPrefix.length).trim();
+  }
+  const body = `${displayName}: ${content} ${SMS_COMPLIANCE_FOOTER}`;
+  if (body.length > SMS_MAX_BODY_LENGTH) {
+    return {
+      success: false,
+      error: `Final SMS body exceeds ${SMS_MAX_BODY_LENGTH} characters after clinic identity and compliance copy are added.`,
+    };
+  }
+  return { success: true, body };
+}
+
+function bodyHash(body: string): string {
+  return createHash("sha256").update(body, "utf8").digest("hex");
+}
+
+function stableDirectKey(opts: {
+  practiceId: string;
+  locationId?: string;
+  clientId?: string;
+  communicationId?: string;
+  to: string;
+  body: string;
+}): string {
+  const digest = bodyHash(
+    [
+      opts.practiceId,
+      opts.locationId ?? "",
+      opts.clientId ?? "",
+      opts.communicationId ?? "",
+      opts.to,
+      opts.body,
+    ].join("\n"),
+  );
+  return `direct:${digest}`;
+}
+
+function validBoundedIdentity(value: string, max: number): boolean {
+  const length = value.trim().length;
+  return length > 0 && length <= max;
+}
+
+async function registeredDisplayName(
+  practiceId: string,
+  provider: MessagingProvider["name"],
+): Promise<string | undefined> {
+  const [registration] = await withSystem(db, (tx) =>
+    tx
+      .select({ displayName: messagingRegistrations.displayName })
+      .from(messagingRegistrations)
+      .where(
+        and(
+          eq(messagingRegistrations.practiceId, practiceId),
+          eq(messagingRegistrations.provider, provider),
+          eq(messagingRegistrations.status, "active"),
+          isNull(messagingRegistrations.deletedAt),
+        ),
+      )
+      .limit(1),
+  );
+  return registration?.displayName?.trim() || undefined;
+}
+
+async function campaignDisplayName(options: {
+  practiceId: string;
+  provider: MessagingProvider["name"];
+  hostedExternalSend: boolean;
+}): Promise<string | undefined> {
+  const registered = await registeredDisplayName(
+    options.practiceId,
+    options.provider,
+  );
+  if (registered) return registered;
+  if (options.hostedExternalSend) return undefined;
+
+  // A self-hosted real provider may be configured outside OpenVPM. Require the
+  // operator to snapshot the exact carrier-registered identity explicitly.
+  if (options.provider !== "console") {
+    const configured = envValue("MESSAGING_REGISTERED_DISPLAY_NAME")?.trim();
+    return configured && configured.length <= 100 ? configured : undefined;
+  }
+
+  // Console transport cannot reach a carrier. Practice name is safe for local
+  // testing and is still snapshotted in the durable attempt.
+  const [practice] = await withSystem(db, (tx) =>
+    tx
+      .select({ name: practices.name })
+      .from(practices)
+      .where(
+        and(eq(practices.id, options.practiceId), isNull(practices.deletedAt)),
+      )
+      .limit(1),
+  );
+  const name = practice?.name.trim();
+  return name && name.length <= 100 ? name : undefined;
+}
+
+function normalizeProviderResult(result: SendMessageResult): SendMessageResult {
+  if (result.status !== "accepted") return result;
+  const id = result.id.trim();
+  return id
+    ? { status: "accepted", id }
+    : {
+        status: "outcome_unknown",
+        error: "Provider returned acceptance without a message id.",
+      };
+}
+
+function eventToDispatchResult(
+  attemptId: string,
+  event: Pick<AttemptEventRow, "outcome" | "providerMessageId" | "detail">,
+  replayed: boolean,
+): SmsDispatchResult {
+  if (event.outcome === "accepted" && event.providerMessageId?.trim()) {
+    return accepted(attemptId, event.providerMessageId.trim(), replayed);
+  }
+  return failure(
+    event.detail?.trim() ||
+      (event.outcome === "outcome_unknown"
+        ? "Provider outcome is unknown. Do not resend until an operator reconciles this attempt."
+        : "SMS delivery was rejected before provider acceptance."),
+    {
+      outcome: event.outcome === "accepted" ? "outcome_unknown" : event.outcome,
+      attemptId,
+      replayed,
+    },
+  );
+}
+
+function effectiveEvent(
+  events: Array<
+    Pick<AttemptEventRow, "kind" | "outcome" | "providerMessageId" | "detail">
+  >,
+) {
+  return (
+    events.find((event) => event.kind === "reconciliation") ??
+    events.find((event) => event.kind === "provider_result")
+  );
+}
+
+export type SmsOpsQueueClassification =
+  | "missing_provider_result"
+  | "outcome_unknown";
+
+/**
+ * Pure mirror of the operator-queue classification. Events must be newest
+ * first, matching the durable ledger query order.
+ */
+export function classifySmsAttemptForOps(input: {
+  createdAt: Date;
+  events: Array<
+    Pick<AttemptEventRow, "kind" | "outcome" | "providerMessageId" | "detail">
+  >;
+  now?: Date;
+}): SmsOpsQueueClassification | null {
+  const now = input.now ?? new Date();
+  if (input.createdAt.getTime() > now.getTime() - SMS_RECONCILIATION_STALE_MS) {
+    return null;
+  }
+  const event = effectiveEvent(input.events);
+  if (!event) return "missing_provider_result";
+  return event.outcome === "outcome_unknown" ? "outcome_unknown" : null;
+}
+
+async function attemptEvents(
+  tx: Database,
+  practiceId: string,
+  attemptId: string,
+) {
+  return tx
+    .select({
+      kind: smsSendAttemptEvents.kind,
+      outcome: smsSendAttemptEvents.outcome,
+      providerMessageId: smsSendAttemptEvents.providerMessageId,
+      detail: smsSendAttemptEvents.detail,
+    })
+    .from(smsSendAttemptEvents)
+    .where(
+      and(
+        eq(smsSendAttemptEvents.practiceId, practiceId),
+        eq(smsSendAttemptEvents.attemptId, attemptId),
+      ),
+    )
+    .orderBy(
+      desc(smsSendAttemptEvents.createdAt),
+      desc(smsSendAttemptEvents.id),
+    );
+}
+
+function sameAttempt(
+  existing: AttemptRow,
+  prepared: PreparedDispatch,
+  providerName: MessagingProvider["name"],
+  sender: MessagingSender,
+): boolean {
+  return (
+    existing.destinationE164 === prepared.to &&
+    existing.body === prepared.body &&
+    existing.bodySha256 === bodyHash(prepared.body) &&
+    existing.registeredDisplayName === prepared.registeredDisplayName &&
+    existing.provider === providerName &&
+    existing.locationId === (prepared.locationId ?? null) &&
+    existing.clientId === (prepared.clientId ?? null) &&
+    existing.communicationId === (prepared.communicationId ?? null) &&
+    existing.source === prepared.source &&
+    existing.sourceId === prepared.sourceId &&
+    existing.resendOfAttemptId === (prepared.resendOfAttemptId ?? null) &&
+    existing.senderMessagingServiceId ===
+      (sender.messagingServiceId?.trim() || null) &&
+    existing.senderE164 === (normalizeE164(sender.from) ?? null) &&
+    existing.requestedByActorType ===
+      (prepared.requestedBy?.actorType ?? null) &&
+    existing.requestedByUserId ===
+      (prepared.requestedBy?.actorUserId ?? null) &&
+    existing.requestedByIdentity ===
+      (prepared.requestedBy?.identity.trim() ?? null) &&
+    existing.requestedByName === (prepared.requestedBy?.name.trim() ?? null)
+  );
+}
+
+async function reserveAttempt(
+  prepared: PreparedDispatch,
+  provider: MessagingProvider,
+  sender: MessagingSender,
+): Promise<
+  | { winner: true; attempt: AttemptRow }
+  | { winner: false; result: SmsDispatchResult }
+> {
+  return withSystem(db, async (tx) => {
+    const [inserted] = await tx
+      .insert(smsSendAttempts)
+      .values({
+        practiceId: prepared.practiceId,
+        clientId: prepared.clientId,
+        locationId: prepared.locationId,
+        communicationId: prepared.communicationId,
+        requestedByActorType: prepared.requestedBy?.actorType,
+        requestedByUserId: prepared.requestedBy?.actorUserId,
+        requestedByIdentity: prepared.requestedBy?.identity.trim(),
+        requestedByName: prepared.requestedBy?.name.trim(),
+        resendOfAttemptId: prepared.resendOfAttemptId,
+        source: prepared.source,
+        sourceId: prepared.sourceId,
+        idempotencyKey: prepared.idempotencyKey,
+        destinationE164: prepared.to,
+        registeredDisplayName: prepared.registeredDisplayName,
+        body: prepared.body,
+        bodySha256: bodyHash(prepared.body),
+        provider: provider.name,
+        senderMessagingServiceId: sender.messagingServiceId?.trim() || null,
+        senderE164: normalizeE164(sender.from) ?? null,
+      })
+      .onConflictDoNothing()
+      .returning();
+    if (inserted) return { winner: true as const, attempt: inserted };
+
+    const [existing] = await tx
+      .select()
+      .from(smsSendAttempts)
+      .where(
+        and(
+          eq(smsSendAttempts.practiceId, prepared.practiceId),
+          eq(smsSendAttempts.idempotencyKey, prepared.idempotencyKey),
+        ),
+      )
+      .limit(1);
+    if (!existing && prepared.resendOfAttemptId) {
+      const [existingResend] = await tx
+        .select()
+        .from(smsSendAttempts)
+        .where(
+          and(
+            eq(smsSendAttempts.practiceId, prepared.practiceId),
+            eq(smsSendAttempts.resendOfAttemptId, prepared.resendOfAttemptId),
+          ),
+        )
+        .limit(1);
+      if (existingResend) {
+        const event = effectiveEvent(
+          await attemptEvents(
+            tx as unknown as Database,
+            prepared.practiceId,
+            existingResend.id,
+          ),
+        );
+        return {
+          winner: false as const,
+          result: event
+            ? eventToDispatchResult(existingResend.id, event, true)
+            : failure(
+                "An explicit resend is already in progress and has no confirmed outcome.",
+                {
+                  outcome: "outcome_unknown",
+                  attemptId: existingResend.id,
+                  replayed: true,
+                },
+              ),
+        };
+      }
+    }
+    if (!existing || !sameAttempt(existing, prepared, provider.name, sender)) {
+      return {
+        winner: false as const,
+        result: failure(
+          "SMS idempotency key was already used for different dispatch data; send blocked.",
+          { attemptId: existing?.id, replayed: true },
+        ),
+      };
+    }
+    const event = effectiveEvent(
+      await attemptEvents(
+        tx as unknown as Database,
+        prepared.practiceId,
+        existing.id,
+      ),
+    );
+    return {
+      winner: false as const,
+      result: event
+        ? eventToDispatchResult(existing.id, event, true)
+        : failure(
+            "A prior dispatch reserved this SMS but has no confirmed provider outcome. Do not resend until an operator reconciles it.",
+            {
+              outcome: "outcome_unknown",
+              attemptId: existing.id,
+              replayed: true,
+            },
+          ),
+    };
+  });
+}
+
+async function appendProviderResult(
+  tx: Database,
+  attempt: AttemptRow,
+  result: SendMessageResult,
+): Promise<void> {
+  const normalized = normalizeProviderResult(result);
+  await tx.insert(smsSendAttemptEvents).values({
+    practiceId: attempt.practiceId,
+    attemptId: attempt.id,
+    kind: "provider_result",
+    outcome: normalized.status,
+    providerMessageId:
+      normalized.status === "accepted" ? normalized.id : undefined,
+    detail:
+      normalized.status === "accepted"
+        ? undefined
+        : boundedDetail(normalized.error),
+    eventKey: `provider-result:${attempt.id}`,
+  });
+
+  // The accepted event and its user-visible communication projection are one
+  // durability unit. A crash must never leave an accepted provider result
+  // hidden behind a permanently pending dedupe claim.
+  if (normalized.status === "accepted" && attempt.communicationId) {
+    const [projected] = await tx
+      .update(communications)
+      .set({ status: "sent", providerMessageId: normalized.id })
+      .where(
+        and(
+          eq(communications.practiceId, attempt.practiceId),
+          eq(communications.id, attempt.communicationId),
+          sql`${communications.status} in ('pending', 'failed')`,
+          isNull(communications.deletedAt),
+        ),
+      )
+      .returning({ id: communications.id });
+    if (!projected) {
+      throw new Error(
+        "Accepted SMS could not be projected to its linked communication",
+      );
+    }
+  }
+}
+
+async function providerCall(
+  provider: MessagingProvider,
+  input: { to: string; body: string; sender: MessagingSender },
+): Promise<SendMessageResult> {
+  try {
+    return normalizeProviderResult(await provider.send(input));
+  } catch (error) {
+    return {
+      status: "outcome_unknown",
+      error:
+        error instanceof Error && error.message
+          ? error.message
+          : "Provider request ended without a known outcome.",
+    };
+  }
+}
+
+async function alertUnknownSmsAttempt(
+  attempt: Pick<AttemptRow, "practiceId" | "id" | "communicationId" | "source">,
+): Promise<void> {
+  try {
+    await alertOps(
+      "SMS provider outcome requires reconciliation",
+      [
+        `practice=${attempt.practiceId}`,
+        `attempt=${attempt.id}`,
+        `communication=${attempt.communicationId ?? "none"}`,
+        `source=${attempt.source}`,
+      ].join(" "),
+    );
+  } catch (error) {
+    // Alerting is secondary to the durable unknown result. Never create a
+    // retry signal after a potentially accepted provider request.
+    console.error("[messaging] SMS unknown-outcome alert failed", error);
+  }
+}
+
+async function dispatchWinner(
+  attempt: AttemptRow,
+  provider: MessagingProvider,
+  sender: MessagingSender,
+  hostedExternalSend: boolean,
+): Promise<SmsDispatchResult> {
+  let result: SendMessageResult;
+  try {
+    result = await withSystem(db, async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${`sms-attempt:${attempt.practiceId}:${attempt.id}`}, 0))`,
+      );
+      if (hostedExternalSend) {
+        const [practice] = await tx
+          .select({
+            tier: practices.subscriptionTier,
+            billingStatus: practices.billingStatus,
+            trialEndsAt: practices.trialEndsAt,
+          })
+          .from(practices)
+          .where(
+            and(
+              eq(practices.id, attempt.practiceId),
+              isNull(practices.deletedAt),
+            ),
+          )
+          .limit(1);
+        if (!practice) {
+          const rejected: SendMessageResult = {
+            status: "definite_failure",
+            error: "Practice not found",
+          };
+          await appendProviderResult(
+            tx as unknown as Database,
+            attempt,
+            rejected,
+          );
+          return rejected;
+        }
+        if (
+          !hasHostedFullAccess(
+            practice.tier,
+            practice.billingStatus,
+            practice.trialEndsAt,
+          )
+        ) {
+          const rejected: SendMessageResult = {
+            status: "definite_failure",
+            error:
+              "OpenVPM Cloud is read-only until your trial or subscription is active.",
+          };
+          await appendProviderResult(
+            tx as unknown as Database,
+            attempt,
+            rejected,
+          );
+          return rejected;
+        }
+      }
+
+      let activeLocationCampaignId: string | null = null;
+      let activeLocationBrandId: string | null = null;
+      if (attempt.locationId) {
+        const [activeSender] = await tx
+          .select({
+            provider: locationMessaging.provider,
+            messagingServiceId: locationMessaging.messagingProfileId,
+            senderE164: locationMessaging.senderE164,
+            enabled: locationMessaging.enabled,
+            registrationStatus: locationMessaging.registrationStatus,
+            a2pCampaignId: locationMessaging.a2pCampaignId,
+            a2pBrandId: locationMessaging.a2pBrandId,
+          })
+          .from(locationMessaging)
+          .where(
+            and(
+              eq(locationMessaging.practiceId, attempt.practiceId),
+              eq(locationMessaging.locationId, attempt.locationId),
+              isNull(locationMessaging.deletedAt),
+            ),
+          )
+          .limit(1)
+          .for("share");
+        if (
+          !activeSender?.enabled ||
+          activeSender.registrationStatus !== "active" ||
+          activeSender.provider !== attempt.provider ||
+          (activeSender.messagingServiceId?.trim() || null) !==
+            attempt.senderMessagingServiceId ||
+          (normalizeE164(activeSender.senderE164) ?? null) !==
+            attempt.senderE164
+        ) {
+          const rejected: SendMessageResult = {
+            status: "definite_failure",
+            error:
+              "The location texting sender changed or became inactive before dispatch; delivery was blocked.",
+          };
+          await appendProviderResult(
+            tx as unknown as Database,
+            attempt,
+            rejected,
+          );
+          return rejected;
+        }
+        activeLocationCampaignId = activeSender.a2pCampaignId?.trim() || null;
+        activeLocationBrandId = activeSender.a2pBrandId?.trim() || null;
+      }
+
+      if (hostedExternalSend) {
+        const [activeRegistration] = await tx
+          .select({
+            displayName: messagingRegistrations.displayName,
+            providerCampaignId: messagingRegistrations.providerCampaignId,
+            providerBrandId: messagingRegistrations.providerBrandId,
+          })
+          .from(messagingRegistrations)
+          .where(
+            and(
+              eq(messagingRegistrations.practiceId, attempt.practiceId),
+              eq(messagingRegistrations.provider, attempt.provider),
+              eq(messagingRegistrations.status, "active"),
+              isNull(messagingRegistrations.deletedAt),
+            ),
+          )
+          .limit(1)
+          .for("share");
+        if (
+          activeRegistration?.displayName?.trim() !==
+            attempt.registeredDisplayName ||
+          !activeRegistration.providerCampaignId?.trim() ||
+          activeRegistration.providerCampaignId.trim() !==
+            activeLocationCampaignId ||
+          !activeRegistration.providerBrandId?.trim() ||
+          activeRegistration.providerBrandId.trim() !== activeLocationBrandId
+        ) {
+          const rejected: SendMessageResult = {
+            status: "definite_failure",
+            error:
+              "The carrier campaign changed or became inactive before dispatch; delivery was blocked.",
+          };
+          await appendProviderResult(
+            tx as unknown as Database,
+            attempt,
+            rejected,
+          );
+          return rejected;
+        }
+      }
+
+      if (attempt.source === "operator_resend" && attempt.communicationId) {
+        const [resendCommunication] = await tx
+          .select({ status: communications.status })
+          .from(communications)
+          .where(
+            and(
+              eq(communications.practiceId, attempt.practiceId),
+              eq(communications.id, attempt.communicationId),
+              isNull(communications.deletedAt),
+            ),
+          )
+          .limit(1)
+          .for("update");
+        if (resendCommunication?.status !== "failed") {
+          const rejected: SendMessageResult = {
+            status: "definite_failure",
+            error:
+              "The linked communication is no longer failed; explicit SMS resend was blocked.",
+          };
+          await appendProviderResult(
+            tx as unknown as Database,
+            attempt,
+            rejected,
+          );
+          return rejected;
+        }
+      }
+
+      await acquireSmsRecipientLockInTransaction(
+        tx,
+        attempt.practiceId,
+        attempt.destinationE164,
+      );
+
+      const ambiguityCutoff = new Date(Date.now() - SMS_AMBIGUITY_LOOKBACK_MS);
+      const [ambiguousPrior] = await tx
+        .select({ id: smsSendAttempts.id })
+        .from(smsSendAttempts)
+        .where(
+          and(
+            eq(smsSendAttempts.practiceId, attempt.practiceId),
+            eq(smsSendAttempts.destinationE164, attempt.destinationE164),
+            ne(smsSendAttempts.id, attempt.id),
+            gte(smsSendAttempts.createdAt, ambiguityCutoff),
+            sql`(
+              not exists (
+                select 1 from sms_send_attempt_events unresolved_event
+                where unresolved_event.practice_id = ${smsSendAttempts.practiceId}
+                  and unresolved_event.attempt_id = ${smsSendAttempts.id}
+              )
+              or coalesce(
+                (
+                  select reconciled.outcome::text
+                  from sms_send_attempt_events reconciled
+                  where reconciled.practice_id = ${smsSendAttempts.practiceId}
+                    and reconciled.attempt_id = ${smsSendAttempts.id}
+                    and reconciled.kind = 'reconciliation'
+                  order by reconciled.created_at desc, reconciled.id desc
+                  limit 1
+                ),
+                (
+                  select provider_result.outcome::text
+                  from sms_send_attempt_events provider_result
+                  where provider_result.practice_id = ${smsSendAttempts.practiceId}
+                    and provider_result.attempt_id = ${smsSendAttempts.id}
+                    and provider_result.kind = 'provider_result'
+                  order by provider_result.created_at desc, provider_result.id desc
+                  limit 1
+                )
+              ) = 'outcome_unknown'
+            )`,
+          ),
+        )
+        .limit(1);
+      if (ambiguousPrior) {
+        const rejected: SendMessageResult = {
+          status: "definite_failure",
+          error:
+            "A recent SMS to this recipient has an unresolved provider outcome. Reconcile it before sending another message.",
+        };
+        await appendProviderResult(
+          tx as unknown as Database,
+          attempt,
+          rejected,
+        );
+        return rejected;
+      }
+
+      if (hostedExternalSend) {
+        const [client] = await tx
+          .select({
+            phone: clients.phone,
+            smsConsent: clients.smsConsent,
+            smsConsentAt: clients.smsConsentAt,
+            smsConsentSource: clients.smsConsentSource,
+            smsConsentDisclosure: clients.smsConsentDisclosure,
+          })
+          .from(clients)
+          .where(
+            and(
+              eq(clients.id, attempt.clientId!),
+              eq(clients.practiceId, attempt.practiceId),
+              isNull(clients.deletedAt),
+            ),
+          )
+          .limit(1)
+          .for("share");
+        if (
+          !client?.smsConsent ||
+          !client.smsConsentAt ||
+          !client.smsConsentSource?.trim() ||
+          !client.smsConsentDisclosure?.trim() ||
+          normalizeE164(client.phone) !== attempt.destinationE164
+        ) {
+          const rejected: SendMessageResult = {
+            status: "definite_failure",
+            error:
+              "Client SMS consent or phone changed before sending; delivery was blocked.",
+          };
+          await appendProviderResult(
+            tx as unknown as Database,
+            attempt,
+            rejected,
+          );
+          return rejected;
+        }
+      }
+
+      const [suppression] = await tx
+        .select({ id: smsSuppressions.id })
+        .from(smsSuppressions)
+        .where(
+          and(
+            eq(smsSuppressions.practiceId, attempt.practiceId),
+            eq(smsSuppressions.phone, attempt.destinationE164),
+            isNull(smsSuppressions.deletedAt),
+          ),
+        )
+        .limit(1);
+      if (suppression) {
+        const rejected: SendMessageResult = {
+          status: "definite_failure",
+          error: "Recipient has opted out of SMS (STOP).",
+        };
+        await appendProviderResult(
+          tx as unknown as Database,
+          attempt,
+          rejected,
+        );
+        return rejected;
+      }
+
+      const providerResult = await providerCall(provider, {
+        to: attempt.destinationE164,
+        body: attempt.body,
+        sender,
+      });
+      await appendProviderResult(
+        tx as unknown as Database,
+        attempt,
+        providerResult,
+      );
+      return providerResult;
+    });
+  } catch (error) {
+    console.error("[messaging] SMS outcome persistence failed", error);
+    await alertUnknownSmsAttempt(attempt);
+    return failure(
+      "SMS dispatch was reserved, but its provider outcome could not be persisted. Do not resend until an operator reconciles it.",
+      { outcome: "outcome_unknown", attemptId: attempt.id },
+    );
+  }
+
+  if (result.status === "outcome_unknown") {
+    await alertUnknownSmsAttempt(attempt);
+  }
+
+  if (result.status === "accepted") {
+    if (provider.name !== "console") {
+      try {
+        await recordUsage({ practiceId: attempt.practiceId, kind: "sms" });
+      } catch (error) {
+        // Delivery is already accepted and durable. Never turn a metering error
+        // into a retry signal that could duplicate the message.
+        console.error("[messaging] accepted SMS usage metering failed", error);
+      }
+    }
+    return accepted(attempt.id, result.id, false);
+  }
+  return failure(result.error, {
+    outcome: result.status,
+    attemptId: attempt.id,
+  });
+}
+
+async function dispatchPreparedSms(
+  prepared: PreparedDispatch,
+): Promise<SmsDispatchResult> {
+  const hostedBilling = billingEnforced();
+  const demoMode = envFlagEnabled("NEXT_PUBLIC_DEMO_MODE");
+  const hostedExternalSend = hostedBilling && !demoMode;
+
+  if (hostedExternalSend) {
+    const launch = hostedMessagingLaunchDecision(prepared);
+    if (!launch.allowed) {
+      return failure(hostedMessagingLaunchBlockMessage(launch.reason));
+    }
+    if (!prepared.clientId) {
+      return failure("Hosted SMS requires an explicit consented client.");
+    }
+  }
+
+  if (
+    !prepared.locationId &&
+    getMessagingProvider().name === "console" &&
+    hostedExternalSend
+  ) {
+    return failure("SMS provider is not configured for hosted sending.");
+  }
+
+  const transport = await resolveMessagingTransport({
+    practiceId: prepared.practiceId,
+    locationId: prepared.locationId,
+    hosted: hostedExternalSend,
+  });
+  if (prepared.locationId && !transport) {
+    return failure("No active texting sender is configured for this location.");
+  }
+  if (!transport) return failure("SMS provider is not configured.");
+
+  const { provider, sender } = transport;
+  if (provider.name !== prepared.expectedProvider) {
+    return failure(
+      "Messaging transport changed while preparing the SMS; send blocked.",
+    );
+  }
+  if (hostedExternalSend && provider.name !== "telnyx") {
+    return failure(
+      "Hosted texting is available only through the approved Telnyx pilot.",
+    );
+  }
+  if (provider.name === "console" && hostedExternalSend) {
+    return failure("SMS provider is not configured for hosted sending.");
+  }
+
+  const currentDisplayName = await campaignDisplayName({
+    practiceId: prepared.practiceId,
+    provider: provider.name,
+    hostedExternalSend,
+  });
+  if (currentDisplayName !== prepared.registeredDisplayName) {
+    return failure(
+      "Active carrier registration changed while preparing the SMS; send blocked.",
+    );
+  }
+
+  let reservation:
+    | { winner: true; attempt: AttemptRow }
+    | { winner: false; result: SmsDispatchResult };
+  try {
+    reservation = await reserveAttempt(prepared, provider, sender);
+  } catch (error) {
+    console.error("[messaging] SMS attempt reservation failed", error);
+    return failure("Could not durably reserve SMS dispatch; send blocked.");
+  }
+  if (!reservation.winner) return reservation.result;
+  return dispatchWinner(
+    reservation.attempt,
+    provider,
+    sender,
+    hostedExternalSend,
+  );
+}
+
+async function sendSmsInternal(
+  options: SmsSendOptions,
+): Promise<SmsDispatchResult> {
+  const recipient = normalizeE164(options.to);
+  if (!recipient) {
+    return failure(
+      "SMS recipient phone number must be a valid E.164 or US/CA number.",
+    );
+  }
+
+  const source = options.source?.trim() || "direct";
+  const provisionalKey =
+    options.idempotencyKey?.trim() ||
+    stableDirectKey({ ...options, to: recipient });
+  const sourceId = options.sourceId?.trim() || provisionalKey;
+  if (
+    !validBoundedIdentity(source, 64) ||
+    !validBoundedIdentity(sourceId, 200) ||
+    !validBoundedIdentity(provisionalKey, 200)
+  ) {
+    return failure(
+      "SMS source and idempotency values must be nonblank and bounded.",
+    );
+  }
+
+  const hostedExternalSend =
+    billingEnforced() && !envFlagEnabled("NEXT_PUBLIC_DEMO_MODE");
+  if (hostedExternalSend) {
+    const launch = hostedMessagingLaunchDecision(options);
+    if (!launch.allowed) {
+      return failure(hostedMessagingLaunchBlockMessage(launch.reason));
+    }
+    if (!options.clientId) {
+      return failure("Hosted SMS requires an explicit consented client.");
+    }
+  }
+  const initialTransport = await resolveMessagingTransport({
+    practiceId: options.practiceId,
+    locationId: options.locationId,
+    hosted: hostedExternalSend,
+  });
+  if (!initialTransport) {
+    return failure(
+      options.locationId
+        ? "No active texting sender is configured for this location."
+        : "SMS provider is not configured.",
+    );
+  }
+
+  let displayName: string | undefined;
+  try {
+    displayName = await campaignDisplayName({
+      practiceId: options.practiceId,
+      provider: initialTransport.provider.name,
+      hostedExternalSend,
+    });
+  } catch (error) {
+    console.error("[messaging] registration display name lookup failed", error);
+  }
+  if (!displayName) {
+    return failure(
+      hostedExternalSend
+        ? "Complete active carrier registration before sending clinic text messages."
+        : "Set MESSAGING_REGISTERED_DISPLAY_NAME to the exact carrier-registered clinic name before sending text messages.",
+    );
+  }
+  const preparedBody = prepareCampaignSmsBody({
+    registeredDisplayName: displayName,
+    content: options.body,
+  });
+  if (!preparedBody.success) return failure(preparedBody.error);
+
+  const result = await dispatchPreparedSms({
+    to: recipient,
+    body: preparedBody.body,
+    registeredDisplayName: displayName,
+    practiceId: options.practiceId,
+    locationId: options.locationId,
+    clientId: options.clientId,
+    communicationId: options.communicationId,
+    source,
+    sourceId,
+    idempotencyKey: provisionalKey,
+    expectedProvider: initialTransport.provider.name,
+  });
+  return result;
+}
+
+export async function sendSms(
+  options: SmsSendOptions,
+): Promise<SmsDispatchResult> {
+  try {
+    return await sendSmsInternal(options);
+  } catch (error) {
+    // Every path after reservation/provider invocation is handled inside the
+    // dispatch boundary. An escape here is therefore a pre-reservation setup
+    // failure and is safe to classify as definite without creating a retry
+    // ambiguity or an orphan pending communication.
+    console.error("[messaging] SMS preparation failed", error);
+    return failure("SMS could not be prepared; send blocked.");
+  }
+}
+
+/**
+ * Append an operator's resolution of an ambiguous attempt. This function never
+ * resolves a transport and never calls a provider.
+ */
+export async function reconcileSmsSendAttempt(options: {
+  practiceId: string;
+  attemptId: string;
+  outcome: "accepted" | "definite_failure";
+  providerMessageId?: string;
+  detail: string;
+  actorUserId: string;
+  actorType?: "clinic_user" | "platform_operator";
+  actorIdentity?: string;
+  actorName: string;
+  reconciliationKey: string;
+}): Promise<SmsDispatchResult> {
+  if (
+    !validBoundedIdentity(options.detail, 2000) ||
+    !validBoundedIdentity(options.actorName, 255) ||
+    !validBoundedIdentity(options.actorIdentity ?? options.actorUserId, 255) ||
+    !validBoundedIdentity(options.reconciliationKey, 200)
+  ) {
+    return failure("Reconciliation evidence is incomplete or too long.");
+  }
+  const providerMessageId = options.providerMessageId?.trim();
+  if (options.outcome === "accepted" && !providerMessageId) {
+    return failure("Accepted reconciliation requires a provider message id.");
+  }
+  if (options.outcome === "definite_failure" && providerMessageId) {
+    return failure(
+      "A definite-failure reconciliation cannot have a provider id.",
+    );
+  }
+
+  let projectionMiss:
+    | { communicationId: string; attemptId: string; outcome: string }
+    | undefined;
+  try {
+    const result = await withSystem(db, async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${`sms-attempt:${options.practiceId}:${options.attemptId}`}, 0))`,
+      );
+      const [attempt] = await tx
+        .select()
+        .from(smsSendAttempts)
+        .where(
+          and(
+            eq(smsSendAttempts.practiceId, options.practiceId),
+            eq(smsSendAttempts.id, options.attemptId),
+          ),
+        )
+        .limit(1);
+      if (!attempt) return failure("SMS send attempt not found.");
+
+      if (
+        new Date(attempt.createdAt).getTime() >
+        Date.now() - SMS_RECONCILIATION_STALE_MS
+      ) {
+        return failure(
+          "This SMS attempt is still within the provider in-flight window. Wait before reconciling it.",
+          { outcome: "outcome_unknown", attemptId: attempt.id },
+        );
+      }
+
+      const actorType = options.actorType ?? "clinic_user";
+      if (actorType === "clinic_user") {
+        const [actor] = await tx
+          .select({ id: users.id })
+          .from(users)
+          .where(
+            and(
+              eq(users.practiceId, options.practiceId),
+              eq(users.id, options.actorUserId),
+              isNull(users.deletedAt),
+            ),
+          )
+          .limit(1);
+        if (!actor) return failure("Reconciliation actor not found.");
+      }
+
+      const priorEvents = await attemptEvents(
+        tx as unknown as Database,
+        options.practiceId,
+        options.attemptId,
+      );
+      const prior = effectiveEvent(priorEvents);
+      if (prior && prior.outcome !== "outcome_unknown") {
+        if (attempt.communicationId) {
+          const [projected] = await tx
+            .update(communications)
+            .set(
+              prior.outcome === "accepted"
+                ? {
+                    status: "sent",
+                    providerMessageId: prior.providerMessageId,
+                  }
+                : { status: "failed" },
+            )
+            .where(
+              and(
+                eq(communications.practiceId, options.practiceId),
+                eq(communications.id, attempt.communicationId),
+                eq(communications.status, "pending"),
+                isNull(communications.deletedAt),
+              ),
+            )
+            .returning({ id: communications.id });
+          if (!projected) {
+            projectionMiss = {
+              communicationId: attempt.communicationId,
+              attemptId: attempt.id,
+              outcome: prior.outcome,
+            };
+          }
+        }
+        return eventToDispatchResult(attempt.id, prior, true);
+      }
+
+      const [event] = await tx
+        .insert(smsSendAttemptEvents)
+        .values({
+          practiceId: options.practiceId,
+          attemptId: attempt.id,
+          kind: "reconciliation",
+          outcome: options.outcome,
+          providerMessageId,
+          detail: boundedDetail(options.detail),
+          actorType,
+          actorUserId:
+            actorType === "clinic_user" ? options.actorUserId : undefined,
+          actorIdentity: (options.actorIdentity ?? options.actorUserId).trim(),
+          actorName: options.actorName.trim(),
+          eventKey: options.reconciliationKey.trim(),
+        })
+        .onConflictDoNothing({
+          target: [
+            smsSendAttemptEvents.practiceId,
+            smsSendAttemptEvents.eventKey,
+          ],
+        })
+        .returning();
+      if (!event) {
+        const current = effectiveEvent(
+          await attemptEvents(
+            tx as unknown as Database,
+            options.practiceId,
+            attempt.id,
+          ),
+        );
+        return current
+          ? eventToDispatchResult(attempt.id, current, true)
+          : failure("Reconciliation key collision; no outcome was changed.", {
+              attemptId: attempt.id,
+              replayed: true,
+            });
+      }
+
+      if (attempt.communicationId) {
+        const [projected] = await tx
+          .update(communications)
+          .set(
+            options.outcome === "accepted"
+              ? { status: "sent", providerMessageId }
+              : { status: "failed" },
+          )
+          .where(
+            and(
+              eq(communications.practiceId, options.practiceId),
+              eq(communications.id, attempt.communicationId),
+              eq(communications.status, "pending"),
+              isNull(communications.deletedAt),
+            ),
+          )
+          .returning({ id: communications.id });
+        if (!projected) {
+          projectionMiss = {
+            communicationId: attempt.communicationId,
+            attemptId: attempt.id,
+            outcome: options.outcome,
+          };
+        }
+      }
+      return eventToDispatchResult(attempt.id, event, false);
+    });
+    if (projectionMiss) {
+      await alertOps(
+        "SMS reconciliation projection requires review",
+        `practice=${options.practiceId} communication=${projectionMiss.communicationId} attempt=${projectionMiss.attemptId} outcome=${projectionMiss.outcome}`,
+      ).catch((error) => {
+        console.error("[messaging] SMS reconciliation alert failed", error);
+      });
+    }
+    return result;
+  } catch (error) {
+    console.error("[messaging] SMS reconciliation failed", error);
+    return failure("Could not persist SMS reconciliation.");
+  }
+}
+
+/** Explicit resend is allowed only after a known failure and creates a new row. */
+export async function resendSmsAttempt(options: {
+  practiceId: string;
+  attemptId: string;
+  idempotencyKey: string;
+  actorUserId: string;
+  actorType?: "clinic_user" | "platform_operator";
+  actorIdentity?: string;
+  actorName?: string;
+}): Promise<SmsDispatchResult> {
+  if (!validBoundedIdentity(options.idempotencyKey, 200)) {
+    return failure(
+      "A bounded idempotency key is required for an explicit resend.",
+    );
+  }
+  const loaded = await withSystem(db, async (tx) => {
+    const [attempt] = await tx
+      .select()
+      .from(smsSendAttempts)
+      .where(
+        and(
+          eq(smsSendAttempts.practiceId, options.practiceId),
+          eq(smsSendAttempts.id, options.attemptId),
+        ),
+      )
+      .limit(1);
+    if (!attempt) return undefined;
+    const [linkedCommunication] = attempt.communicationId
+      ? await tx
+          .select({ status: communications.status })
+          .from(communications)
+          .where(
+            and(
+              eq(communications.practiceId, options.practiceId),
+              eq(communications.id, attempt.communicationId),
+              isNull(communications.deletedAt),
+            ),
+          )
+          .limit(1)
+      : [undefined];
+    const actorType = options.actorType ?? "clinic_user";
+    const [actor] =
+      actorType === "clinic_user"
+        ? await tx
+            .select({ id: users.id, name: users.name, email: users.email })
+            .from(users)
+            .where(
+              and(
+                eq(users.practiceId, options.practiceId),
+                eq(users.id, options.actorUserId),
+                isNull(users.deletedAt),
+              ),
+            )
+            .limit(1)
+        : [
+            {
+              id: options.actorUserId,
+              name: options.actorName,
+              email: options.actorIdentity,
+            },
+          ];
+    const event = effectiveEvent(
+      await attemptEvents(
+        tx as unknown as Database,
+        options.practiceId,
+        options.attemptId,
+      ),
+    );
+    return { attempt, actor, event, linkedCommunication };
+  });
+  if (!loaded?.attempt) return failure("SMS send attempt not found.");
+  if (!loaded.actor) return failure("Resend actor not found.");
+  if (
+    new Date(loaded.attempt.createdAt).getTime() >
+    Date.now() - SMS_RECONCILIATION_STALE_MS
+  ) {
+    return failure(
+      "Wait for the provider and fallback delivery window before resending this SMS attempt.",
+      { attemptId: loaded.attempt.id },
+    );
+  }
+  if (
+    loaded.attempt.communicationId &&
+    loaded.linkedCommunication?.status !== "failed"
+  ) {
+    return failure(
+      loaded.linkedCommunication
+        ? "The linked communication must be definitively failed before an SMS can be resent. Finish any email fallback or reconciliation first."
+        : "The linked communication could not be verified; SMS resend was blocked.",
+      { attemptId: loaded.attempt.id },
+    );
+  }
+  if (loaded.event?.outcome !== "definite_failure") {
+    return failure(
+      "Only a definitively failed SMS may be resent. Reconcile ambiguous attempts first.",
+      { attemptId: loaded.attempt.id },
+    );
+  }
+
+  const currentDisplayName = await campaignDisplayName({
+    practiceId: options.practiceId,
+    provider: loaded.attempt.provider as MessagingProvider["name"],
+    hostedExternalSend:
+      billingEnforced() && !envFlagEnabled("NEXT_PUBLIC_DEMO_MODE"),
+  });
+  if (currentDisplayName !== loaded.attempt.registeredDisplayName) {
+    return failure(
+      "Registered clinic identity no longer matches the original attempt; resend blocked.",
+      { attemptId: loaded.attempt.id },
+    );
+  }
+  const result = await dispatchPreparedSms({
+    to: loaded.attempt.destinationE164,
+    body: loaded.attempt.body,
+    registeredDisplayName: loaded.attempt.registeredDisplayName,
+    practiceId: loaded.attempt.practiceId,
+    locationId: loaded.attempt.locationId ?? undefined,
+    clientId: loaded.attempt.clientId ?? undefined,
+    communicationId: loaded.attempt.communicationId ?? undefined,
+    source: "operator_resend",
+    sourceId: `${loaded.attempt.id}:${options.actorUserId}`,
+    idempotencyKey: options.idempotencyKey.trim(),
+    resendOfAttemptId: loaded.attempt.id,
+    expectedProvider: loaded.attempt.provider as MessagingProvider["name"],
+    requestedBy: {
+      actorType: options.actorType ?? "clinic_user",
+      actorUserId:
+        (options.actorType ?? "clinic_user") === "clinic_user"
+          ? options.actorUserId
+          : undefined,
+      identity:
+        options.actorIdentity ?? loaded.actor.email ?? options.actorUserId,
+      name: options.actorName ?? loaded.actor.name ?? "Platform operator",
+    },
+  });
+  // Accepted projection is part of dispatchPreparedSms's provider-result
+  // transaction, including explicit resends. No second crash-prone projection
+  // is permitted here.
+  return result;
+}

--- a/apps/web/lib/sms.ts
+++ b/apps/web/lib/sms.ts
@@ -1,21 +1,21 @@
-import { recordUsage } from "@/lib/billing/usage";
-import { db } from "@openpims/db/client";
-import { clients, practices, smsSuppressions } from "@openpims/db";
-import { and, eq, isNull } from "drizzle-orm";
-import { withSystem } from "@/lib/tenant-db";
-import { billingEnforced, hasHostedFullAccess } from "@/lib/billing/plans";
 import {
-  getMessagingProvider,
-  normalizeE164,
-  resolveMessagingTransport,
-  isSuppressed,
-  acquireSmsRecipientLockInTransaction,
-} from "@/lib/messaging";
-import { envFlagEnabled } from "@/lib/env-bool";
-import {
-  hostedMessagingLaunchBlockMessage,
-  hostedMessagingLaunchDecision,
-} from "@/lib/messaging/launch-gate";
+  sendSms,
+  type SmsDispatchResult,
+} from "@/lib/sms-dispatch";
+
+export {
+  prepareCampaignSmsBody,
+  reconcileSmsSendAttempt,
+  resendSmsAttempt,
+  sendSms,
+  SMS_COMPLIANCE_FOOTER,
+  SMS_MAX_BODY_LENGTH,
+} from "@/lib/sms-dispatch";
+export type {
+  SmsDispatchOutcome,
+  SmsDispatchResult,
+  SmsSendOptions,
+} from "@/lib/sms-dispatch";
 
 // ---------------------------------------------------------------------------
 // Core send function
@@ -25,229 +25,6 @@ import {
 // without a location retain the env-selected provider/sender fallback for dev.
 // This module keeps the hosted entitlement gate and usage metering.
 // ---------------------------------------------------------------------------
-
-export async function sendSms(options: {
-  to: string;
-  body: string;
-  /** When set (and a real send occurs), meters the SMS for hosted billing. */
-  practiceId?: string;
-  /** Selects the location's bound provider and number/messaging profile. */
-  locationId?: string;
-  /** Client whose current consent and destination must match immediately before dispatch. */
-  clientId?: string;
-}): Promise<{ success: boolean; sid?: string; error?: string }> {
-  const hostedBilling = billingEnforced();
-  const demoMode = envFlagEnabled("NEXT_PUBLIC_DEMO_MODE");
-  const hostedExternalSend = hostedBilling && !demoMode;
-  const recipient = normalizeE164(options.to);
-
-  if (!recipient) {
-    return {
-      success: false,
-      error:
-        "SMS recipient phone number must be a valid E.164 or US/CA number.",
-    };
-  }
-
-  if (hostedExternalSend) {
-    const launch = hostedMessagingLaunchDecision(options);
-    if (!launch.allowed) {
-      return {
-        success: false,
-        error: hostedMessagingLaunchBlockMessage(launch.reason),
-      };
-    }
-    if (!options.clientId) {
-      return {
-        success: false,
-        error: "Hosted SMS requires an explicit consented client.",
-      };
-    }
-  }
-
-  // Preserve the locationless hosted guard without consulting the global
-  // provider for explicit locations. Their provider comes only from the DB row.
-  if (
-    !options.locationId &&
-    getMessagingProvider().name === "console" &&
-    hostedBilling &&
-    !demoMode
-  ) {
-    return {
-      success: false,
-      error: "SMS provider is not configured for hosted sending.",
-    };
-  }
-
-  if (options.practiceId && hostedBilling) {
-    const [practice] = await withSystem(db, (tx) =>
-      tx
-        .select({
-          tier: practices.subscriptionTier,
-          billingStatus: practices.billingStatus,
-          trialEndsAt: practices.trialEndsAt,
-        })
-        .from(practices)
-        .where(
-          and(
-            eq(practices.id, options.practiceId!),
-            isNull(practices.deletedAt)
-          )
-        )
-        .limit(1)
-    );
-    if (!practice) {
-      return { success: false, error: "Practice not found" };
-    }
-    if (
-      !hasHostedFullAccess(
-        practice.tier,
-        practice.billingStatus,
-        practice.trialEndsAt
-      )
-    ) {
-      return {
-        success: false,
-        error:
-          "OpenVPM Cloud is read-only until your trial or subscription is active.",
-      };
-    }
-  }
-
-  // Hard opt-out gate: never text a number on the practice's suppression list.
-  // Fail closed — if we can't verify opt-out status, block rather than risk it.
-  // Hosted dispatch repeats this check under a per-recipient transaction lock
-  // immediately before the provider call, so stale automation snapshots cannot
-  // outrun a concurrent STOP/manual revoke.
-  if (options.practiceId && !hostedExternalSend) {
-    try {
-      if (await isSuppressed(options.practiceId, recipient)) {
-        return {
-          success: false,
-          error: "Recipient has opted out of SMS (STOP).",
-        };
-      }
-    } catch {
-      return {
-        success: false,
-        error: "Could not verify SMS opt-out status; send blocked.",
-      };
-    }
-  }
-
-  const transport = await resolveMessagingTransport({
-    practiceId: options.practiceId,
-    locationId: options.locationId,
-    hosted: hostedExternalSend,
-  });
-  if (options.locationId && !transport) {
-    return {
-      success: false,
-      error: "No active texting sender is configured for this location.",
-    };
-  }
-
-  if (!transport) {
-    return { success: false, error: "SMS provider is not configured." };
-  }
-
-  const { provider, sender } = transport;
-  if (hostedExternalSend && provider.name !== "telnyx") {
-    return {
-      success: false,
-      error:
-        "Hosted texting is available only through the approved Telnyx pilot.",
-    };
-  }
-  if (provider.name === "console" && hostedBilling && !demoMode) {
-    return {
-      success: false,
-      error: "SMS provider is not configured for hosted sending.",
-    };
-  }
-
-  const result = hostedExternalSend
-    ? await withSystem(db, async (tx) => {
-        try {
-          const practiceId = options.practiceId!;
-          const clientId = options.clientId!;
-          await acquireSmsRecipientLockInTransaction(tx, practiceId, recipient);
-
-          const [client] = await tx
-            .select({
-              phone: clients.phone,
-              smsConsent: clients.smsConsent,
-              smsConsentAt: clients.smsConsentAt,
-              smsConsentSource: clients.smsConsentSource,
-              smsConsentDisclosure: clients.smsConsentDisclosure,
-            })
-            .from(clients)
-            .where(
-              and(
-                eq(clients.id, clientId),
-                eq(clients.practiceId, practiceId),
-                isNull(clients.deletedAt)
-              )
-            )
-            .limit(1)
-            .for("share");
-          if (
-            !client?.smsConsent ||
-            !client.smsConsentAt ||
-            !client.smsConsentSource?.trim() ||
-            !client.smsConsentDisclosure?.trim() ||
-            normalizeE164(client.phone) !== recipient
-          ) {
-            return {
-              success: false,
-              error:
-                "Client SMS consent or phone changed before sending; delivery was blocked.",
-            };
-          }
-
-          const [suppression] = await tx
-            .select({ id: smsSuppressions.id })
-            .from(smsSuppressions)
-            .where(
-              and(
-                eq(smsSuppressions.practiceId, practiceId),
-                eq(smsSuppressions.phone, recipient)
-              )
-            )
-            .limit(1);
-          if (suppression) {
-            return {
-              success: false,
-              error: "Recipient has opted out of SMS (STOP).",
-            };
-          }
-
-          return provider.send({
-            to: recipient,
-            body: options.body,
-            sender,
-          });
-        } catch (error) {
-          console.error("[messaging] hosted dispatch preflight failed", error);
-          return {
-            success: false,
-            error: "Could not verify SMS consent; send blocked.",
-          };
-        }
-      })
-    : await provider.send({
-        to: recipient,
-        body: options.body,
-        sender,
-      });
-
-  // Meter only real sends (not the dev-console fallback); no-op on self-host.
-  if (result.success && provider.name !== "console" && options.practiceId) {
-    await recordUsage({ practiceId: options.practiceId, kind: "sms" });
-  }
-
-  return { success: result.success, sid: result.id, error: result.error };
-}
 
 // ---------------------------------------------------------------------------
 // Appointment reminder SMS
@@ -260,15 +37,19 @@ export async function sendAppointmentReminderSms(data: {
   appointmentTime: string;
   practiceName: string;
   practicePhone?: string;
-  practiceId?: string;
+  practiceId: string;
   locationId?: string;
   clientId?: string;
-}): Promise<{ success: boolean; sid?: string; error?: string }> {
+  communicationId?: string;
+  source?: string;
+  sourceId?: string;
+  idempotencyKey?: string;
+}): Promise<SmsDispatchResult> {
   const phoneInfo = data.practicePhone
     ? `Call ${data.practicePhone} to reschedule.`
     : "Contact us to reschedule.";
 
-  const body = `Hi! Reminder: ${data.patientName} has an appointment on ${data.appointmentDate} at ${data.appointmentTime}. ${phoneInfo} - ${data.practiceName}`;
+  const body = `Reminder: ${data.patientName} has an appointment on ${data.appointmentDate} at ${data.appointmentTime}. ${phoneInfo}`;
 
   const result = await sendSms({
     to: data.to,
@@ -276,8 +57,12 @@ export async function sendAppointmentReminderSms(data: {
     practiceId: data.practiceId,
     locationId: data.locationId,
     clientId: data.clientId,
+    communicationId: data.communicationId,
+    source: data.source ?? "appointment_reminder",
+    sourceId: data.sourceId,
+    idempotencyKey: data.idempotencyKey,
   });
-  return { success: result.success, sid: result.sid, error: result.error };
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -290,15 +75,18 @@ export async function sendVaccinationReminderSms(data: {
   vaccineName: string;
   practiceName: string;
   practicePhone?: string;
-  practiceId?: string;
+  practiceId: string;
   locationId?: string;
   clientId?: string;
-}): Promise<{ success: boolean; sid?: string; error?: string }> {
+  communicationId?: string;
+  sourceId?: string;
+  idempotencyKey?: string;
+}): Promise<SmsDispatchResult> {
   const phoneInfo = data.practicePhone
     ? `Call ${data.practicePhone} to schedule.`
     : "Contact us to schedule.";
 
-  const body = `Hi! ${data.patientName} is due for their ${data.vaccineName} vaccination. ${phoneInfo} - ${data.practiceName}`;
+  const body = `${data.patientName} is due for their ${data.vaccineName} vaccination. ${phoneInfo}`;
 
   const result = await sendSms({
     to: data.to,
@@ -306,6 +94,10 @@ export async function sendVaccinationReminderSms(data: {
     practiceId: data.practiceId,
     locationId: data.locationId,
     clientId: data.clientId,
+    communicationId: data.communicationId,
+    source: "vaccination_recall",
+    sourceId: data.sourceId,
+    idempotencyKey: data.idempotencyKey,
   });
-  return { success: result.success, sid: result.sid, error: result.error };
+  return result;
 }

--- a/apps/web/server/__tests__/admin-sms-queue.test.ts
+++ b/apps/web/server/__tests__/admin-sms-queue.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync("server/routers/admin.ts", "utf8");
+
+describe("SMS operator recovery queue", () => {
+  const queue = source.slice(
+    source.indexOf("smsSendAttemptQueue:"),
+    source.indexOf("smsSendAttempt:", source.indexOf("smsSendAttemptQueue:")),
+  );
+
+  it("includes only stale pending communication claims with no attempt", () => {
+    expect(queue).toContain('"orphan_pending_communication"');
+    expect(queue).toContain('eq(communications.channel, "sms")');
+    expect(queue).toContain('eq(communications.direction, "outbound")');
+    expect(queue).toContain('eq(communications.status, "pending")');
+    expect(queue).toContain("lte(communications.createdAt, cutoff)");
+    expect(queue).toContain("not exists (");
+    expect(queue).toContain("orphan_attempt.communication_id");
+  });
+
+  it("surfaces terminal attempt outcomes whose communication stayed pending", () => {
+    expect(queue).toContain('"terminal_projection_pending"');
+    expect(queue).toContain("in ('accepted', 'definite_failure')");
+    expect(queue).toContain("pending_projection.status = 'pending'");
+  });
+
+  it("keeps the queue bounded, oldest-first, and no-store", () => {
+    expect(queue).toContain("noStore()");
+    expect(queue).toContain(".slice(0, input.limit)");
+    expect(queue).toContain('cacheControl: "no-store" as const');
+  });
+});

--- a/apps/web/server/__tests__/communications-send.test.ts
+++ b/apps/web/server/__tests__/communications-send.test.ts
@@ -6,6 +6,8 @@ const mocks = vi.hoisted(() => ({
   sendSms: vi.fn(),
   recordAuditLog: vi.fn(async () => undefined),
   alertOps: vi.fn(async () => undefined),
+  durableDb: {} as Record<string, unknown>,
+  withDurableSmsCommunication: vi.fn(),
 }));
 
 vi.mock("@/lib/email", () => ({
@@ -24,6 +26,10 @@ vi.mock("@/lib/alerts", () => ({
   alertOps: mocks.alertOps,
 }));
 
+vi.mock("@/lib/messaging/durable-sms-communication", () => ({
+  withDurableSmsCommunication: mocks.withDurableSmsCommunication,
+}));
+
 const {
   COMMUNICATION_CONTENT_MAX_LENGTH,
   COMMUNICATION_SUBJECT_MAX_LENGTH,
@@ -37,9 +43,15 @@ const OTHER_USER_ID = "00000000-0000-0000-0000-000000000009";
 const CLIENT_ID = "00000000-0000-0000-0000-000000000002";
 const COMM_ID = "00000000-0000-0000-0000-000000000003";
 const LOCATION_ID = "00000000-0000-0000-0000-000000000004";
+const REQUEST_ID = "00000000-0000-0000-0000-000000000099";
 const routerSource = readFileSync("server/routers/communications.ts", "utf8");
 
 function callerWithDb(db: Record<string, unknown>, role = "front_desk") {
+  mocks.durableDb = db;
+  mocks.withDurableSmsCommunication.mockImplementation(
+    (_practiceId: string, fn: (durableDb: unknown) => unknown) =>
+      fn(mocks.durableDb),
+  );
   const session = {
     user: {
       id: USER_ID,
@@ -66,14 +78,14 @@ function sqlIncludesColumnName(value: unknown, columnName: string): boolean {
   }
 
   return candidate.queryChunks.some((item) =>
-    sqlIncludesColumnName(item, columnName)
+    sqlIncludesColumnName(item, columnName),
   );
 }
 
 function sqlIncludesValue(
   value: unknown,
   needle: unknown,
-  seen = new WeakSet<object>()
+  seen = new WeakSet<object>(),
 ): boolean {
   if (Object.is(value, needle)) {
     return true;
@@ -95,12 +107,12 @@ function sqlIncludesValue(
   const candidate = value as { queryChunks?: unknown[] };
   if (Array.isArray(candidate.queryChunks)) {
     return candidate.queryChunks.some((item) =>
-      sqlIncludesValue(item, needle, seen)
+      sqlIncludesValue(item, needle, seen),
     );
   }
 
   return Object.values(value as Record<string, unknown>).some((item) =>
-    sqlIncludesValue(item, needle, seen)
+    sqlIncludesValue(item, needle, seen),
   );
 }
 
@@ -111,6 +123,8 @@ function createDb(opts?: {
   conversationAssignment?: Record<string, unknown> | null;
   inserted?: Record<string, unknown>;
   updated?: Record<string, unknown> | null;
+  selectResults?: unknown[][];
+  insertResults?: Array<Record<string, unknown>[]>;
 }) {
   const client = opts?.client ?? {
     id: CLIENT_ID,
@@ -142,7 +156,7 @@ function createDb(opts?: {
   };
   const updated =
     opts && "updated" in opts ? opts.updated : { ...inserted, status: "sent" };
-  const selectResults = [
+  const selectResults = opts?.selectResults ?? [
     [client].filter(Boolean),
     [practice].filter(Boolean),
     [conversationAssignment].filter(Boolean),
@@ -150,10 +164,12 @@ function createDb(opts?: {
   ];
 
   const selectLimit = vi.fn(async () => selectResults.shift() ?? []);
+  const selectFor = vi.fn(() => ({ limit: selectLimit }));
   const selectOrderBy = vi.fn(() => ({ limit: selectLimit }));
   const selectWhere = vi.fn(() => ({
     limit: selectLimit,
     orderBy: selectOrderBy,
+    for: selectFor,
   }));
   const selectInnerJoin = vi.fn(() => ({ where: selectWhere }));
   const selectLeftJoin = vi.fn(() => ({
@@ -168,8 +184,14 @@ function createDb(opts?: {
   }));
   const select = vi.fn(() => ({ from: selectFrom }));
 
-  const insertReturning = vi.fn(async () => [inserted]);
-  const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const insertReturning = vi.fn(async () =>
+    opts?.insertResults ? (opts.insertResults.shift() ?? []) : [inserted],
+  );
+  const insertOnConflict = vi.fn(() => ({ returning: insertReturning }));
+  const insertValues = vi.fn(() => ({
+    returning: insertReturning,
+    onConflictDoNothing: insertOnConflict,
+  }));
   const insert = vi.fn(() => ({ values: insertValues }));
 
   const updateReturning = vi.fn(async () => (updated ? [updated] : []));
@@ -201,24 +223,24 @@ describe("communications.create delivery", () => {
       routerSource.indexOf("create: inboxStaffProcedure"),
       routerSource.indexOf(
         "updateStatus:",
-        routerSource.indexOf("create: inboxStaffProcedure")
-      )
+        routerSource.indexOf("create: inboxStaffProcedure"),
+      ),
     );
 
     expect(createBlock).toMatch(
-      /select\(\{\s*name: practices\.name,\s*timezone: practices\.timezone,\s*email: practices\.email,\s*\}\)[\s\S]+?where\(activePracticeWhere\(ctx\.practiceId\)\)/s
+      /select\(\{\s*name: practices\.name,\s*timezone: practices\.timezone,\s*email: practices\.email,\s*\}\)[\s\S]+?where\(activePracticeWhere\(ctx\.practiceId\)\)/s,
     );
     expect(createBlock).toContain("if (!practice)");
     expect(createBlock).toContain("throw practiceNotFound()");
     expect(createBlock).toContain(
-      "sql`${emailSuppressions.email} = lower(trim(${clients.email}))`"
+      "sql`${emailSuppressions.email} = lower(trim(${clients.email}))`",
     );
     expect(createBlock).toContain("hasNonBlankMessagingSender()");
     expect(createBlock).not.toContain(
-      "isNotNull(locationMessaging.senderE164)"
+      "isNotNull(locationMessaging.senderE164)",
     );
     expect(createBlock).not.toContain(
-      "isNotNull(locationMessaging.messagingProfileId)"
+      "isNotNull(locationMessaging.messagingProfileId)",
     );
     expect(createBlock).not.toContain(': [{ name: "OpenVPM"');
     expect(createBlock).not.toContain("practice?.name");
@@ -235,7 +257,7 @@ describe("communications.create delivery", () => {
         channel: "email",
         direction: "outbound",
         content: "Hello",
-      })
+      }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
 
     expect(select).not.toHaveBeenCalled();
@@ -255,7 +277,7 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         subject: "A".repeat(COMMUNICATION_SUBJECT_MAX_LENGTH + 1),
         content: "Hello",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -264,7 +286,7 @@ describe("communications.create delivery", () => {
         channel: "email",
         direction: "outbound",
         content: "A".repeat(COMMUNICATION_CONTENT_MAX_LENGTH + 1),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -273,7 +295,8 @@ describe("communications.create delivery", () => {
         channel: "sms",
         direction: "outbound",
         content: "A".repeat(SMS_COMMUNICATION_CONTENT_MAX_LENGTH + 1),
-      })
+        requestId: REQUEST_ID,
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -301,7 +324,7 @@ describe("communications.create delivery", () => {
         channel: "portal",
         direction: "outbound",
         content: "See your estimate in the portal.",
-      })
+      }),
     ).resolves.toMatchObject({ status: "delivered" });
 
     expect(insertValues).toHaveBeenCalledWith(
@@ -312,7 +335,7 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         content: "See your estimate in the portal.",
         status: "delivered",
-      })
+      }),
     );
     expect(updateSet).not.toHaveBeenCalled();
     expect(mocks.sendEmail).not.toHaveBeenCalled();
@@ -330,7 +353,7 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         subject: "Follow up",
         content: "Hello\n<script>",
-      })
+      }),
     ).resolves.toMatchObject({ status: "sent" });
 
     expect(insertValues).toHaveBeenCalledWith(
@@ -343,7 +366,7 @@ describe("communications.create delivery", () => {
         content: "Hello\n<script>",
         assignedTo: USER_ID,
         status: "pending",
-      })
+      }),
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -351,14 +374,14 @@ describe("communications.create delivery", () => {
         subject: "Follow up",
         replyTo: "clinic@example.com",
         html: expect.stringContaining("Hello<br />&lt;script&gt;"),
-      })
+      }),
     );
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         html: expect.stringContaining(
-          "Email replies are not imported into OpenVPM yet."
+          "Email replies are not imported into OpenVPM yet.",
         ),
-      })
+      }),
     );
     expect(updateSet).toHaveBeenCalledWith({
       status: "sent",
@@ -379,7 +402,7 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         subject: "Follow up",
         content: "Hello",
-      })
+      }),
     ).resolves.toMatchObject({ status: "sent" });
 
     expect(insertValues).toHaveBeenCalledWith(
@@ -390,7 +413,7 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         assignedTo: OTHER_USER_ID,
         status: "pending",
-      })
+      }),
     );
   });
 
@@ -414,13 +437,13 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         subject: "Follow up",
         content: "Hello",
-      })
+      }),
     ).resolves.toMatchObject({ status: "sent" });
 
     expect(mocks.sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         to: "ada@example.com",
-      })
+      }),
     );
   });
 
@@ -441,14 +464,14 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         subject: "Follow up",
         content: "Hello",
-      })
+      }),
     ).resolves.toMatchObject({ status: "sent" });
 
     const [sendArgs] = mocks.sendEmail.mock.calls[0] ?? [];
     expect(sendArgs).not.toHaveProperty("replyTo");
     expect(sendArgs).toMatchObject({
       html: expect.stringContaining(
-        "Please contact Neighborhood Veterinary directly"
+        "Please contact Neighborhood Veterinary directly",
       ),
     });
   });
@@ -473,7 +496,7 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         subject: "Follow up",
         content: "Hello",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message:
@@ -495,7 +518,7 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         subject: "Follow up",
         content: "Hello",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -516,7 +539,7 @@ describe("communications.create delivery", () => {
         channel: "portal",
         direction: "outbound",
         content: "See your estimate in the portal.",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -539,7 +562,7 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         subject: "Follow up",
         content: "Hello",
-      })
+      }),
     ).resolves.toMatchObject({ status: "sent" });
 
     const condition = updateWhere.mock.calls[0]?.[0];
@@ -559,7 +582,8 @@ describe("communications.create delivery", () => {
         channel: "sms",
         direction: "outbound",
         content: "Your refill is ready.",
-      })
+        requestId: REQUEST_ID,
+      }),
     ).resolves.toMatchObject({ status: "sent" });
 
     expect(mocks.sendSms).toHaveBeenCalledWith({
@@ -568,11 +592,87 @@ describe("communications.create delivery", () => {
       practiceId: PRACTICE_ID,
       locationId: LOCATION_ID,
       clientId: CLIENT_ID,
+      communicationId: COMM_ID,
+      source: "inbox",
+      sourceId: REQUEST_ID,
+      idempotencyKey: `sms:inbox:${PRACTICE_ID}:${REQUEST_ID}`,
     });
     expect(updateSet).toHaveBeenCalledWith({
       status: "sent",
       providerMessageId: "sms-1",
     });
+    expect(mocks.withDurableSmsCommunication).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses one durable inbox request after a lost response", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T18:00:00Z"));
+    mocks.sendSms.mockResolvedValue({ success: true, sid: "sms-1" });
+    const client = {
+      id: CLIENT_ID,
+      firstName: "Ada",
+      lastName: "Lovelace",
+      email: "ada@example.com",
+      phone: "(555) 555-0100",
+      smsConsent: true,
+    };
+    const practice = {
+      name: "Neighborhood Veterinary",
+      timezone: "America/New_York",
+      email: "clinic@example.com",
+    };
+    const pending = {
+      id: COMM_ID,
+      practiceId: PRACTICE_ID,
+      clientId: CLIENT_ID,
+      channel: "sms",
+      direction: "outbound",
+      subject: null,
+      content: "Your refill is ready.",
+      status: "pending",
+    };
+    const sent = { ...pending, status: "sent", providerMessageId: "sms-1" };
+    const { db, insertValues } = createDb({
+      inserted: pending,
+      updated: sent,
+      insertResults: [[pending], []],
+      selectResults: [
+        [client],
+        [practice],
+        [],
+        [{ locationId: LOCATION_ID }],
+        [client],
+        [practice],
+        [],
+        [{ locationId: LOCATION_ID }],
+        [sent],
+      ],
+    });
+    const caller = callerWithDb(db);
+    const input = {
+      clientId: CLIENT_ID,
+      channel: "sms" as const,
+      direction: "outbound" as const,
+      content: "Your refill is ready.",
+      requestId: REQUEST_ID,
+    };
+
+    await expect(caller.create(input)).resolves.toMatchObject({
+      status: "sent",
+    });
+    await expect(caller.create(input)).resolves.toMatchObject({
+      status: "sent",
+    });
+
+    expect(mocks.sendSms).toHaveBeenCalledOnce();
+    expect(insertValues).toHaveBeenCalledTimes(2);
+    expect(mocks.sendSms).toHaveBeenCalledWith(
+      expect.objectContaining({
+        communicationId: COMM_ID,
+        sourceId: REQUEST_ID,
+        idempotencyKey: `sms:inbox:${PRACTICE_ID}:${REQUEST_ID}`,
+      }),
+    );
   });
 
   it("blocks SMS when the practice has no active texting sender", async () => {
@@ -586,7 +686,8 @@ describe("communications.create delivery", () => {
         channel: "sms",
         direction: "outbound",
         content: "Your refill is ready.",
-      })
+        requestId: REQUEST_ID,
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(mocks.sendSms).not.toHaveBeenCalled();
@@ -604,7 +705,8 @@ describe("communications.create delivery", () => {
         channel: "sms",
         direction: "outbound",
         content: "Late reminder",
-      })
+        requestId: REQUEST_ID,
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(mocks.sendSms).not.toHaveBeenCalled();
@@ -623,7 +725,7 @@ describe("communications.create delivery", () => {
         channel: "email",
         direction: "outbound",
         content: "Hello",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(updateSet).toHaveBeenCalledWith({ status: "failed" });
@@ -640,7 +742,7 @@ describe("communications.create delivery", () => {
         direction: "outbound",
         subject: "Follow up",
         content: "Hello",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "INTERNAL_SERVER_ERROR",
       message:
@@ -653,7 +755,7 @@ describe("communications.create delivery", () => {
     });
     expect(mocks.alertOps).toHaveBeenCalledWith(
       "Communication delivery status update failed",
-      expect.stringContaining(`communication=${COMM_ID}`)
+      expect.stringContaining(`communication=${COMM_ID}`),
     );
   });
 
@@ -669,7 +771,7 @@ describe("communications.create delivery", () => {
         channel: "email",
         direction: "outbound",
         content: "Hello",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Resend timed out",
@@ -678,7 +780,7 @@ describe("communications.create delivery", () => {
     expect(updateSet).toHaveBeenCalledWith({ status: "failed" });
   });
 
-  it("marks the row failed when SMS transport throws", async () => {
+  it("keeps the row pending when SMS transport throws ambiguously", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-15T18:00:00Z")); // 1pm America/New_York
     mocks.sendSms.mockRejectedValue(new Error("Telnyx timed out"));
@@ -692,12 +794,13 @@ describe("communications.create delivery", () => {
         channel: "sms",
         direction: "outbound",
         content: "Your refill is ready.",
-      })
+        requestId: REQUEST_ID,
+      }),
     ).rejects.toMatchObject({
-      code: "BAD_REQUEST",
-      message: "Telnyx timed out",
+      code: "CONFLICT",
+      message: expect.stringContaining("provider outcome is unknown"),
     });
 
-    expect(updateSet).toHaveBeenCalledWith({ status: "failed" });
+    expect(updateSet).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => {
   class MockTelnyxError extends Error {
     constructor(
       message: string,
-      readonly status: number
+      readonly status: number,
     ) {
       super(message);
     }
@@ -119,7 +119,7 @@ function callerWithDb(db: Record<string, unknown>) {
 function sqlIncludesColumnParamPair(
   value: unknown,
   columnName: string,
-  paramValue: unknown
+  paramValue: unknown,
 ): boolean {
   if (!value || typeof value !== "object") {
     return false;
@@ -134,7 +134,7 @@ function sqlIncludesColumnParamPair(
     (item) =>
       !!item &&
       typeof item === "object" &&
-      (item as { name?: unknown }).name === columnName
+      (item as { name?: unknown }).name === columnName,
   );
   const hasParam = chunk.queryChunks.some((item) => {
     if (!item || typeof item !== "object") {
@@ -149,7 +149,7 @@ function sqlIncludesColumnParamPair(
   return (
     (hasColumn && hasParam) ||
     chunk.queryChunks.some((item) =>
-      sqlIncludesColumnParamPair(item, columnName, paramValue)
+      sqlIncludesColumnParamPair(item, columnName, paramValue),
     )
   );
 }
@@ -169,7 +169,7 @@ function createDb(opts?: {
     limit: selectLimit,
     then: (
       resolve: (value: unknown[]) => unknown,
-      reject: (reason: unknown) => unknown
+      reject: (reason: unknown) => unknown,
     ) => Promise.resolve(nextSelectRows()).then(resolve, reject),
   }));
   const selectInnerJoin = vi.fn(() => ({ where: selectWhere }));
@@ -252,13 +252,13 @@ describe("messaging provisioning kill-switch", () => {
     const { db, select } = createDb();
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining("almost ready"),
     });
     await expect(
-      callerWithDb(db).searchNumbers({ areaCode: "212" })
+      callerWithDb(db).searchNumbers({ areaCode: "212" }),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
 
     // No DB reads and no Telnyx calls happen while the switch is off.
@@ -279,7 +279,7 @@ describe("messaging provisioning kill-switch", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining("approved pilot clinics"),
@@ -341,7 +341,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).getRegistrationDefaults()
+      callerWithDb(db).getRegistrationDefaults(),
     ).resolves.toMatchObject({
       displayName: "",
       contactEmail: "admin@example.com",
@@ -383,7 +383,7 @@ describe("messaging location target safety", () => {
   it("encrypts clinic tax IDs and upserts registration details tenant-scoped", async () => {
     vi.stubEnv(
       "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
-      Buffer.alloc(32, 9).toString("base64")
+      Buffer.alloc(32, 9).toString("base64"),
     );
     const { db, insertValues } = createDb({ selectResults: [[]] });
 
@@ -405,7 +405,7 @@ describe("messaging location target safety", () => {
         privacyPolicyUrl: "https://example.com/privacy",
         termsUrl: "https://example.com/terms",
         certifyAccuracyAndConsent: true,
-      })
+      }),
     ).resolves.toEqual({ ok: true, taxIdLast4: "6789" });
 
     const values = insertValues.mock.calls[0]?.[0] as Record<string, unknown>;
@@ -424,7 +424,7 @@ describe("messaging location target safety", () => {
   it("uses the hosted clinic SMS policies when custom links are omitted", async () => {
     vi.stubEnv(
       "MESSAGING_REGISTRATION_ENCRYPTION_KEY",
-      Buffer.alloc(32, 9).toString("base64")
+      Buffer.alloc(32, 9).toString("base64"),
     );
     vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
     const { db, insertValues } = createDb({ selectResults: [[]] });
@@ -459,14 +459,15 @@ describe("messaging location target safety", () => {
       callerWithDb(db).provisionNumber({
         ...startNumberInput(),
         phoneNumber: "12345",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).testSend({
         locationId: LOCATION_ID,
         to: "1".repeat(33),
-      })
+        requestId: "00000000-0000-0000-0000-000000000099",
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -490,14 +491,14 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      caller.searchNumbers({ areaCode: "212" })
+      caller.searchNumbers({ areaCode: "212" }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
     });
 
     await expect(
-      caller.provisionNumber(startNumberInput())
+      caller.provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -524,7 +525,7 @@ describe("messaging location target safety", () => {
     expect(mocks.usageForPractice).toHaveBeenCalledWith(
       PRACTICE_ID,
       "sms",
-      "2026-06"
+      "2026-06",
     );
   });
 
@@ -532,7 +533,7 @@ describe("messaging location target safety", () => {
     const { db } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).checkEligibility({ locationId: LOCATION_ID })
+      callerWithDb(db).checkEligibility({ locationId: LOCATION_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(mocks.findMessagingProfilesByName).not.toHaveBeenCalled();
@@ -544,7 +545,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).checkEligibility({ locationId: LOCATION_ID })
+      callerWithDb(db).checkEligibility({ locationId: LOCATION_ID }),
     ).resolves.toEqual({
       eligible: false,
       detail: expect.stringContaining("has not ported or changed"),
@@ -561,7 +562,7 @@ describe("messaging location target safety", () => {
       callerWithDb(db).provisionNumber({
         locationId: LOCATION_ID,
         mode: "host",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining("has not ported or changed"),
@@ -577,7 +578,7 @@ describe("messaging location target safety", () => {
     const { db } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
@@ -592,7 +593,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(missingEnv.db).provisionNumber(startNumberInput())
+      callerWithDb(missingEnv.db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -607,7 +608,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(localEnv.db).provisionNumber(startNumberInput())
+      callerWithDb(localEnv.db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
     });
@@ -624,7 +625,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message: expect.stringContaining("could not reserve"),
@@ -642,7 +643,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).resolves.toMatchObject({
       ok: true,
       senderE164: "+15555550100",
@@ -667,7 +668,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).resolves.toEqual({
       ok: true,
       senderE164: "+15555550100",
@@ -693,7 +694,7 @@ describe("messaging location target safety", () => {
         registrationStatus: "not_started",
         registrationDetail: expect.stringContaining("Number order accepted"),
         enabled: false,
-      })
+      }),
     );
     expect(insertUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -706,7 +707,7 @@ describe("messaging location target safety", () => {
           deletedAt: null,
           updatedAt: expect.any(Date),
         }),
-      })
+      }),
     );
   });
 
@@ -728,7 +729,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).resolves.toEqual({
       ok: true,
       senderE164: "+15555550100",
@@ -776,7 +777,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(resumeNumberInput())
+      callerWithDb(db).provisionNumber(resumeNumberInput()),
     ).resolves.toMatchObject({ recovered: true, numberSource: "purchased" });
 
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
@@ -785,7 +786,7 @@ describe("messaging location target safety", () => {
       expect.objectContaining({
         registrationStatus: "not_started",
         enabled: false,
-      })
+      }),
     );
   });
 
@@ -824,7 +825,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(resumeNumberInput())
+      callerWithDb(db).provisionNumber(resumeNumberInput()),
     ).resolves.toMatchObject({ recovered: true, senderE164: "+15555550100" });
 
     expect(mocks.buyNumber).not.toHaveBeenCalled();
@@ -833,7 +834,7 @@ describe("messaging location target safety", () => {
         messagingProfileId: "profile_123",
         senderE164: "+15555550100",
         registrationStatus: "not_started",
-      })
+      }),
     );
   });
 
@@ -867,12 +868,12 @@ describe("messaging location target safety", () => {
         },
       ]);
     mocks.buyNumber.mockRejectedValueOnce(
-      new mocks.TelnyxMutationUncertainError(`${scenario}: reconcile required`)
+      new mocks.TelnyxMutationUncertainError(`${scenario}: reconcile required`),
     );
 
     const first = createDb({ selectResults: [[{ id: LOCATION_ID }], []] });
     await expect(
-      callerWithDb(first.db).provisionNumber(startNumberInput())
+      callerWithDb(first.db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({ code: "BAD_GATEWAY" });
 
     const retry = createDb({
@@ -890,7 +891,7 @@ describe("messaging location target safety", () => {
       ],
     });
     await expect(
-      callerWithDb(retry.db).provisionNumber(resumeNumberInput())
+      callerWithDb(retry.db).provisionNumber(resumeNumberInput()),
     ).resolves.toMatchObject({ recovered: true });
     expect(mocks.buyNumber).toHaveBeenCalledTimes(1);
   });
@@ -907,8 +908,8 @@ describe("messaging location target safety", () => {
       process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
       mocks.createMessagingProfile.mockRejectedValueOnce(
         new mocks.TelnyxMutationUncertainError(
-          `${scenario}: profile reconciliation required`
-        )
+          `${scenario}: profile reconciliation required`,
+        ),
       );
       mocks.reserveMessagingProfileAttempt.mockResolvedValueOnce(true);
       const gate = preparedMessagingGate();
@@ -917,7 +918,7 @@ describe("messaging location target safety", () => {
       });
 
       await expect(
-        callerWithDb(first.db).provisionNumber(startNumberInput())
+        callerWithDb(first.db).provisionNumber(startNumberInput()),
       ).rejects.toMatchObject({ code: "BAD_GATEWAY" });
       expect(mocks.reserveMessagingProfileAttempt).toHaveBeenCalledWith({
         practiceId: PRACTICE_ID,
@@ -925,11 +926,11 @@ describe("messaging location target safety", () => {
         senderE164: "+15555550100",
         customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
         detail: expect.stringContaining(
-          "will not create another provider profile"
+          "will not create another provider profile",
         ),
       });
       expect(
-        mocks.reserveMessagingProfileAttempt.mock.invocationCallOrder[0]
+        mocks.reserveMessagingProfileAttempt.mock.invocationCallOrder[0],
       ).toBeLessThan(mocks.createMessagingProfile.mock.invocationCallOrder[0]!);
       expect(first.insertValues).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -938,14 +939,14 @@ describe("messaging location target safety", () => {
           numberSource: "purchased",
           registrationStatus: "failed",
           enabled: false,
-        })
+        }),
       );
 
       const retry = createDb({
         selectResults: [[{ id: LOCATION_ID }], [gate]],
       });
       await expect(
-        callerWithDb(retry.db).provisionNumber(resumeNumberInput())
+        callerWithDb(retry.db).provisionNumber(resumeNumberInput()),
       ).rejects.toMatchObject({
         code: "CONFLICT",
         message: expect.stringContaining("No additional purchase"),
@@ -954,7 +955,7 @@ describe("messaging location target safety", () => {
       expect(mocks.createMessagingProfile).toHaveBeenCalledTimes(1);
       expect(mocks.buyNumber).not.toHaveBeenCalled();
       expect(mocks.releaseMessagingProfileAttempt).not.toHaveBeenCalled();
-    }
+    },
   );
 
   it("keeps resume read-only when the exact profile later becomes visible", async () => {
@@ -972,20 +973,20 @@ describe("messaging location target safety", () => {
         },
       ]);
     mocks.createMessagingProfile.mockRejectedValueOnce(
-      new mocks.TelnyxMutationUncertainError("profile response timed out")
+      new mocks.TelnyxMutationUncertainError("profile response timed out"),
     );
     const first = createDb({
       selectResults: [[{ id: LOCATION_ID }], [gate], [gate]],
     });
     await expect(
-      callerWithDb(first.db).provisionNumber(startNumberInput())
+      callerWithDb(first.db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({ code: "BAD_GATEWAY" });
 
     const retry = createDb({
       selectResults: [[{ id: LOCATION_ID }], [gate], [gate]],
     });
     await expect(
-      callerWithDb(retry.db).provisionNumber(resumeNumberInput())
+      callerWithDb(retry.db).provisionNumber(resumeNumberInput()),
     ).rejects.toMatchObject({ code: "CONFLICT" });
 
     expect(mocks.createMessagingProfile).toHaveBeenCalledTimes(1);
@@ -1028,7 +1029,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(resumeNumberInput())
+      callerWithDb(db).provisionNumber(resumeNumberInput()),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message: expect.stringContaining("No additional purchase"),
@@ -1043,7 +1044,7 @@ describe("messaging location target safety", () => {
       callerWithDb(noConfirmation.db).provisionNumber({
         ...startNumberInput(),
         confirmProviderCharges: false,
-      } as never)
+      } as never),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     mocks.reserveMessagingProfileAttempt
@@ -1066,7 +1067,7 @@ describe("messaging location target safety", () => {
       selectResults: [[{ id: LOCATION_ID }], [gate]],
     });
     await expect(
-      callerWithDb(changedQuote.db).provisionNumber(startNumberInput())
+      callerWithDb(changedQuote.db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message: expect.stringContaining("price changed"),
@@ -1077,7 +1078,7 @@ describe("messaging location target safety", () => {
       senderE164: "+15555550100",
       customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
       detail: expect.stringContaining(
-        "will not create another provider profile"
+        "will not create another provider profile",
       ),
     });
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
@@ -1087,7 +1088,7 @@ describe("messaging location target safety", () => {
       selectResults: [[{ id: LOCATION_ID }], [gate]],
     });
     await expect(
-      callerWithDb(retryAfterRelease.db).provisionNumber(startNumberInput())
+      callerWithDb(retryAfterRelease.db).provisionNumber(startNumberInput()),
     ).resolves.toMatchObject({
       ok: true,
       senderE164: "+15555550100",
@@ -1100,14 +1101,14 @@ describe("messaging location target safety", () => {
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
     const gate = preparedMessagingGate();
     mocks.findMessagingProfilesByName.mockRejectedValueOnce(
-      new mocks.TelnyxNotConfiguredError()
+      new mocks.TelnyxNotConfiguredError(),
     );
 
     const missingConfig = createDb({
       selectResults: [[{ id: LOCATION_ID }], [gate], [gate]],
     });
     await expect(
-      callerWithDb(missingConfig.db).provisionNumber(startNumberInput())
+      callerWithDb(missingConfig.db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
 
     expect(mocks.releaseMessagingProfileAttempt).toHaveBeenCalledWith({
@@ -1116,7 +1117,7 @@ describe("messaging location target safety", () => {
       senderE164: "+15555550100",
       customerReference: `openvpm:${PRACTICE_ID}:${LOCATION_ID}`,
       detail: expect.stringContaining(
-        "will not create another provider profile"
+        "will not create another provider profile",
       ),
     });
     expect(mocks.createMessagingProfile).not.toHaveBeenCalled();
@@ -1127,8 +1128,8 @@ describe("messaging location target safety", () => {
     });
     await expect(
       callerWithDb(retryAfterConfiguration.db).provisionNumber(
-        startNumberInput()
-      )
+        startNumberInput(),
+      ),
     ).resolves.toMatchObject({
       ok: true,
       senderE164: "+15555550100",
@@ -1141,7 +1142,7 @@ describe("messaging location target safety", () => {
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
     const gate = preparedMessagingGate();
     mocks.findOwnedPhoneNumbers.mockRejectedValueOnce(
-      new mocks.TelnyxNotConfiguredError()
+      new mocks.TelnyxNotConfiguredError(),
     );
 
     const interruptedAfterProfile = createDb({
@@ -1149,8 +1150,8 @@ describe("messaging location target safety", () => {
     });
     await expect(
       callerWithDb(interruptedAfterProfile.db).provisionNumber(
-        startNumberInput()
-      )
+        startNumberInput(),
+      ),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
 
     expect(mocks.createMessagingProfile).toHaveBeenCalledTimes(1);
@@ -1177,7 +1178,7 @@ describe("messaging location target safety", () => {
       ],
     });
     await expect(
-      callerWithDb(retry.db).provisionNumber(resumeNumberInput())
+      callerWithDb(retry.db).provisionNumber(resumeNumberInput()),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message: expect.stringContaining("No additional purchase"),
@@ -1209,7 +1210,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message: expect.stringContaining("more than one incomplete"),
@@ -1234,7 +1235,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message: expect.stringContaining("unsafe settings"),
@@ -1267,7 +1268,7 @@ describe("messaging location target safety", () => {
       .mockResolvedValueOnce(undefined);
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({
       code: "INTERNAL_SERVER_ERROR",
       message: expect.not.stringContaining("database write failed"),
@@ -1281,11 +1282,11 @@ describe("messaging location target safety", () => {
         senderE164: "+15555550100",
         registrationStatus: "failed",
         enabled: false,
-      })
+      }),
     );
     expect(errorLog).toHaveBeenCalledWith(
       "Unexpected messaging provisioning failure",
-      expect.any(Error)
+      expect.any(Error),
     );
   });
 
@@ -1310,7 +1311,7 @@ describe("messaging location target safety", () => {
     insertUpdate.mockRejectedValueOnce(new Error("database write failed"));
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({ code: "INTERNAL_SERVER_ERROR" });
 
     expect(mocks.deleteOwnedPhoneNumber).not.toHaveBeenCalled();
@@ -1321,14 +1322,14 @@ describe("messaging location target safety", () => {
   it("keeps a deterministic profile recoverable after an uncertain order timeout", async () => {
     process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
     mocks.buyNumber.mockRejectedValue(
-      new mocks.TelnyxMutationUncertainError("request outcome uncertain")
+      new mocks.TelnyxMutationUncertainError("request outcome uncertain"),
     );
     const { db, insertValues } = createDb({
       selectResults: [[{ id: LOCATION_ID }], []],
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({ code: "BAD_GATEWAY" });
 
     expect(mocks.deleteOwnedPhoneNumber).not.toHaveBeenCalled();
@@ -1337,7 +1338,7 @@ describe("messaging location target safety", () => {
       expect.objectContaining({
         messagingProfileId: "profile_123",
         registrationStatus: "failed",
-      })
+      }),
     );
   });
 
@@ -1352,7 +1353,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).provisionNumber(startNumberInput())
+      callerWithDb(db).provisionNumber(startNumberInput()),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
 
     expect(mocks.buyNumber).not.toHaveBeenCalled();
@@ -1361,7 +1362,7 @@ describe("messaging location target safety", () => {
       expect.objectContaining({
         messagingProfileId: "profile_123",
         registrationStatus: "failed",
-      })
+      }),
     );
   });
 
@@ -1369,7 +1370,7 @@ describe("messaging location target safety", () => {
     const { db, updateSet } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true })
+      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(updateSet).not.toHaveBeenCalled();
@@ -1381,7 +1382,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true })
+      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -1398,7 +1399,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true })
+      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true }),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message:
@@ -1411,7 +1412,7 @@ describe("messaging location target safety", () => {
     });
     const condition = updateWhere.mock.calls[0]?.[0];
     expect(
-      sqlIncludesColumnParamPair(condition, "registration_status", "active")
+      sqlIncludesColumnParamPair(condition, "registration_status", "active"),
     ).toBe(true);
   });
 
@@ -1422,7 +1423,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: false })
+      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: false }),
     ).resolves.toEqual({ ok: true, enabled: false });
 
     expect(updateSet).toHaveBeenCalledWith({
@@ -1445,7 +1446,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true })
+      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining("not enabled for this clinic pilot"),
@@ -1477,7 +1478,7 @@ describe("messaging location target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true })
+      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true }),
     ).resolves.toEqual({ ok: true, enabled: true });
     expect(updateSet).toHaveBeenCalledWith({
       enabled: true,
@@ -1494,7 +1495,8 @@ describe("messaging location target safety", () => {
       callerWithDb(db).testSend({
         locationId: LOCATION_ID,
         to: "+15555550100",
-      })
+        requestId: "00000000-0000-0000-0000-000000000099",
+      }),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
 
     expect(mocks.sendSms).not.toHaveBeenCalled();
@@ -1516,7 +1518,8 @@ describe("messaging location target safety", () => {
       callerWithDb(db).testSend({
         locationId: LOCATION_ID,
         to: "+15555550100",
-      })
+        requestId: "00000000-0000-0000-0000-000000000099",
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: expect.stringContaining("test sends are disabled"),
@@ -1535,7 +1538,8 @@ describe("messaging location target safety", () => {
       callerWithDb(db).testSend({
         locationId: LOCATION_ID,
         to: "(555) 555-0100",
-      })
+        requestId: "00000000-0000-0000-0000-000000000099",
+      }),
     ).resolves.toEqual({ ok: true, id: "sms_123" });
 
     expect(mocks.sendSms).toHaveBeenCalledWith({
@@ -1543,6 +1547,9 @@ describe("messaging location target safety", () => {
       body: "OpenVPM test message — your texting is set up correctly.",
       practiceId: PRACTICE_ID,
       locationId: LOCATION_ID,
+      source: "self_host_test",
+      sourceId: "00000000-0000-0000-0000-000000000099",
+      idempotencyKey: "sms:self-host-test:00000000-0000-0000-0000-000000000099",
     });
   });
 });
@@ -1557,13 +1564,13 @@ describe("messaging location sender join scoping", () => {
       new RegExp(
         `innerJoin\\(\\s*locations,\\s*and\\(\\s*eq\\(locations\\.id, locationMessaging\\.locationId\\),\\s*eq\\(locations\\.practiceId, ${practiceExpr.replace(
           ".",
-          "\\."
+          "\\.",
         )}\\),\\s*(?:activePracticePredicate\\(${practiceExpr.replace(
           ".",
-          "\\."
+          "\\.",
         )}\\),\\s*)?isNull\\(locations\\.deletedAt\\)\\s*,?\\s*\\)\\s*,?\\s*\\)`,
-        "s"
-      )
+        "s",
+      ),
     );
   }
 
@@ -1586,14 +1593,14 @@ describe("messaging location sender join scoping", () => {
     expect(source).not.toContain('practice?.tier ?? "free"');
 
     const statusJoins = source.match(
-      /leftJoin\(\s*locationMessaging,\s*and\([\s\S]+?isNull\(locationMessaging\.deletedAt\)[\s\S]+?\)\s*\)/g
+      /leftJoin\(\s*locationMessaging,\s*and\([\s\S]+?isNull\(locationMessaging\.deletedAt\)[\s\S]+?\)\s*\)/g,
     );
 
     expect(statusJoins).toHaveLength(2);
     for (const join of statusJoins ?? []) {
       expect(join).toContain("eq(locationMessaging.locationId, locations.id)");
       expect(join).toContain(
-        "eq(locationMessaging.practiceId, ctx.practiceId)"
+        "eq(locationMessaging.practiceId, ctx.practiceId)",
       );
       expect(join).toContain("activePracticePredicate(ctx.practiceId)");
       expect(join).toContain("isNull(locationMessaging.deletedAt)");
@@ -1615,10 +1622,10 @@ describe("messaging location sender join scoping", () => {
 
   it("requires active sender lookups to have a nonblank sender or messaging profile", () => {
     expect(readSource("lib/messaging/sender-query.ts")).toContain(
-      "nullif(trim(${locationMessaging.senderE164}), '') is not null"
+      "nullif(trim(${locationMessaging.senderE164}), '') is not null",
     );
     expect(readSource("lib/messaging/sender-query.ts")).toContain(
-      "nullif(trim(${locationMessaging.messagingProfileId}), '') is not null"
+      "nullif(trim(${locationMessaging.messagingProfileId}), '') is not null",
     );
 
     for (const path of [
@@ -1632,7 +1639,7 @@ describe("messaging location sender join scoping", () => {
       expect(source).toContain("hasNonBlankMessagingSender()");
       expect(source).not.toContain("isNotNull(locationMessaging.senderE164)");
       expect(source).not.toContain(
-        "isNotNull(locationMessaging.messagingProfileId)"
+        "isNotNull(locationMessaging.messagingProfileId)",
       );
     }
   });
@@ -1640,11 +1647,11 @@ describe("messaging location sender join scoping", () => {
   it("scopes cron and webhook sender lookups to active matching locations", () => {
     expectScopedLocationJoin(
       readSource("app/api/cron/reminders/route.ts"),
-      "practiceId"
+      "practiceId",
     );
     expectScopedLocationJoin(
       readSource("lib/messaging/inbound.ts"),
-      "locationMessaging.practiceId"
+      "locationMessaging.practiceId",
     );
   });
 
@@ -1655,19 +1662,19 @@ describe("messaging location sender join scoping", () => {
     expect(source).toContain("findMessagingLocationForWebhook");
     expect(source).toContain("locationMessaging.messagingProfileId");
     expect(readSource("app/api/webhooks/telnyx/route.ts")).toContain(
-      "findMessagingLocationForWebhook({"
+      "findMessagingLocationForWebhook({",
     );
     expect(readSource("app/api/webhooks/telnyx/route.ts")).toContain(
-      'provider: "telnyx"'
+      'provider: "telnyx"',
     );
     expect(readSource("app/api/webhooks/twilio/route.ts")).toContain(
-      "findMessagingLocationForWebhook({"
+      "findMessagingLocationForWebhook({",
     );
     expect(readSource("app/api/webhooks/twilio/route.ts")).toContain(
-      'provider: "twilio"'
+      'provider: "twilio"',
     );
     expect(readSource("app/api/webhooks/twilio/route.ts")).toContain(
-      "handleInboundSmsReply({"
+      "handleInboundSmsReply({",
     );
   });
 
@@ -1676,10 +1683,10 @@ describe("messaging location sender join scoping", () => {
 
     expect(source).toContain("if (!opts.practiceId) return undefined");
     expect(source).toMatch(
-      /innerJoin\(\s*locations,\s*and\(\s*eq\(locations\.id, locationMessaging\.locationId\),\s*eq\(locations\.practiceId, opts\.practiceId!\),\s*isNull\(locations\.deletedAt\)\s*,?\s*\)\s*,?\s*\)/s
+      /innerJoin\(\s*locations,\s*and\(\s*eq\(locations\.id, locationMessaging\.locationId\),\s*eq\(locations\.practiceId, opts\.practiceId!\),\s*isNull\(locations\.deletedAt\)\s*,?\s*\)\s*,?\s*\)/s,
     );
     expect(source).toContain(
-      "eq(locationMessaging.practiceId, opts.practiceId!)"
+      "eq(locationMessaging.practiceId, opts.practiceId!)",
     );
   });
 });

--- a/apps/web/server/__tests__/notifications-safety.test.ts
+++ b/apps/web/server/__tests__/notifications-safety.test.ts
@@ -28,6 +28,9 @@ const mocks = vi.hoisted(() => ({
     error: undefined as string | undefined,
   })),
   recordAuditLog: vi.fn(async () => undefined),
+  alertOps: vi.fn(async () => undefined),
+  durableDb: {} as Record<string, unknown>,
+  withDurableSmsCommunication: vi.fn(),
 }));
 
 vi.mock("@/lib/email", () => ({
@@ -43,6 +46,12 @@ vi.mock("@/lib/sms", () => ({
 
 vi.mock("@/lib/audit", () => ({
   recordAuditLog: mocks.recordAuditLog,
+}));
+
+vi.mock("@/lib/alerts", () => ({ alertOps: mocks.alertOps }));
+
+vi.mock("@/lib/messaging/durable-sms-communication", () => ({
+  withDurableSmsCommunication: mocks.withDurableSmsCommunication,
 }));
 
 const { REMINDER_BATCH_MAX_TARGETS, notificationsRouter } =
@@ -70,6 +79,11 @@ const PRACTICE_SETTINGS = {
 };
 
 function callerWithDb(db: Record<string, unknown>) {
+  mocks.durableDb = db;
+  mocks.withDurableSmsCommunication.mockImplementation(
+    (_practiceId: string, fn: (durableDb: unknown) => unknown) =>
+      fn(mocks.durableDb),
+  );
   const session = {
     user: {
       id: USER_ID,
@@ -97,7 +111,7 @@ function createDb(opts?: {
       orderBy: vi.fn(async () => result),
       then: (
         resolve: (value: unknown[]) => unknown,
-        reject?: (error: unknown) => unknown
+        reject?: (error: unknown) => unknown,
       ) => Promise.resolve(result).then(resolve, reject),
     };
     const builder = {
@@ -117,7 +131,7 @@ function createDb(opts?: {
     onConflictDoNothing,
     then: (
       resolve: (value: undefined) => unknown,
-      reject?: (error: unknown) => unknown
+      reject?: (error: unknown) => unknown,
     ) => Promise.resolve(undefined).then(resolve, reject),
   }));
   const insert = vi.fn(() => ({ values: insertValues }));
@@ -153,7 +167,7 @@ describe("notification target safety", () => {
     const caller = callerWithDb(db);
 
     await expect(
-      caller.sendAppointmentReminder({ appointmentId: APPOINTMENT_ID })
+      caller.sendAppointmentReminder({ appointmentId: APPOINTMENT_ID }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -165,7 +179,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      caller.sendInvoiceEmail({ invoiceId: INVOICE_ID })
+      caller.sendInvoiceEmail({ invoiceId: INVOICE_ID }),
     ).rejects.toMatchObject({
       code: "NOT_FOUND",
       message: "Practice not found",
@@ -189,7 +203,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendAppointmentReminder({
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
@@ -198,7 +212,7 @@ describe("notification target safety", () => {
   });
 
   it("rejects manual reminders for an unconfirmed appointment request", async () => {
-    const { db, insertValues } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [
           {
@@ -221,7 +235,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendAppointmentReminder({
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message: "Confirm the appointment before sending a reminder.",
@@ -243,7 +257,7 @@ describe("notification target safety", () => {
       sid: "sms-manual-1",
       error: undefined,
     });
-    const { db, insertValues } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [
           {
@@ -271,7 +285,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendAppointmentReminder({
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     ).resolves.toEqual({ success: true, channel: "sms" });
 
     expect(mocks.sendAppointmentReminderSms).toHaveBeenCalledWith(
@@ -284,23 +298,30 @@ describe("notification target safety", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         practiceId: PRACTICE_ID,
         clientId: CLIENT_ID,
         channel: "sms",
-        content: "Appointment reminder sent for Miso on Tuesday, June 30, 2026",
+        direction: "outbound",
+        status: "pending",
+      }),
+    );
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "sms",
         status: "sent",
         providerMessageId: "sms-manual-1",
-      })
+      }),
     );
+    expect(mocks.withDurableSmsCommunication).toHaveBeenCalledTimes(2);
   });
 
   it("blocks an SMS-only manual reminder during the clinic's quiet hours", async () => {
     vi.setSystemTime(new Date("2026-07-02T05:00:00Z")); // 10 PM in Los Angeles
-    const { db, insertValues } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [
           {
@@ -327,7 +348,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendAppointmentReminder({
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -341,7 +362,7 @@ describe("notification target safety", () => {
 
   it("falls back to email instead of texting during quiet hours", async () => {
     vi.setSystemTime(new Date("2026-07-02T05:00:00Z")); // 10 PM in Los Angeles
-    const { db, insertValues } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [
           {
@@ -368,13 +389,16 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendAppointmentReminder({
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     ).resolves.toEqual({ success: true, channel: "email" });
 
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
     expect(mocks.sendAppointmentReminder).toHaveBeenCalledOnce();
     expect(insertValues).toHaveBeenCalledWith(
-      expect.objectContaining({ channel: "email", status: "sent" })
+      expect.objectContaining({ channel: "email", status: "pending" }),
+    );
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "email", status: "sent" }),
     );
   });
 
@@ -384,7 +408,7 @@ describe("notification target safety", () => {
       id: "email-manual-1",
       error: undefined,
     });
-    const { db, insertValues } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [
           {
@@ -410,7 +434,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendAppointmentReminder({
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     ).resolves.toEqual({ success: true, channel: "email" });
 
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
@@ -420,14 +444,20 @@ describe("notification target safety", () => {
         practiceId: PRACTICE_ID,
         clientId: CLIENT_ID,
         channel: "email",
+        status: "pending",
+      }),
+    );
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "email",
         status: "sent",
         providerMessageId: "email-manual-1",
-      })
+      }),
     );
   });
 
   it("blocks manual appointment reminder emails to provider-suppressed recipients", async () => {
-    const { db, insertValues } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [
           {
@@ -453,7 +483,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendAppointmentReminder({
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message:
@@ -465,7 +495,7 @@ describe("notification target safety", () => {
   });
 
   it("rejects manual SMS-only reminders when no active sender exists", async () => {
-    const { db, insertValues } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [
           {
@@ -491,7 +521,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendAppointmentReminder({
         appointmentId: APPOINTMENT_ID,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
@@ -500,7 +530,7 @@ describe("notification target safety", () => {
   });
 
   it("counts stale or cross-tenant appointment ids as failed bulk reminders", async () => {
-    const { db, insertValues } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [
           {
@@ -526,7 +556,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendBulkReminders({
         appointmentIds: [APPOINTMENT_ID, STALE_APPOINTMENT_ID],
-      })
+      }),
     ).resolves.toEqual({ sent: 1, failed: 1 });
 
     expect(mocks.sendAppointmentReminder).toHaveBeenCalledOnce();
@@ -537,7 +567,7 @@ describe("notification target safety", () => {
         appointmentTime: "9:30 PM",
         practiceName: "Neighborhood Veterinary",
         practicePhone: "555-0100",
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledTimes(1);
     expect(insertValues).toHaveBeenCalledWith(
@@ -545,14 +575,16 @@ describe("notification target safety", () => {
         practiceId: PRACTICE_ID,
         clientId: CLIENT_ID,
         channel: "email",
-        content: "Reminder sent for Miso on Tuesday, June 30, 2026",
-        status: "sent",
-      })
+        status: "pending",
+      }),
+    );
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "email", status: "sent" }),
     );
   });
 
   it("routes bulk SMS reminders through an active practice sender", async () => {
-    const { db, insertValues } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [
           {
@@ -579,7 +611,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendBulkReminders({
         appointmentIds: [APPOINTMENT_ID, STALE_APPOINTMENT_ID],
-      })
+      }),
     ).resolves.toEqual({ sent: 1, failed: 1 });
 
     expect(mocks.sendAppointmentReminderSms).toHaveBeenCalledOnce();
@@ -593,7 +625,7 @@ describe("notification target safety", () => {
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
         clientId: CLIENT_ID,
-      })
+      }),
     );
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
     expect(insertValues).toHaveBeenCalledTimes(1);
@@ -602,9 +634,11 @@ describe("notification target safety", () => {
         practiceId: PRACTICE_ID,
         clientId: CLIENT_ID,
         channel: "sms",
-        content: "Reminder sent for Miso on Tuesday, June 30, 2026",
-        status: "sent",
-      })
+        status: "pending",
+      }),
+    );
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "sms", status: "sent" }),
     );
   });
 
@@ -614,7 +648,7 @@ describe("notification target safety", () => {
       id: "email-bulk-1",
       error: undefined,
     });
-    const { db, insertValues } = createDb({
+    const { db, insertValues, updateSet } = createDb({
       selectResults: [
         [
           {
@@ -639,7 +673,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendBulkReminders({ appointmentIds: [APPOINTMENT_ID] })
+      callerWithDb(db).sendBulkReminders({ appointmentIds: [APPOINTMENT_ID] }),
     ).resolves.toEqual({ sent: 1, failed: 0 });
 
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
@@ -649,10 +683,15 @@ describe("notification target safety", () => {
         practiceId: PRACTICE_ID,
         clientId: CLIENT_ID,
         channel: "email",
-        content: "Reminder sent for Miso on Wednesday, July 1, 2026",
+        status: "pending",
+      }),
+    );
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "email",
         status: "sent",
         providerMessageId: "email-bulk-1",
-      })
+      }),
     );
   });
 
@@ -682,16 +721,16 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendBulkReminders({ appointmentIds: [APPOINTMENT_ID] })
+      callerWithDb(db).sendBulkReminders({ appointmentIds: [APPOINTMENT_ID] }),
     ).resolves.toEqual({ sent: 0, failed: 1 });
 
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("falls back to email when bulk SMS transport throws", async () => {
+  it("preserves the pending claim when bulk SMS transport throws", async () => {
     mocks.sendAppointmentReminderSms.mockRejectedValueOnce(
-      new Error("Provider unavailable")
+      new Error("Provider unavailable"),
     );
     const { db, insertValues } = createDb({
       selectResults: [
@@ -718,19 +757,18 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendBulkReminders({ appointmentIds: [APPOINTMENT_ID] })
-    ).resolves.toEqual({ sent: 1, failed: 0 });
+      callerWithDb(db).sendBulkReminders({ appointmentIds: [APPOINTMENT_ID] }),
+    ).resolves.toEqual({ sent: 0, failed: 1 });
 
     expect(mocks.sendAppointmentReminderSms).toHaveBeenCalledOnce();
-    expect(mocks.sendAppointmentReminder).toHaveBeenCalledOnce();
+    expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         practiceId: PRACTICE_ID,
         clientId: CLIENT_ID,
-        channel: "email",
-        content: "Reminder sent for Miso on Wednesday, July 1, 2026",
-        status: "sent",
-      })
+        channel: "sms",
+        status: "pending",
+      }),
     );
   });
 
@@ -759,7 +797,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendBulkReminders({ appointmentIds: [APPOINTMENT_ID] })
+      callerWithDb(db).sendBulkReminders({ appointmentIds: [APPOINTMENT_ID] }),
     ).resolves.toEqual({ sent: 0, failed: 1 });
 
     expect(mocks.sendAppointmentReminderSms).not.toHaveBeenCalled();
@@ -773,7 +811,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendBulkReminders({
         appointmentIds: [STALE_APPOINTMENT_ID],
-      })
+      }),
     ).resolves.toEqual({ sent: 0, failed: 1 });
 
     expect(mocks.sendAppointmentReminder).not.toHaveBeenCalled();
@@ -788,18 +826,18 @@ describe("notification target safety", () => {
       callerWithDb(db).sendBulkReminders({
         appointmentIds: Array.from(
           { length: REMINDER_BATCH_MAX_TARGETS + 1 },
-          () => APPOINTMENT_ID
+          () => APPOINTMENT_ID,
         ),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       callerWithDb(db).sendVaccinationReminders({
         patientIds: Array.from(
           { length: REMINDER_BATCH_MAX_TARGETS + 1 },
-          () => PATIENT_ID
+          () => PATIENT_ID,
         ),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(select).not.toHaveBeenCalled();
@@ -839,7 +877,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendVaccinationReminders({
         patientIds: [PATIENT_ID, STALE_PATIENT_ID],
-      })
+      }),
     ).resolves.toEqual({ sent: 1, failed: 0, blocked: 1, deduped: 0 });
 
     expect(mocks.sendVaccinationReminder).toHaveBeenCalledOnce();
@@ -849,7 +887,7 @@ describe("notification target safety", () => {
         dueDate: "Jun 1, 2026",
         practiceName: "Neighborhood Veterinary",
         practicePhone: "555-0100",
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -859,13 +897,13 @@ describe("notification target safety", () => {
         subject: "Vaccination Reminder",
         status: "pending",
         dedupeKey: expect.stringContaining("vaccination-recall:v1"),
-      })
+      }),
     );
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "email",
         status: "sent",
-      })
+      }),
     );
   });
 
@@ -910,7 +948,7 @@ describe("notification target safety", () => {
     await expect(
       callerWithDb(db).sendVaccinationReminders({
         patientIds: [PATIENT_ID, STALE_PATIENT_ID],
-      })
+      }),
     ).resolves.toEqual({ sent: 1, failed: 0, blocked: 1, deduped: 0 });
 
     expect(mocks.sendVaccinationReminderSms).toHaveBeenCalledOnce();
@@ -923,7 +961,7 @@ describe("notification target safety", () => {
         practicePhone: "555-0100",
         practiceId: PRACTICE_ID,
         locationId: LOCATION_ID,
-      })
+      }),
     );
     expect(mocks.sendVaccinationReminder).not.toHaveBeenCalled();
     expect(insertValues).toHaveBeenCalledTimes(1);
@@ -936,7 +974,7 @@ describe("notification target safety", () => {
         content: "Vaccination reminder for Miso: Rabies, Bordetella",
         status: "pending",
         dedupeKey: expect.stringContaining("vaccination-recall:v1"),
-      })
+      }),
     );
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -944,7 +982,7 @@ describe("notification target safety", () => {
         content: "Vaccination reminder sent for Miso: Rabies, Bordetella",
         status: "sent",
         providerMessageId: "sms-vax-1",
-      })
+      }),
     );
   });
 
@@ -973,7 +1011,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] })
+      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] }),
     ).resolves.toEqual({ sent: 1, failed: 0, blocked: 0, deduped: 0 });
 
     expect(mocks.sendVaccinationReminderSms).not.toHaveBeenCalled();
@@ -985,14 +1023,14 @@ describe("notification target safety", () => {
         channel: "email",
         subject: "Vaccination Reminder",
         status: "pending",
-      })
+      }),
     );
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "email",
         content: "Vaccination reminder sent for Miso: Rabies",
         status: "sent",
-      })
+      }),
     );
   });
 
@@ -1021,13 +1059,13 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] })
+      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] }),
     ).resolves.toEqual({ sent: 1, failed: 0, blocked: 0, deduped: 0 });
 
     expect(mocks.sendVaccinationReminderSms).not.toHaveBeenCalled();
     expect(mocks.sendVaccinationReminder).toHaveBeenCalledOnce();
     expect(updateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ channel: "email", status: "sent" })
+      expect.objectContaining({ channel: "email", status: "sent" }),
     );
   });
 
@@ -1074,7 +1112,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] })
+      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] }),
     ).resolves.toEqual({ sent: 1, failed: 0, blocked: 0, deduped: 0 });
 
     expect(mocks.sendVaccinationReminder).toHaveBeenCalledOnce();
@@ -1082,7 +1120,7 @@ describe("notification target safety", () => {
       expect.objectContaining({
         vaccineName: "Rabies, Bordetella",
         dueDate: "Jun 1, 2026",
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledTimes(1);
     expect(insertValues).toHaveBeenCalledWith(
@@ -1094,7 +1132,7 @@ describe("notification target safety", () => {
         content: "Vaccination reminder for Miso: Rabies, Bordetella",
         status: "pending",
         dedupeKey: expect.stringContaining("vaccination-recall:v1"),
-      })
+      }),
     );
     expect(updateSet).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1102,7 +1140,7 @@ describe("notification target safety", () => {
         content: "Vaccination reminder sent for Miso: Rabies, Bordetella",
         status: "sent",
         providerMessageId: "email-vax-combined",
-      })
+      }),
     );
   });
 
@@ -1131,16 +1169,16 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] })
+      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] }),
     ).resolves.toEqual({ sent: 0, failed: 0, blocked: 1, deduped: 0 });
 
     expect(mocks.sendVaccinationReminder).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("falls back to email when vaccination SMS transport throws", async () => {
+  it("preserves the pending claim when vaccination SMS transport throws", async () => {
     mocks.sendVaccinationReminderSms.mockRejectedValueOnce(
-      new Error("Provider unavailable")
+      new Error("Provider unavailable"),
     );
     const { db, insertValues, updateSet } = createDb({
       selectResults: [
@@ -1166,11 +1204,11 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] })
-    ).resolves.toEqual({ sent: 1, failed: 0, blocked: 0, deduped: 0 });
+      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] }),
+    ).resolves.toEqual({ sent: 0, failed: 1, blocked: 0, deduped: 0 });
 
     expect(mocks.sendVaccinationReminderSms).toHaveBeenCalledOnce();
-    expect(mocks.sendVaccinationReminder).toHaveBeenCalledOnce();
+    expect(mocks.sendVaccinationReminder).not.toHaveBeenCalled();
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
         practiceId: PRACTICE_ID,
@@ -1178,15 +1216,9 @@ describe("notification target safety", () => {
         channel: "sms",
         subject: "Vaccination Reminder",
         status: "pending",
-      })
+      }),
     );
-    expect(updateSet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channel: "email",
-        content: "Vaccination reminder sent for Miso: Rabies",
-        status: "sent",
-      })
-    );
+    expect(updateSet).not.toHaveBeenCalled();
   });
 
   it("releases a failed recall claim so a deliberate retry is possible", async () => {
@@ -1224,11 +1256,11 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] })
+      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] }),
     ).resolves.toEqual({ sent: 0, failed: 1, blocked: 0, deduped: 0 });
 
     expect(updateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ status: "failed", dedupeKey: null })
+      expect.objectContaining({ status: "failed", dedupeKey: null }),
     );
   });
 
@@ -1257,7 +1289,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] })
+      callerWithDb(db).sendVaccinationReminders({ patientIds: [PATIENT_ID] }),
     ).resolves.toEqual({ sent: 0, failed: 0, blocked: 1, deduped: 0 });
 
     expect(mocks.sendVaccinationReminderSms).not.toHaveBeenCalled();
@@ -1303,7 +1335,7 @@ describe("notification target safety", () => {
     const { db, insertValues } = createDb({ selectResults: [[]] });
 
     await expect(
-      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID })
+      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
 
     expect(mocks.sendInvoiceEmail).not.toHaveBeenCalled();
@@ -1331,7 +1363,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID })
+      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID }),
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
       message:
@@ -1361,7 +1393,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID })
+      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID }),
     ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
     expect(mocks.sendInvoiceEmail).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
@@ -1395,7 +1427,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID })
+      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID }),
     ).resolves.toEqual({ success: true });
 
     expect(mocks.sendInvoiceEmail).toHaveBeenCalledWith(
@@ -1406,7 +1438,7 @@ describe("notification target safety", () => {
         dueDate: "Jul 1, 2026",
         practiceName: "Neighborhood Veterinary",
         practicePhone: "555-0100",
-      })
+      }),
     );
     expect(insertValues).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1417,7 +1449,7 @@ describe("notification target safety", () => {
         content: "Invoice sent — amount due: $88.45",
         status: "sent",
         providerMessageId: "email-invoice-1",
-      })
+      }),
     );
   });
 
@@ -1443,7 +1475,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID })
+      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message:
@@ -1481,7 +1513,7 @@ describe("notification target safety", () => {
     });
 
     await expect(
-      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID })
+      callerWithDb(db).sendInvoiceEmail({ invoiceId: INVOICE_ID }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Email provider rejected the message",
@@ -1494,11 +1526,11 @@ describe("notification target safety", () => {
 describe("notification query scoping", () => {
   const routerSource = readFileSync(
     new URL("../routers/notifications.ts", import.meta.url),
-    "utf8"
+    "utf8",
   );
   const recallSource = readFileSync(
     new URL("../vaccination-recalls.ts", import.meta.url),
-    "utf8"
+    "utf8",
   );
   const source = `${routerSource}\n${recallSource}`;
 
@@ -1507,22 +1539,22 @@ describe("notification query scoping", () => {
     table: string,
     foreignKey: string,
     tenantExpr: string,
-    minCount = 1
+    minCount = 1,
   ) {
     const joins = source.match(
       new RegExp(
         `${joinKind}\\(\\s*${table},\\s*and\\(\\s*eq\\(${foreignKey.replace(
           ".",
-          "\\."
+          "\\.",
         )}, ${table}\\.id\\),\\s*eq\\(${table}\\.practiceId, ${tenantExpr.replace(
           ".",
-          "\\."
+          "\\.",
         )}\\),\\s*activePracticePredicate\\(${tenantExpr.replace(
           ".",
-          "\\."
-        )}\\),\\s*isNull\\(${table}\\.deletedAt\\)\\s*\\)\\s*\\)`,
-        "gs"
-      )
+          "\\.",
+        )}\\),\\s*isNull\\(${table}\\.deletedAt\\),?\\s*\\),?\\s*\\)`,
+        "gs",
+      ),
     );
     expect(joins?.length).toBeGreaterThanOrEqual(minCount);
   }
@@ -1533,7 +1565,7 @@ describe("notification query scoping", () => {
     expect(source).toContain("throw practiceNotFound()");
 
     const appointmentPatientJoins = source.match(
-      /leftJoin\(\s*patients,\s*and\(\s*eq\(appointments\.patientId, patients\.id\),\s*eq\(patients\.clientId, appointments\.clientId\),\s*eq\(patients\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\),\s*isNull\(patients\.deletedAt\)\s*\)\s*\)/gs
+      /leftJoin\(\s*patients,\s*and\(\s*eq\(appointments\.patientId, patients\.id\),\s*eq\(patients\.clientId, appointments\.clientId\),\s*eq\(patients\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\),\s*isNull\(patients\.deletedAt\),?\s*\),?\s*\)/gs,
     );
     expect(appointmentPatientJoins?.length).toBeGreaterThanOrEqual(3);
     expectScopedJoin(
@@ -1541,31 +1573,31 @@ describe("notification query scoping", () => {
       "clients",
       "appointments.clientId",
       "ctx.practiceId",
-      3
+      3,
     );
     expectScopedJoin(
       "leftJoin",
       "users",
       "appointments.doctorId",
-      "ctx.practiceId"
+      "ctx.practiceId",
     );
     expect(source).not.toContain(
-      'inArray(appointments.status, ["scheduled", "confirmed"])'
+      'inArray(appointments.status, ["scheduled", "confirmed"])',
     );
     expect(source).toContain('if (appt.status !== "confirmed")');
     expect(
-      source.match(/eq\(appointments\.status, "confirmed"\)/g)?.length
+      source.match(/eq\(appointments\.status, "confirmed"\)/g)?.length,
     ).toBeGreaterThanOrEqual(2);
   });
 
   it("keeps active reminder SMS sender lookup tenant scoped and active", () => {
     const senderBlock = source.slice(
       source.indexOf("async function activeReminderSmsSender"),
-      source.indexOf("export const notificationsRouter")
+      source.indexOf("export const notificationsRouter"),
     );
 
     expect(senderBlock).toContain(
-      "eq(locationMessaging.practiceId, ctx.practiceId)"
+      "eq(locationMessaging.practiceId, ctx.practiceId)",
     );
     expect(senderBlock).toContain("activePracticePredicate(ctx.practiceId)");
     expect(senderBlock).toContain("eq(locations.practiceId, ctx.practiceId)");
@@ -1573,14 +1605,14 @@ describe("notification query scoping", () => {
     expect(senderBlock).toContain("isNull(locations.deletedAt)");
     expect(senderBlock).toContain("eq(locationMessaging.enabled, true)");
     expect(senderBlock).toContain(
-      'eq(locationMessaging.registrationStatus, "active")'
+      'eq(locationMessaging.registrationStatus, "active")',
     );
     expect(senderBlock).toContain("hasNonBlankMessagingSender()");
     expect(senderBlock).not.toContain(
-      "isNotNull(locationMessaging.senderE164)"
+      "isNotNull(locationMessaging.senderE164)",
     );
     expect(senderBlock).not.toContain(
-      "isNotNull(locationMessaging.messagingProfileId)"
+      "isNotNull(locationMessaging.messagingProfileId)",
     );
   });
 
@@ -1589,54 +1621,54 @@ describe("notification query scoping", () => {
       "leftJoin",
       "clients",
       "invoices.clientId",
-      "ctx.practiceId"
+      "ctx.practiceId",
     );
     expectScopedJoin(
       "innerJoin",
       "patients",
       "vaccinationRecords.patientId",
       "ctx.practiceId",
-      2
+      2,
     );
     expectScopedJoin(
       "innerJoin",
       "clients",
       "patients.clientId",
       "ctx.practiceId",
-      2
+      2,
     );
   });
 
   it("matches provider suppressions against trimmed normalized client emails", () => {
     const suppressionJoins = source.match(
-      /sql`\$\{emailSuppressions\.email\} = lower\(trim\(\$\{clients\.email\}\)\)`/g
+      /sql`\$\{emailSuppressions\.email\} = lower\(trim\(\$\{clients\.email\}\)\)`/g,
     );
 
     expect(suppressionJoins?.length).toBeGreaterThanOrEqual(4);
     expect(source).not.toContain(
-      "sql`${emailSuppressions.email} = lower(${clients.email})`"
+      "sql`${emailSuppressions.email} = lower(${clients.email})`",
     );
   });
 
   it("uses the practice timezone for vaccination overdue cutoffs", () => {
     const recallPreviewBlock = recallSource.slice(
       recallSource.indexOf("async function loadVaccinationRecallRecipients"),
-      recallSource.indexOf("export async function getVaccinationRecallPreview")
+      recallSource.indexOf("export async function getVaccinationRecallPreview"),
     );
     const vaccinationBlock = source.slice(
       source.indexOf("getOverdueVaccinations:"),
-      source.indexOf("sendVaccinationReminders:")
+      source.indexOf("sendVaccinationReminders:"),
     );
 
     expect(source).toContain("async function practiceDateInput");
     expect(source).toContain(
-      "formatDateInputForTimeZone(new Date(), practice.timezone)"
+      "formatDateInputForTimeZone(new Date(), practice.timezone)",
     );
     expect(vaccinationBlock).toContain(
-      "const today = await practiceDateInput(ctx)"
+      "const today = await practiceDateInput(ctx)",
     );
     expect(recallPreviewBlock).toContain(
-      "const today = formatDateInputForTimeZone(new Date(), practice.timezone)"
+      "const today = formatDateInputForTimeZone(new Date(), practice.timezone)",
     );
     expect(recallPreviewBlock).toContain("latestVaccinationRecordPredicate()");
     expect(recallPreviewBlock).toContain('eq(patients.status, "active")');
@@ -1645,17 +1677,17 @@ describe("notification query scoping", () => {
 
   it("formats manual appointment reminder labels in the practice timezone", () => {
     expect(source).toContain(
-      "function formatDate(d: Date | string, timeZone?: string | null)"
+      "function formatDate(d: Date | string, timeZone?: string | null)",
     );
     expect(source).toContain(
-      "function formatTime(d: Date | string, timeZone?: string | null)"
+      "function formatTime(d: Date | string, timeZone?: string | null)",
     );
     expect(source).toContain("practiceTimezone: practices.timezone");
     expect(source).toContain(
-      "formatDate(appt.startTime, appt.practiceTimezone)"
+      "formatDate(appt.startTime, appt.practiceTimezone)",
     );
     expect(source).toContain(
-      "formatTime(appt.startTime, appt.practiceTimezone)"
+      "formatTime(appt.startTime, appt.practiceTimezone)",
     );
     expect(source).not.toContain("formatDate(appt.startTime)");
     expect(source).not.toContain("formatTime(appt.startTime)");
@@ -1665,7 +1697,7 @@ describe("notification query scoping", () => {
     expect(source).toContain("function practiceDisplayName");
     expect(source).toContain("async function practiceNotificationSettings");
     expect(source).toContain(
-      "practiceName: practiceDisplayName(appt.practiceName)"
+      "practiceName: practiceDisplayName(appt.practiceName)",
     );
     expect(source).toContain("name: practiceDisplayName(practice.name)");
     expect(source).not.toContain("practice?.name");

--- a/apps/web/server/__tests__/tenant-scoping.test.ts
+++ b/apps/web/server/__tests__/tenant-scoping.test.ts
@@ -32,12 +32,21 @@ describe("tenant scoping", () => {
       if (ALLOWLIST[file]) return;
       expect(
         src.includes("practiceId"),
-        `${file} queries the DB but never references practiceId — possible cross-tenant leak`
+        `${file} queries the DB but never references practiceId — possible cross-tenant leak`,
       ).toBe(true);
     });
   }
 
   it("keeps the allowlist small and intentional", () => {
     expect(Object.keys(ALLOWLIST).length).toBeLessThanOrEqual(3);
+  });
+
+  it("keeps platform SMS recovery available during operator read-only billing", () => {
+    const source = readFileSync(
+      fileURLToPath(new URL("../trpc.ts", import.meta.url)),
+      "utf8",
+    );
+    expect(source).toContain('"admin.reconcileSmsSendAttempt"');
+    expect(source).toContain('"admin.resendSmsSendAttempt"');
   });
 });

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
-import { and, eq, isNull, sql, desc } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, lte, sql } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
+import { unstable_noStore as noStore } from "next/cache";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure } from "../trpc";
 import { db } from "@openpims/db/client";
@@ -12,6 +13,9 @@ import {
   locations,
   messagingRegistrations,
   locationMessaging,
+  communications,
+  smsSendAttemptEvents,
+  smsSendAttempts,
 } from "@openpims/db";
 import { isPlatformAdmin } from "@/lib/platform-admin";
 import { computeActivationFunnel } from "@/lib/admin/activation-funnel";
@@ -49,6 +53,7 @@ import {
   observedRegistrationStatus,
 } from "@/lib/messaging/a2p-lifecycle";
 import { messagingProgramUrls } from "@/lib/messaging/public-program";
+import { reconcileSmsSendAttempt, resendSmsAttempt } from "@/lib/sms-dispatch";
 
 /**
  * Platform-operator only. Crosses tenant boundaries deliberately, so it is
@@ -56,7 +61,10 @@ import { messagingProgramUrls } from "@/lib/messaging/public-program";
  */
 const platformAdminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
   if (!isPlatformAdmin(ctx.session?.user?.email)) {
-    throw new TRPCError({ code: "FORBIDDEN", message: "Platform admin access only." });
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Platform admin access only.",
+    });
   }
   return next();
 });
@@ -128,11 +136,10 @@ export function messagingCampaignCopy(input: {
   return {
     description:
       "Veterinary clinic communications including appointment reminders, vaccination and care follow-ups, and two-way client support. Messages are sent only to clients whose SMS consent is recorded by the clinic.",
-    sample1: `${input.displayName}: Reminder—your pet's appointment is tomorrow at 10:00 AM. Call ${input.businessPhone} if you need to reschedule. Reply STOP to opt out.`,
-    sample2: `${input.displayName}: Your pet's care instructions are ready. Reply here with questions or call ${input.businessPhone}. Reply STOP to opt out.`,
-    sample3: `${input.displayName}: Clinic text messaging information: ${input.programUrl} Reply HELP for help or STOP to opt out.`,
-    messageFlow:
-      `Clients opt in during phone or in-person intake. Clinic staff read or show the exact disclosure at ${input.optInUrl}, ask for an explicit choice, and record the consent decision, timestamp, disclosure, consent source, and mobile number in OpenVPM. The consent control is optional and unchecked by default. No SMS is sent before consent is recorded. Message frequency varies. Message and data rates may apply. Consent is not a condition of purchase. Reply STOP to opt out or HELP for help. Privacy: ${input.privacyPolicyUrl} Terms: ${input.termsUrl}`,
+    sample1: `${input.displayName}: Reminder—your pet's appointment is tomorrow at 10:00 AM. Call ${input.businessPhone} if you need to reschedule. Reply STOP to opt out or HELP for help.`,
+    sample2: `${input.displayName}: Your pet's care instructions are ready. Reply here with questions or call ${input.businessPhone}. Reply STOP to opt out or HELP for help.`,
+    sample3: `${input.displayName}: Clinic text messaging information: ${input.programUrl} Reply STOP to opt out or HELP for help.`,
+    messageFlow: `Clients opt in during phone or in-person intake. Clinic staff read or show the exact disclosure at ${input.optInUrl}, ask for an explicit choice, and record the consent decision, timestamp, disclosure, consent source, and mobile number in OpenVPM. The consent control is optional and unchecked by default. No SMS is sent before consent is recorded. Message frequency varies. Message and data rates may apply. Consent is not a condition of purchase. Reply STOP to opt out or HELP for help. Privacy: ${input.privacyPolicyUrl} Terms: ${input.termsUrl}`,
     helpMessage: `Contact ${input.displayName} at ${input.businessPhone} or ${input.website}. Reply STOP to opt out.`,
     optinMessage: `${input.displayName}: You agreed to receive clinic service texts. Frequency varies. Msg & data rates may apply. Consent is not a condition of purchase. Reply HELP for help or STOP to opt out.`,
     optoutMessage: `${input.displayName}: You have been unsubscribed and will receive no further SMS messages. Reply START to opt back in.`,
@@ -147,8 +154,8 @@ async function registrationForOperator(practiceId: string) {
       .where(
         and(
           eq(messagingRegistrations.practiceId, practiceId),
-          isNull(messagingRegistrations.deletedAt)
-        )
+          isNull(messagingRegistrations.deletedAt),
+        ),
       )
       .limit(1);
     if (!row) {
@@ -187,8 +194,8 @@ async function claimRegistrationOperation(opts: {
           isNull(messagingRegistrations.submissionLockId),
           opts.allowReviewedRetry
             ? sql`true`
-            : sql`${messagingRegistrations.lastError} is null`
-        )
+            : sql`${messagingRegistrations.lastError} is null`,
+        ),
       )
       .returning({ id: messagingRegistrations.id });
     if (!claimed) {
@@ -220,8 +227,8 @@ async function finishRegistrationOperation(opts: {
         and(
           eq(messagingRegistrations.id, opts.registrationId),
           eq(messagingRegistrations.submissionLockId, opts.lockId),
-          isNull(messagingRegistrations.deletedAt)
-        )
+          isNull(messagingRegistrations.deletedAt),
+        ),
       )
       .returning({ id: messagingRegistrations.id });
     if (!updated) {
@@ -265,8 +272,8 @@ async function failRegistrationOperation(opts: {
         and(
           eq(locationMessaging.practiceId, opts.practiceId),
           eq(locationMessaging.provider, "telnyx"),
-          isNull(locationMessaging.deletedAt)
-        )
+          isNull(locationMessaging.deletedAt),
+        ),
       );
   });
 }
@@ -345,38 +352,47 @@ export const adminRouter = createRouter({
   overview: platformAdminProcedure.query(async () =>
     // Bypass tenant RLS — this view legitimately spans all practices.
     withSystem(db, async (tx) => {
-    const rows = await tx
-      .select({
-        id: practices.id,
-        name: practices.name,
-        tier: practices.subscriptionTier,
-        billingStatus: practices.billingStatus,
-        trialEndsAt: practices.trialEndsAt,
-        timezone: practices.timezone,
-        country: practices.country,
-        createdAt: practices.createdAt,
-        settings: practices.settings,
-      })
-      .from(practices)
-      .where(isNull(practices.deletedAt))
-      .orderBy(desc(practices.createdAt));
-
-    const countBy = async (
-      table: typeof users | typeof clients | typeof patients | typeof locations
-    ) => {
-      const res = await tx
+      const rows = await tx
         .select({
-          practiceId: table.practiceId,
-          c: sql<number>`count(*)::int`,
+          id: practices.id,
+          name: practices.name,
+          tier: practices.subscriptionTier,
+          billingStatus: practices.billingStatus,
+          trialEndsAt: practices.trialEndsAt,
+          timezone: practices.timezone,
+          country: practices.country,
+          createdAt: practices.createdAt,
+          settings: practices.settings,
         })
-        .from(table)
-        .where(isNull(table.deletedAt))
-        .groupBy(table.practiceId);
-      return new Map(res.map((r) => [r.practiceId, Number(r.c)]));
-    };
+        .from(practices)
+        .where(isNull(practices.deletedAt))
+        .orderBy(desc(practices.createdAt));
 
-    const [userCounts, clientCounts, patientCounts, locationCounts, adminRows] =
-      await Promise.all([
+      const countBy = async (
+        table:
+          | typeof users
+          | typeof clients
+          | typeof patients
+          | typeof locations,
+      ) => {
+        const res = await tx
+          .select({
+            practiceId: table.practiceId,
+            c: sql<number>`count(*)::int`,
+          })
+          .from(table)
+          .where(isNull(table.deletedAt))
+          .groupBy(table.practiceId);
+        return new Map(res.map((r) => [r.practiceId, Number(r.c)]));
+      };
+
+      const [
+        userCounts,
+        clientCounts,
+        patientCounts,
+        locationCounts,
+        adminRows,
+      ] = await Promise.all([
         countBy(users),
         countBy(clients),
         countBy(patients),
@@ -394,76 +410,79 @@ export const adminRouter = createRouter({
           .orderBy(users.practiceId, users.createdAt),
       ]);
 
-    const primaryAdminByPractice = new Map<
-      string,
-      (typeof adminRows)[number]
-    >();
-    for (const admin of adminRows) {
-      if (!primaryAdminByPractice.has(admin.practiceId)) {
-        primaryAdminByPractice.set(admin.practiceId, admin);
+      const primaryAdminByPractice = new Map<
+        string,
+        (typeof adminRows)[number]
+      >();
+      for (const admin of adminRows) {
+        if (!primaryAdminByPractice.has(admin.practiceId)) {
+          primaryAdminByPractice.set(admin.practiceId, admin);
+        }
       }
-    }
 
-    const practiceRows = rows.map((p) => {
-      const { settings, ...practice } = p;
-      const primaryAdmin = primaryAdminByPractice.get(p.id);
-      const userCount = userCounts.get(p.id) ?? 0;
-      const locationCount = Math.max(1, locationCounts.get(p.id) ?? 0);
-      const estimatedMrr =
-        p.billingStatus === "active" && getPlan(p.tier).tier === "cloud"
-          ? locationCount * CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD +
-            userCount * CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD
-          : 0;
-      return {
-        ...practice,
-        ...conversionContext(settings),
-        userCount,
-        locationCount,
-        estimatedMrr,
-        clientCount: clientCounts.get(p.id) ?? 0,
-        patientCount: patientCounts.get(p.id) ?? 0,
-        adminName: primaryAdmin?.name ?? null,
-        adminEmail: primaryAdmin?.email ?? null,
-        adminEmailVerifiedAt: primaryAdmin?.emailVerifiedAt ?? null,
-      };
-    });
+      const practiceRows = rows.map((p) => {
+        const { settings, ...practice } = p;
+        const primaryAdmin = primaryAdminByPractice.get(p.id);
+        const userCount = userCounts.get(p.id) ?? 0;
+        const locationCount = Math.max(1, locationCounts.get(p.id) ?? 0);
+        const estimatedMrr =
+          p.billingStatus === "active" && getPlan(p.tier).tier === "cloud"
+            ? locationCount * CLOUD_LOCATION_UNIT_PRICE_MONTHLY_USD +
+              userCount * CLOUD_SEAT_UNIT_PRICE_MONTHLY_USD
+            : 0;
+        return {
+          ...practice,
+          ...conversionContext(settings),
+          userCount,
+          locationCount,
+          estimatedMrr,
+          clientCount: clientCounts.get(p.id) ?? 0,
+          patientCount: patientCounts.get(p.id) ?? 0,
+          adminName: primaryAdmin?.name ?? null,
+          adminEmail: primaryAdmin?.email ?? null,
+          adminEmailVerifiedAt: primaryAdmin?.emailVerifiedAt ?? null,
+        };
+      });
 
-    // MRR: active hosted Cloud subscriptions use hybrid location + staff pricing.
-    const estimatedMrr = practiceRows
-      .filter(
-        (p) => p.billingStatus === "active" && getPlan(p.tier).tier === "cloud"
-      )
-      .reduce((sum, p) => sum + p.estimatedMrr, 0);
-
-    const byTier: Record<PlanTier, number> = {
-      free: 0,
-      cloud: 0,
-      enterprise: 0,
-    };
-    for (const p of practiceRows) {
-      const t = getPlan(p.tier).tier;
-      byTier[t] += 1;
-    }
-
-    const overviewNow = new Date();
-
-    return {
-      practices: practiceRows,
-      totals: {
-        practices: practiceRows.length,
-        estimatedMrr,
-        byTier,
-        activeTrials: practiceRows.filter(
+      // MRR: active hosted Cloud subscriptions use hybrid location + staff pricing.
+      const estimatedMrr = practiceRows
+        .filter(
           (p) =>
-            p.billingStatus === "trialing" &&
-            p.trialEndsAt != null &&
-            p.trialEndsAt.getTime() > overviewNow.getTime()
-        ).length,
-        active: practiceRows.filter((p) => p.billingStatus === "active").length,
-        pastDue: practiceRows.filter((p) => p.billingStatus === "past_due").length,
-      },
-    };
-    })
+            p.billingStatus === "active" && getPlan(p.tier).tier === "cloud",
+        )
+        .reduce((sum, p) => sum + p.estimatedMrr, 0);
+
+      const byTier: Record<PlanTier, number> = {
+        free: 0,
+        cloud: 0,
+        enterprise: 0,
+      };
+      for (const p of practiceRows) {
+        const t = getPlan(p.tier).tier;
+        byTier[t] += 1;
+      }
+
+      const overviewNow = new Date();
+
+      return {
+        practices: practiceRows,
+        totals: {
+          practices: practiceRows.length,
+          estimatedMrr,
+          byTier,
+          activeTrials: practiceRows.filter(
+            (p) =>
+              p.billingStatus === "trialing" &&
+              p.trialEndsAt != null &&
+              p.trialEndsAt.getTime() > overviewNow.getTime(),
+          ).length,
+          active: practiceRows.filter((p) => p.billingStatus === "active")
+            .length,
+          pastDue: practiceRows.filter((p) => p.billingStatus === "past_due")
+            .length,
+        },
+      };
+    }),
   ),
 
   /**
@@ -477,7 +496,7 @@ export const adminRouter = createRouter({
       z.object({
         practiceId: z.string().uuid(),
         days: z.number().int().min(1).max(90),
-      })
+      }),
     )
     .mutation(async ({ input }) =>
       withSystem(db, async (tx) => {
@@ -489,12 +508,18 @@ export const adminRouter = createRouter({
           })
           .from(practices)
           .where(
-            and(eq(practices.id, input.practiceId), isNull(practices.deletedAt))
+            and(
+              eq(practices.id, input.practiceId),
+              isNull(practices.deletedAt),
+            ),
           )
           .limit(1);
 
         if (!practice) {
-          throw new TRPCError({ code: "NOT_FOUND", message: "Practice not found." });
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Practice not found.",
+          });
         }
         if (practice.billingStatus !== "trialing") {
           throw new TRPCError({
@@ -517,7 +542,7 @@ export const adminRouter = createRouter({
           .where(eq(practices.id, input.practiceId));
 
         return { practiceId: input.practiceId, trialEndsAt };
-      })
+      }),
     ),
 
   /** Reversibly exclude internal/test practices from conversion reporting. */
@@ -526,20 +551,25 @@ export const adminRouter = createRouter({
       z.object({
         practiceId: z.string().uuid(),
         excluded: z.boolean(),
-      })
+      }),
     )
     .mutation(async ({ input }) =>
       withSystem(db, async (tx) => {
         const [updated] = await tx
           .update(practices)
           .set({
-            settings: sql`coalesce(${practices.settings}, '{}'::jsonb) || ${JSON.stringify({
-              analyticsExcluded: input.excluded,
-            })}::jsonb`,
+            settings: sql`coalesce(${practices.settings}, '{}'::jsonb) || ${JSON.stringify(
+              {
+                analyticsExcluded: input.excluded,
+              },
+            )}::jsonb`,
             updatedAt: new Date(),
           })
           .where(
-            and(eq(practices.id, input.practiceId), isNull(practices.deletedAt))
+            and(
+              eq(practices.id, input.practiceId),
+              isNull(practices.deletedAt),
+            ),
           )
           .returning({ id: practices.id });
 
@@ -550,7 +580,7 @@ export const adminRouter = createRouter({
           });
         }
         return { practiceId: input.practiceId, excluded: input.excluded };
-      })
+      }),
     ),
 
   /** Redacted A2P work queue. Legal tax IDs are never exposed here. */
@@ -583,8 +613,8 @@ export const adminRouter = createRouter({
           practices,
           and(
             eq(practices.id, messagingRegistrations.practiceId),
-            isNull(practices.deletedAt)
-          )
+            isNull(practices.deletedAt),
+          ),
         )
         .where(isNull(messagingRegistrations.deletedAt))
         .orderBy(desc(messagingRegistrations.updatedAt));
@@ -601,10 +631,10 @@ export const adminRouter = createRouter({
       return rows.map((row) => ({
         ...row,
         senders: senders.filter(
-          (sender) => sender.practiceId === row.practiceId
+          (sender) => sender.practiceId === row.practiceId,
         ),
       }));
-    })
+    }),
   ),
 
   /** Fee-bearing TCR brand creation; platform operator only and explicitly confirmed. */
@@ -614,7 +644,7 @@ export const adminRouter = createRouter({
         practiceId: z.string().uuid(),
         confirmProviderCharges: z.literal(true),
         retryAfterProviderReview: z.boolean().default(false),
-      })
+      }),
     )
     .mutation(async ({ input }) => {
       assertMessagingProviderMutationsEnabled();
@@ -685,7 +715,7 @@ export const adminRouter = createRouter({
         practiceId: z.string().uuid(),
         confirmProviderCharges: z.literal(true),
         retryAfterProviderReview: z.boolean().default(false),
-      })
+      }),
     )
     .mutation(async ({ input }) => {
       assertMessagingProviderMutationsEnabled();
@@ -707,7 +737,7 @@ export const adminRouter = createRouter({
       const brand = await getA2pBrand(registration.providerBrandId);
       if (
         !new Set(["VERIFIED", "VETTED_VERIFIED"]).has(
-          brand.identityStatus ?? ""
+          brand.identityStatus ?? "",
         )
       ) {
         await withSystem(db, async (tx) => {
@@ -828,7 +858,7 @@ export const adminRouter = createRouter({
       z.object({
         practiceId: z.string().uuid(),
         confirmProviderMutation: z.literal(true),
-      })
+      }),
     )
     .mutation(async ({ input }) => {
       assertMessagingProviderMutationsEnabled();
@@ -859,9 +889,9 @@ export const adminRouter = createRouter({
               eq(locationMessaging.practiceId, input.practiceId),
               eq(locationMessaging.provider, "telnyx"),
               isNull(locationMessaging.deletedAt),
-              sql`nullif(trim(${locationMessaging.senderE164}), '') is not null`
-            )
-          )
+              sql`nullif(trim(${locationMessaging.senderE164}), '') is not null`,
+            ),
+          ),
       );
       if (senders.length === 0) {
         throw new TRPCError({
@@ -877,7 +907,7 @@ export const adminRouter = createRouter({
           await ensureA2pNumberAssignment({
             phoneNumber: sender.phoneNumber,
             campaignId: registration.providerCampaignId,
-          })
+          }),
         );
       }
       const observed = observedRegistrationStatus({
@@ -926,12 +956,265 @@ export const adminRouter = createRouter({
             and(
               eq(locationMessaging.practiceId, input.practiceId),
               eq(locationMessaging.provider, "telnyx"),
-              isNull(locationMessaging.deletedAt)
-            )
+              isNull(locationMessaging.deletedAt),
+            ),
           );
       });
       return { ok: true, status: next, assigned: assignments.length };
     }),
+
+  smsSendAttemptQueue: platformAdminProcedure
+    .input(
+      z.object({
+        practiceId: z.string().uuid().optional(),
+        staleMinutes: z
+          .number()
+          .int()
+          .min(15)
+          .max(7 * 24 * 60)
+          .default(15),
+        limit: z.number().int().min(1).max(100).default(50),
+      }),
+    )
+    .query(({ input }) => {
+      noStore();
+      const cutoff = new Date(Date.now() - input.staleMinutes * 60 * 1000);
+      return withSystem(db, async (tx) => {
+        const hasAnyEvent = sql<boolean>`exists (
+          select 1
+          from sms_send_attempt_events queue_event
+          where queue_event.practice_id = ${smsSendAttempts.practiceId}
+            and queue_event.attempt_id = ${smsSendAttempts.id}
+        )`;
+        const effectiveOutcome = sql<string | null>`coalesce(
+          (
+            select reconciliation.outcome::text
+            from sms_send_attempt_events reconciliation
+            where reconciliation.practice_id = ${smsSendAttempts.practiceId}
+              and reconciliation.attempt_id = ${smsSendAttempts.id}
+              and reconciliation.kind = 'reconciliation'
+            order by reconciliation.created_at desc, reconciliation.id desc
+            limit 1
+          ),
+          (
+            select provider_result.outcome::text
+            from sms_send_attempt_events provider_result
+            where provider_result.practice_id = ${smsSendAttempts.practiceId}
+              and provider_result.attempt_id = ${smsSendAttempts.id}
+              and provider_result.kind = 'provider_result'
+            order by provider_result.created_at desc, provider_result.id desc
+            limit 1
+          )
+        )`;
+        const attemptItems = await tx
+          .select({
+            attemptId: smsSendAttempts.id,
+            practiceId: smsSendAttempts.practiceId,
+            createdAt: smsSendAttempts.createdAt,
+            communicationId: smsSendAttempts.communicationId,
+            source: smsSendAttempts.source,
+            provider: smsSendAttempts.provider,
+            classification: sql<
+              | "missing_provider_result"
+              | "outcome_unknown"
+              | "terminal_projection_pending"
+            >`case
+                when not (${hasAnyEvent}) then 'missing_provider_result'
+                when (${effectiveOutcome}) = 'outcome_unknown' then 'outcome_unknown'
+                else 'terminal_projection_pending'
+              end`,
+          })
+          .from(smsSendAttempts)
+          .where(
+            and(
+              lte(smsSendAttempts.createdAt, cutoff),
+              input.practiceId
+                ? eq(smsSendAttempts.practiceId, input.practiceId)
+                : undefined,
+              sql`(
+                (${effectiveOutcome}) is null
+                or (${effectiveOutcome}) = 'outcome_unknown'
+                or (
+                  (${effectiveOutcome}) in ('accepted', 'definite_failure')
+                  and exists (
+                    select 1
+                    from communications pending_projection
+                    where pending_projection.practice_id = ${smsSendAttempts.practiceId}
+                      and pending_projection.id = ${smsSendAttempts.communicationId}
+                      and pending_projection.status = 'pending'
+                      and pending_projection.deleted_at is null
+                  )
+                )
+              )`,
+            ),
+          )
+          .orderBy(asc(smsSendAttempts.createdAt), asc(smsSendAttempts.id))
+          .limit(input.limit);
+        const orphanItems = await tx
+          .select({
+            attemptId: sql<string | null>`null::uuid`,
+            practiceId: communications.practiceId,
+            createdAt: communications.createdAt,
+            communicationId: communications.id,
+            source: sql<"communication_claim">`'communication_claim'`,
+            provider: sql<null>`null::text`,
+            classification: sql<"orphan_pending_communication">`'orphan_pending_communication'`,
+          })
+          .from(communications)
+          .where(
+            and(
+              lte(communications.createdAt, cutoff),
+              eq(communications.channel, "sms"),
+              eq(communications.direction, "outbound"),
+              eq(communications.status, "pending"),
+              isNull(communications.deletedAt),
+              input.practiceId
+                ? eq(communications.practiceId, input.practiceId)
+                : undefined,
+              sql`not exists (
+                select 1
+                from sms_send_attempts orphan_attempt
+                where orphan_attempt.practice_id = ${communications.practiceId}
+                  and orphan_attempt.communication_id = ${communications.id}
+              )`,
+            ),
+          )
+          .orderBy(asc(communications.createdAt), asc(communications.id))
+          .limit(input.limit);
+        const items = [...attemptItems, ...orphanItems]
+          .sort((left, right) => {
+            const byTime =
+              new Date(left.createdAt).getTime() -
+              new Date(right.createdAt).getTime();
+            if (byTime !== 0) return byTime;
+            return (left.attemptId ?? left.communicationId ?? "").localeCompare(
+              right.attemptId ?? right.communicationId ?? "",
+            );
+          })
+          .slice(0, input.limit);
+        return { cacheControl: "no-store" as const, items };
+      });
+    }),
+
+  smsSendAttempt: platformAdminProcedure
+    .input(
+      z.object({
+        practiceId: z.string().uuid(),
+        attemptId: z.string().uuid(),
+      }),
+    )
+    .query(({ input }) => {
+      noStore();
+      return withSystem(db, async (tx) => {
+        const [attempt] = await tx
+          .select({
+            id: smsSendAttempts.id,
+            createdAt: smsSendAttempts.createdAt,
+            practiceId: smsSendAttempts.practiceId,
+            clientId: smsSendAttempts.clientId,
+            locationId: smsSendAttempts.locationId,
+            communicationId: smsSendAttempts.communicationId,
+            resendOfAttemptId: smsSendAttempts.resendOfAttemptId,
+            source: smsSendAttempts.source,
+            sourceId: smsSendAttempts.sourceId,
+            idempotencyKey: smsSendAttempts.idempotencyKey,
+            registeredDisplayName: smsSendAttempts.registeredDisplayName,
+            provider: smsSendAttempts.provider,
+            senderMessagingServiceId: smsSendAttempts.senderMessagingServiceId,
+            senderE164: smsSendAttempts.senderE164,
+            requestedByActorType: smsSendAttempts.requestedByActorType,
+            requestedByUserId: smsSendAttempts.requestedByUserId,
+            requestedByIdentity: smsSendAttempts.requestedByIdentity,
+            requestedByName: smsSendAttempts.requestedByName,
+          })
+          .from(smsSendAttempts)
+          .where(
+            and(
+              eq(smsSendAttempts.practiceId, input.practiceId),
+              eq(smsSendAttempts.id, input.attemptId),
+            ),
+          )
+          .limit(1);
+        if (!attempt) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "SMS send attempt not found.",
+          });
+        }
+        const events = await tx
+          .select({
+            id: smsSendAttemptEvents.id,
+            createdAt: smsSendAttemptEvents.createdAt,
+            kind: smsSendAttemptEvents.kind,
+            outcome: smsSendAttemptEvents.outcome,
+            providerMessageId: smsSendAttemptEvents.providerMessageId,
+            detail: smsSendAttemptEvents.detail,
+            actorType: smsSendAttemptEvents.actorType,
+            actorUserId: smsSendAttemptEvents.actorUserId,
+            actorIdentity: smsSendAttemptEvents.actorIdentity,
+            actorName: smsSendAttemptEvents.actorName,
+            eventKey: smsSendAttemptEvents.eventKey,
+          })
+          .from(smsSendAttemptEvents)
+          .where(
+            and(
+              eq(smsSendAttemptEvents.practiceId, input.practiceId),
+              eq(smsSendAttemptEvents.attemptId, input.attemptId),
+            ),
+          )
+          .orderBy(
+            desc(smsSendAttemptEvents.createdAt),
+            desc(smsSendAttemptEvents.id),
+          );
+        return { cacheControl: "no-store" as const, attempt, events };
+      });
+    }),
+
+  reconcileSmsSendAttempt: platformAdminProcedure
+    .input(
+      z.object({
+        practiceId: z.string().uuid(),
+        attemptId: z.string().uuid(),
+        reconciliationId: z.string().uuid(),
+        outcome: z.enum(["accepted", "definite_failure"]),
+        providerMessageId: z.string().trim().min(1).max(255).optional(),
+        detail: z.string().trim().min(1).max(2000),
+      }),
+    )
+    .mutation(({ ctx, input }) =>
+      reconcileSmsSendAttempt({
+        practiceId: input.practiceId,
+        attemptId: input.attemptId,
+        outcome: input.outcome,
+        providerMessageId: input.providerMessageId,
+        detail: input.detail,
+        actorType: "platform_operator",
+        actorUserId: ctx.session!.user.id,
+        actorIdentity: ctx.session!.user.email,
+        actorName: ctx.session!.user.name?.trim() || ctx.session!.user.email,
+        reconciliationKey: `operator-reconciliation:${input.reconciliationId}`,
+      }),
+    ),
+
+  resendSmsSendAttempt: platformAdminProcedure
+    .input(
+      z.object({
+        practiceId: z.string().uuid(),
+        attemptId: z.string().uuid(),
+        resendId: z.string().uuid(),
+      }),
+    )
+    .mutation(({ ctx, input }) =>
+      resendSmsAttempt({
+        practiceId: input.practiceId,
+        attemptId: input.attemptId,
+        idempotencyKey: `sms:operator-resend:${input.resendId}`,
+        actorType: "platform_operator",
+        actorUserId: ctx.session!.user.id,
+        actorIdentity: ctx.session!.user.email,
+        actorName: ctx.session!.user.name?.trim() || ctx.session!.user.email,
+      }),
+    ),
 
   /**
    * Recover an ambiguous provider timeout after an operator confirms the IDs in
@@ -945,7 +1228,7 @@ export const adminRouter = createRouter({
         providerBrandId: z.string().trim().min(3).max(128),
         providerCampaignId: z.string().trim().min(3).max(128).optional(),
         confirmProviderPortalReviewed: z.literal(true),
-      })
+      }),
     )
     .mutation(async ({ input }) =>
       withSystem(db, async (tx) => {
@@ -967,8 +1250,8 @@ export const adminRouter = createRouter({
           .where(
             and(
               eq(messagingRegistrations.practiceId, input.practiceId),
-              isNull(messagingRegistrations.deletedAt)
-            )
+              isNull(messagingRegistrations.deletedAt),
+            ),
           )
           .returning({ id: messagingRegistrations.id });
         if (!updated) {
@@ -978,7 +1261,7 @@ export const adminRouter = createRouter({
           });
         }
         return { ok: true };
-      })
+      }),
     ),
 
   /**
@@ -993,7 +1276,7 @@ export const adminRouter = createRouter({
         providerObject: z.enum(["brand", "campaign"]),
         confirmProviderPortalReviewed: z.literal(true),
         confirmNoProviderObjectExists: z.literal("NO_PROVIDER_OBJECT"),
-      })
+      }),
     )
     .mutation(async ({ input }) =>
       withSystem(db, async (tx) => {
@@ -1009,8 +1292,8 @@ export const adminRouter = createRouter({
           .where(
             and(
               eq(messagingRegistrations.practiceId, input.practiceId),
-              isNull(messagingRegistrations.deletedAt)
-            )
+              isNull(messagingRegistrations.deletedAt),
+            ),
           )
           .limit(1);
         if (!registration?.submissionLockId || !registration.submissionLockAt) {
@@ -1058,10 +1341,10 @@ export const adminRouter = createRouter({
               eq(messagingRegistrations.id, registration.id),
               eq(
                 messagingRegistrations.submissionLockId,
-                registration.submissionLockId
+                registration.submissionLockId,
               ),
-              isNull(messagingRegistrations.deletedAt)
-            )
+              isNull(messagingRegistrations.deletedAt),
+            ),
           )
           .returning({ id: messagingRegistrations.id });
         if (!updated) {
@@ -1083,11 +1366,11 @@ export const adminRouter = createRouter({
             and(
               eq(locationMessaging.practiceId, input.practiceId),
               eq(locationMessaging.provider, "telnyx"),
-              isNull(locationMessaging.deletedAt)
-            )
+              isNull(locationMessaging.deletedAt),
+            ),
           );
         return { ok: true, providerObject: input.providerObject };
-      })
+      }),
     ),
 
   /** Read-only provider reconciliation. Safe to retry and never enables sending. */
@@ -1115,9 +1398,9 @@ export const adminRouter = createRouter({
                 eq(locationMessaging.practiceId, input.practiceId),
                 eq(locationMessaging.provider, "telnyx"),
                 isNull(locationMessaging.deletedAt),
-                sql`nullif(trim(${locationMessaging.senderE164}), '') is not null`
-              )
-            )
+                sql`nullif(trim(${locationMessaging.senderE164}), '') is not null`,
+              ),
+            ),
         );
         const assignments: Array<TelnyxNumberAssignment | null> = [];
         if (campaign) {
@@ -1186,8 +1469,8 @@ export const adminRouter = createRouter({
               and(
                 eq(locationMessaging.practiceId, input.practiceId),
                 eq(locationMessaging.provider, "telnyx"),
-                isNull(locationMessaging.deletedAt)
-              )
+                isNull(locationMessaging.deletedAt),
+              ),
             );
         });
         return { ok: true, status: next, assignments: assignments.length };
@@ -1204,13 +1487,13 @@ export const adminRouter = createRouter({
     .input(
       z
         .object({ days: z.number().int().min(1).max(365).default(30) })
-        .optional()
+        .optional(),
     )
     .query(({ input }) => computeActivationFunnel(db, input?.days ?? 30)),
 
   /** Ranked, cross-tenant operator queue for recovering clinic activation. */
   activationRecovery: platformAdminProcedure.query(() =>
-    computeActivationRecovery(db, new Date())
+    computeActivationRecovery(db, new Date()),
   ),
 
   /** Privacy-safe first-touch cohorts spanning visit through paid. */
@@ -1218,7 +1501,7 @@ export const adminRouter = createRouter({
     .input(
       z
         .object({ days: z.number().int().min(1).max(365).default(30) })
-        .optional()
+        .optional(),
     )
     .query(({ input }) => computeJourneyFunnel(db, input?.days ?? 30)),
 });

--- a/apps/web/server/routers/communications.ts
+++ b/apps/web/server/routers/communications.ts
@@ -18,6 +18,7 @@ import { normalizeE164 } from "@/lib/messaging";
 import { hasNonBlankMessagingSender } from "@/lib/messaging/sender-query";
 import { isQuietHours } from "@/lib/messaging/reminders";
 import { sendSms } from "@/lib/sms";
+import { withDurableSmsCommunication } from "@/lib/messaging/durable-sms-communication";
 import { listOffsetInput } from "./pagination";
 import {
   emailSuppressionSendBlockMessage,
@@ -36,7 +37,7 @@ export {
 } from "@/lib/communications/policy";
 
 const inboxStaffProcedure = protectedProcedure.use(
-  requireRole("admin", "veterinarian", "technician", "front_desk")
+  requireRole("admin", "veterinarian", "technician", "front_desk"),
 );
 
 function escapeHtml(value: string): string {
@@ -99,7 +100,7 @@ function renderComposedEmail(opts: {
 }
 
 function validReplyToEmail(
-  value: string | null | undefined
+  value: string | null | undefined,
 ): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
@@ -165,7 +166,7 @@ function dbNumber(value: number | string | bigint | null | undefined): number {
 }
 
 async function practiceTimeZone(
-  ctx: CommunicationsContext
+  ctx: CommunicationsContext,
 ): Promise<string | null> {
   const [practice] = await ctx.db
     .select({ timezone: practices.timezone })
@@ -190,11 +191,12 @@ const createCommunicationInput = z
       .min(1, "Message content is required")
       .max(
         COMMUNICATION_CONTENT_MAX_LENGTH,
-        `Message content must be at most ${COMMUNICATION_CONTENT_MAX_LENGTH} characters.`
+        `Message content must be at most ${COMMUNICATION_CONTENT_MAX_LENGTH} characters.`,
       ),
     status: z
       .enum(["pending", "sent", "delivered", "read", "failed"])
       .optional(),
+    requestId: z.string().uuid().optional(),
   })
   .superRefine((input, ctx) => {
     if (
@@ -205,6 +207,17 @@ const createCommunicationInput = z
         code: z.ZodIssueCode.custom,
         path: ["content"],
         message: `SMS messages must be at most ${SMS_COMMUNICATION_CONTENT_MAX_LENGTH} characters.`,
+      });
+    }
+    if (
+      input.channel === "sms" &&
+      input.direction === "outbound" &&
+      !input.requestId
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["requestId"],
+        message: "A stable request ID is required to send an SMS.",
       });
     }
   });
@@ -224,7 +237,7 @@ export const communicationsRouter = createRouter({
         inboxFilter: z.enum(["all", "unread", "sent"]).optional(),
         limit: z.number().int().min(1).max(100).default(25),
         offset: listOffsetInput,
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const conditions = [
@@ -236,8 +249,8 @@ export const communicationsRouter = createRouter({
           and(
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )!,
       ];
 
@@ -253,7 +266,7 @@ export const communicationsRouter = createRouter({
         conditions.push(
           eq(communications.direction, "inbound"),
           isNull(communications.readAt),
-          ne(communications.status, "read")
+          ne(communications.status, "read"),
         );
       } else if (input.inboxFilter === "sent") {
         conditions.push(
@@ -261,8 +274,8 @@ export const communicationsRouter = createRouter({
           or(
             eq(communications.status, "sent"),
             eq(communications.status, "delivered"),
-            eq(communications.status, "read")
-          )!
+            eq(communications.status, "read"),
+          )!,
         );
       }
 
@@ -291,8 +304,8 @@ export const communicationsRouter = createRouter({
               eq(communications.clientId, clients.id),
               eq(clients.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(clients.deletedAt)
-            )
+              isNull(clients.deletedAt),
+            ),
           )
           .leftJoin(
             users,
@@ -300,8 +313,8 @@ export const communicationsRouter = createRouter({
               eq(communications.assignedTo, users.id),
               eq(users.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(users.deletedAt)
-            )
+              isNull(users.deletedAt),
+            ),
           )
           .where(and(...conditions))
           .orderBy(desc(communications.createdAt))
@@ -316,8 +329,8 @@ export const communicationsRouter = createRouter({
               eq(communications.clientId, clients.id),
               eq(clients.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(clients.deletedAt)
-            )
+              isNull(clients.deletedAt),
+            ),
           )
           .where(and(...conditions)),
       ]);
@@ -334,7 +347,7 @@ export const communicationsRouter = createRouter({
         inboxFilter: z.enum(["all", "unread", "sent"]).optional(),
         limit: z.number().int().min(1).max(100).default(25),
         offset: listOffsetInput,
-      })
+      }),
     )
     .query(async ({ ctx, input }) => {
       const filterClause =
@@ -470,8 +483,8 @@ export const communicationsRouter = createRouter({
             eq(communications.clientId, clients.id),
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .leftJoin(
           users,
@@ -479,16 +492,16 @@ export const communicationsRouter = createRouter({
             eq(communications.assignedTo, users.id),
             eq(users.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(users.deletedAt)
-          )
+            isNull(users.deletedAt),
+          ),
         )
         .where(
           and(
             eq(communications.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             eq(communications.clientId, input.clientId),
-            isNull(communications.deletedAt)
-          )
+            isNull(communications.deletedAt),
+          ),
         )
         .orderBy(desc(communications.createdAt));
     }),
@@ -504,8 +517,8 @@ export const communicationsRouter = createRouter({
             eq(clients.id, input.clientId),
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -524,8 +537,8 @@ export const communicationsRouter = createRouter({
             eq(communications.direction, "inbound"),
             isNull(communications.readAt),
             ne(communications.status, "read"),
-            isNull(communications.deletedAt)
-          )
+            isNull(communications.deletedAt),
+          ),
         )
         .returning({ id: communications.id });
 
@@ -538,15 +551,15 @@ export const communicationsRouter = createRouter({
         clientId: z.string().uuid(),
         action: z.enum(["assign_to_me", "unassign"]),
         expectedAssignedTo: z.string().uuid().nullable(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       return ctx.db.transaction(async (tx) => {
         await tx.execute(
           sql`select pg_advisory_xact_lock(hashtext(${inboxAssignmentLockKey(
             ctx.practiceId,
-            input.clientId
-          )}::text))`
+            input.clientId,
+          )}::text))`,
         );
 
         const [client] = await tx
@@ -557,8 +570,8 @@ export const communicationsRouter = createRouter({
               eq(clients.id, input.clientId),
               eq(clients.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(clients.deletedAt)
-            )
+              isNull(clients.deletedAt),
+            ),
           )
           .limit(1);
 
@@ -578,8 +591,8 @@ export const communicationsRouter = createRouter({
               activePracticePredicate(ctx.practiceId),
               eq(communications.clientId, input.clientId),
               isNotNull(communications.assignedTo),
-              isNull(communications.deletedAt)
-            )
+              isNull(communications.deletedAt),
+            ),
           )
           .orderBy(desc(communications.createdAt), desc(communications.id))
           .limit(1);
@@ -601,8 +614,8 @@ export const communicationsRouter = createRouter({
               eq(communications.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
               eq(communications.clientId, input.clientId),
-              isNull(communications.deletedAt)
-            )
+              isNull(communications.deletedAt),
+            ),
           )
           .returning({ id: communications.id });
 
@@ -620,7 +633,7 @@ export const communicationsRouter = createRouter({
       z.object({
         communicationId: z.string().uuid(),
         clientId: z.string().uuid(),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       const [comm] = await ctx.db
@@ -635,8 +648,8 @@ export const communicationsRouter = createRouter({
             eq(communications.id, input.communicationId),
             eq(communications.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(communications.deletedAt)
-          )
+            isNull(communications.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -669,8 +682,8 @@ export const communicationsRouter = createRouter({
             eq(clients.id, input.clientId),
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -687,8 +700,8 @@ export const communicationsRouter = createRouter({
             activePracticePredicate(ctx.practiceId),
             eq(communications.clientId, input.clientId),
             isNotNull(communications.assignedTo),
-            isNull(communications.deletedAt)
-          )
+            isNull(communications.deletedAt),
+          ),
         )
         .orderBy(desc(communications.createdAt))
         .limit(1);
@@ -706,8 +719,8 @@ export const communicationsRouter = createRouter({
             eq(communications.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             isNull(communications.clientId),
-            isNull(communications.deletedAt)
-          )
+            isNull(communications.deletedAt),
+          ),
         )
         .returning({
           id: communications.id,
@@ -764,16 +777,16 @@ export const communicationsRouter = createRouter({
             eq(emailSuppressions.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
             sql`${emailSuppressions.email} = lower(trim(${clients.email}))`,
-            isNull(emailSuppressions.deletedAt)
-          )
+            isNull(emailSuppressions.deletedAt),
+          ),
         )
         .where(
           and(
             eq(clients.id, input.clientId),
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -811,8 +824,8 @@ export const communicationsRouter = createRouter({
             activePracticePredicate(ctx.practiceId),
             eq(communications.clientId, input.clientId),
             isNotNull(communications.assignedTo),
-            isNull(communications.deletedAt)
-          )
+            isNull(communications.deletedAt),
+          ),
         )
         .orderBy(desc(communications.createdAt))
         .limit(1);
@@ -857,8 +870,8 @@ export const communicationsRouter = createRouter({
               eq(locations.id, locationMessaging.locationId),
               eq(locations.practiceId, ctx.practiceId),
               activePracticePredicate(ctx.practiceId),
-              isNull(locations.deletedAt)
-            )
+              isNull(locations.deletedAt),
+            ),
           )
           .where(
             and(
@@ -869,8 +882,8 @@ export const communicationsRouter = createRouter({
               isNull(locations.deletedAt),
               eq(locationMessaging.enabled, true),
               eq(locationMessaging.registrationStatus, "active"),
-              hasNonBlankMessagingSender()
-            )
+              hasNonBlankMessagingSender(),
+            ),
           )
           .limit(2);
 
@@ -909,14 +922,19 @@ export const communicationsRouter = createRouter({
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: emailSuppressionSendBlockMessage(
-            client.emailSuppressionReason
+            client.emailSuppressionReason,
           ),
         });
       }
 
-      const [comm] = await ctx.db
-        .insert(communications)
-        .values({
+      const inboxSmsDedupeKey =
+        isDeliverableOutbound && input.channel === "sms"
+          ? `sms:inbox:${ctx.practiceId}:${input.requestId!}`
+          : undefined;
+      const insertCommunication = async (
+        tx: Pick<Database, "insert" | "select">,
+      ) => {
+        const insert = tx.insert(communications).values({
           practiceId: ctx.practiceId,
           clientId: input.clientId,
           channel: input.channel,
@@ -924,6 +942,7 @@ export const communicationsRouter = createRouter({
           subject,
           content,
           assignedTo,
+          dedupeKey: inboxSmsDedupeKey,
           readAt: input.status === "read" ? new Date() : undefined,
           status: isDeliverableOutbound
             ? "pending"
@@ -933,13 +952,75 @@ export const communicationsRouter = createRouter({
                   ? "delivered"
                   : "sent"
                 : "pending")),
-        })
-        .returning();
+        });
+        if (!inboxSmsDedupeKey) {
+          const [communication] = await insert.returning();
+          return { communication, replayed: false };
+        }
+
+        const [inserted] = await insert
+          .onConflictDoNothing({ target: communications.dedupeKey })
+          .returning();
+        if (inserted) return { communication: inserted, replayed: false };
+
+        const [existing] = await tx
+          .select()
+          .from(communications)
+          .where(
+            and(
+              eq(communications.practiceId, ctx.practiceId),
+              eq(communications.dedupeKey, inboxSmsDedupeKey),
+              eq(communications.clientId, input.clientId),
+              eq(communications.channel, "sms"),
+              eq(communications.direction, "outbound"),
+              isNull(communications.deletedAt),
+            ),
+          )
+          .for("update")
+          .limit(1);
+        if (!existing) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "SMS request ID is already in use.",
+          });
+        }
+        if (
+          existing.content !== content ||
+          (existing.subject ?? undefined) !== subject
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "SMS request ID was already used for different message data.",
+          });
+        }
+        return { communication: existing, replayed: true };
+      };
+      const durableSmsCommunication =
+        isDeliverableOutbound && input.channel === "sms";
+      const claim = durableSmsCommunication
+        ? await withDurableSmsCommunication(ctx.practiceId, insertCommunication)
+        : await insertCommunication(ctx.db);
+      const comm = claim.communication;
 
       if (!comm) {
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "Could not create communication",
+        });
+      }
+
+      if (
+        claim.replayed &&
+        new Set(["sent", "delivered", "read"]).has(comm.status)
+      ) {
+        return comm;
+      }
+      if (claim.replayed && comm.status === "failed") {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "This SMS request failed definitively. Start a new send to create a new request ID.",
         });
       }
 
@@ -950,6 +1031,7 @@ export const communicationsRouter = createRouter({
         id?: string;
         sid?: string;
         error?: string;
+        outcome?: "accepted" | "definite_failure" | "outcome_unknown";
       };
       let providerMessageId: string | undefined;
       try {
@@ -960,6 +1042,10 @@ export const communicationsRouter = createRouter({
             practiceId: ctx.practiceId,
             locationId: smsSenderLocationId,
             clientId: input.clientId,
+            communicationId: comm.id,
+            source: "inbox",
+            sourceId: input.requestId!,
+            idempotencyKey: inboxSmsDedupeKey!,
           });
           providerMessageId = deliveryResult.sid;
         } else {
@@ -978,11 +1064,25 @@ export const communicationsRouter = createRouter({
       } catch (error) {
         deliveryResult = {
           success: false,
+          outcome:
+            input.channel === "sms" ? "outcome_unknown" : "definite_failure",
           error:
             error instanceof Error && error.message
               ? error.message
               : "Message delivery failed",
         };
+      }
+
+      if (
+        input.channel === "sms" &&
+        !deliveryResult.success &&
+        deliveryResult.outcome === "outcome_unknown"
+      ) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message:
+            "The texting provider outcome is unknown. This message will not be retried automatically; contact OpenVPM support before sending it again.",
+        });
       }
 
       const status = deliveryResult.success ? "sent" : "failed";
@@ -994,19 +1094,34 @@ export const communicationsRouter = createRouter({
         updatePatch.providerMessageId = providerMessageId;
       }
 
-      const [updated] = await ctx.db
-        .update(communications)
-        .set(updatePatch)
-        .where(
-          and(
-            eq(communications.id, comm.id),
-            eq(communications.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            eq(communications.status, "pending"),
-            isNull(communications.deletedAt)
+      const projectCommunication = (tx: Pick<Database, "update">) =>
+        tx
+          .update(communications)
+          .set(updatePatch)
+          .where(
+            and(
+              eq(communications.id, comm.id),
+              eq(communications.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              or(
+                eq(communications.status, "pending"),
+                and(
+                  eq(communications.status, "sent"),
+                  providerMessageId
+                    ? eq(communications.providerMessageId, providerMessageId)
+                    : undefined,
+                ),
+              ),
+              isNull(communications.deletedAt),
+            ),
           )
-        )
-        .returning();
+          .returning();
+      const [updated] = durableSmsCommunication
+        ? await withDurableSmsCommunication(
+            ctx.practiceId,
+            projectCommunication,
+          )
+        : await projectCommunication(ctx.db);
 
       if (!updated) {
         await alertOps(
@@ -1017,7 +1132,7 @@ export const communicationsRouter = createRouter({
             `channel=${input.channel}`,
             `status=${status}`,
             `providerMessageId=${providerMessageId ?? "none"}`,
-          ].join(" ")
+          ].join(" "),
         );
 
         if (deliveryResult.success) {
@@ -1044,7 +1159,7 @@ export const communicationsRouter = createRouter({
       z.object({
         id: z.string().uuid(),
         status: z.enum(["pending", "sent", "delivered", "read", "failed"]),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       if (input.status !== "read") {
@@ -1068,8 +1183,8 @@ export const communicationsRouter = createRouter({
             eq(communications.direction, "inbound"),
             isNull(communications.readAt),
             ne(communications.status, "read"),
-            isNull(communications.deletedAt)
-          )
+            isNull(communications.deletedAt),
+          ),
         )
         .returning();
       if (!comm) {

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -1492,7 +1492,13 @@ export const messagingRouter = createRouter({
 
   /** Send a test SMS to a staff number from the location's sender. */
   testSend: adminOnly
-    .input(z.object({ locationId: z.string().uuid(), to: messagingPhoneInput }))
+    .input(
+      z.object({
+        locationId: z.string().uuid(),
+        to: messagingPhoneInput,
+        requestId: z.string().uuid(),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       if (billingEnforced()) {
         throw new TRPCError({
@@ -1560,6 +1566,9 @@ export const messagingRouter = createRouter({
         body: "OpenVPM test message — your texting is set up correctly.",
         practiceId: ctx.practiceId,
         locationId: input.locationId,
+        source: "self_host_test",
+        sourceId: input.requestId,
+        idempotencyKey: `sms:self-host-test:${input.requestId}`,
       });
       if (!result.success) {
         throw new TRPCError({

--- a/apps/web/server/routers/notifications.ts
+++ b/apps/web/server/routers/notifications.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, isNull, gte, lte, lt, inArray, sql } from "drizzle-orm";
+import { eq, and, isNull, gte, lte, lt, inArray, or, sql } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
 import type { Database } from "@openpims/db/client";
@@ -36,6 +36,13 @@ import {
   normalizeEmailSuppressionAddress,
 } from "@/lib/email-suppression";
 import { hasNonBlankMessagingSender } from "@/lib/messaging/sender-query";
+import {
+  appointmentReminderDedupeKey,
+  appointmentReminderSmsIdempotencyKey,
+  claimAppointmentReminderCommunication,
+} from "@/lib/messaging/appointment-reminder";
+import { withDurableSmsCommunication } from "@/lib/messaging/durable-sms-communication";
+import { alertOps } from "@/lib/alerts";
 import {
   getVaccinationRecallPreview,
   sendVaccinationRecallReminders,
@@ -205,7 +212,7 @@ async function activeReminderSmsSender(
     db: NotificationsDb;
     practiceId: string;
   },
-  locationId?: string
+  locationId?: string,
 ): Promise<{ locationId: string } | null> {
   const smsSenders = await ctx.db
     .select({ locationId: locationMessaging.locationId })
@@ -216,8 +223,8 @@ async function activeReminderSmsSender(
         eq(locations.id, locationMessaging.locationId),
         eq(locations.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(locations.deletedAt)
-      )
+        isNull(locations.deletedAt),
+      ),
     )
     .where(
       and(
@@ -230,8 +237,8 @@ async function activeReminderSmsSender(
         eq(locationMessaging.enabled, true),
         eq(locationMessaging.registrationStatus, "active"),
         ...(locationId ? [eq(locationMessaging.locationId, locationId)] : []),
-        hasNonBlankMessagingSender()
-      )
+        hasNonBlankMessagingSender(),
+      ),
     )
     .limit(2);
   return smsSenders.length === 1 ? smsSenders[0]! : null;
@@ -270,8 +277,8 @@ export const notificationsRouter = createRouter({
             eq(patients.clientId, appointments.clientId),
             eq(patients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(patients.deletedAt)
-          )
+            isNull(patients.deletedAt),
+          ),
         )
         .leftJoin(
           clients,
@@ -279,32 +286,32 @@ export const notificationsRouter = createRouter({
             eq(appointments.clientId, clients.id),
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .leftJoin(
           emailSuppressions,
           and(
             eq(emailSuppressions.practiceId, ctx.practiceId),
             sql`${emailSuppressions.email} = lower(trim(${clients.email}))`,
-            isNull(emailSuppressions.deletedAt)
-          )
+            isNull(emailSuppressions.deletedAt),
+          ),
         )
         .leftJoin(
           practices,
           and(
             eq(appointments.practiceId, practices.id),
             eq(practices.id, ctx.practiceId),
-            isNull(practices.deletedAt)
-          )
+            isNull(practices.deletedAt),
+          ),
         )
         .leftJoin(
           rooms,
           and(
             eq(appointments.roomId, rooms.id),
             eq(rooms.practiceId, ctx.practiceId),
-            isNull(rooms.deletedAt)
-          )
+            isNull(rooms.deletedAt),
+          ),
         )
         .where(
           and(
@@ -315,8 +322,8 @@ export const notificationsRouter = createRouter({
             isNull(patients.deletedAt),
             eq(clients.practiceId, ctx.practiceId),
             isNull(clients.deletedAt),
-            isNull(appointments.deletedAt)
-          )
+            isNull(appointments.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -335,23 +342,52 @@ export const notificationsRouter = createRouter({
 
       // Manual send: respect the client's preferred channel + SMS consent.
       // Quiet hours don't apply — this is a deliberate staff action.
-      const logReminder = (
+      let reminderCommunicationId: string | null = null;
+      let durableSmsCommunication = false;
+      const logReminder = async (
         channel: "sms" | "email",
-        providerMessageId?: string
-      ) =>
-        ctx.db.insert(communications).values({
-          practiceId: ctx.practiceId,
-          clientId: appt.clientId!,
-          channel,
-          direction: "outbound",
-          subject: "Appointment Reminder",
-          content: `Appointment reminder sent for ${appt.patientName} on ${formatDate(
-            appt.startTime,
-            appt.practiceTimezone
-          )}`,
-          status: "sent",
-          providerMessageId,
-        });
+        providerMessageId?: string,
+        status: "sent" | "failed" = "sent",
+      ) => {
+        const project = (tx: Pick<Database, "update">) =>
+          tx
+            .update(communications)
+            .set({
+              channel,
+              content: `Appointment reminder ${status === "sent" ? "sent" : "failed"} for ${appt.patientName} on ${formatDate(
+                appt.startTime,
+                appt.practiceTimezone,
+              )}`,
+              status,
+              providerMessageId,
+            })
+            .where(
+              and(
+                eq(communications.id, reminderCommunicationId!),
+                eq(communications.practiceId, ctx.practiceId),
+                or(
+                  eq(communications.status, "pending"),
+                  and(
+                    eq(communications.status, "sent"),
+                    providerMessageId
+                      ? eq(communications.providerMessageId, providerMessageId)
+                      : undefined,
+                  ),
+                ),
+                isNull(communications.deletedAt),
+              ),
+            );
+        if (!durableSmsCommunication) return project(ctx.db);
+        try {
+          return await withDurableSmsCommunication(ctx.practiceId, project);
+        } catch (error) {
+          await alertOps(
+            "SMS appointment reminder projection failed",
+            `practice=${ctx.practiceId} communication=${reminderCommunicationId ?? "unknown"} source=appointment_reminder status=${status}`,
+          ).catch(() => undefined);
+          throw error;
+        }
+      };
 
       const sendEmail = async () => {
         const clientEmail = normalizeEmailSuppressionAddress(appt.clientEmail);
@@ -365,7 +401,7 @@ export const notificationsRouter = createRouter({
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: emailSuppressionSendBlockMessage(
-              appt.emailSuppressionReason
+              appt.emailSuppressionReason,
             ),
           });
         }
@@ -379,6 +415,7 @@ export const notificationsRouter = createRouter({
           practicePhone: appt.practicePhone ?? undefined,
         });
         if (!result.success) {
+          await logReminder("email", undefined, "failed");
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: result.error ?? "Could not send email reminder",
@@ -387,7 +424,7 @@ export const notificationsRouter = createRouter({
         await logReminder("email", result.id);
       };
 
-      const channel = pickReminderChannel({
+      let channel = pickReminderChannel({
         preferredContactMethod: appt.preferredContactMethod,
         phone: appt.clientPhone,
         smsConsent: appt.smsConsent ?? false,
@@ -411,41 +448,95 @@ export const notificationsRouter = createRouter({
         });
       }
 
+      let smsSender: { locationId: string } | null = null;
       if (channel === "sms") {
-        const smsSender = appt.locationId
+        smsSender = appt.locationId
           ? await activeReminderSmsSender(ctx, appt.locationId)
           : null;
-        const result = smsSender
-          ? await sendAppointmentReminderSms({
-              to: appt.clientPhone!,
-              patientName: appt.patientName ?? "Unknown",
-              appointmentDate: formatDate(
-                appt.startTime,
-                appt.practiceTimezone
-              ),
-              appointmentTime: formatTime(
-                appt.startTime,
-                appt.practiceTimezone
-              ),
-              practiceName: practiceDisplayName(appt.practiceName),
-              practicePhone: appt.practicePhone ?? undefined,
-              practiceId: ctx.practiceId,
-              locationId: smsSender.locationId,
-              clientId: appt.clientId!,
-            })
-          : {
-              success: false,
-              error:
+        if (!smsSender) {
+          if (
+            normalizeEmailSuppressionAddress(appt.clientEmail) &&
+            !appt.emailSuppressionReason
+          ) {
+            channel = "email";
+          } else {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
                 "Set up an active texting number before sending SMS reminders",
-            };
+            });
+          }
+        }
+      }
+      if (channel === "email") {
+        if (!normalizeEmailSuppressionAddress(appt.clientEmail)) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "Client does not have an email address on file",
+          });
+        }
+        if (appt.emailSuppressionReason) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: emailSuppressionSendBlockMessage(
+              appt.emailSuppressionReason,
+            ),
+          });
+        }
+      }
+
+      const claimOptions = {
+        practiceId: ctx.practiceId,
+        appointmentId: appt.id,
+        clientId: appt.clientId!,
+        channel,
+        patientName: appt.patientName,
+        startTime: new Date(appt.startTime),
+      };
+      durableSmsCommunication = channel === "sms";
+      reminderCommunicationId = durableSmsCommunication
+        ? await withDurableSmsCommunication(ctx.practiceId, (tx) =>
+            claimAppointmentReminderCommunication(tx, claimOptions),
+          )
+        : await claimAppointmentReminderCommunication(ctx.db, claimOptions);
+      if (!reminderCommunicationId) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message:
+            "A reminder for this appointment is already pending or was already sent.",
+        });
+      }
+
+      if (channel === "sms") {
+        const result = await sendAppointmentReminderSms({
+          to: appt.clientPhone!,
+          patientName: appt.patientName ?? "Unknown",
+          appointmentDate: formatDate(appt.startTime, appt.practiceTimezone),
+          appointmentTime: formatTime(appt.startTime, appt.practiceTimezone),
+          practiceName: practiceDisplayName(appt.practiceName),
+          practicePhone: appt.practicePhone ?? undefined,
+          practiceId: ctx.practiceId,
+          locationId: smsSender!.locationId,
+          clientId: appt.clientId!,
+          communicationId: reminderCommunicationId,
+          source: "appointment_reminder",
+          sourceId: appointmentReminderDedupeKey(appt),
+          idempotencyKey: appointmentReminderSmsIdempotencyKey(appt),
+        });
         if (result.success) {
           await logReminder("sms", result.sid);
           return { success: true, channel: "sms" as const };
         }
         // SMS blocked (e.g. opted out) — fall back to email if we can.
-        if (normalizeEmailSuppressionAddress(appt.clientEmail)) {
+        if (
+          result.outcome !== "outcome_unknown" &&
+          normalizeEmailSuppressionAddress(appt.clientEmail)
+        ) {
           await sendEmail();
           return { success: true, channel: "email" as const };
+        }
+        if (result.outcome === "definite_failure") {
+          await logReminder("sms", undefined, "failed");
         }
         throw new TRPCError({
           code: "BAD_REQUEST",
@@ -484,16 +575,16 @@ export const notificationsRouter = createRouter({
             eq(invoices.clientId, clients.id),
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .leftJoin(
           emailSuppressions,
           and(
             eq(emailSuppressions.practiceId, ctx.practiceId),
             sql`${emailSuppressions.email} = lower(trim(${clients.email}))`,
-            isNull(emailSuppressions.deletedAt)
-          )
+            isNull(emailSuppressions.deletedAt),
+          ),
         )
         .where(
           and(
@@ -502,8 +593,8 @@ export const notificationsRouter = createRouter({
             activePracticePredicate(ctx.practiceId),
             eq(clients.practiceId, ctx.practiceId),
             isNull(clients.deletedAt),
-            isNull(invoices.deletedAt)
-          )
+            isNull(invoices.deletedAt),
+          ),
         )
         .limit(1);
 
@@ -528,7 +619,7 @@ export const notificationsRouter = createRouter({
       }
       await assertVisitInvoiceReadyForFinancialAction(
         ctx,
-        invoice.appointmentId
+        invoice.appointmentId,
       );
       const clientEmail = normalizeEmailSuppressionAddress(invoice.clientEmail);
       if (!clientEmail) {
@@ -541,7 +632,7 @@ export const notificationsRouter = createRouter({
         throw new TRPCError({
           code: "BAD_REQUEST",
           message: emailSuppressionSendBlockMessage(
-            invoice.emailSuppressionReason
+            invoice.emailSuppressionReason,
           ),
         });
       }
@@ -560,15 +651,15 @@ export const notificationsRouter = createRouter({
                 and ${invoices.clientId} = ${invoice.clientId}
                 and ${invoices.deletedAt} is null
             )`,
-            isNull(invoiceAdjustments.deletedAt)
-          )
+            isNull(invoiceAdjustments.deletedAt),
+          ),
         );
       const adjustedCents = adjustmentRows.reduce(
         (sum, row) => sum + moneyToCents(row.amount),
-        0
+        0,
       );
       const amountDue = centsToMoney(
-        invoiceBalanceCents(invoice, adjustedCents)
+        invoiceBalanceCents(invoice, adjustedCents),
       );
 
       // Format the live balance in the practice's region currency.
@@ -576,7 +667,7 @@ export const notificationsRouter = createRouter({
       const totalFormatted = formatCurrency(
         amountDue,
         practice.currency,
-        practice.country
+        practice.country,
       );
 
       const emailResult = await sendInvoiceEmail({
@@ -587,7 +678,7 @@ export const notificationsRouter = createRouter({
           ? formatClinicalDate(
               invoice.dueDate,
               practice.timezone,
-              invoice.dueDate
+              invoice.dueDate,
             )
           : undefined,
         practiceName: practice.name,
@@ -639,8 +730,8 @@ export const notificationsRouter = createRouter({
           eq(patients.clientId, appointments.clientId),
           eq(patients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(patients.deletedAt)
-        )
+          isNull(patients.deletedAt),
+        ),
       )
       .leftJoin(
         clients,
@@ -648,8 +739,8 @@ export const notificationsRouter = createRouter({
           eq(appointments.clientId, clients.id),
           eq(clients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(clients.deletedAt)
-        )
+          isNull(clients.deletedAt),
+        ),
       )
       .leftJoin(
         users,
@@ -657,8 +748,8 @@ export const notificationsRouter = createRouter({
           eq(appointments.doctorId, users.id),
           eq(users.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(users.deletedAt)
-        )
+          isNull(users.deletedAt),
+        ),
       )
       .where(
         and(
@@ -671,8 +762,8 @@ export const notificationsRouter = createRouter({
           isNull(appointments.deletedAt),
           gte(appointments.startTime, now),
           lte(appointments.startTime, in24h),
-          eq(appointments.status, "confirmed")
-        )
+          eq(appointments.status, "confirmed"),
+        ),
       )
       .orderBy(appointments.startTime);
   }),
@@ -685,9 +776,9 @@ export const notificationsRouter = createRouter({
           .array(z.string().uuid())
           .max(
             REMINDER_BATCH_MAX_TARGETS,
-            `Bulk reminders can target at most ${REMINDER_BATCH_MAX_TARGETS} appointments.`
+            `Bulk reminders can target at most ${REMINDER_BATCH_MAX_TARGETS} appointments.`,
           ),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
@@ -720,8 +811,8 @@ export const notificationsRouter = createRouter({
             eq(patients.clientId, appointments.clientId),
             eq(patients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(patients.deletedAt)
-          )
+            isNull(patients.deletedAt),
+          ),
         )
         .leftJoin(
           clients,
@@ -729,32 +820,32 @@ export const notificationsRouter = createRouter({
             eq(appointments.clientId, clients.id),
             eq(clients.practiceId, ctx.practiceId),
             activePracticePredicate(ctx.practiceId),
-            isNull(clients.deletedAt)
-          )
+            isNull(clients.deletedAt),
+          ),
         )
         .leftJoin(
           emailSuppressions,
           and(
             eq(emailSuppressions.practiceId, ctx.practiceId),
             sql`${emailSuppressions.email} = lower(trim(${clients.email}))`,
-            isNull(emailSuppressions.deletedAt)
-          )
+            isNull(emailSuppressions.deletedAt),
+          ),
         )
         .leftJoin(
           practices,
           and(
             eq(appointments.practiceId, practices.id),
             eq(practices.id, ctx.practiceId),
-            isNull(practices.deletedAt)
-          )
+            isNull(practices.deletedAt),
+          ),
         )
         .leftJoin(
           rooms,
           and(
             eq(appointments.roomId, rooms.id),
             eq(rooms.practiceId, ctx.practiceId),
-            isNull(rooms.deletedAt)
-          )
+            isNull(rooms.deletedAt),
+          ),
         )
         .where(
           and(
@@ -766,8 +857,8 @@ export const notificationsRouter = createRouter({
             eq(clients.practiceId, ctx.practiceId),
             isNull(clients.deletedAt),
             isNull(appointments.deletedAt),
-            eq(appointments.status, "confirmed")
-          )
+            eq(appointments.status, "confirmed"),
+          ),
         );
 
       let sent = 0;
@@ -789,31 +880,63 @@ export const notificationsRouter = createRouter({
       for (const appt of appts) {
         const appointmentDate = formatDate(
           appt.startTime,
-          appt.practiceTimezone
+          appt.practiceTimezone,
         );
         const appointmentTime = formatTime(
           appt.startTime,
-          appt.practiceTimezone
+          appt.practiceTimezone,
         );
 
-        const logReminder = (
+        let reminderCommunicationId: string | null = null;
+        let durableSmsCommunication = false;
+        const logReminder = async (
           channel: "sms" | "email",
-          providerMessageId?: string
-        ) =>
-          ctx.db.insert(communications).values({
-            practiceId: ctx.practiceId,
-            clientId: appt.clientId!,
-            channel,
-            direction: "outbound",
-            subject: "Appointment Reminder",
-            content: `Reminder sent for ${appt.patientName} on ${appointmentDate}`,
-            status: "sent",
-            providerMessageId,
-          });
+          providerMessageId?: string,
+          status: "sent" | "failed" = "sent",
+        ) => {
+          const project = (tx: Pick<Database, "update">) =>
+            tx
+              .update(communications)
+              .set({
+                channel,
+                content: `Reminder ${status === "sent" ? "sent" : "failed"} for ${appt.patientName} on ${appointmentDate}`,
+                status,
+                providerMessageId,
+              })
+              .where(
+                and(
+                  eq(communications.id, reminderCommunicationId!),
+                  eq(communications.practiceId, ctx.practiceId),
+                  or(
+                    eq(communications.status, "pending"),
+                    and(
+                      eq(communications.status, "sent"),
+                      providerMessageId
+                        ? eq(
+                            communications.providerMessageId,
+                            providerMessageId,
+                          )
+                        : undefined,
+                    ),
+                  ),
+                  isNull(communications.deletedAt),
+                ),
+              );
+          if (!durableSmsCommunication) return project(ctx.db);
+          try {
+            return await withDurableSmsCommunication(ctx.practiceId, project);
+          } catch (error) {
+            await alertOps(
+              "SMS appointment reminder projection failed",
+              `practice=${ctx.practiceId} communication=${reminderCommunicationId ?? "unknown"} source=appointment_reminder status=${status}`,
+            ).catch(() => undefined);
+            throw error;
+          }
+        };
 
         const sendEmail = async (): Promise<boolean> => {
           const clientEmail = normalizeEmailSuppressionAddress(
-            appt.clientEmail
+            appt.clientEmail,
           );
           if (!clientEmail) return false;
           if (appt.emailSuppressionReason) return false;
@@ -835,7 +958,7 @@ export const notificationsRouter = createRouter({
           }
         };
 
-        const channel = pickReminderChannel({
+        let channel = pickReminderChannel({
           preferredContactMethod: appt.preferredContactMethod,
           phone: appt.clientPhone,
           smsConsent: appt.smsConsent ?? false,
@@ -843,36 +966,86 @@ export const notificationsRouter = createRouter({
           quietHours: isQuietHours(new Date(), appt.practiceTimezone),
         });
 
+        if (channel === "none" || channel === "skip") {
+          failed++;
+          continue;
+        }
+        let smsSender: { locationId: string } | null = null;
         if (channel === "sms") {
-          const smsSender = await getSmsSender(appt.locationId);
-          let result: { success: boolean; sid?: string; error?: string };
-          if (smsSender) {
-            try {
-              result = await sendAppointmentReminderSms({
-                to: appt.clientPhone!,
-                patientName: appt.patientName ?? "Unknown",
-                appointmentDate,
-                appointmentTime,
-                practiceName: practiceDisplayName(appt.practiceName),
-                practicePhone: appt.practicePhone ?? undefined,
-                practiceId: ctx.practiceId,
-                locationId: smsSender.locationId,
-                clientId: appt.clientId!,
-              });
-            } catch (error) {
-              result = {
-                success: false,
-                error:
-                  error instanceof Error
-                    ? error.message
-                    : "Could not send SMS reminder",
-              };
+          smsSender = await getSmsSender(appt.locationId);
+          if (!smsSender) {
+            if (
+              normalizeEmailSuppressionAddress(appt.clientEmail) &&
+              !appt.emailSuppressionReason
+            ) {
+              channel = "email";
+            } else {
+              failed++;
+              continue;
             }
-          } else {
+          }
+        }
+        if (
+          channel === "email" &&
+          (!normalizeEmailSuppressionAddress(appt.clientEmail) ||
+            appt.emailSuppressionReason)
+        ) {
+          failed++;
+          continue;
+        }
+        const claimOptions = {
+          practiceId: ctx.practiceId,
+          appointmentId: appt.id,
+          clientId: appt.clientId!,
+          channel,
+          patientName: appt.patientName,
+          startTime: new Date(appt.startTime),
+        };
+        durableSmsCommunication = channel === "sms";
+        reminderCommunicationId = durableSmsCommunication
+          ? await withDurableSmsCommunication(ctx.practiceId, (tx) =>
+              claimAppointmentReminderCommunication(tx, claimOptions),
+            )
+          : await claimAppointmentReminderCommunication(ctx.db, claimOptions);
+        if (!reminderCommunicationId) {
+          failed++;
+          continue;
+        }
+
+        if (channel === "sms") {
+          let result:
+            | Awaited<ReturnType<typeof sendAppointmentReminderSms>>
+            | {
+                success: false;
+                outcome: "definite_failure";
+                replayed: false;
+                error: string;
+              };
+          try {
+            result = await sendAppointmentReminderSms({
+              to: appt.clientPhone!,
+              patientName: appt.patientName ?? "Unknown",
+              appointmentDate,
+              appointmentTime,
+              practiceName: practiceDisplayName(appt.practiceName),
+              practicePhone: appt.practicePhone ?? undefined,
+              practiceId: ctx.practiceId,
+              locationId: smsSender!.locationId,
+              clientId: appt.clientId!,
+              communicationId: reminderCommunicationId,
+              source: "appointment_reminder",
+              sourceId: appointmentReminderDedupeKey(appt),
+              idempotencyKey: appointmentReminderSmsIdempotencyKey(appt),
+            });
+          } catch (error) {
             result = {
               success: false,
+              outcome: "outcome_unknown",
+              replayed: false,
               error:
-                "Set up an active texting number before sending SMS reminders",
+                error instanceof Error
+                  ? error.message
+                  : "Could not send SMS reminder",
             };
           }
           if (result.success) {
@@ -881,9 +1054,13 @@ export const notificationsRouter = createRouter({
             continue;
           }
 
-          if (await sendEmail()) {
+          if (result.outcome !== "outcome_unknown" && (await sendEmail())) {
             sent++;
             continue;
+          }
+
+          if (result.outcome === "definite_failure") {
+            await logReminder("sms", undefined, "failed");
           }
 
           failed++;
@@ -894,6 +1071,7 @@ export const notificationsRouter = createRouter({
           if (await sendEmail()) {
             sent++;
           } else {
+            await logReminder("email", undefined, "failed");
             failed++;
           }
           continue;
@@ -927,8 +1105,8 @@ export const notificationsRouter = createRouter({
           eq(vaccinationRecords.patientId, patients.id),
           eq(patients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(patients.deletedAt)
-        )
+          isNull(patients.deletedAt),
+        ),
       )
       .innerJoin(
         clients,
@@ -936,8 +1114,8 @@ export const notificationsRouter = createRouter({
           eq(patients.clientId, clients.id),
           eq(clients.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(clients.deletedAt)
-        )
+          isNull(clients.deletedAt),
+        ),
       )
       .where(
         and(
@@ -950,8 +1128,8 @@ export const notificationsRouter = createRouter({
           isNull(patients.deletedAt),
           eq(clients.practiceId, ctx.practiceId),
           isNull(clients.deletedAt),
-          lt(vaccinationRecords.nextDueDate, today)
-        )
+          lt(vaccinationRecords.nextDueDate, today),
+        ),
       )
       .orderBy(patients.name);
 
@@ -1010,15 +1188,15 @@ export const notificationsRouter = createRouter({
           .array(z.string().uuid())
           .max(
             REMINDER_BATCH_MAX_TARGETS,
-            `Vaccination reminders can target at most ${REMINDER_BATCH_MAX_TARGETS} patients.`
+            `Vaccination reminders can target at most ${REMINDER_BATCH_MAX_TARGETS} patients.`,
           ),
-      })
+      }),
     )
     .mutation(async ({ ctx, input }) => {
       await assertActivePractice(ctx);
       const result = await sendVaccinationRecallReminders(
         ctx,
-        input.patientIds
+        input.patientIds,
       );
       if (!result) throw practiceNotFound();
       return result;

--- a/apps/web/server/trpc.ts
+++ b/apps/web/server/trpc.ts
@@ -52,31 +52,31 @@ function clientIp(req?: Request): string | null {
 
 async function activeSessionOrNull(
   database: Database,
-  session: AppSession | null
+  session: AppSession | null,
 ): Promise<AppSession | null> {
   if (!session?.user?.id || !session.user.practiceId) {
     return null;
   }
 
-  const [activeUser] = await withTenant(database, session.user.practiceId, (tx) =>
-    tx
-      .select({ id: users.id })
-      .from(users)
-      .innerJoin(
-        practices,
-        and(
-          eq(practices.id, users.practiceId),
-          isNull(practices.deletedAt)
+  const [activeUser] = await withTenant(
+    database,
+    session.user.practiceId,
+    (tx) =>
+      tx
+        .select({ id: users.id })
+        .from(users)
+        .innerJoin(
+          practices,
+          and(eq(practices.id, users.practiceId), isNull(practices.deletedAt)),
         )
-      )
-      .where(
-        and(
-          eq(users.id, session.user.id),
-          eq(users.practiceId, session.user.practiceId),
-          isNull(users.deletedAt)
+        .where(
+          and(
+            eq(users.id, session.user.id),
+            eq(users.practiceId, session.user.practiceId),
+            isNull(users.deletedAt),
+          ),
         )
-      )
-      .limit(1)
+        .limit(1),
   );
 
   return activeUser ? session : null;
@@ -123,6 +123,8 @@ const HOSTED_READ_ONLY_MUTATION_ALLOWLIST = new Set([
   "admin.attachMessagingProviderIds",
   "admin.clearStaleMessagingSubmissionLock",
   "admin.reconcileMessagingRegistration",
+  "admin.reconcileSmsSendAttempt",
+  "admin.resendSmsSendAttempt",
 ]);
 
 function practiceNotFound(): TRPCError {
@@ -135,9 +137,7 @@ function practiceNotFound(): TRPCError {
  * limits), so they run in a system DB context that bypasses tenant RLS.
  */
 export const publicProcedure = t.procedure.use(async ({ ctx, next }) => {
-  return withSystem(ctx.db, (tx) =>
-    next({ ctx: { ...ctx, db: tx } })
-  );
+  return withSystem(ctx.db, (tx) => next({ ctx: { ...ctx, db: tx } }));
 });
 
 /** Requires an authenticated session */
@@ -177,7 +177,7 @@ export const protectedProcedure = t.procedure.use(
           })
           .from(practices)
           .where(
-            and(eq(practices.id, user.practiceId), isNull(practices.deletedAt))
+            and(eq(practices.id, user.practiceId), isNull(practices.deletedAt)),
           )
           .limit(1);
         if (!practice) {
@@ -187,7 +187,7 @@ export const protectedProcedure = t.procedure.use(
           !hasHostedFullAccess(
             practice.tier,
             practice.billingStatus,
-            practice.trialEndsAt
+            practice.trialEndsAt,
           )
         ) {
           throw new TRPCError({
@@ -199,7 +199,12 @@ export const protectedProcedure = t.procedure.use(
       }
 
       const result = await next({
-        ctx: { session: ctx.session, user, practiceId: user.practiceId, db: tx },
+        ctx: {
+          session: ctx.session,
+          user,
+          practiceId: user.practiceId,
+          db: tx,
+        },
       });
 
       // Audit every successful mutation: who changed what, when, from where.
@@ -215,13 +220,13 @@ export const protectedProcedure = t.procedure.use(
             path,
             rawInput,
             resultData: (result as { data?: unknown }).data,
-          })
+          }),
         ).catch(() => {});
       }
 
       return result;
     });
-  }
+  },
 );
 
 /**
@@ -247,8 +252,8 @@ export function requireFeature(feature: Feature) {
         .where(
           and(
             eq(practices.id, ctx.session.user.practiceId),
-            isNull(practices.deletedAt)
-          )
+            isNull(practices.deletedAt),
+          ),
         )
         .limit(1);
       if (!practice) {
@@ -257,7 +262,7 @@ export function requireFeature(feature: Feature) {
       const tier = effectiveTier(
         practice.tier,
         practice.billingStatus,
-        practice.trialEndsAt
+        practice.trialEndsAt,
       );
       if (!isEntitled(tier, feature, true)) {
         throw new TRPCError({

--- a/apps/web/server/vaccination-recalls.ts
+++ b/apps/web/server/vaccination-recalls.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, lt, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import type { Database } from "@openpims/db/client";
 import {
   clients,
@@ -19,6 +19,12 @@ import { normalizeE164 } from "@/lib/messaging/phone";
 import { hasNonBlankMessagingSender } from "@/lib/messaging/sender-query";
 import { formatClinicalDate } from "@/lib/records/clinical-dates";
 import { sendVaccinationReminderSms } from "@/lib/sms";
+import { withDurableSmsCommunication } from "@/lib/messaging/durable-sms-communication";
+import {
+  recoverStaleUnreservedSmsCommunication,
+  STALE_SMS_COMMUNICATION_CLAIM_MS,
+} from "@/lib/messaging/durable-sms-communication";
+import { alertOps } from "@/lib/alerts";
 import {
   evaluateVaccinationRecallRecipient,
   vaccinationRecallDedupeKey,
@@ -112,8 +118,8 @@ async function activeReminderSmsSender(ctx: {
         eq(locations.id, locationMessaging.locationId),
         eq(locations.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(locations.deletedAt)
-      )
+        isNull(locations.deletedAt),
+      ),
     )
     .where(
       and(
@@ -124,8 +130,8 @@ async function activeReminderSmsSender(ctx: {
         isNull(locations.deletedAt),
         eq(locationMessaging.enabled, true),
         eq(locationMessaging.registrationStatus, "active"),
-        hasNonBlankMessagingSender()
-      )
+        hasNonBlankMessagingSender(),
+      ),
     )
     .limit(2);
   return senders.length === 1 ? senders[0]! : null;
@@ -179,7 +185,7 @@ function groupRows(rows: VaccinationRecallRow[]): VaccinationRecallCandidate[] {
     vaccines: candidate.vaccines.sort(
       (left, right) =>
         left.nextDueDate.localeCompare(right.nextDueDate) ||
-        left.vaccineName.localeCompare(right.vaccineName)
+        left.vaccineName.localeCompare(right.vaccineName),
     ),
   }));
 }
@@ -195,7 +201,7 @@ export type VaccinationRecallPreview = {
 
 async function loadVaccinationRecallRecipients(
   ctx: { db: Database; practiceId: string },
-  patientIds?: string[]
+  patientIds?: string[],
 ) {
   const practice = await practiceNotificationSettings(ctx);
   if (!practice) return null;
@@ -227,8 +233,8 @@ async function loadVaccinationRecallRecipients(
         eq(vaccinationRecords.patientId, patients.id),
         eq(patients.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(patients.deletedAt)
-      )
+        isNull(patients.deletedAt),
+      ),
     )
     .innerJoin(
       clients,
@@ -236,16 +242,16 @@ async function loadVaccinationRecallRecipients(
         eq(patients.clientId, clients.id),
         eq(clients.practiceId, ctx.practiceId),
         activePracticePredicate(ctx.practiceId),
-        isNull(clients.deletedAt)
-      )
+        isNull(clients.deletedAt),
+      ),
     )
     .leftJoin(
       emailSuppressions,
       and(
         eq(emailSuppressions.practiceId, ctx.practiceId),
         sql`${emailSuppressions.email} = lower(trim(${clients.email}))`,
-        isNull(emailSuppressions.deletedAt)
-      )
+        isNull(emailSuppressions.deletedAt),
+      ),
     )
     .where(
       and(
@@ -260,8 +266,8 @@ async function loadVaccinationRecallRecipients(
         targetPredicate,
         lt(vaccinationRecords.nextDueDate, today),
         validVaccinationRecordPredicate(),
-        latestVaccinationRecordPredicate()
-      )
+        latestVaccinationRecordPredicate(),
+      ),
     )
     .orderBy(patients.name, vaccinationRecords.nextDueDate);
 
@@ -275,24 +281,33 @@ async function loadVaccinationRecallRecipients(
         and(
           eq(smsSuppressions.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(smsSuppressions.deletedAt)
-        )
+          isNull(smsSuppressions.deletedAt),
+        ),
       ),
   ]);
   const smsSuppressedPhones = new Set(
     suppressedRows
       .map((row) => normalizeE164(row.phone))
-      .filter((phone): phone is string => Boolean(phone))
+      .filter((phone): phone is string => Boolean(phone)),
   );
   const dedupeKeys = candidates.map((candidate) =>
-    vaccinationRecallDedupeKey(ctx.practiceId, candidate)
+    vaccinationRecallDedupeKey(ctx.practiceId, candidate),
   );
   const priorRows =
     dedupeKeys.length > 0
       ? await ctx.db
           .select({
+            id: communications.id,
             dedupeKey: communications.dedupeKey,
+            channel: communications.channel,
+            status: communications.status,
             createdAt: communications.createdAt,
+            hasSmsAttempt: sql<boolean>`exists (
+              select 1
+              from sms_send_attempts recall_attempt
+              where recall_attempt.practice_id = ${communications.practiceId}
+                and recall_attempt.communication_id = ${communications.id}
+            )`,
           })
           .from(communications)
           .where(
@@ -306,14 +321,22 @@ async function loadVaccinationRecallRecipients(
                 "delivered",
                 "read",
               ]),
-              isNull(communications.deletedAt)
-            )
+              isNull(communications.deletedAt),
+            ),
           )
       : [];
   const priorByKey = new Map(
-    priorRows.flatMap((row) =>
-      row.dedupeKey ? [[row.dedupeKey, { createdAt: row.createdAt }]] : []
-    )
+    priorRows.flatMap((row) => {
+      const isRecoverableOrphan =
+        row.channel === "sms" &&
+        row.status === "pending" &&
+        new Date(row.createdAt).getTime() <=
+          Date.now() - STALE_SMS_COMMUNICATION_CLAIM_MS &&
+        !row.hasSmsAttempt;
+      return row.dedupeKey && !isRecoverableOrphan
+        ? [[row.dedupeKey, { createdAt: row.createdAt }]]
+        : [];
+    }),
   );
   const practiceSettings = vaccinationRecallPracticeSettings(practice.settings);
   const quietHours = isQuietHours(new Date(), practice.timezone);
@@ -346,7 +369,7 @@ export async function getVaccinationRecallPreview(ctx: {
     blocked: result.recipients.filter((item) => item.status === "blocked")
       .length,
     alreadySent: result.recipients.filter(
-      (item) => item.status === "already_sent"
+      (item) => item.status === "already_sent",
     ).length,
     recipients: result.recipients,
   };
@@ -354,7 +377,7 @@ export async function getVaccinationRecallPreview(ctx: {
 
 export async function sendVaccinationRecallReminders(
   ctx: { db: Database; practiceId: string },
-  patientIds: string[]
+  patientIds: string[],
 ) {
   if (patientIds.length === 0) {
     return { sent: 0, failed: 0, blocked: 0, deduped: 0 };
@@ -370,29 +393,45 @@ export async function sendVaccinationRecallReminders(
     recipients.length +
     recipients.filter((recipient) => recipient.status === "blocked").length;
   let deduped = recipients.filter(
-    (recipient) => recipient.status === "already_sent"
+    (recipient) => recipient.status === "already_sent",
   ).length;
 
   for (const recipient of recipients) {
     if (recipient.status !== "eligible" || !recipient.channel) continue;
+    const reminderChannel = recipient.channel;
     const vaccineNames = recipient.vaccines
       .map((vaccine) => vaccine.vaccineName)
       .join(", ");
     const dueDate = recipient.vaccines[0]?.nextDueDate;
-    const [claim] = await ctx.db
-      .insert(communications)
-      .values({
+    const durableSmsCommunication =
+      reminderChannel === "sms" && Boolean(smsSender);
+    const claimCommunication = async (
+      tx: Pick<Database, "insert" | "select">,
+    ) => {
+      const [insertedClaim] = await tx
+        .insert(communications)
+        .values({
+          practiceId: ctx.practiceId,
+          clientId: recipient.clientId,
+          channel: reminderChannel,
+          direction: "outbound",
+          subject: "Vaccination Reminder",
+          content: `Vaccination reminder for ${recipient.patientName}: ${vaccineNames}`,
+          status: "pending",
+          dedupeKey: recipient.dedupeKey,
+        })
+        .onConflictDoNothing({ target: communications.dedupeKey })
+        .returning({ id: communications.id });
+      if (insertedClaim || reminderChannel !== "sms") return insertedClaim;
+      const recoveredId = await recoverStaleUnreservedSmsCommunication(tx, {
         practiceId: ctx.practiceId,
-        clientId: recipient.clientId,
-        channel: recipient.channel,
-        direction: "outbound",
-        subject: "Vaccination Reminder",
-        content: `Vaccination reminder for ${recipient.patientName}: ${vaccineNames}`,
-        status: "pending",
         dedupeKey: recipient.dedupeKey,
-      })
-      .onConflictDoNothing({ target: communications.dedupeKey })
-      .returning({ id: communications.id });
+      });
+      return recoveredId ? { id: recoveredId } : undefined;
+    };
+    const claim = durableSmsCommunication
+      ? await withDurableSmsCommunication(ctx.practiceId, claimCommunication)
+      : await claimCommunication(ctx.db);
     if (!claim) {
       deduped++;
       continue;
@@ -400,7 +439,7 @@ export async function sendVaccinationRecallReminders(
 
     const sendEmail = async () => {
       const clientEmail = normalizeEmailSuppressionAddress(
-        recipient.clientEmail
+        recipient.clientEmail,
       );
       if (!clientEmail || recipient.emailSuppressionReason || !dueDate) {
         return { success: false as const };
@@ -423,6 +462,7 @@ export async function sendVaccinationRecallReminders(
     let deliveredChannel: "sms" | "email" = recipient.channel;
     let providerMessageId: string | undefined;
     let delivered = false;
+    let smsOutcomeUnknown = false;
     if (recipient.channel === "sms" && smsSender) {
       try {
         const smsResult = await sendVaccinationReminderSms({
@@ -434,13 +474,18 @@ export async function sendVaccinationRecallReminders(
           practiceId: ctx.practiceId,
           locationId: smsSender.locationId,
           clientId: recipient.clientId,
+          communicationId: claim.id,
+          sourceId: recipient.dedupeKey,
+          idempotencyKey: `sms:${recipient.dedupeKey}`,
         });
         delivered = smsResult.success;
         providerMessageId = smsResult.sid;
+        smsOutcomeUnknown = smsResult.outcome === "outcome_unknown";
       } catch {
         delivered = false;
+        smsOutcomeUnknown = true;
       }
-      if (!delivered) {
+      if (!delivered && !smsOutcomeUnknown) {
         const emailResult = await sendEmail();
         delivered = emailResult.success;
         if (delivered) {
@@ -454,42 +499,81 @@ export async function sendVaccinationRecallReminders(
       providerMessageId = emailResult.id;
     }
 
+    if (smsOutcomeUnknown) {
+      // Preserve pending + dedupeKey. The immutable SMS ledger is authoritative
+      // until a provider event or operator reconciliation resolves the attempt.
+      failed++;
+      continue;
+    }
+
     if (delivered) {
-      await ctx.db
+      const projectSent = (tx: Pick<Database, "update">) =>
+        tx
+          .update(communications)
+          .set({
+            channel: deliveredChannel,
+            content: `Vaccination reminder sent for ${recipient.patientName}: ${vaccineNames}`,
+            status: "sent",
+            providerMessageId,
+          })
+          .where(
+            and(
+              eq(communications.id, claim.id),
+              eq(communications.practiceId, ctx.practiceId),
+              eq(communications.dedupeKey, recipient.dedupeKey),
+              or(
+                eq(communications.status, "pending"),
+                and(
+                  eq(communications.status, "sent"),
+                  providerMessageId
+                    ? eq(communications.providerMessageId, providerMessageId)
+                    : undefined,
+                ),
+              ),
+              isNull(communications.deletedAt),
+            ),
+          );
+      try {
+        if (durableSmsCommunication) {
+          await withDurableSmsCommunication(ctx.practiceId, projectSent);
+        } else {
+          await projectSent(ctx.db);
+        }
+      } catch (error) {
+        if (durableSmsCommunication) {
+          await alertOps(
+            "SMS vaccination reminder projection failed",
+            `practice=${ctx.practiceId} communication=${claim.id} source=vaccination_recall status=sent`,
+          ).catch(() => undefined);
+        }
+        throw error;
+      }
+      sent++;
+      continue;
+    }
+
+    const projectFailed = (tx: Pick<Database, "update">) =>
+      tx
         .update(communications)
         .set({
-          channel: deliveredChannel,
-          content: `Vaccination reminder sent for ${recipient.patientName}: ${vaccineNames}`,
-          status: "sent",
-          providerMessageId,
+          content: `Vaccination reminder failed for ${recipient.patientName}: ${vaccineNames}`,
+          status: "failed",
+          dedupeKey: null,
         })
         .where(
           and(
             eq(communications.id, claim.id),
             eq(communications.practiceId, ctx.practiceId),
             eq(communications.dedupeKey, recipient.dedupeKey),
-            isNull(communications.deletedAt)
-          )
+            eq(communications.status, "pending"),
+            isNull(communications.deletedAt),
+          ),
         );
-      sent++;
-      continue;
+    if (durableSmsCommunication) {
+      await withDurableSmsCommunication(ctx.practiceId, projectFailed);
+    } else {
+      await projectFailed(ctx.db);
     }
-
-    await ctx.db
-      .update(communications)
-      .set({
-        content: `Vaccination reminder failed for ${recipient.patientName}: ${vaccineNames}`,
-        status: "failed",
-        dedupeKey: null,
-      })
-      .where(
-        and(
-          eq(communications.id, claim.id),
-          eq(communications.practiceId, ctx.practiceId),
-          eq(communications.dedupeKey, recipient.dedupeKey),
-          isNull(communications.deletedAt)
-        )
-      );
     failed++;
   }
 

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -135,6 +135,13 @@ For a Twilio fallback deployment, set `MESSAGING_PROVIDER=twilio` and provide
 `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER` instead of
 the Telnyx send envs.
 
+Self-hosted external SMS must also set `MESSAGING_REGISTERED_DISPLAY_NAME` to
+the exact clinic name approved on that provider's active campaign. OpenVPM
+snapshots that identity on every durable send attempt and adds the canonical
+STOP/HELP footer. Hosted sends do not use this override: they require an active,
+provider-matching `messaging_registrations` row. Console-only local testing may
+use the practice name because it never contacts a carrier.
+
 Hosted AI defaults to Claude and requires `ANTHROPIC_API_KEY`. If you choose a
 Gemini `AI_MODEL`, set either `GOOGLE_API_KEY` or the legacy
 `GOOGLE_GENERATIVE_AI_API_KEY`; `/api/health` requires one matching provider

--- a/packages/db/drizzle/0057_calm_molten_man.sql
+++ b/packages/db/drizzle/0057_calm_molten_man.sql
@@ -1,0 +1,199 @@
+CREATE TYPE "public"."sms_send_actor_type" AS ENUM('clinic_user', 'platform_operator');--> statement-breakpoint
+CREATE TYPE "public"."sms_send_attempt_event_kind" AS ENUM('provider_result', 'reconciliation');--> statement-breakpoint
+CREATE TYPE "public"."sms_send_outcome" AS ENUM('accepted', 'definite_failure', 'outcome_unknown');--> statement-breakpoint
+CREATE TABLE "sms_send_attempt_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"practice_id" uuid NOT NULL,
+	"attempt_id" uuid NOT NULL,
+	"kind" "sms_send_attempt_event_kind" NOT NULL,
+	"outcome" "sms_send_outcome" NOT NULL,
+	"provider_message_id" varchar(255),
+	"detail" text,
+	"actor_type" "sms_send_actor_type",
+	"actor_user_id" uuid,
+	"actor_identity" varchar(255),
+	"actor_name" varchar(255),
+	"event_key" varchar(200) NOT NULL,
+	CONSTRAINT "sms_send_attempt_events_event_key_check" CHECK (length(btrim("sms_send_attempt_events"."event_key")) between 1 and 200),
+	CONSTRAINT "sms_send_attempt_events_detail_check" CHECK ("sms_send_attempt_events"."detail" is null or length("sms_send_attempt_events"."detail") <= 2000),
+	CONSTRAINT "sms_send_attempt_events_outcome_shape_check" CHECK ((
+          "sms_send_attempt_events"."outcome" = 'accepted'
+          and length(btrim(coalesce("sms_send_attempt_events"."provider_message_id", ''))) > 0
+        ) or (
+          "sms_send_attempt_events"."outcome" in ('definite_failure', 'outcome_unknown')
+          and "sms_send_attempt_events"."provider_message_id" is null
+        )),
+	CONSTRAINT "sms_send_attempt_events_actor_shape_check" CHECK ((
+          "sms_send_attempt_events"."kind" = 'provider_result'
+          and "sms_send_attempt_events"."actor_type" is null
+          and "sms_send_attempt_events"."actor_user_id" is null
+          and "sms_send_attempt_events"."actor_identity" is null
+          and "sms_send_attempt_events"."actor_name" is null
+        ) or (
+          "sms_send_attempt_events"."kind" = 'reconciliation'
+          and "sms_send_attempt_events"."outcome" in ('accepted', 'definite_failure')
+          and "sms_send_attempt_events"."actor_type" is not null
+          and length(btrim(coalesce("sms_send_attempt_events"."actor_identity", ''))) between 1 and 255
+          and length(btrim(coalesce("sms_send_attempt_events"."actor_name", ''))) between 1 and 255
+          and (
+            ("sms_send_attempt_events"."actor_type" = 'clinic_user' and "sms_send_attempt_events"."actor_user_id" is not null)
+            or ("sms_send_attempt_events"."actor_type" = 'platform_operator' and "sms_send_attempt_events"."actor_user_id" is null)
+          )
+        ))
+);
+--> statement-breakpoint
+CREATE TABLE "sms_send_attempts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"practice_id" uuid NOT NULL,
+	"client_id" uuid,
+	"location_id" uuid,
+	"communication_id" uuid,
+	"requested_by_actor_type" "sms_send_actor_type",
+	"requested_by_user_id" uuid,
+	"requested_by_identity" varchar(255),
+	"requested_by_name" varchar(255),
+	"resend_of_attempt_id" uuid,
+	"source" varchar(64) NOT NULL,
+	"source_id" varchar(200) NOT NULL,
+	"idempotency_key" varchar(200) NOT NULL,
+	"destination_e164" varchar(16) NOT NULL,
+	"registered_display_name" varchar(100) NOT NULL,
+	"body" text NOT NULL,
+	"body_sha256" varchar(64) NOT NULL,
+	"provider" varchar(16) NOT NULL,
+	"sender_messaging_service_id" varchar(128),
+	"sender_e164" varchar(16),
+	CONSTRAINT "sms_send_attempts_source_check" CHECK (length(btrim("sms_send_attempts"."source")) between 1 and 64),
+	CONSTRAINT "sms_send_attempts_source_id_check" CHECK (length(btrim("sms_send_attempts"."source_id")) between 1 and 200),
+	CONSTRAINT "sms_send_attempts_idempotency_key_check" CHECK (length(btrim("sms_send_attempts"."idempotency_key")) between 1 and 200),
+	CONSTRAINT "sms_send_attempts_destination_check" CHECK ("sms_send_attempts"."destination_e164" ~ '^\+[1-9][0-9]{7,14}$'),
+	CONSTRAINT "sms_send_attempts_display_name_check" CHECK (length(btrim("sms_send_attempts"."registered_display_name")) between 1 and 100),
+	CONSTRAINT "sms_send_attempts_body_check" CHECK (length("sms_send_attempts"."body") between 1 and 1600),
+	CONSTRAINT "sms_send_attempts_body_hash_check" CHECK ("sms_send_attempts"."body_sha256" ~ '^[0-9a-f]{64}$'),
+	CONSTRAINT "sms_send_attempts_provider_check" CHECK ("sms_send_attempts"."provider" in ('telnyx', 'twilio', 'console')),
+	CONSTRAINT "sms_send_attempts_sender_check" CHECK ("sms_send_attempts"."provider" = 'console'
+        or length(btrim(coalesce("sms_send_attempts"."sender_messaging_service_id", ''))) > 0
+        or "sms_send_attempts"."sender_e164" ~ '^\+[1-9][0-9]{7,14}$'),
+	CONSTRAINT "sms_send_attempts_requester_check" CHECK ((
+          "sms_send_attempts"."source" = 'operator_resend'
+          and "sms_send_attempts"."requested_by_actor_type" is not null
+          and length(btrim(coalesce("sms_send_attempts"."requested_by_identity", ''))) between 1 and 255
+          and length(btrim(coalesce("sms_send_attempts"."requested_by_name", ''))) between 1 and 255
+          and (
+            ("sms_send_attempts"."requested_by_actor_type" = 'clinic_user' and "sms_send_attempts"."requested_by_user_id" is not null)
+            or ("sms_send_attempts"."requested_by_actor_type" = 'platform_operator' and "sms_send_attempts"."requested_by_user_id" is null)
+          )
+        ) or (
+          "sms_send_attempts"."source" <> 'operator_resend'
+          and (
+            (
+              "sms_send_attempts"."requested_by_actor_type" is null
+              and "sms_send_attempts"."requested_by_user_id" is null
+              and "sms_send_attempts"."requested_by_identity" is null
+              and "sms_send_attempts"."requested_by_name" is null
+            )
+            or (
+              "sms_send_attempts"."requested_by_actor_type" is not null
+              and length(btrim(coalesce("sms_send_attempts"."requested_by_identity", ''))) between 1 and 255
+              and length(btrim(coalesce("sms_send_attempts"."requested_by_name", ''))) between 1 and 255
+              and (
+                ("sms_send_attempts"."requested_by_actor_type" = 'clinic_user' and "sms_send_attempts"."requested_by_user_id" is not null)
+                or ("sms_send_attempts"."requested_by_actor_type" = 'platform_operator' and "sms_send_attempts"."requested_by_user_id" is null)
+              )
+            )
+          )
+        ))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_send_attempts_practice_id_uq" ON "sms_send_attempts" USING btree ("practice_id","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "communications_practice_id_uq" ON "communications" USING btree ("practice_id","id");--> statement-breakpoint
+ALTER TABLE "sms_send_attempt_events" ADD CONSTRAINT "sms_send_attempt_events_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempt_events" ADD CONSTRAINT "sms_send_attempt_events_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempt_events" ADD CONSTRAINT "sms_send_attempt_events_attempt_tenant_fk" FOREIGN KEY ("practice_id","attempt_id") REFERENCES "public"."sms_send_attempts"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempt_events" ADD CONSTRAINT "sms_send_attempt_events_actor_tenant_fk" FOREIGN KEY ("practice_id","actor_user_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempts" ADD CONSTRAINT "sms_send_attempts_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempts" ADD CONSTRAINT "sms_send_attempts_client_id_clients_id_fk" FOREIGN KEY ("client_id") REFERENCES "public"."clients"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempts" ADD CONSTRAINT "sms_send_attempts_location_id_locations_id_fk" FOREIGN KEY ("location_id") REFERENCES "public"."locations"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempts" ADD CONSTRAINT "sms_send_attempts_communication_id_communications_id_fk" FOREIGN KEY ("communication_id") REFERENCES "public"."communications"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempts" ADD CONSTRAINT "sms_send_attempts_requested_by_user_id_users_id_fk" FOREIGN KEY ("requested_by_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempts" ADD CONSTRAINT "sms_send_attempts_resend_tenant_fk" FOREIGN KEY ("practice_id","resend_of_attempt_id") REFERENCES "public"."sms_send_attempts"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempts" ADD CONSTRAINT "sms_send_attempts_client_tenant_fk" FOREIGN KEY ("practice_id","client_id") REFERENCES "public"."clients"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempts" ADD CONSTRAINT "sms_send_attempts_location_tenant_fk" FOREIGN KEY ("practice_id","location_id") REFERENCES "public"."locations"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempts" ADD CONSTRAINT "sms_send_attempts_communication_tenant_fk" FOREIGN KEY ("practice_id","communication_id") REFERENCES "public"."communications"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sms_send_attempts" ADD CONSTRAINT "sms_send_attempts_requester_tenant_fk" FOREIGN KEY ("practice_id","requested_by_user_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_send_attempt_events_practice_event_key_uq" ON "sms_send_attempt_events" USING btree ("practice_id","event_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_send_attempt_events_provider_result_uq" ON "sms_send_attempt_events" USING btree ("practice_id","attempt_id") WHERE "sms_send_attempt_events"."kind" = 'provider_result';--> statement-breakpoint
+CREATE INDEX "sms_send_attempt_events_attempt_history_idx" ON "sms_send_attempt_events" USING btree ("practice_id","attempt_id","created_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_send_attempt_events_provider_message_uq" ON "sms_send_attempt_events" USING btree ("practice_id","provider_message_id") WHERE "sms_send_attempt_events"."provider_message_id" is not null;--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_send_attempts_practice_idempotency_uq" ON "sms_send_attempts" USING btree ("practice_id","idempotency_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_send_attempts_resend_of_uq" ON "sms_send_attempts" USING btree ("practice_id","resend_of_attempt_id") WHERE "sms_send_attempts"."resend_of_attempt_id" is not null;--> statement-breakpoint
+CREATE INDEX "sms_send_attempts_client_history_idx" ON "sms_send_attempts" USING btree ("practice_id","client_id","created_at","id");--> statement-breakpoint
+CREATE INDEX "sms_send_attempts_communication_idx" ON "sms_send_attempts" USING btree ("practice_id","communication_id");--> statement-breakpoint
+CREATE INDEX "sms_send_attempts_source_history_idx" ON "sms_send_attempts" USING btree ("practice_id","source","source_id","created_at");--> statement-breakpoint
+CREATE INDEX "sms_send_attempts_destination_history_idx" ON "sms_send_attempts" USING btree ("practice_id","destination_e164","created_at","id");--> statement-breakpoint
+CREATE FUNCTION reject_sms_send_ledger_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+	IF coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+		AND current_user = (
+			SELECT pg_catalog.pg_get_userbyid(class.relowner)
+			FROM pg_catalog.pg_class class
+			JOIN pg_catalog.pg_namespace namespace
+				ON namespace.oid = class.relnamespace
+			WHERE namespace.nspname = TG_TABLE_SCHEMA
+				AND class.relname = TG_TABLE_NAME
+		)
+	THEN
+		IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+		RETURN NEW;
+	END IF;
+	RAISE EXCEPTION USING
+		ERRCODE = '55000',
+		MESSAGE = 'SMS send ledger rows are append-only and cannot be updated or deleted.';
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER sms_send_attempts_immutable
+	BEFORE UPDATE OR DELETE ON sms_send_attempts
+	FOR EACH ROW EXECUTE FUNCTION reject_sms_send_ledger_mutation();--> statement-breakpoint
+CREATE TRIGGER sms_send_attempt_events_immutable
+	BEFORE UPDATE OR DELETE ON sms_send_attempt_events
+	FOR EACH ROW EXECUTE FUNCTION reject_sms_send_ledger_mutation();--> statement-breakpoint
+ALTER TABLE sms_send_attempts ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY tenant_isolation ON sms_send_attempts
+	USING (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	)
+	WITH CHECK (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	);--> statement-breakpoint
+ALTER TABLE sms_send_attempt_events ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY tenant_isolation ON sms_send_attempt_events
+	USING (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	)
+	WITH CHECK (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	);--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'openpims_app') THEN
+		REVOKE ALL ON sms_send_attempts, sms_send_attempt_events FROM openpims_app;
+		GRANT SELECT, INSERT ON sms_send_attempts, sms_send_attempt_events TO openpims_app;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+		REVOKE ALL ON sms_send_attempts, sms_send_attempt_events FROM anon;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+		REVOKE ALL ON sms_send_attempts, sms_send_attempt_events FROM authenticated;
+	END IF;
+END
+$$;

--- a/packages/db/drizzle/meta/0057_snapshot.json
+++ b/packages/db/drizzle/meta/0057_snapshot.json
@@ -1,0 +1,16835 @@
+{
+  "id": "f285306e-bf32-487f-8b46-977ad4001e8a",
+  "prevId": "d10444e5-906e-4403-af2f-a06cfddcab9e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "performed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "practice_id",
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n      )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "resend_of_attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": [
+            "practice_id",
+            "milestone"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": [
+        "entered_in_error"
+      ]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign",
+        "vaccination_record"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invoiced",
+        "waived"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": [
+        "staff",
+        "client",
+        "system"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator"
+      ]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": [
+        "provider_result",
+        "reconciliation"
+      ]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": [
+        "practice_created",
+        "product_records",
+        "stripe_webhook"
+      ]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": [
+        "unresolved",
+        "charged",
+        "no_charge",
+        "voided"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1786263915731,
       "tag": "0056_lively_magdalene",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1786265983669,
+      "tag": "0057_calm_molten_man",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -19,6 +19,8 @@ const TABLES = [
   "api_keys",
   "treatment_template_items",
   "treatment_templates",
+  "sms_send_attempt_events",
+  "sms_send_attempts",
   "sms_consent_events",
   "patient_merge_events",
   "dispense_charge_queue",

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -55,7 +55,7 @@ DECLARE
     'capture_sessions','cases','clients','clinical_notes','clinical_record_corrections','communications','consent_forms','consent_requests','controlled_substance_log','dispense_charge_queue','email_suppressions',
     'files','insurance_claims','insurance_policies','invoices','lab_results','location_messaging','messaging_registrations','migration_runs',
     'locations','patient_merge_events','patients','practice_payment_accounts','prescription_events','prescriptions','problem_list','procedures','products','purchase_orders',
-    'recurring_series','rooms','services','sms_consent_events','sms_suppressions','soap_notes','staff_schedules','suppliers',
+    'recurring_series','rooms','services','sms_consent_events','sms_send_attempt_events','sms_send_attempts','sms_suppressions','soap_notes','staff_schedules','suppliers',
     'treatment_plans','treatment_templates','usage_records','users','vaccination_records',
     'visit_closeouts','visit_work_items','vital_signs','webhooks','wellness_enrollments','wellness_plans'
   ];
@@ -92,6 +92,11 @@ GRANT SELECT, INSERT ON patient_merge_events TO openpims_app;
 -- consent projection may change; its evidence history may only be appended.
 REVOKE ALL ON sms_consent_events FROM openpims_app;
 GRANT SELECT, INSERT ON sms_consent_events TO openpims_app;
+
+-- Outbound SMS reservations and outcomes form one append-only operational and
+-- compliance ledger. Reconciliation is a new event, never a row rewrite.
+REVOKE ALL ON sms_send_attempts, sms_send_attempt_events FROM openpims_app;
+GRANT SELECT, INSERT ON sms_send_attempts, sms_send_attempt_events TO openpims_app;
 
 -- Dispense charge snapshots are durable revenue work. The app may advance or
 -- reopen their attributed workflow status, while database triggers prevent
@@ -192,7 +197,7 @@ BEGIN
   FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
       EXECUTE format(
-        'REVOKE ALL ON auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, patient_merge_events, practice_conversion_milestones, prescription_events, sessions, stripe_events, verification_tokens FROM %I', r
+        'REVOKE ALL ON auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, patient_merge_events, practice_conversion_milestones, prescription_events, sessions, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
       );
     END IF;
   END LOOP;

--- a/packages/db/schema/communications.ts
+++ b/packages/db/schema/communications.ts
@@ -23,10 +23,7 @@ export const channelEnum = pgEnum("comm_channel", [
   "portal",
 ]);
 
-export const directionEnum = pgEnum("comm_direction", [
-  "inbound",
-  "outbound",
-]);
+export const directionEnum = pgEnum("comm_direction", ["inbound", "outbound"]);
 
 export const commStatusEnum = pgEnum("comm_status", [
   "pending",
@@ -59,38 +56,42 @@ export const communications = pgTable(
     dedupeKey: varchar("dedupe_key", { length: 160 }),
   },
   (table) => ({
+    tenantIdUq: uniqueIndex("communications_practice_id_uq").on(
+      table.practiceId,
+      table.id,
+    ),
     practiceListIdx: index("communications_practice_list_idx").on(
       table.practiceId,
       table.deletedAt,
-      table.createdAt
+      table.createdAt,
     ),
     clientTimelineIdx: index("communications_client_timeline_idx").on(
       table.practiceId,
       table.clientId,
       table.deletedAt,
-      table.createdAt
+      table.createdAt,
     ),
     inboxStatusIdx: index("communications_inbox_status_idx").on(
       table.practiceId,
       table.direction,
       table.status,
-      table.deletedAt
+      table.deletedAt,
     ),
     assignedIdx: index("communications_assigned_idx").on(
       table.practiceId,
       table.assignedTo,
-      table.deletedAt
+      table.deletedAt,
     ),
     dedupeKeyIdx: uniqueIndex("communications_dedupe_key_idx").on(
-      table.dedupeKey
+      table.dedupeKey,
     ),
     providerMessageIdx: index("communications_provider_message_idx").on(
       table.practiceId,
       table.providerMessageId,
       table.channel,
-      table.direction
+      table.direction,
     ),
-  })
+  }),
 );
 
 export const webhooks = pgTable(
@@ -109,9 +110,9 @@ export const webhooks = pgTable(
     practiceActiveIdx: index("webhooks_practice_active_idx").on(
       table.practiceId,
       table.deletedAt,
-      table.active
+      table.active,
     ),
-  })
+  }),
 );
 
 export const apiKeys = pgTable(
@@ -134,9 +135,9 @@ export const apiKeys = pgTable(
     practiceCreatedIdx: index("api_keys_practice_created_idx").on(
       table.practiceId,
       table.deletedAt,
-      table.createdAt
+      table.createdAt,
     ),
-  })
+  }),
 );
 
 export const auditLog = pgTable(
@@ -152,29 +153,32 @@ export const auditLog = pgTable(
     ipAddress: varchar("ip_address", { length: 45 }),
   },
   (table) => ({
-    practiceIdx: index("audit_log_practice_idx").on(table.practiceId, table.createdAt),
-    entityIdx: index("audit_log_entity_idx").on(table.entityType, table.entityId),
-  })
+    practiceIdx: index("audit_log_practice_idx").on(
+      table.practiceId,
+      table.createdAt,
+    ),
+    entityIdx: index("audit_log_entity_idx").on(
+      table.entityType,
+      table.entityId,
+    ),
+  }),
 );
 
 // Relations
-export const communicationsRelations = relations(
-  communications,
-  ({ one }) => ({
-    practice: one(practices, {
-      fields: [communications.practiceId],
-      references: [practices.id],
-    }),
-    client: one(clients, {
-      fields: [communications.clientId],
-      references: [clients.id],
-    }),
-    assignedToUser: one(users, {
-      fields: [communications.assignedTo],
-      references: [users.id],
-    }),
-  })
-);
+export const communicationsRelations = relations(communications, ({ one }) => ({
+  practice: one(practices, {
+    fields: [communications.practiceId],
+    references: [practices.id],
+  }),
+  client: one(clients, {
+    fields: [communications.clientId],
+    references: [clients.id],
+  }),
+  assignedToUser: one(users, {
+    fields: [communications.assignedTo],
+    references: [users.id],
+  }),
+}));
 
 export const webhooksRelations = relations(webhooks, ({ one }) => ({
   practice: one(practices, {

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -22,6 +22,7 @@ export * from "./usage";
 export * from "./auth-tokens";
 export * from "./messaging";
 export * from "./sms-consent-events";
+export * from "./sms-send-attempts";
 export * from "./demo-access";
 export * from "./booking";
 export * from "./funnel-events";

--- a/packages/db/schema/sms-send-attempts.ts
+++ b/packages/db/schema/sms-send-attempts.ts
@@ -1,0 +1,345 @@
+import { relations, sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { clients } from "./clients";
+import { communications } from "./communications";
+import { locations, practices } from "./practices";
+import { users } from "./users";
+
+export const smsSendOutcomeEnum = pgEnum("sms_send_outcome", [
+  "accepted",
+  "definite_failure",
+  "outcome_unknown",
+]);
+
+export const smsSendAttemptEventKindEnum = pgEnum(
+  "sms_send_attempt_event_kind",
+  ["provider_result", "reconciliation"],
+);
+
+export const smsSendActorTypeEnum = pgEnum("sms_send_actor_type", [
+  "clinic_user",
+  "platform_operator",
+]);
+
+/**
+ * Immutable reservation and exact payload for one provider dispatch. The row is
+ * committed before the provider call, so a crash can leave an unresolved
+ * attempt but can never erase the idempotency claim and invite a blind retry.
+ */
+export const smsSendAttempts = pgTable(
+  "sms_send_attempts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    clientId: uuid("client_id").references(() => clients.id),
+    locationId: uuid("location_id").references(() => locations.id),
+    communicationId: uuid("communication_id").references(
+      () => communications.id,
+    ),
+    requestedByActorType: smsSendActorTypeEnum("requested_by_actor_type"),
+    requestedByUserId: uuid("requested_by_user_id").references(() => users.id),
+    requestedByIdentity: varchar("requested_by_identity", { length: 255 }),
+    requestedByName: varchar("requested_by_name", { length: 255 }),
+    resendOfAttemptId: uuid("resend_of_attempt_id"),
+    source: varchar("source", { length: 64 }).notNull(),
+    sourceId: varchar("source_id", { length: 200 }).notNull(),
+    idempotencyKey: varchar("idempotency_key", { length: 200 }).notNull(),
+    destinationE164: varchar("destination_e164", { length: 16 }).notNull(),
+    registeredDisplayName: varchar("registered_display_name", {
+      length: 100,
+    }).notNull(),
+    body: text("body").notNull(),
+    bodySha256: varchar("body_sha256", { length: 64 }).notNull(),
+    provider: varchar("provider", { length: 16 }).notNull(),
+    senderMessagingServiceId: varchar("sender_messaging_service_id", {
+      length: 128,
+    }),
+    senderE164: varchar("sender_e164", { length: 16 }),
+  },
+  (table) => ({
+    tenantIdUq: uniqueIndex("sms_send_attempts_practice_id_uq").on(
+      table.practiceId,
+      table.id,
+    ),
+    idempotencyUq: uniqueIndex("sms_send_attempts_practice_idempotency_uq").on(
+      table.practiceId,
+      table.idempotencyKey,
+    ),
+    resendOfUq: uniqueIndex("sms_send_attempts_resend_of_uq")
+      .on(table.practiceId, table.resendOfAttemptId)
+      .where(sql`${table.resendOfAttemptId} is not null`),
+    clientHistoryIdx: index("sms_send_attempts_client_history_idx").on(
+      table.practiceId,
+      table.clientId,
+      table.createdAt,
+      table.id,
+    ),
+    communicationIdx: index("sms_send_attempts_communication_idx").on(
+      table.practiceId,
+      table.communicationId,
+    ),
+    sourceHistoryIdx: index("sms_send_attempts_source_history_idx").on(
+      table.practiceId,
+      table.source,
+      table.sourceId,
+      table.createdAt,
+    ),
+    resendTenantFk: foreignKey({
+      columns: [table.practiceId, table.resendOfAttemptId],
+      foreignColumns: [table.practiceId, table.id],
+      name: "sms_send_attempts_resend_tenant_fk",
+    }),
+    clientTenantFk: foreignKey({
+      columns: [table.practiceId, table.clientId],
+      foreignColumns: [clients.practiceId, clients.id],
+      name: "sms_send_attempts_client_tenant_fk",
+    }),
+    locationTenantFk: foreignKey({
+      columns: [table.practiceId, table.locationId],
+      foreignColumns: [locations.practiceId, locations.id],
+      name: "sms_send_attempts_location_tenant_fk",
+    }),
+    communicationTenantFk: foreignKey({
+      columns: [table.practiceId, table.communicationId],
+      foreignColumns: [communications.practiceId, communications.id],
+      name: "sms_send_attempts_communication_tenant_fk",
+    }),
+    requesterTenantFk: foreignKey({
+      columns: [table.practiceId, table.requestedByUserId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "sms_send_attempts_requester_tenant_fk",
+    }),
+    sourceCheck: check(
+      "sms_send_attempts_source_check",
+      sql`length(btrim(${table.source})) between 1 and 64`,
+    ),
+    sourceIdCheck: check(
+      "sms_send_attempts_source_id_check",
+      sql`length(btrim(${table.sourceId})) between 1 and 200`,
+    ),
+    idempotencyCheck: check(
+      "sms_send_attempts_idempotency_key_check",
+      sql`length(btrim(${table.idempotencyKey})) between 1 and 200`,
+    ),
+    destinationCheck: check(
+      "sms_send_attempts_destination_check",
+      sql`${table.destinationE164} ~ '^\\+[1-9][0-9]{7,14}$'`,
+    ),
+    destinationHistoryIdx: index(
+      "sms_send_attempts_destination_history_idx",
+    ).on(table.practiceId, table.destinationE164, table.createdAt, table.id),
+    displayNameCheck: check(
+      "sms_send_attempts_display_name_check",
+      sql`length(btrim(${table.registeredDisplayName})) between 1 and 100`,
+    ),
+    bodyCheck: check(
+      "sms_send_attempts_body_check",
+      sql`length(${table.body}) between 1 and 1600`,
+    ),
+    bodyHashCheck: check(
+      "sms_send_attempts_body_hash_check",
+      sql`${table.bodySha256} ~ '^[0-9a-f]{64}$'`,
+    ),
+    providerCheck: check(
+      "sms_send_attempts_provider_check",
+      sql`${table.provider} in ('telnyx', 'twilio', 'console')`,
+    ),
+    senderCheck: check(
+      "sms_send_attempts_sender_check",
+      sql`${table.provider} = 'console'
+        or length(btrim(coalesce(${table.senderMessagingServiceId}, ''))) > 0
+        or ${table.senderE164} ~ '^\\+[1-9][0-9]{7,14}$'`,
+    ),
+    requesterCheck: check(
+      "sms_send_attempts_requester_check",
+      sql`(
+          ${table.source} = 'operator_resend'
+          and ${table.requestedByActorType} is not null
+          and length(btrim(coalesce(${table.requestedByIdentity}, ''))) between 1 and 255
+          and length(btrim(coalesce(${table.requestedByName}, ''))) between 1 and 255
+          and (
+            (${table.requestedByActorType} = 'clinic_user' and ${table.requestedByUserId} is not null)
+            or (${table.requestedByActorType} = 'platform_operator' and ${table.requestedByUserId} is null)
+          )
+        ) or (
+          ${table.source} <> 'operator_resend'
+          and (
+            (
+              ${table.requestedByActorType} is null
+              and ${table.requestedByUserId} is null
+              and ${table.requestedByIdentity} is null
+              and ${table.requestedByName} is null
+            )
+            or (
+              ${table.requestedByActorType} is not null
+              and length(btrim(coalesce(${table.requestedByIdentity}, ''))) between 1 and 255
+              and length(btrim(coalesce(${table.requestedByName}, ''))) between 1 and 255
+              and (
+                (${table.requestedByActorType} = 'clinic_user' and ${table.requestedByUserId} is not null)
+                or (${table.requestedByActorType} = 'platform_operator' and ${table.requestedByUserId} is null)
+              )
+            )
+          )
+        )`,
+    ),
+  }),
+);
+
+/** Append-only provider outcomes and operator reconciliations for an attempt. */
+export const smsSendAttemptEvents = pgTable(
+  "sms_send_attempt_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    attemptId: uuid("attempt_id").notNull(),
+    kind: smsSendAttemptEventKindEnum("kind").notNull(),
+    outcome: smsSendOutcomeEnum("outcome").notNull(),
+    providerMessageId: varchar("provider_message_id", { length: 255 }),
+    detail: text("detail"),
+    actorType: smsSendActorTypeEnum("actor_type"),
+    actorUserId: uuid("actor_user_id").references(() => users.id),
+    actorIdentity: varchar("actor_identity", { length: 255 }),
+    actorName: varchar("actor_name", { length: 255 }),
+    eventKey: varchar("event_key", { length: 200 }).notNull(),
+  },
+  (table) => ({
+    eventKeyUq: uniqueIndex("sms_send_attempt_events_practice_event_key_uq").on(
+      table.practiceId,
+      table.eventKey,
+    ),
+    providerResultUq: uniqueIndex("sms_send_attempt_events_provider_result_uq")
+      .on(table.practiceId, table.attemptId)
+      .where(sql`${table.kind} = 'provider_result'`),
+    attemptHistoryIdx: index("sms_send_attempt_events_attempt_history_idx").on(
+      table.practiceId,
+      table.attemptId,
+      table.createdAt,
+      table.id,
+    ),
+    providerMessageUq: uniqueIndex(
+      "sms_send_attempt_events_provider_message_uq",
+    )
+      .on(table.practiceId, table.providerMessageId)
+      .where(sql`${table.providerMessageId} is not null`),
+    attemptTenantFk: foreignKey({
+      columns: [table.practiceId, table.attemptId],
+      foreignColumns: [smsSendAttempts.practiceId, smsSendAttempts.id],
+      name: "sms_send_attempt_events_attempt_tenant_fk",
+    }),
+    actorTenantFk: foreignKey({
+      columns: [table.practiceId, table.actorUserId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "sms_send_attempt_events_actor_tenant_fk",
+    }),
+    eventKeyCheck: check(
+      "sms_send_attempt_events_event_key_check",
+      sql`length(btrim(${table.eventKey})) between 1 and 200`,
+    ),
+    detailCheck: check(
+      "sms_send_attempt_events_detail_check",
+      sql`${table.detail} is null or length(${table.detail}) <= 2000`,
+    ),
+    outcomeShapeCheck: check(
+      "sms_send_attempt_events_outcome_shape_check",
+      sql`(
+          ${table.outcome} = 'accepted'
+          and length(btrim(coalesce(${table.providerMessageId}, ''))) > 0
+        ) or (
+          ${table.outcome} in ('definite_failure', 'outcome_unknown')
+          and ${table.providerMessageId} is null
+        )`,
+    ),
+    actorShapeCheck: check(
+      "sms_send_attempt_events_actor_shape_check",
+      sql`(
+          ${table.kind} = 'provider_result'
+          and ${table.actorType} is null
+          and ${table.actorUserId} is null
+          and ${table.actorIdentity} is null
+          and ${table.actorName} is null
+        ) or (
+          ${table.kind} = 'reconciliation'
+          and ${table.outcome} in ('accepted', 'definite_failure')
+          and ${table.actorType} is not null
+          and length(btrim(coalesce(${table.actorIdentity}, ''))) between 1 and 255
+          and length(btrim(coalesce(${table.actorName}, ''))) between 1 and 255
+          and (
+            (${table.actorType} = 'clinic_user' and ${table.actorUserId} is not null)
+            or (${table.actorType} = 'platform_operator' and ${table.actorUserId} is null)
+          )
+        )`,
+    ),
+  }),
+);
+
+export const smsSendAttemptsRelations = relations(
+  smsSendAttempts,
+  ({ one, many }) => ({
+    practice: one(practices, {
+      fields: [smsSendAttempts.practiceId],
+      references: [practices.id],
+    }),
+    client: one(clients, {
+      fields: [smsSendAttempts.clientId],
+      references: [clients.id],
+    }),
+    location: one(locations, {
+      fields: [smsSendAttempts.locationId],
+      references: [locations.id],
+    }),
+    communication: one(communications, {
+      fields: [smsSendAttempts.communicationId],
+      references: [communications.id],
+    }),
+    requester: one(users, {
+      fields: [smsSendAttempts.requestedByUserId],
+      references: [users.id],
+    }),
+    resendOf: one(smsSendAttempts, {
+      fields: [smsSendAttempts.resendOfAttemptId],
+      references: [smsSendAttempts.id],
+      relationName: "smsAttemptResends",
+    }),
+    resends: many(smsSendAttempts, { relationName: "smsAttemptResends" }),
+    events: many(smsSendAttemptEvents),
+  }),
+);
+
+export const smsSendAttemptEventsRelations = relations(
+  smsSendAttemptEvents,
+  ({ one }) => ({
+    practice: one(practices, {
+      fields: [smsSendAttemptEvents.practiceId],
+      references: [practices.id],
+    }),
+    attempt: one(smsSendAttempts, {
+      fields: [smsSendAttemptEvents.attemptId],
+      references: [smsSendAttempts.id],
+    }),
+    actor: one(users, {
+      fields: [smsSendAttemptEvents.actorUserId],
+      references: [users.id],
+    }),
+  }),
+);

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -66,6 +66,12 @@ const aDispenseCharge = randomUUID();
 const bDispenseCharge = randomUUID();
 const aSmsConsentEvent = randomUUID();
 const bSmsConsentEvent = randomUUID();
+const aSmsSendAttempt = randomUUID();
+const bSmsSendAttempt = randomUUID();
+const aSmsSendAttemptEvent = randomUUID();
+const bSmsSendAttemptEvent = randomUUID();
+const aAppSmsSendAttempt = randomUUID();
+const aAppSmsSendAttemptEvent = randomUUID();
 const funnelEventId = randomUUID();
 const conversionEvidenceKey = `practice:${aId}`;
 let failures = 0;
@@ -94,6 +100,17 @@ try {
     values
     (${aSmsConsentEvent}, ${aId}, ${aClient}, '+15555550101', 'revoked', 'rls_test:v1', 'Tenant A event', 'system', ${`rls:${aSmsConsentEvent}`}),
     (${bSmsConsentEvent}, ${bId}, ${bClient}, '+15555550102', 'revoked', 'rls_test:v1', 'Tenant B event', 'system', ${`rls:${bSmsConsentEvent}`})`;
+  await owner`insert into sms_send_attempts
+    (id, practice_id, source, source_id, idempotency_key, destination_e164,
+     registered_display_name, body, body_sha256, provider)
+    values
+    (${aSmsSendAttempt}, ${aId}, 'rls_test', ${aSmsSendAttempt}, ${`rls:${aSmsSendAttempt}`}, '+15555550101', 'RLS Clinic A', 'RLS Clinic A: Test. Reply STOP to opt out or HELP for help.', ${"a".repeat(64)}, 'console'),
+    (${bSmsSendAttempt}, ${bId}, 'rls_test', ${bSmsSendAttempt}, ${`rls:${bSmsSendAttempt}`}, '+15555550102', 'RLS Clinic B', 'RLS Clinic B: Test. Reply STOP to opt out or HELP for help.', ${"b".repeat(64)}, 'console')`;
+  await owner`insert into sms_send_attempt_events
+    (id, practice_id, attempt_id, kind, outcome, detail, event_key)
+    values
+    (${aSmsSendAttemptEvent}, ${aId}, ${aSmsSendAttempt}, 'provider_result', 'definite_failure', 'RLS test rejection', ${`rls:${aSmsSendAttemptEvent}`}),
+    (${bSmsSendAttemptEvent}, ${bId}, ${bSmsSendAttempt}, 'provider_result', 'definite_failure', 'RLS test rejection', ${`rls:${bSmsSendAttemptEvent}`})`;
   await owner`insert into patients (id, practice_id, client_id, name, species)
     select ${aPatient}, ${aId}, id, 'RLS Pet A', 'canine'
     from clients where practice_id = ${aId}`;
@@ -229,6 +246,120 @@ try {
   check(
     "cross-tenant SMS consent INSERT is blocked",
     crossTenantSmsConsentInsertBlocked,
+  );
+
+  const aSmsSendAttempts = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id, practice_id from sms_send_attempts where id in (${aSmsSendAttempt}, ${bSmsSendAttempt})`;
+  });
+  check(
+    "tenant A sees only A's SMS send attempts",
+    aSmsSendAttempts.length === 1 &&
+      aSmsSendAttempts[0]!.id === aSmsSendAttempt,
+  );
+
+  const aSmsSendEvents = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id, practice_id from sms_send_attempt_events where id in (${aSmsSendAttemptEvent}, ${bSmsSendAttemptEvent})`;
+  });
+  check(
+    "tenant A sees only A's SMS send outcome events",
+    aSmsSendEvents.length === 1 &&
+      aSmsSendEvents[0]!.id === aSmsSendAttemptEvent,
+  );
+
+  let smsSendAttemptUpdateBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`update sms_send_attempts set source = 'tampered' where id = ${aSmsSendAttempt}`;
+    });
+  } catch {
+    smsSendAttemptUpdateBlocked = true;
+  }
+  check(
+    "application role cannot rewrite SMS send attempts",
+    smsSendAttemptUpdateBlocked,
+  );
+
+  let smsSendEventDeleteBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`delete from sms_send_attempt_events where id = ${aSmsSendAttemptEvent}`;
+    });
+  } catch {
+    smsSendEventDeleteBlocked = true;
+  }
+  check(
+    "application role cannot delete SMS send outcome events",
+    smsSendEventDeleteBlocked,
+  );
+
+  let sameTenantSmsSendInsertAllowed = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into sms_send_attempts
+        (id, practice_id, source, source_id, idempotency_key,
+         destination_e164, registered_display_name, body, body_sha256, provider)
+        values (${aAppSmsSendAttempt}, ${aId}, 'rls_app_test',
+          ${aAppSmsSendAttempt}, ${`rls:${aAppSmsSendAttempt}`},
+          '+15555550103', 'RLS Clinic A',
+          'RLS Clinic A: App test. Reply STOP to opt out or HELP for help.',
+          ${"c".repeat(64)}, 'console')`;
+      await tx`insert into sms_send_attempt_events
+        (id, practice_id, attempt_id, kind, outcome, detail, event_key)
+        values (${aAppSmsSendAttemptEvent}, ${aId}, ${aAppSmsSendAttempt},
+          'provider_result', 'definite_failure', 'App role test rejection',
+          ${`rls:${aAppSmsSendAttemptEvent}`})`;
+    });
+    sameTenantSmsSendInsertAllowed = true;
+  } catch {
+    sameTenantSmsSendInsertAllowed = false;
+  }
+  check(
+    "same-tenant app role can append SMS attempt and provider outcome",
+    sameTenantSmsSendInsertAllowed,
+  );
+
+  let crossTenantSmsAttemptInsertBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into sms_send_attempts
+        (practice_id, source, source_id, idempotency_key, destination_e164,
+         registered_display_name, body, body_sha256, provider)
+        values (${bId}, 'rls_cross_tenant', ${randomUUID()},
+          ${`rls:cross:${randomUUID()}`}, '+15555550104', 'RLS Clinic B',
+          'RLS Clinic B: Cross test. Reply STOP to opt out or HELP for help.',
+          ${"d".repeat(64)}, 'console')`;
+    });
+  } catch {
+    crossTenantSmsAttemptInsertBlocked = true;
+  }
+  check(
+    "cross-tenant SMS send attempt INSERT is blocked",
+    crossTenantSmsAttemptInsertBlocked,
+  );
+
+  let crossTenantSmsSendInsertBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into sms_send_attempt_events
+        (practice_id, attempt_id, kind, outcome, detail, actor_type,
+         actor_identity, actor_name, event_key)
+        values (${bId}, ${bSmsSendAttempt}, 'reconciliation', 'definite_failure',
+          'Cross tenant', 'platform_operator', 'operator@example.com',
+          'RLS Operator', ${`rls:cross:${randomUUID()}`})`;
+    });
+  } catch {
+    crossTenantSmsSendInsertBlocked = true;
+  }
+  check(
+    "cross-tenant SMS send event INSERT is blocked",
+    crossTenantSmsSendInsertBlocked,
   );
 
   const aPrescriptionEvents = await appTransaction(async (tx) => {
@@ -619,6 +750,8 @@ try {
   await owner.begin(async (tx) => {
     const cleanup = tx as unknown as typeof owner;
     await cleanup`select set_config('app.ledger_maintenance', 'on', true)`;
+    await cleanup`delete from sms_send_attempt_events where id in (${aSmsSendAttemptEvent}, ${bSmsSendAttemptEvent}, ${aAppSmsSendAttemptEvent})`;
+    await cleanup`delete from sms_send_attempts where id in (${aSmsSendAttempt}, ${bSmsSendAttempt}, ${aAppSmsSendAttempt})`;
     await cleanup`delete from sms_consent_events where id in (${aSmsConsentEvent}, ${bSmsConsentEvent})`;
     await cleanup`delete from patient_merge_events where id in (${aPatientMergeEvent}, ${bPatientMergeEvent})`;
     await cleanup`delete from dispense_charge_queue where id in (${aDispenseCharge}, ${bDispenseCharge})`;


### PR DESCRIPTION
## Summary

- add immutable, tenant-scoped SMS send attempts and append-only outcome events
- make accepted provider outcomes and linked communication projection atomic
- classify accepted, definite failure, and unknown outcomes without unsafe automatic retries
- apply one registered campaign format across inbox, reminders, and vaccination recalls
- add durable request/claim idempotency, stale orphan recovery, and explicit resend safeguards
- revalidate consent, suppression, sender, carrier campaign, brand, and billing access immediately before dispatch
- add bounded platform-operator queues for ambiguous or incomplete outcomes, with reconciliation and alerting
- preserve the default-off hosted launch interlock; this change does not activate provider traffic

## Safety

- no raw provider credentials or payloads are stored
- app roles receive SELECT/INSERT only on the append-only ledger
- tenant foreign keys and RLS cover attempts, events, users, clients, locations, and communications
- ambiguous provider outcomes are quarantined and never retried automatically
- explicit resend requires a stale, definitively failed attempt and rechecks the linked communication under lock
- hosted sends require an exact active location sender, campaign, and brand match

## Validation

- 306 test files / 2,986 tests pass after rebasing onto main
- root typecheck passes
- production build passed before rebase; PR CI will rerun it on the rebased head
- schema generation reports no drift
- staged secret scan reports no leaks
- independent blocker audit: SHIP
- disposable PostgreSQL migration and RLS checks remain required in PR CI