### PR TITLE
Secure email verification recovery

### DIFF
--- a/apps/web/app/(auth)/verify-email/page.tsx
+++ b/apps/web/app/(auth)/verify-email/page.tsx
@@ -9,12 +9,12 @@ import { trpc } from "@/lib/trpc";
 function VerifyEmailInner() {
   const params = useSearchParams();
   const token = params.get("token") ?? "";
-  const email = params.get("email") ?? "";
 
-  // Two modes: confirm a token (clicked from the email), or the post-signup
-  // "check your inbox" pending screen (no token) with a resend option.
+  // Token links confirm the address. Recovery is intentionally authenticated:
+  // signed-in users can resend from the in-app banner without exposing an
+  // email-address endpoint that could invalidate another user's link.
   if (token) return <ConfirmToken token={token} />;
-  return <PendingVerification email={email} />;
+  return <VerificationRecovery />;
 }
 
 function ConfirmToken({ token }: { token: string }) {
@@ -44,7 +44,8 @@ function ConfirmToken({ token }: { token: string }) {
       {status === "ok" && (
         <>
           <p className="mt-3 text-sm text-foreground">
-            Your email is verified. Your OpenVPM trial is ready.
+            Email confirmed. Your trial was already active, so you can continue
+            where you left off.
           </p>
           <Link
             href="/"
@@ -60,10 +61,10 @@ function ConfirmToken({ token }: { token: string }) {
             This verification link is invalid or has expired.
           </p>
           <Link
-            href="/verify-email"
+            href="/"
             className="mt-6 inline-block text-sm text-primary hover:underline"
           >
-            Send a new link
+            Open OpenVPM to resend
           </Link>
         </>
       )}
@@ -71,12 +72,7 @@ function ConfirmToken({ token }: { token: string }) {
   );
 }
 
-function PendingVerification({ email }: { email: string }) {
-  const [sent, setSent] = useState(false);
-  const resend = trpc.auth.resendVerification.useMutation({
-    onSuccess: () => setSent(true),
-  });
-
+function VerificationRecovery() {
   return (
     <Shell>
       <div className="mt-4 flex justify-center">
@@ -85,52 +81,21 @@ function PendingVerification({ email }: { email: string }) {
         </span>
       </div>
       <h2 className="mt-4 font-heading text-lg font-semibold text-foreground">
-        Check your inbox
+        Confirm your email
       </h2>
       <p className="mt-2 text-sm text-muted-foreground">
-        {email ? (
-          <>
-            We sent a verification link to{" "}
-            <span className="font-medium text-foreground">{email}</span>. Click it
-            to confirm your address. Your trial is already active.
-          </>
-        ) : (
-          <>
-            We sent a verification link to your email. Click it to confirm your
-            address. Your trial is already active.
-          </>
-        )}
+        Your trial is already active. Open OpenVPM and use the verification
+        banner to send a new link securely. Any unexpired verification link will
+        work.
       </p>
-
-      {sent ? (
-        <p className="mt-6 rounded-md border border-primary/20 bg-primary/5 p-3 text-sm text-primary">
-          Sent. If it&apos;s not in your inbox, check spam.
-        </p>
-      ) : (
-        <button
-          type="button"
-          disabled={!email || resend.isPending}
-          onClick={() => email && resend.mutate({ email })}
-          className="mt-6 inline-flex items-center justify-center gap-2 rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:border-primary hover:text-primary disabled:opacity-50"
-        >
-          {resend.isPending ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : null}
-          Resend verification email
-        </button>
-      )}
-
-      <p className="mt-6 text-xs text-muted-foreground">
-        Wrong address?{" "}
-        <Link href="/register" className="text-primary hover:underline">
-          Use a different email
-        </Link>
-      </p>
-      <p className="mt-2 text-xs text-muted-foreground">
-        Already verified?{" "}
-        <Link href="/login" className="text-primary hover:underline">
-          Sign in
-        </Link>
+      <Link
+        href="/"
+        className="mt-6 inline-block rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+      >
+        Open OpenVPM
+      </Link>
+      <p className="mt-4 text-xs text-muted-foreground">
+        If you&apos;re signed out, OpenVPM will ask you to sign in first.
       </p>
     </Shell>
   );

--- a/apps/web/components/layout/verify-email-banner.tsx
+++ b/apps/web/components/layout/verify-email-banner.tsx
@@ -88,12 +88,17 @@ export function VerifyEmailBanner() {
             account and keep reminders deliverable.
           </>
         )}
+        {resend.error ? (
+          <span className="mt-1 block text-xs text-destructive">
+            {resend.error.message}
+          </span>
+        ) : null}
       </p>
       {!resend.isSuccess && (
         <button
           type="button"
-          disabled={resend.isPending || !data.email}
-          onClick={() => data.email && resend.mutate({ email: data.email })}
+          disabled={resend.isPending}
+          onClick={() => resend.mutate()}
           className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-amber-300 bg-white px-2.5 py-1 text-xs font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-50"
         >
           {resend.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}

--- a/apps/web/lib/__tests__/auth-login-rate-limit.test.ts
+++ b/apps/web/lib/__tests__/auth-login-rate-limit.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => {
     role: "admin",
     practiceId: "practice-1",
     passwordHash: "hashed-password",
+    emailVerifiedAt: null,
   };
   const selectLimit = vi.fn(async (): Promise<unknown[]> => [activeUser]);
   const selectWhere = vi.fn(() => ({ limit: selectLimit }));
@@ -102,6 +103,20 @@ afterEach(() => {
 });
 
 describe("credentials login rate-limit cleanup", () => {
+  it("keeps trial access open while the user's email is unverified", async () => {
+    const user = await credentialsProvider().authorize(
+      { email: "admin@example.com", password: "password123" },
+      { headers: { "x-forwarded-for": "203.0.113.10" } }
+    );
+
+    expect(user).toMatchObject({
+      id: "user-1",
+      email: "admin@example.com",
+      practiceId: "practice-1",
+    });
+    expect(mocks.activeUser.emailVerifiedAt).toBeNull();
+  });
+
   it("clears the email bucket after successful sign-in without resetting the IP bucket", async () => {
     const user = await credentialsProvider().authorize(
       { email: " Admin@Example.COM ", password: "password123" },

--- a/apps/web/lib/__tests__/auth-tokens.test.ts
+++ b/apps/web/lib/__tests__/auth-tokens.test.ts
@@ -119,6 +119,7 @@ describe("createAuthToken", () => {
     });
     expect(row.tokenHash).not.toBe(raw);
     expect(row.expiresAt).toEqual(new Date("2026-06-13T00:00:00Z"));
+    expect(fake.update).not.toHaveBeenCalled();
   });
 
   it("supersedes previous unused unexpired tokens for the same user and type", async () => {

--- a/apps/web/lib/__tests__/email.test.ts
+++ b/apps/web/lib/__tests__/email.test.ts
@@ -220,6 +220,29 @@ describe("sendEmail", () => {
     ).resolves.toMatchObject({ success: true, id: "email-invoice-1" });
   });
 
+  it("keeps verification provider evidence and says the trial is already active", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    mocks.resendSend.mockResolvedValue({ data: { id: "email-verify-1" } });
+    const { sendVerificationEmail } = await loadEmail();
+
+    await expect(
+      sendVerificationEmail({
+        to: "admin@example.com",
+        name: "Dr Admin",
+        verifyUrl: "https://app.openvpm.com/verify-email?token=safe-token",
+      })
+    ).resolves.toEqual({ success: true, id: "email-verify-1" });
+
+    const [payload] = mocks.resendSend.mock.calls[0] ?? [];
+    expect(payload).toMatchObject({
+      to: "admin@example.com",
+      subject: "Verify your OpenVPM email",
+    });
+    expect(payload.html).toContain("Your trial is already active.");
+    expect(payload.html).toContain("Confirm email");
+    expect(payload.html).not.toMatch(/activate your account|start your free trial/i);
+  });
+
   it("aborts hung Resend sends and returns a timeout error", async () => {
     vi.useFakeTimers();
     vi.stubEnv("RESEND_API_KEY", "re_test");

--- a/apps/web/lib/__tests__/verify-email-banner-ui.test.ts
+++ b/apps/web/lib/__tests__/verify-email-banner-ui.test.ts
@@ -19,4 +19,12 @@ describe("verify email banner UI", () => {
     );
     expect(source).not.toContain("if (!data?.verificationEnabled || data.emailVerified)");
   });
+
+  it("uses the authenticated inputless resend and renders real failures", () => {
+    expect(source).toContain("trpc.auth.resendVerification.useMutation()");
+    expect(source).toContain("onClick={() => resend.mutate()}");
+    expect(source).not.toContain("resend.mutate({ email:");
+    expect(source).toContain("resend.error.message");
+    expect(source).toContain("Verification email sent. Check your inbox (and spam).");
+  });
 });

--- a/apps/web/lib/__tests__/verify-email-page-ui.test.ts
+++ b/apps/web/lib/__tests__/verify-email-page-ui.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("verify email recovery UI", () => {
+  const source = readFileSync("app/(auth)/verify-email/page.tsx", "utf8");
+
+  it("keeps verification optional and routes recovery through the signed-in app", () => {
+    expect(source).toContain("Your trial is already active.");
+    expect(source).toContain("Any unexpired verification link will");
+    expect(source).toContain("Open OpenVPM to resend");
+    expect(source).not.toContain("resendVerification.useMutation");
+    expect(source).not.toContain('href="/register"');
+    expect(source).not.toContain("disabled={!email");
+  });
+
+  it("does not claim confirmation activates a trial", () => {
+    expect(source).toContain("Email confirmed. Your trial was already active");
+    expect(source).not.toMatch(/activate your account|start your free trial/i);
+  });
+});

--- a/apps/web/lib/auth-tokens.ts
+++ b/apps/web/lib/auth-tokens.ts
@@ -31,17 +31,23 @@ export async function createAuthToken(opts: {
   const raw = randomBytes(32).toString("hex");
   const now = opts.now ?? new Date();
   const issueToken = async (tx: Database) => {
-    await tx
-      .update(authTokens)
-      .set({ usedAt: now })
-      .where(
-        and(
-          eq(authTokens.userId, opts.userId),
-          eq(authTokens.type, opts.type),
-          isNull(authTokens.usedAt),
-          gt(authTokens.expiresAt, now)
-        )
-      );
+    // Keep unexpired verification links valid. A resend may be delayed or the
+    // provider may reject it, and neither case should burn a working link that
+    // is already in the user's inbox. Password-reset and invite tokens retain
+    // single-newest-link semantics because they grant new credentials/access.
+    if (opts.type !== "email_verify") {
+      await tx
+        .update(authTokens)
+        .set({ usedAt: now })
+        .where(
+          and(
+            eq(authTokens.userId, opts.userId),
+            eq(authTokens.type, opts.type),
+            isNull(authTokens.usedAt),
+            gt(authTokens.expiresAt, now)
+          )
+        );
+    }
 
     await tx.insert(authTokens).values({
       userId: opts.userId,

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -387,11 +387,11 @@ export async function sendVerificationEmail(data: {
   to: string;
   name: string;
   verifyUrl: string;
-}): Promise<{ success: boolean }> {
+}): Promise<{ success: boolean; id?: string; error?: string }> {
   const body = `
     <p style="margin:0 0 16px;color:#111827;font-size:15px;line-height:1.6;">Hi ${data.name},</p>
-    <p style="margin:0 0 8px;color:#111827;font-size:15px;line-height:1.6;">Welcome to OpenVPM! Please confirm your email address to activate your account and start your free trial.</p>
-    ${ctaButton("Verify my email", data.verifyUrl)}
+    <p style="margin:0 0 8px;color:#111827;font-size:15px;line-height:1.6;">Welcome to OpenVPM! Your trial is already active. Please confirm your email address to secure your workspace and keep important account messages deliverable.</p>
+    ${ctaButton("Confirm email", data.verifyUrl)}
     <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.5;">This link expires in 24 hours. If you didn't create an OpenVPM account, you can ignore this email.</p>
   `;
   const html = emailLayout("OpenVPM", body);
@@ -400,7 +400,7 @@ export async function sendVerificationEmail(data: {
     subject: "Verify your OpenVPM email",
     html,
   });
-  return { success: result.success };
+  return result;
 }
 
 export async function sendPasswordResetEmail(data: {

--- a/apps/web/server/__tests__/auth-router.test.ts
+++ b/apps/web/server/__tests__/auth-router.test.ts
@@ -6,7 +6,11 @@ const mocks = vi.hoisted(() => ({
   createAuthToken: vi.fn(async () => "token-123"),
   consumeAuthToken: vi.fn(),
   sendPasswordResetEmail: vi.fn(async () => ({ success: true })),
-  sendVerificationEmail: vi.fn(async () => ({ success: true })),
+  sendVerificationEmail: vi.fn(
+    async (): Promise<{ success: boolean; id?: string; error?: string }> => ({
+      success: true,
+    })
+  ),
   sendWelcomeEmail: vi.fn(async () => ({ success: true })),
   createSubscriptionCheckoutSession: vi.fn(async () => ({
     url: "https://stripe.example/signup-checkout",
@@ -102,6 +106,21 @@ function sqlIncludesValue(
 
 function callerWithDb(db: Record<string, unknown>) {
   return authRouter.createCaller({ db, session: null } as never);
+}
+
+function callerWithSession(db: Record<string, unknown>) {
+  return authRouter.createCaller({
+    db,
+    session: {
+      user: {
+        id: "user-1",
+        email: "admin@example.com",
+        name: "Admin",
+        role: "admin",
+        practiceId: "practice-1",
+      },
+    },
+  } as never);
 }
 
 function createSelectDb(selectResults: unknown[][]) {
@@ -202,6 +221,8 @@ afterEach(() => {
   });
   mocks.billingEnforced.mockReturnValue(false);
   mocks.noCardTrialEnabled.mockReturnValue(false);
+  mocks.createAuthToken.mockResolvedValue("token-123");
+  mocks.sendVerificationEmail.mockResolvedValue({ success: true });
   mocks.createSubscriptionCheckoutSession.mockResolvedValue({
     url: "https://stripe.example/signup-checkout",
   });
@@ -628,39 +649,115 @@ describe("auth router email normalization", () => {
     });
   });
 
-  it("normalizes verification-resend keys and active account lookups", async () => {
-    const { db, selectWhere } = createSelectDb([
-      [
-        {
-          id: "user-1",
-          email: "admin@example.com",
-          name: "Admin",
-          emailVerifiedAt: null,
-        },
-      ],
-    ]);
+});
 
-    await expect(
-      callerWithDb(db).resendVerification({ email: "Admin@Example.COM" })
-    ).resolves.toEqual({ ok: true });
+describe("authenticated verification resend", () => {
+  const unverifiedUser = {
+    id: "user-1",
+    email: "admin@example.com",
+    name: "Admin",
+    emailVerifiedAt: null,
+  };
 
+  it("rejects logged-out callers before account lookup", async () => {
+    const { db } = createSelectDb([]);
+
+    await expect(callerWithDb(db).resendVerification()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("binds resend to the signed-in account and reports provider acceptance", async () => {
+    const { db, selectWhere } = createSelectDb([[unverifiedUser]]);
+
+    await expect(callerWithSession(db).resendVerification()).resolves.toEqual({
+      ok: true,
+      alreadyVerified: false,
+    });
+
+    const condition = selectWhere.mock.calls[0]?.[0];
+    expect(sqlIncludesValue(condition, "user-1")).toBe(true);
+    expect(sqlIncludesValue(condition, "practice-1")).toBe(true);
+    expect(sqlIncludesValue(condition, users.deletedAt)).toBe(true);
     expect(mocks.rateLimit).toHaveBeenCalledWith({
       key: "verifyresend:admin@example.com",
       limit: 5,
       windowMs: 3600000,
     });
-    expect(sqlIncludesValue(selectWhere.mock.calls[0]?.[0], "admin@example.com")).toBe(
-      true
-    );
-    expect(sqlIncludesValue(selectWhere.mock.calls[0]?.[0], users.deletedAt)).toBe(
-      true
-    );
     expect(mocks.createAuthToken).toHaveBeenCalledWith({
       userId: "user-1",
       email: "admin@example.com",
       type: "email_verify",
       db,
     });
+    expect(mocks.sendVerificationEmail).toHaveBeenCalledWith({
+      to: "admin@example.com",
+      name: "Admin",
+      verifyUrl: "http://localhost:3000/verify-email?token=token-123",
+    });
+  });
+
+  it("does not send another message after the account is verified", async () => {
+    const { db } = createSelectDb([
+      [{ ...unverifiedUser, emailVerifiedAt: new Date("2026-08-09T12:00:00Z") }],
+    ]);
+
+    await expect(callerWithSession(db).resendVerification()).resolves.toEqual({
+      ok: true,
+      alreadyVerified: true,
+    });
+    expect(mocks.rateLimit).not.toHaveBeenCalled();
+    expect(mocks.createAuthToken).not.toHaveBeenCalled();
+    expect(mocks.sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it("reports provider rejection instead of claiming the email was sent", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { db } = createSelectDb([[unverifiedUser]]);
+    mocks.sendVerificationEmail.mockResolvedValueOnce({
+      success: false,
+      error: "provider unavailable",
+    });
+
+    try {
+      await expect(callerWithSession(db).resendVerification()).rejects.toMatchObject({
+        code: "INTERNAL_SERVER_ERROR",
+        message:
+          "We couldn't send the verification email. Please try again in a moment.",
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[resendVerification] email failed:",
+        expect.any(Error)
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("fails closed when the resend limiter is unavailable", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const { db } = createSelectDb([[unverifiedUser]]);
+    mocks.rateLimit.mockRejectedValueOnce(new Error("rate limiter down"));
+
+    try {
+      await expect(callerWithSession(db).resendVerification()).rejects.toMatchObject({
+        code: "TOO_MANY_REQUESTS",
+        message: "Too many requests. Please try again later.",
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[auth.resendVerification] rate limit failed:",
+        expect.any(Error)
+      );
+      expect(mocks.createAuthToken).not.toHaveBeenCalled();
+      expect(mocks.sendVerificationEmail).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });
 
@@ -677,13 +774,6 @@ describe("auth router rate-limit failure guards", () => {
           password: "password123",
           practiceName: "Neighborhood Veterinary",
         }),
-    },
-    {
-      label: "verification resend",
-      logContext: "resendVerification",
-      expectedMessage: "Too many requests. Please try again later.",
-      call: (caller: ReturnType<typeof callerWithDb>) =>
-        caller.resendVerification({ email: "owner@example.com" }),
     },
     {
       label: "password reset",

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -464,51 +464,72 @@ export const authRouter = createRouter({
       return { ok: true };
     }),
 
-  /** Resend the email-verification link. Generic response (no enumeration). */
-  resendVerification: publicProcedure
-    .input(z.object({ email: authEmailInput }))
-    .mutation(async ({ ctx, input }) => {
-      const email = normalizeAuthEmail(input.email);
-      await assertPreAuthRateLimit({
-        key: `verifyresend:${email}`,
-        limit: 5,
-        windowMs: 3600000,
-        message: "Too many requests. Please try again later.",
-        logContext: "resendVerification",
+  /**
+   * Resend verification for the signed-in user and report delivery failures.
+   * This procedure can be truthful because the session already proves which
+   * account is making the request; there is no logged-out email resend route.
+   */
+  resendVerification: protectedProcedure.mutation(async ({ ctx }) => {
+    const [user] = await ctx.db
+      .select({
+        id: users.id,
+        email: users.email,
+        name: users.name,
+        emailVerifiedAt: users.emailVerifiedAt,
+      })
+      .from(users)
+      .where(
+        and(
+          eq(users.id, ctx.user.id),
+          eq(users.practiceId, ctx.practiceId),
+          isNull(users.deletedAt)
+        )
+      )
+      .limit(1);
+
+    if (!user) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Account not found." });
+    }
+    if (user.emailVerifiedAt) {
+      return { ok: true, alreadyVerified: true };
+    }
+
+    await assertPreAuthRateLimit({
+      key: `verifyresend:${normalizeAuthEmail(user.email)}`,
+      limit: 5,
+      windowMs: 3600000,
+      message: "Too many requests. Please try again later.",
+      logContext: "resendVerification",
+    });
+
+    try {
+      const token = await createAuthToken({
+        userId: user.id,
+        email: user.email,
+        type: "email_verify",
+        db: ctx.db,
       });
-
-      const [user] = await ctx.db
-        .select({
-          id: users.id,
-          email: users.email,
-          name: users.name,
-          emailVerifiedAt: users.emailVerifiedAt,
-        })
-        .from(users)
-        .where(and(eq(users.email, email), isNull(users.deletedAt)))
-        .limit(1);
-
-      // Only send for an existing, not-yet-verified account. Respond the same
-      // either way so the endpoint can't be used to probe for accounts.
-      if (user && !user.emailVerifiedAt) {
-        try {
-          const token = await createAuthToken({
-            userId: user.id,
-            email: user.email,
-            type: "email_verify",
-            db: ctx.db,
-          });
-          await sendVerificationEmail({
-            to: user.email,
-            name: user.name,
-            verifyUrl: `${appBaseUrl()}/verify-email?token=${token}`,
-          });
-        } catch (err) {
-          console.error("[resendVerification] email failed:", err);
-        }
+      const result = await sendVerificationEmail({
+        to: user.email,
+        name: user.name,
+        verifyUrl: `${appBaseUrl()}/verify-email?token=${token}`,
+      });
+      if (!result.success) {
+        throw new Error(
+          result.error || "Email provider did not accept the verification message."
+        );
       }
-      return { ok: true };
-    }),
+    } catch (err) {
+      console.error("[resendVerification] email failed:", err);
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message:
+          "We couldn't send the verification email. Please try again in a moment.",
+      });
+    }
+
+    return { ok: true, alreadyVerified: false };
+  }),
 
   /** Request a password-reset email. Always succeeds (no account enumeration). */
   requestPasswordReset: publicProcedure

--- a/apps/web/server/trpc.ts
+++ b/apps/web/server/trpc.ts
@@ -110,6 +110,7 @@ const t = initTRPC.context<TRPCContext>().create({
 export const createRouter = t.router;
 
 const HOSTED_READ_ONLY_MUTATION_ALLOWLIST = new Set([
+  "auth.resendVerification",
   "settings.requestAccountDeletion",
   "subscription.createCheckout",
   "subscription.openBillingPortal",


### PR DESCRIPTION
## Summary
- bind verification resends to the signed-in account and remove the abusable public email endpoint
- report provider failures truthfully while keeping verification optional and available after trial expiry
- keep unexpired verification links valid across resends and align all copy with the already-active no-card trial
- replace the duplicate-registration recovery dead end with a secure in-app path

## Verification
- `pnpm type-check`
- `pnpm test` (311 files, 3110 tests)
- `pnpm build`
