### PR TITLE
Require fresh values for lab replacements

### DIFF
--- a/apps/web/app/(dashboard)/records/page.tsx
+++ b/apps/web/app/(dashboard)/records/page.tsx
@@ -1085,6 +1085,7 @@ function RecordsPageContent() {
   const canSubmitLabResult =
     Boolean(patientId) &&
     (!replacesLabResultId || Boolean(replacementPatient)) &&
+    (!replacesLabResultId || Boolean(labForm.resultValue.trim())) &&
     isLabRequiredTextInputValid(labForm.testName, LAB_TEST_NAME_MAX_LENGTH) &&
     isLabOptionalTextInputValid(
       labForm.resultValue,
@@ -2785,7 +2786,9 @@ function RecordsPageContent() {
                       </div>
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      Entering a value records this result as completed and sends it to the clinic Lab Inbox for review. A result without values stays pending.
+                      {replacesLabResultId
+                        ? "Enter a fresh result value to create a completed replacement and send it to the clinic Lab Inbox for review. A replacement cannot be saved as an empty pending result."
+                        : "Entering a value records this result as completed and sends it to the clinic Lab Inbox for review. A result without values stays pending."}
                     </p>
                     <div className="flex gap-2">
                       <Button

--- a/apps/web/lib/__tests__/lab-result-safety.test.ts
+++ b/apps/web/lib/__tests__/lab-result-safety.test.ts
@@ -156,6 +156,12 @@ describe("lab result clinical safety contract", () => {
     );
 
     expect(creation).toContain("input.replacesLabResultId && ctx.user.role");
+    expect(router).toContain(
+      "input.replacesLabResultId && !input.resultValue?.trim()",
+    );
+    expect(router).toContain(
+      "A fresh result value is required when replacing an entered-in-error lab result.",
+    );
     expect(creation).toContain('kind: "create"');
     expect(creation).toContain(
       "replacesLabResultId: input.replacesLabResultId ?? null",
@@ -246,6 +252,12 @@ describe("lab result clinical safety contract", () => {
     expect(records).toContain("replacementPatient?.id === selectedPatient?.id");
     expect(records).toContain("replacementSourceLabResult?.appointmentId ??");
     expect(records).toContain("Only the test name was copied");
+    expect(records).toContain(
+      "!replacesLabResultId || Boolean(labForm.resultValue.trim())",
+    );
+    expect(records).toContain(
+      "A replacement cannot be saved as an empty pending result.",
+    );
     expect(records).toContain('resultValue: ""');
     expect(records).toContain('resultFlag: "unknown"');
     expect(records).toContain("lab.replacementLabResultPatientId ?? patientId");

--- a/apps/web/server/__tests__/records-target-safety.test.ts
+++ b/apps/web/server/__tests__/records-target-safety.test.ts
@@ -295,6 +295,32 @@ describe("records target safety", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
+  it("rejects an empty lab replacement before DB work", async () => {
+    const { db, select, insertValues } = createDb();
+
+    await expect(
+      callerWithDb(db).createLabResult({
+        patientId: PATIENT_ID,
+        testName: "CBC",
+        operationId: FORM_ID,
+        replacesLabResultId: RECORD_ID,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    await expect(
+      callerWithDb(db).createLabResult({
+        patientId: PATIENT_ID,
+        testName: "CBC",
+        resultValue: "   ",
+        operationId: FORM_ID,
+        replacesLabResultId: RECORD_ID,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("rejects clinical record text that exceeds backing columns before DB work", async () => {
     const { db, select, insertValues } = createDb();
 

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -333,6 +333,14 @@ const createLabResultInput = z
         message: "A result value is required before a lab result can be completed.",
       });
     }
+    if (input.replacesLabResultId && !input.resultValue?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["resultValue"],
+        message:
+          "A fresh result value is required when replacing an entered-in-error lab result.",
+      });
+    }
     if (
       input.status === "pending" &&
       (input.resultValue != null ||


### PR DESCRIPTION
## Summary
- prevent an entered-in-error lab replacement from being saved as an empty pending result
- enforce the fresh-value rule in both the Records UI and server input validation
- explain the requirement at the form and cover omitted plus whitespace-only bypass attempts

## Evidence
A controlled synthetic production smoke test after #148 found the replacement form enabled with no fresh result value. No invalid replacement was submitted.

## Verification
- 310 test files / 3,102 tests pass
- web type-check passes
- optimized production build passes
- focused bypass tests pass
- git diff check passes
- independent audit found no P0/P1 issues

No migration is required. Texting remains disabled.