### PR TITLE
Guide saved appointments into visit workflow

### DIFF
--- a/apps/web/app/(dashboard)/schedule/page.tsx
+++ b/apps/web/app/(dashboard)/schedule/page.tsx
@@ -1694,9 +1694,15 @@ function BookingForm({
     roomsQuery.isLoading || Boolean(roomsQuery.error) || roomsMissing;
 
   const createAppointment = trpc.appointments.create.useMutation({
-    onSuccess: () => {
-      toast.success("Appointment created");
-      utils.appointments.list.invalidate();
+    onSuccess: (appointment) => {
+      toast.success("Appointment created", {
+        action: {
+          label: "Open visit",
+          onClick: () =>
+            window.location.assign(`/encounters/${appointment.id}`),
+        },
+      });
+      void utils.appointments.list.invalidate();
       onClose();
     },
     onError: (err) => {

--- a/apps/web/lib/__tests__/schedule-ui.test.ts
+++ b/apps/web/lib/__tests__/schedule-ui.test.ts
@@ -19,6 +19,17 @@ import {
 } from "../scheduling/appointment-policy";
 
 describe("schedule appointment form UX", () => {
+  it("offers a direct handoff from a saved appointment into the visit workflow", () => {
+    const source = readFileSync("app/(dashboard)/schedule/page.tsx", "utf8");
+
+    expect(source).toContain("onSuccess: (appointment) => {");
+    expect(source).toContain('toast.success("Appointment created", {');
+    expect(source).toContain('label: "Open visit"');
+    expect(source).toContain(
+      "window.location.assign(`/encounters/${appointment.id}`)",
+    );
+  });
+
   it("bounds New Appointment inputs before creating appointments", () => {
     const source = readFileSync("app/(dashboard)/schedule/page.tsx", "utf8");
 

--- a/e2e/fresh-clinic-mock-launch.spec.ts
+++ b/e2e/fresh-clinic-mock-launch.spec.ts
@@ -571,6 +571,11 @@ test.describe.serial("Fresh clinic mock launch", () => {
       .selectOption({ index: 1 }, { timeout: 5_000 })
       .catch(() => undefined);
     await page.getByRole("button", { name: /^Save$/ }).click();
+    await page.getByRole("button", { name: "Open visit" }).click();
+    await page.waitForURL("**/encounters/**", { timeout: 20_000 });
+    await expect(
+      page.getByRole("button", { name: "Check in" })
+    ).toBeVisible();
     // Hosted signup seeds demo appointments, so assert on OUR patient's row.
     const appointmentRow = await waitUntil(
       async () => {


### PR DESCRIPTION
## Summary
- add an immediate Open visit action after saving an appointment
- take clinic users directly into the encounter workspace
- extend the fresh-clinic launch smoke through the Check in handoff

## Verification
- `pnpm --filter @openpims/web test -- lib/__tests__/schedule-ui.test.ts`
- `pnpm --filter @openpims/web type-check`
- `pnpm test`
- `pnpm build`
- `git diff --check`

## Safety
- no schema or billing changes
- no new onboarding gate
- recurring appointment behavior is unchanged