### PR TITLE
Repair captured funnel attribution safely

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -688,8 +688,11 @@ export default function AdminPage() {
               Rates are visit-to-step for demo and registration, then step-to-step.{" "}
               Stalls require seven full days; an active trial with a collected
               payment method is not treated as payment-abandoned.
-              {journey.totals.unattributedRegistrations > 0
-                ? ` ${journey.totals.unattributedRegistrations} registration(s) could not be matched to a first touch.`
+              {journey.totals.historicalUnattributedRegistrations > 0
+                ? ` ${journey.totals.historicalUnattributedRegistrations} historical registration(s) have no captured journey ID and remain explicitly unknown.`
+                : ""}
+              {journey.totals.repairableAttributionGaps > 0
+                ? ` ${journey.totals.repairableAttributionGaps} registration(s) have a journey ID but are missing a first touch; reconciliation will repair them.`
                 : ""}
             </p>
           </>

--- a/apps/web/app/api/cron/activation-digest/route.test.ts
+++ b/apps/web/app/api/cron/activation-digest/route.test.ts
@@ -93,6 +93,8 @@ function journey(days: number): JourneyFunnel {
       activationAbandoned: 1,
       paymentAbandoned: 0,
       unattributedRegistrations: 0,
+      historicalUnattributedRegistrations: 0,
+      repairableAttributionGaps: 0,
       clientErrors: 2,
       demoRate: 0.4,
       registrationRate: 0.25,

--- a/apps/web/app/api/cron/activation-digest/route.ts
+++ b/apps/web/app/api/cron/activation-digest/route.ts
@@ -168,7 +168,8 @@ function journeySection(title: string, funnel: JourneyFunnel): string {
     <td style="padding:2px 0;">${firstPositivePayment} <span style="font-size:13px;color:#6b7280;font-weight:400;">${pct(positivePaymentRate)}</span></td>
   </tr>
 </table>
-<p style="margin:8px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Left before trying: ${funnel.totals.leftBeforeTrying} · Demo without signup: ${funnel.totals.demoAbandoned} · Signup without activation: ${funnel.totals.registrationAbandoned} · Activated without payment method: ${funnel.totals.activationAbandoned} · Payment method without positive payment after trial: ${funnel.totals.paymentAbandoned} · Client errors: ${funnel.totals.clientErrors}</p>`;
+<p style="margin:8px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Left before trying: ${funnel.totals.leftBeforeTrying} · Demo without signup: ${funnel.totals.demoAbandoned} · Signup without activation: ${funnel.totals.registrationAbandoned} · Activated without payment method: ${funnel.totals.activationAbandoned} · Payment method without positive payment after trial: ${funnel.totals.paymentAbandoned} · Client errors: ${funnel.totals.clientErrors}</p>
+<p style="margin:4px 0 0;color:#6b7280;font-size:13px;line-height:1.5;">Attribution quality: ${funnel.totals.historicalUnattributedRegistrations} historical/unknown registration(s) · ${funnel.totals.repairableAttributionGaps} captured-ID telemetry gap(s).</p>`;
 }
 
 function digestHtml(

--- a/apps/web/app/api/cron/conversion-reconcile/route.test.ts
+++ b/apps/web/app/api/cron/conversion-reconcile/route.test.ts
@@ -4,6 +4,7 @@ const mocks = vi.hoisted(() => ({
   db: {},
   cronAuthError: vi.fn((): Response | null => null),
   reconcileConversionMilestones: vi.fn(),
+  reconcileRegistrationFirstTouches: vi.fn(),
   reportCronHeartbeat: vi.fn(async () => undefined),
   alertOps: vi.fn(async () => undefined),
 }));
@@ -12,6 +13,9 @@ vi.mock("@openpims/db/client", () => ({ db: mocks.db }));
 vi.mock("@/lib/cron-auth", () => ({ cronAuthError: mocks.cronAuthError }));
 vi.mock("@/lib/conversion-milestones", () => ({
   reconcileConversionMilestones: mocks.reconcileConversionMilestones,
+}));
+vi.mock("@/lib/funnel-events-server", () => ({
+  reconcileRegistrationFirstTouches: mocks.reconcileRegistrationFirstTouches,
 }));
 vi.mock("@/lib/cron-heartbeat", () => ({
   reportCronHeartbeat: mocks.reportCronHeartbeat,
@@ -32,6 +36,7 @@ describe("conversion reconciliation cron", () => {
 
     expect(response.status).toBe(401);
     expect(mocks.reconcileConversionMilestones).not.toHaveBeenCalled();
+    expect(mocks.reconcileRegistrationFirstTouches).not.toHaveBeenCalled();
   });
 
   it("reports exact local repairs and heartbeat counts", async () => {
@@ -40,6 +45,10 @@ describe("conversion reconciliation cron", () => {
       activationsRepaired: 1,
       paymentMethodsRepaired: 1,
       positivePaymentsRepaired: 1,
+    });
+    mocks.reconcileRegistrationFirstTouches.mockResolvedValueOnce({
+      validFunnelIdMissingTouchRepaired: 2,
+      missingFunnelIdHistoricalUnknown: 15,
     });
 
     const response = await GET(new Request("https://openvpm.test/api/cron/conversion-reconcile"));
@@ -50,14 +59,20 @@ describe("conversion reconciliation cron", () => {
       activationsRepaired: 1,
       paymentMethodsRepaired: 1,
       positivePaymentsRepaired: 1,
-      repaired: 5,
+      validFunnelIdMissingTouchRepaired: 2,
+      missingFunnelIdHistoricalUnknown: 15,
+      repaired: 7,
     });
     expect(mocks.reconcileConversionMilestones).toHaveBeenCalledWith(mocks.db);
+    expect(mocks.reconcileRegistrationFirstTouches).toHaveBeenCalledWith(mocks.db);
     expect(mocks.reportCronHeartbeat).toHaveBeenCalledWith(
       expect.objectContaining({
         job: "conversion-reconcile",
         status: "ok",
-        metrics: expect.objectContaining({ repaired: 5 }),
+        metrics: expect.objectContaining({
+          repaired: 7,
+          missingFunnelIdHistoricalUnknown: 15,
+        }),
       }),
     );
   });

--- a/apps/web/app/api/cron/conversion-reconcile/route.ts
+++ b/apps/web/app/api/cron/conversion-reconcile/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@openpims/db/client";
 import { alertOps } from "@/lib/alerts";
 import { reconcileConversionMilestones } from "@/lib/conversion-milestones";
+import { reconcileRegistrationFirstTouches } from "@/lib/funnel-events-server";
 import { cronAuthError } from "@/lib/cron-auth";
 import { reportCronHeartbeat } from "@/lib/cron-heartbeat";
 
@@ -17,11 +18,15 @@ export async function GET(request: Request) {
   if (authError) return authError;
 
   try {
-    const result = await reconcileConversionMilestones(db);
-    const repaired = Object.values(result).reduce(
+    const milestones = await reconcileConversionMilestones(db);
+    const attribution = await reconcileRegistrationFirstTouches(db);
+    const milestoneRepairs = Object.values(milestones).reduce(
       (total, count) => total + count,
       0,
     );
+    const repaired =
+      milestoneRepairs + attribution.validFunnelIdMissingTouchRepaired;
+    const result = { ...milestones, ...attribution };
     await reportCronHeartbeat({
       job: "conversion-reconcile",
       status: "ok",

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -86,6 +86,8 @@ describe("admin UI", () => {
     expect(source).toContain("journey.totals.activationAbandoned");
     expect(source).toContain("journey.totals.paymentAbandoned");
     expect(source).toContain("journey.totals.clientErrors");
+    expect(source).toContain("journey.totals.historicalUnattributedRegistrations");
+    expect(source).toContain("journey.totals.repairableAttributionGaps");
     expect(source).toContain("journey.weeks.map");
     expect(source).toContain("Stalls require seven full days");
     expect(source).toContain("active trial with a collected");

--- a/apps/web/lib/__tests__/funnel-events-server.test.ts
+++ b/apps/web/lib/__tests__/funnel-events-server.test.ts
@@ -18,9 +18,11 @@ const mocks = vi.hoisted(() => {
   const onConflictDoNothing = vi.fn(() => ({ returning }));
   const values = vi.fn(() => ({ onConflictDoNothing }));
   const insert = vi.fn(() => ({ values }));
+  const executeResults: unknown[][] = [];
+  const execute = vi.fn(async () => executeResults.shift() ?? []);
 
   return {
-    db: { select, insert },
+    db: { select, insert, execute },
     selectResults,
     insertResults,
     select,
@@ -28,6 +30,8 @@ const mocks = vi.hoisted(() => {
     values,
     onConflictDoNothing,
     returning,
+    executeResults,
+    execute,
     upsertPracticeConversionMilestone: vi.fn(async () => true),
     withSystem: vi.fn(
       async (database: unknown, fn: (tx: unknown) => Promise<unknown>) =>
@@ -46,6 +50,7 @@ vi.mock("@/lib/conversion-milestones", () => ({
 
 const {
   ensureRegistrationFirstTouch,
+  reconcileRegistrationFirstTouches,
   recordRegistration,
 } = await import("../funnel-events-server");
 
@@ -57,6 +62,7 @@ afterEach(() => {
   vi.clearAllMocks();
   mocks.selectResults.length = 0;
   mocks.insertResults.length = 0;
+  mocks.executeResults.length = 0;
 });
 
 describe("registration funnel attribution", () => {
@@ -161,6 +167,35 @@ describe("registration funnel attribution", () => {
     expect(mocks.select).toHaveBeenCalledOnce();
     expect(mocks.values).not.toHaveBeenCalled();
     expect(mocks.upsertPracticeConversionMilestone).toHaveBeenCalledOnce();
+  });
+
+  it("repairs only registrations with a captured UUID and reports unknown history", async () => {
+    mocks.executeResults.push(
+      [],
+      [
+        {
+          validFunnelIdMissingTouchRepaired: "2",
+          missingFunnelIdHistoricalUnknown: "15",
+        },
+      ]
+    );
+
+    await expect(
+      reconcileRegistrationFirstTouches(mocks.db as never)
+    ).resolves.toEqual({
+      validFunnelIdMissingTouchRepaired: 2,
+      missingFunnelIdHistoricalUnknown: 15,
+    });
+
+    const source = readFileSync(
+      new URL("../funnel-events-server.ts", import.meta.url),
+      "utf8"
+    );
+    expect(source).toContain("pg_advisory_xact_lock");
+    expect(source).toContain("jsonb_build_object('serverFallback', true, 'repaired', true)");
+    expect(source).toContain("missingFunnelIdHistoricalUnknown");
+    expect(source).not.toMatch(/from demo_accesses|client_ip/i);
+    expect(mocks.execute).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/apps/web/lib/__tests__/journey-funnel.test.ts
+++ b/apps/web/lib/__tests__/journey-funnel.test.ts
@@ -46,7 +46,7 @@ describe("computeJourneyFunnel", () => {
           paymentAbandoned: "0",
         },
       ],
-      [{ count: "2" }],
+      [{ historicalUnknown: "2", repairableGap: "1" }],
       [{ count: "4" }]
     );
 
@@ -75,7 +75,9 @@ describe("computeJourneyFunnel", () => {
       registrationAbandoned: 3,
       activationAbandoned: 1,
       paymentAbandoned: 0,
-      unattributedRegistrations: 2,
+      unattributedRegistrations: 3,
+      historicalUnattributedRegistrations: 2,
+      repairableAttributionGaps: 1,
       clientErrors: 4,
       demoRate: 0.4,
       registrationRate: 0.25,

--- a/apps/web/lib/admin/journey-funnel.ts
+++ b/apps/web/lib/admin/journey-funnel.ts
@@ -29,6 +29,8 @@ export interface JourneyFunnelTotals {
   activationAbandoned: number;
   paymentAbandoned: number;
   unattributedRegistrations: number;
+  historicalUnattributedRegistrations: number;
+  repairableAttributionGaps: number;
   clientErrors: number;
   demoRate: number;
   registrationRate: number;
@@ -201,29 +203,33 @@ export async function computeJourneyFunnel(
     `);
 
     const unattributedResult = await tx.execute(sql`
-      select count(*)::int as count
+      select
+        count(*) filter (
+          where not (
+            coalesce(p.settings -> 'acquisition' ->> 'funnelId', '')
+              ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+          )
+        )::int as "historicalUnknown",
+        count(*) filter (
+          where coalesce(p.settings -> 'acquisition' ->> 'funnelId', '')
+              ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+            and not exists (
+              select 1
+              from funnel_events touch
+              where touch.anonymous_id = lower(
+                p.settings -> 'acquisition' ->> 'funnelId'
+              )
+                and touch.deleted_at is null
+                and touch.event_name in (
+                  'visit', 'demo_land', 'demo_gate_viewed',
+                  'demo_gate_submitted', 'signup_land'
+                )
+            )
+        )::int as "repairableGap"
       from practices p
       where p.created_at >= ${windowStart}::timestamptz
         and p.deleted_at is null
         and p.settings ->> 'analyticsExcluded' is distinct from 'true'
-        and (
-          not (
-            coalesce(p.settings -> 'acquisition' ->> 'funnelId', '')
-              ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-          )
-          or not exists (
-            select 1
-            from funnel_events touch
-            where touch.anonymous_id = lower(
-              p.settings -> 'acquisition' ->> 'funnelId'
-            )
-              and touch.deleted_at is null
-              and touch.event_name in (
-                'visit', 'demo_land', 'demo_gate_viewed',
-                'demo_gate_submitted', 'signup_land'
-              )
-          )
-        )
     `);
     const errorsResult = await tx.execute(sql`
       select count(*)::int as count
@@ -254,9 +260,14 @@ export async function computeJourneyFunnel(
   const activated = sum("activated");
   const paymentMethodCollected = sum("paymentMethodCollected");
   const firstPositivePayment = sum("firstPositivePayment");
-  const unattributedRows = rowsFromExecute<{ count: number | string }>(
-    unattributedResult
-  );
+  const unattributedRows = rowsFromExecute<{
+    historicalUnknown: number | string;
+    repairableGap: number | string;
+  }>(unattributedResult);
+  const historicalUnattributedRegistrations =
+    Number(unattributedRows[0]?.historicalUnknown) || 0;
+  const repairableAttributionGaps =
+    Number(unattributedRows[0]?.repairableGap) || 0;
   const errorRows = rowsFromExecute<{ count: number | string }>(errorsResult);
 
   return {
@@ -274,7 +285,10 @@ export async function computeJourneyFunnel(
       registrationAbandoned: sum("registrationAbandoned"),
       activationAbandoned: sum("activationAbandoned"),
       paymentAbandoned: sum("paymentAbandoned"),
-      unattributedRegistrations: Number(unattributedRows[0]?.count) || 0,
+      unattributedRegistrations:
+        historicalUnattributedRegistrations + repairableAttributionGaps,
+      historicalUnattributedRegistrations,
+      repairableAttributionGaps,
       clientErrors: Number(errorRows[0]?.count) || 0,
       demoRate: funnelRate(demos, visitors),
       registrationRate: funnelRate(registrations, visitors),

--- a/apps/web/lib/funnel-events-server.ts
+++ b/apps/web/lib/funnel-events-server.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { Database } from "@openpims/db/client";
 import { funnelEvents, practices } from "@openpims/db";
 import { withSystem } from "@/lib/tenant-db";
@@ -26,6 +26,17 @@ const FIRST_TOUCH_EVENT_NAMES = [
   "demo_gate_submitted",
   "signup_land",
 ];
+
+export interface RegistrationAttributionReconciliationResult {
+  validFunnelIdMissingTouchRepaired: number;
+  missingFunnelIdHistoricalUnknown: number;
+}
+
+function rowsFromExecute<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  const rows = (result as { rows?: unknown[] } | null)?.rows;
+  return Array.isArray(rows) ? (rows as T[]) : [];
+}
 
 export async function insertFunnelEvent(
   db: Database,
@@ -94,6 +105,99 @@ export async function ensureRegistrationFirstTouch(
     path: "/register",
     metadata: { serverFallback: true },
     createdAt: input.createdAt,
+  });
+}
+
+/**
+ * Repair only attribution that is already proven by a captured funnel UUID.
+ * Registrations without that UUID stay explicitly historical/unknown; no
+ * email, IP, timestamp proximity, or other probabilistic identity is invented.
+ */
+export async function reconcileRegistrationFirstTouches(
+  db: Database
+): Promise<RegistrationAttributionReconciliationResult> {
+  return withSystem(db, async (tx) => {
+    // Acquire this before the repair statement so a waiting transaction gets a
+    // fresh READ COMMITTED snapshot after the prior repair commits.
+    await tx.execute(sql`
+      select pg_advisory_xact_lock(
+        hashtext('openvpm:registration-first-touch-repair')
+      )
+    `);
+    const result = await tx.execute(sql`
+      with repairable as (
+        select distinct on (
+          lower(p.settings -> 'acquisition' ->> 'funnelId')
+        )
+          lower(p.settings -> 'acquisition' ->> 'funnelId') as anonymous_id,
+          nullif(btrim(p.settings -> 'acquisition' ->> 'source'), '') as source,
+          p.created_at
+        from practices p
+        where p.deleted_at is null
+          and p.settings ->> 'analyticsExcluded' is distinct from 'true'
+          and coalesce(p.settings -> 'acquisition' ->> 'funnelId', '')
+            ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+          and not exists (
+            select 1
+            from funnel_events touch
+            where touch.anonymous_id = lower(
+              p.settings -> 'acquisition' ->> 'funnelId'
+            )
+              and touch.deleted_at is null
+              and touch.event_name in (
+                'visit', 'demo_land', 'demo_gate_viewed',
+                'demo_gate_submitted', 'signup_land'
+              )
+          )
+        order by
+          lower(p.settings -> 'acquisition' ->> 'funnelId'),
+          p.created_at,
+          p.id
+      ), inserted as (
+        insert into funnel_events (
+          event_name,
+          anonymous_id,
+          source,
+          path,
+          metadata,
+          created_at
+        )
+        select
+          'signup_land',
+          repairable.anonymous_id,
+          repairable.source,
+          '/register',
+          jsonb_build_object('serverFallback', true, 'repaired', true),
+          repairable.created_at
+        from repairable
+        returning id
+      )
+      select
+        (select count(*)::int from inserted)
+          as "validFunnelIdMissingTouchRepaired",
+        (
+          select count(*)::int
+          from practices historical
+          where historical.deleted_at is null
+            and historical.settings ->> 'analyticsExcluded' is distinct from 'true'
+            and not (
+              coalesce(
+                historical.settings -> 'acquisition' ->> 'funnelId',
+                ''
+              ) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+            )
+        ) as "missingFunnelIdHistoricalUnknown"
+    `);
+    const row = rowsFromExecute<{
+      validFunnelIdMissingTouchRepaired: number | string;
+      missingFunnelIdHistoricalUnknown: number | string;
+    }>(result)[0];
+    return {
+      validFunnelIdMissingTouchRepaired:
+        Number(row?.validFunnelIdMissingTouchRepaired) || 0,
+      missingFunnelIdHistoricalUnknown:
+        Number(row?.missingFunnelIdHistoricalUnknown) || 0,
+    };
   });
 }
 


### PR DESCRIPTION
## Summary
- repair missing first-touch rows only when registration already captured a valid shared funnel UUID
- serialize repair runs and keep historical registrations without a UUID explicitly unknown
- separate historical unknowns from repairable telemetry gaps in the admin dashboard and weekly activation digest
- expose repair and unknown counts in the existing conversion reconciliation heartbeat

No email, IP, timestamp matching, or other probabilistic attribution is used.

## Verification
- `pnpm type-check`
- `pnpm test` (311 files, 3111 tests)
- `pnpm build`
