### PR TITLE
Gate hosted SMS on verified provider profiles

### DIFF
--- a/apps/web/app/(dashboard)/admin/page.tsx
+++ b/apps/web/app/(dashboard)/admin/page.tsx
@@ -122,6 +122,26 @@ export default function AdminPage() {
     },
     onError: (err) => setMessagingError(err.message),
   });
+  const inspectMessagingProfile =
+    trpc.admin.inspectMessagingProfile.useMutation({
+      onSuccess: (result) => {
+        setMessagingError(
+          result.blockers.length > 0
+            ? `Provider profile is not ready: ${result.blockers.join("; ")}.`
+            : null,
+        );
+        refreshMessagingQueue();
+      },
+      onError: (err) => setMessagingError(err.message),
+    });
+  const setMessagingProfileEnabled =
+    trpc.admin.setMessagingProfileEnabled.useMutation({
+      onSuccess: () => {
+        setMessagingError(null);
+        refreshMessagingQueue();
+      },
+      onError: (err) => setMessagingError(err.message),
+    });
   const attachMessagingProviderIds =
     trpc.admin.attachMessagingProviderIds.useMutation({
       onSuccess: () => {
@@ -375,6 +395,8 @@ export default function AdminPage() {
                     submitMessagingBrand.isPending ||
                     submitMessagingCampaign.isPending ||
                     assignMessagingNumbers.isPending ||
+                    inspectMessagingProfile.isPending ||
+                    setMessagingProfileEnabled.isPending ||
                     attachMessagingProviderIds.isPending ||
                     clearStaleMessagingSubmissionLock.isPending ||
                     reconcileMessagingRegistration.isPending;
@@ -409,7 +431,15 @@ export default function AdminPage() {
                           : registration.senders
                               .map(
                                 (sender) =>
-                                  `${sender.senderE164 ?? "—"} (${sender.registrationStatus})`
+                                  `${sender.senderE164 ?? "—"} (${sender.registrationStatus}; ${
+                                    sender.providerProfileReady
+                                      ? "provider ready"
+                                      : "provider not verified"
+                                  })${
+                                    sender.registrationDetail
+                                      ? ` — ${sender.registrationDetail}`
+                                      : ""
+                                  }`
                               )
                               .join(", ")}
                       </td>
@@ -493,6 +523,75 @@ export default function AdminPage() {
                               Assign numbers
                             </button>
                           ) : null}
+                          {registration.senders.map((sender) =>
+                            sender.messagingProfileId ? (
+                              <span
+                                key={sender.locationId}
+                                className="contents"
+                              >
+                                <button
+                                  type="button"
+                                  disabled={anyMutationPending}
+                                  className="rounded border border-border px-2 py-1 text-xs font-medium hover:bg-muted disabled:opacity-50"
+                                  onClick={() =>
+                                    inspectMessagingProfile.mutate({
+                                      practiceId: registration.practiceId,
+                                      locationId: sender.locationId,
+                                    })
+                                  }
+                                >
+                                  Inspect profile
+                                </button>
+                                {!sender.providerProfileReady &&
+                                registration.status === "active" &&
+                                sender.registrationStatus === "active" ? (
+                                  <button
+                                    type="button"
+                                    disabled={anyMutationPending}
+                                    className="rounded border border-green-300 bg-green-50 px-2 py-1 text-xs font-medium text-green-900 hover:bg-green-100 disabled:opacity-50"
+                                    onClick={() => {
+                                      if (
+                                        window.confirm(
+                                          `Enable ${registration.practiceName}'s Telnyx profile only after OpenVPM verifies its exact webhook, US-only destination list, $10 daily cap, active campaign, and assigned number? Clinic sending will remain off.`,
+                                        )
+                                      ) {
+                                        setMessagingProfileEnabled.mutate({
+                                          practiceId:
+                                            registration.practiceId,
+                                          locationId: sender.locationId,
+                                          enabled: true,
+                                          confirmProviderMutation: true,
+                                        });
+                                      }
+                                    }}
+                                  >
+                                    Enable provider profile
+                                  </button>
+                                ) : null}
+                                <button
+                                  type="button"
+                                  disabled={anyMutationPending}
+                                  className="rounded border border-destructive/40 px-2 py-1 text-xs font-medium text-destructive hover:bg-destructive/5 disabled:opacity-50"
+                                  onClick={() => {
+                                    if (
+                                      window.confirm(
+                                        `Disable ${registration.practiceName}'s Telnyx profile and keep clinic sending off?`,
+                                      )
+                                    ) {
+                                      setMessagingProfileEnabled.mutate({
+                                        practiceId: registration.practiceId,
+                                        locationId: sender.locationId,
+                                        enabled: false,
+                                        confirmProviderMutation: true,
+                                      });
+                                    }
+                                  }}
+                                >
+                                  Disable provider profile
+                                </button>
+                              </span>
+                            ) : null,
+                          )}
                           {registration.providerBrandId ? (
                             <button
                               type="button"

--- a/apps/web/app/api/webhooks/telnyx/route.test.ts
+++ b/apps/web/app/api/webhooks/telnyx/route.test.ts
@@ -275,6 +275,8 @@ describe("Telnyx webhook", () => {
       expect.objectContaining({
         registrationStatus: "action_required",
         enabled: false,
+        providerProfileReady: false,
+        providerProfileSyncedAt: null,
       }),
     );
     expect(mocks.withTenant).not.toHaveBeenCalled();

--- a/apps/web/app/api/webhooks/telnyx/route.ts
+++ b/apps/web/app/api/webhooks/telnyx/route.ts
@@ -169,11 +169,17 @@ async function handleA2pLifecycleWebhook(opts: {
           : {}),
         status: next,
         statusDetail:
-          next === "action_required" || next === "suspended"
+          next === "action_required" ||
+          next === "failed" ||
+          next === "suspended"
             ? "Carrier registration needs OpenVPM operator review."
             : "Carrier update received; OpenVPM will confirm full registration status.",
         lastError:
-          next === "action_required" || next === "suspended" ? detail : null,
+          next === "action_required" ||
+          next === "failed" ||
+          next === "suspended"
+            ? detail
+            : null,
         lastSyncedAt: new Date(),
         updatedAt: new Date(),
       })
@@ -184,11 +190,17 @@ async function handleA2pLifecycleWebhook(opts: {
       .set({
         registrationStatus: next,
         registrationDetail:
-          next === "action_required" || next === "suspended"
+          next === "action_required" ||
+          next === "failed" ||
+          next === "suspended"
             ? "Carrier registration needs OpenVPM review."
             : "Carrier registration update received; confirmation is pending.",
-        ...(next === "action_required" || next === "suspended"
-          ? { enabled: false }
+        ...(next !== "active"
+          ? {
+              enabled: false,
+              providerProfileReady: false,
+              providerProfileSyncedAt: null,
+            }
           : {}),
         updatedAt: new Date(),
       })

--- a/apps/web/components/settings/messaging-tab.tsx
+++ b/apps/web/components/settings/messaging-tab.tsx
@@ -292,7 +292,13 @@ function ConfiguredLocation({
   const canEnableSending =
     m.registrationStatus === "active" &&
     hasConfiguredSender(m) &&
-    m.launchEligible !== false;
+    m.launchEligible !== false &&
+    m.providerProfileAttestationFresh !== false;
+  const waitingForProviderVerification =
+    m.registrationStatus === "active" &&
+    hasConfiguredSender(m) &&
+    m.launchEligible !== false &&
+    m.providerProfileAttestationFresh === false;
   const canSendTest =
     testSendAllowed &&
     m.enabled &&
@@ -338,6 +344,18 @@ function ConfiguredLocation({
           {m.registrationDetail}
         </p>
       )}
+
+      {waitingForProviderVerification ? (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-950">
+          <p className="font-medium">Provider safety check required</p>
+          <p className="mt-1">
+            OpenVPM must verify the exact texting profile immediately before
+            sending can be enabled. Your clinic does not need to repeat carrier
+            registration; this operational check keeps the webhook, US-only
+            destinations, and spend cap in the approved state.
+          </p>
+        </div>
+      ) : null}
 
       {m.registrationStatus === "failed" && !m.enabled ? (
         <Button

--- a/apps/web/components/settings/messaging-wizard.tsx
+++ b/apps/web/components/settings/messaging-wizard.tsx
@@ -45,6 +45,9 @@ export type MessagingSetupLocation = {
       | "failed"
       | "suspended";
     registrationDetail: string | null;
+    providerProfileReady?: boolean;
+    providerProfileSyncedAt?: Date | string | null;
+    providerProfileAttestationFresh?: boolean;
     enabled: boolean;
     launchEligible?: boolean;
   } | null;

--- a/apps/web/lib/__tests__/admin-ui.test.ts
+++ b/apps/web/lib/__tests__/admin-ui.test.ts
@@ -108,6 +108,22 @@ describe("admin UI", () => {
     expect(source).toContain('!p.adminEmailVerifiedAt ? " · unverified" : ""');
   });
 
+  it("gives operators an explicit provider-profile inspection and switch", () => {
+    expect(source).toContain("trpc.admin.inspectMessagingProfile.useMutation");
+    expect(source).toContain(
+      "trpc.admin.setMessagingProfileEnabled.useMutation",
+    );
+    expect(source).toContain("provider not verified");
+    expect(source).toContain("Inspect profile");
+    expect(source).toContain("Enable provider profile");
+    expect(source).toContain("Disable provider profile");
+    expect(source).toContain("Clinic sending will remain off");
+    expect(source).toContain("US-only destination list");
+    expect(source).toContain("$10 daily cap");
+    expect(source).toContain('result.blockers.join("; ")');
+    expect(source).toContain("sender.registrationDetail");
+  });
+
   it("renders practice dates in each practice timezone", () => {
     expect(source).toContain(
       "function formatDate(d: Date | string | null, timeZone?: string | null)"

--- a/apps/web/lib/__tests__/messaging-settings-ui.test.ts
+++ b/apps/web/lib/__tests__/messaging-settings-ui.test.ts
@@ -50,6 +50,20 @@ describe("messaging settings UI", () => {
     expect(tabSource).toContain('m.registrationStatus === "active"');
     expect(tabSource).toContain("hasConfiguredSender(m)");
     expect(tabSource).toContain("m.launchEligible !== false");
+    expect(tabSource).toContain(
+      "m.providerProfileAttestationFresh !== false",
+    );
+    expect(tabSource).toContain("waitingForProviderVerification");
+    expect(tabSource).toContain("Provider safety check required");
+    expect(tabSource).toContain("does not need to repeat carrier");
+    expect(tabSource).toContain("registration; this operational check");
+    expect(routerSource).toContain(
+      "providerProfileReady: locationMessaging.providerProfileReady",
+    );
+    expect(routerSource).toContain("providerProfileAttestationFresh:");
+    expect(routerSource).toContain(
+      "HOSTED_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS",
+    );
     expect(tabSource).toContain("testSendAllowed &&");
     expect(tabSource).toContain("isMessagingPhoneInputValid(testTo)");
     expect(tabSource).toContain("maxLength={MESSAGING_PHONE_MAX_LENGTH}");

--- a/apps/web/lib/messaging/__tests__/index.test.ts
+++ b/apps/web/lib/messaging/__tests__/index.test.ts
@@ -402,6 +402,9 @@ describe("resolveMessagingTransport", () => {
     expect(
       sqlIncludesColumnParamPair(condition, "registration_status", "active")
     ).toBe(true);
+    expect(
+      sqlIncludesColumnParamPair(condition, "provider_profile_ready", true)
+    ).toBe(true);
     expect(mocks.selectLimit).toHaveBeenLastCalledWith(2);
   });
 

--- a/apps/web/lib/messaging/__tests__/public-webhook.test.ts
+++ b/apps/web/lib/messaging/__tests__/public-webhook.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { publicTelnyxWebhookUrl } from "../public-webhook";
+
+describe("publicTelnyxWebhookUrl", () => {
+  it("returns the canonical callback for a public HTTPS origin", () => {
+    expect(publicTelnyxWebhookUrl("https://app.example.com/some/path")).toBe(
+      "https://app.example.com/api/webhooks/telnyx",
+    );
+  });
+
+  it.each([
+    "http://app.example.com",
+    "https://localhost:3000",
+    "https://127.0.0.1",
+    "https://0.0.0.0",
+    "https://[::1]",
+    "https://clinic.local",
+  ])("rejects non-public callback origin %s", (origin) => {
+    expect(publicTelnyxWebhookUrl(origin)).toBeNull();
+  });
+
+  it("rejects invalid, credentialed, and missing origins", () => {
+    expect(publicTelnyxWebhookUrl(undefined)).toBeNull();
+    expect(publicTelnyxWebhookUrl("not a url")).toBeNull();
+    expect(
+      publicTelnyxWebhookUrl("https://user:password@app.example.com"),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/messaging/__tests__/telnyx-provisioning.test.ts
+++ b/apps/web/lib/messaging/__tests__/telnyx-provisioning.test.ts
@@ -6,6 +6,10 @@ import {
   TelnyxNotConfiguredError,
   TelnyxMutationUncertainError,
   createMessagingProfile,
+  getMessagingProfile,
+  messagingProfileSafetyIssues,
+  openVpmMessagingProfileName,
+  updateMessagingProfileEnabled,
   buyNumber,
   deleteMessagingProfile,
   deleteOwnedPhoneNumber,
@@ -194,6 +198,131 @@ describe("Telnyx provisioning requests", () => {
       smart_encoding: true,
     });
   });
+
+  it("reads and validates the exact safe messaging-profile launch state", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    const profileId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    const locationId = "00000000-0000-0000-0000-000000000002";
+    const webhookUrl = "https://app.openvpm.com/api/webhooks/telnyx";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            data: {
+              id: profileId,
+              name: openVpmMessagingProfileName(locationId),
+              webhook_url: webhookUrl,
+              webhook_api_version: "2",
+              enabled: true,
+              whitelisted_destinations: ["US"],
+              daily_spend_limit_enabled: true,
+              daily_spend_limit: "10.00",
+              smart_encoding: true,
+            },
+          }),
+        ),
+      ),
+    );
+
+    const profile = await getMessagingProfile(profileId);
+    expect(profile).toMatchObject({
+      id: profileId,
+      enabled: true,
+      whitelistedDestinations: ["US"],
+      dailySpendLimitEnabled: true,
+      dailySpendLimit: "10.00",
+      smartEncoding: true,
+    });
+    expect(
+      messagingProfileSafetyIssues(profile, {
+        id: profileId,
+        name: openVpmMessagingProfileName(locationId),
+        webhookUrl,
+      }),
+    ).toEqual([]);
+  });
+
+  it("fails the profile safety check on broadened or incomplete provider state", () => {
+    expect(
+      messagingProfileSafetyIssues(
+        {
+          id: "profile-1",
+          name: "Unexpected profile",
+          webhookUrl: "https://wrong.example/webhook",
+          webhookApiVersion: "1",
+          enabled: false,
+          whitelistedDestinations: ["US", "CA"],
+          dailySpendLimitEnabled: false,
+          dailySpendLimit: "100.00",
+          smartEncoding: false,
+        },
+        {
+          id: "profile-1",
+          name: "OpenVPM provision location-1",
+          webhookUrl: "https://app.example.com/api/webhooks/telnyx",
+        },
+      ),
+    ).toEqual([
+      "profile name mismatch",
+      "webhook URL mismatch",
+      "webhook API version is not v2",
+      "destination allowlist is not US-only",
+      "daily spend limit is not enabled",
+      "daily spend limit is not $10.00",
+      "smart encoding is not enabled",
+    ]);
+  });
+
+  it("uses an explicit PATCH for profile activation and verifies its response", async () => {
+    vi.stubEnv("TELNYX_API_KEY", "KEY123");
+    const profileId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            id: profileId,
+            name: "OpenVPM provision location-1",
+            enabled: true,
+          },
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      updateMessagingProfileEnabled({ profileId, enabled: true }),
+    ).resolves.toMatchObject({ id: profileId, enabled: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `https://api.telnyx.com/v2/messaging_profiles/${profileId}`,
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ enabled: true }),
+      }),
+    );
+  });
+
+  it.each([408, 429, 500, 503])(
+    "classifies a profile-activation HTTP %s as uncertain",
+    async (status) => {
+      vi.stubEnv("TELNYX_API_KEY", "KEY123");
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          new Response(JSON.stringify({ errors: [{ detail: "temporary" }] }), {
+            status,
+          }),
+        ),
+      );
+
+      await expect(
+        updateMessagingProfileEnabled({
+          profileId: "profile-123",
+          enabled: true,
+        }),
+      ).rejects.toBeInstanceOf(TelnyxMutationUncertainError);
+    },
+  );
 
   it.each([408, 429, 500, 503])(
     "classifies a messaging-profile HTTP %s as uncertain",

--- a/apps/web/lib/messaging/index.ts
+++ b/apps/web/lib/messaging/index.ts
@@ -118,6 +118,7 @@ export async function resolveMessagingTransport(opts: {
                   isNull(locations.deletedAt),
                   eq(locationMessaging.enabled, true),
                   eq(locationMessaging.registrationStatus, "active"),
+                  eq(locationMessaging.providerProfileReady, true),
                   hasNonBlankMessagingSender(),
                 )
               : and(

--- a/apps/web/lib/messaging/public-webhook.ts
+++ b/apps/web/lib/messaging/public-webhook.ts
@@ -1,0 +1,27 @@
+import { normalizeAppBaseUrl } from "@/lib/app-url";
+
+const LOCAL_WEBHOOK_HOSTNAMES = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "::1",
+  "[::1]",
+]);
+
+/** Build the canonical Telnyx callback only from a publicly routable HTTPS origin. */
+export function publicTelnyxWebhookUrl(rawBase: unknown): string | null {
+  const normalized = normalizeAppBaseUrl(rawBase);
+  if (!normalized) return null;
+
+  const baseUrl = new URL(normalized);
+  const hostname = baseUrl.hostname.toLowerCase();
+  if (
+    baseUrl.protocol !== "https:" ||
+    LOCAL_WEBHOOK_HOSTNAMES.has(hostname) ||
+    hostname.endsWith(".local")
+  ) {
+    return null;
+  }
+
+  return new URL("/api/webhooks/telnyx", baseUrl).toString();
+}

--- a/apps/web/lib/messaging/telnyx-provisioning.ts
+++ b/apps/web/lib/messaging/telnyx-provisioning.ts
@@ -199,6 +199,114 @@ export interface TelnyxMessagingProfile {
   enabled: boolean | null;
 }
 
+export interface TelnyxMessagingProfileDetail
+  extends TelnyxMessagingProfile {
+  webhookApiVersion: string | null;
+  whitelistedDestinations: string[] | null;
+  dailySpendLimitEnabled: boolean | null;
+  dailySpendLimit: string | null;
+  smartEncoding: boolean | null;
+}
+
+export const OPENVPM_MESSAGING_PROFILE_DAILY_SPEND_LIMIT = "10.00";
+
+export function openVpmMessagingProfileName(locationId: string): string {
+  return `OpenVPM provision ${locationId}`;
+}
+
+function parseMessagingProfileDetail(
+  payload:
+    | {
+        id?: string;
+        name?: string;
+        webhook_url?: string | null;
+        enabled?: boolean;
+        webhook_api_version?: string;
+        whitelisted_destinations?: unknown;
+        daily_spend_limit_enabled?: boolean;
+        daily_spend_limit?: string;
+        smart_encoding?: boolean;
+      }
+    | undefined,
+  expectedId: string,
+): TelnyxMessagingProfileDetail {
+  if (!payload?.id || !payload.name || payload.id !== expectedId) {
+    throw new TelnyxError(
+      "The provider returned an incomplete or mismatched messaging profile.",
+      502,
+    );
+  }
+  const destinations = payload.whitelisted_destinations;
+  return {
+    id: payload.id,
+    name: payload.name,
+    webhookUrl: payload.webhook_url ?? null,
+    enabled: payload.enabled ?? null,
+    webhookApiVersion: payload.webhook_api_version ?? null,
+    whitelistedDestinations:
+      Array.isArray(destinations) &&
+      destinations.every(
+        (destination): destination is string =>
+          typeof destination === "string",
+      )
+      ? destinations
+      : null,
+    dailySpendLimitEnabled: payload.daily_spend_limit_enabled ?? null,
+    dailySpendLimit: payload.daily_spend_limit ?? null,
+    smartEncoding: payload.smart_encoding ?? null,
+  };
+}
+
+export function messagingProfileSafetyIssues(
+  profile: TelnyxMessagingProfileDetail,
+  expected: {
+    id: string;
+    name: string;
+    webhookUrl: string;
+  },
+): string[] {
+  const issues: string[] = [];
+  if (profile.id !== expected.id) issues.push("profile identity mismatch");
+  if (profile.name !== expected.name) issues.push("profile name mismatch");
+  if (profile.webhookUrl !== expected.webhookUrl) {
+    issues.push("webhook URL mismatch");
+  }
+  if (profile.webhookApiVersion !== "2") {
+    issues.push("webhook API version is not v2");
+  }
+  if (
+    !profile.whitelistedDestinations ||
+    profile.whitelistedDestinations.length !== 1 ||
+    profile.whitelistedDestinations[0] !== "US"
+  ) {
+    issues.push("destination allowlist is not US-only");
+  }
+  if (profile.dailySpendLimitEnabled !== true) {
+    issues.push("daily spend limit is not enabled");
+  }
+  if (
+    profile.dailySpendLimit === null ||
+    Number(profile.dailySpendLimit) !==
+      Number(OPENVPM_MESSAGING_PROFILE_DAILY_SPEND_LIMIT)
+  ) {
+    issues.push("daily spend limit is not $10.00");
+  }
+  if (profile.smartEncoding !== true) {
+    issues.push("smart encoding is not enabled");
+  }
+  return issues;
+}
+
+/** Retrieve one exact provider profile for launch-readiness checks. Read-only. */
+export async function getMessagingProfile(
+  profileId: string,
+): Promise<TelnyxMessagingProfileDetail> {
+  const json = await telnyxRequest<{
+    data?: Parameters<typeof parseMessagingProfileDetail>[0];
+  }>("GET", `/messaging_profiles/${encodeURIComponent(profileId)}`);
+  return parseMessagingProfileDetail(json.data, profileId);
+}
+
 /** Find profiles by an exact, durable operation name. Read-only. */
 export async function findMessagingProfilesByName(
   name: string
@@ -415,7 +523,7 @@ export async function createMessagingProfile(opts: {
       // Bound pilot blast radius at the provider as well as in OpenVPM. Smart
       // encoding keeps common punctuation from unexpectedly multiplying parts.
       daily_spend_limit_enabled: true,
-      daily_spend_limit: "10.00",
+      daily_spend_limit: OPENVPM_MESSAGING_PROFILE_DAILY_SPEND_LIMIT,
       smart_encoding: true,
     });
   } catch (error) {
@@ -439,6 +547,44 @@ export async function createMessagingProfile(opts: {
     );
   }
   return { id };
+}
+
+/** Explicitly change provider sending state; callers must perform readback. */
+export async function updateMessagingProfileEnabled(opts: {
+  profileId: string;
+  enabled: boolean;
+}): Promise<TelnyxMessagingProfileDetail> {
+  let json: {
+    data?: Parameters<typeof parseMessagingProfileDetail>[0];
+  };
+  try {
+    json = await telnyxRequest(
+      "PATCH",
+      `/messaging_profiles/${encodeURIComponent(opts.profileId)}`,
+      { enabled: opts.enabled },
+    );
+  } catch (error) {
+    if (
+      !(error instanceof TelnyxError) ||
+      error.status === 408 ||
+      error.status === 429 ||
+      error.status >= 500
+    ) {
+      throw new TelnyxMutationUncertainError(
+        "The messaging-profile activation outcome is uncertain and must be reconciled before retrying.",
+        error,
+      );
+    }
+    throw error;
+  }
+  try {
+    return parseMessagingProfileDetail(json.data, opts.profileId);
+  } catch (error) {
+    throw new TelnyxMutationUncertainError(
+      "The provider accepted the messaging-profile activation request without returning verifiable state.",
+      error,
+    );
+  }
 }
 
 /** Delete an unused messaging profile created by an incomplete attempt. */

--- a/apps/web/server/__tests__/admin-messaging-operations.test.ts
+++ b/apps/web/server/__tests__/admin-messaging-operations.test.ts
@@ -25,14 +25,22 @@ const mocks = vi.hoisted(() => {
     db,
     selectResults,
     update,
+    updateReturning,
     updateSet,
     createA2pBrand: vi.fn(),
     createA2pCampaign: vi.fn(),
     ensureA2pNumberAssignment: vi.fn(),
     findA2pCampaignByReference: vi.fn(),
+    findOwnedPhoneNumbers: vi.fn(),
     getA2pBrand: vi.fn(),
     getA2pCampaign: vi.fn(),
     getA2pNumberAssignment: vi.fn(),
+    getMessagingProfile: vi.fn(),
+    messagingProfileSafetyIssues: vi.fn((): string[] => []),
+    openVpmMessagingProfileName: vi.fn(
+      (locationId: string) => `OpenVPM provision ${locationId}`,
+    ),
+    updateMessagingProfileEnabled: vi.fn(),
     MockTelnyxError,
     withTenant: vi.fn(
       async (
@@ -57,9 +65,14 @@ vi.mock("@/lib/messaging/telnyx-provisioning", () => ({
   createA2pCampaign: mocks.createA2pCampaign,
   ensureA2pNumberAssignment: mocks.ensureA2pNumberAssignment,
   findA2pCampaignByReference: mocks.findA2pCampaignByReference,
+  findOwnedPhoneNumbers: mocks.findOwnedPhoneNumbers,
   getA2pBrand: mocks.getA2pBrand,
   getA2pCampaign: mocks.getA2pCampaign,
   getA2pNumberAssignment: mocks.getA2pNumberAssignment,
+  getMessagingProfile: mocks.getMessagingProfile,
+  messagingProfileSafetyIssues: mocks.messagingProfileSafetyIssues,
+  openVpmMessagingProfileName: mocks.openVpmMessagingProfileName,
+  updateMessagingProfileEnabled: mocks.updateMessagingProfileEnabled,
   TelnyxError: mocks.MockTelnyxError,
 }));
 
@@ -67,6 +80,47 @@ const { adminRouter, messagingCampaignCopy } = await import("../routers/admin");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const USER_ID = "00000000-0000-0000-0000-000000000001";
+const LOCATION_ID = "00000000-0000-0000-0000-000000000002";
+const REGISTRATION_ID = "00000000-0000-0000-0000-000000000008";
+
+function activeRegistration() {
+  return {
+    id: REGISTRATION_ID,
+    practiceId: PRACTICE_ID,
+    providerBrandId: "brand-123",
+    providerCampaignId: "campaign-123",
+    status: "active",
+  };
+}
+
+function activeSender() {
+  return {
+    practiceId: PRACTICE_ID,
+    locationId: LOCATION_ID,
+    provider: "telnyx",
+    messagingProfileId: "profile-123",
+    senderE164: "+15555550100",
+    registrationStatus: "active",
+    registrationDetail: null,
+    providerProfileReady: false,
+    providerProfileSyncedAt: null,
+    enabled: false,
+  };
+}
+
+function providerProfile(enabled: boolean) {
+  return {
+    id: "profile-123",
+    name: `OpenVPM provision ${LOCATION_ID}`,
+    webhookUrl: "https://app.openvpm.com/api/webhooks/telnyx",
+    webhookApiVersion: "2",
+    enabled,
+    whitelistedDestinations: ["US"],
+    dailySpendLimitEnabled: true,
+    dailySpendLimit: "10.00",
+    smartEncoding: true,
+  };
+}
 
 function caller(email = "ops@example.com") {
   return adminRouter.createCaller({
@@ -86,6 +140,9 @@ function caller(email = "ops@example.com") {
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.clearAllMocks();
+  mocks.updateReturning.mockResolvedValue([
+    { id: "00000000-0000-0000-0000-000000000009" },
+  ]);
   mocks.selectResults.length = 0;
 });
 
@@ -223,6 +280,422 @@ describe("platform messaging operations", () => {
       })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(mocks.createA2pBrand).not.toHaveBeenCalled();
+  });
+
+  it("enables an exact safe provider profile but keeps clinic sending off", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    mocks.selectResults.push(
+      [activeSender()],
+      [activeRegistration()],
+      [activeSender()],
+    );
+    mocks.getMessagingProfile
+      .mockResolvedValueOnce(providerProfile(false))
+      .mockResolvedValueOnce(providerProfile(true));
+    mocks.findOwnedPhoneNumbers.mockResolvedValue([
+      {
+        id: "number-123",
+        phoneNumber: "+15555550100",
+        messagingProfileId: "profile-123",
+        status: "active",
+      },
+    ]);
+    mocks.getA2pBrand.mockResolvedValue({
+      brandId: "brand-123",
+      identityStatus: "VERIFIED",
+    });
+    mocks.getA2pCampaign.mockResolvedValue({
+      campaignId: "campaign-123",
+      status: "ACTIVE",
+    });
+    mocks.getA2pNumberAssignment.mockResolvedValue({
+      phoneNumber: "+15555550100",
+      campaignId: "campaign-123",
+      assignmentStatus: "ASSIGNED",
+    });
+    mocks.updateMessagingProfileEnabled.mockResolvedValue(
+      providerProfile(true),
+    );
+
+    await expect(
+      caller().setMessagingProfileEnabled({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        enabled: true,
+        confirmProviderMutation: true,
+      }),
+    ).resolves.toEqual({
+      locationId: LOCATION_ID,
+      enabled: true,
+      clinicEnabled: false,
+      reused: false,
+    });
+
+    expect(mocks.updateMessagingProfileEnabled).toHaveBeenCalledWith({
+      profileId: "profile-123",
+      enabled: true,
+    });
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerProfileReady: true,
+        providerProfileSyncedAt: expect.any(Date),
+      }),
+    );
+    expect(mocks.updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+
+  it("refuses to record readiness when messaging state changes during verification", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    mocks.selectResults.push(
+      [activeSender()],
+      [activeRegistration()],
+      [activeSender()],
+    );
+    mocks.getMessagingProfile.mockResolvedValue(providerProfile(true));
+    mocks.findOwnedPhoneNumbers.mockResolvedValue([
+      {
+        id: "number-123",
+        phoneNumber: "+15555550100",
+        messagingProfileId: "profile-123",
+        status: "active",
+      },
+    ]);
+    mocks.getA2pBrand.mockResolvedValue({
+      brandId: "brand-123",
+      identityStatus: "VERIFIED",
+    });
+    mocks.getA2pCampaign.mockResolvedValue({
+      campaignId: "campaign-123",
+      status: "ACTIVE",
+    });
+    mocks.getA2pNumberAssignment.mockResolvedValue({
+      phoneNumber: "+15555550100",
+      campaignId: "campaign-123",
+      assignmentStatus: "ASSIGNED",
+    });
+    mocks.updateReturning.mockResolvedValueOnce([]);
+
+    await expect(
+      caller().setMessagingProfileEnabled({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        enabled: true,
+        confirmProviderMutation: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: expect.stringContaining("state changed"),
+    });
+
+    expect(mocks.updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+
+  it("activates the sender identity returned by the fresh provider inspection", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    const inspectedSender = {
+      ...activeSender(),
+      messagingProfileId: "profile-current",
+      senderE164: "+15555550101",
+    };
+    mocks.selectResults.push(
+      [activeSender()],
+      [activeRegistration()],
+      [inspectedSender],
+    );
+    mocks.getMessagingProfile
+      .mockResolvedValueOnce({
+        ...providerProfile(false),
+        id: "profile-current",
+      })
+      .mockResolvedValueOnce({
+        ...providerProfile(true),
+        id: "profile-current",
+      });
+    mocks.findOwnedPhoneNumbers.mockResolvedValue([
+      {
+        id: "number-123",
+        phoneNumber: "+15555550101",
+        messagingProfileId: "profile-current",
+        status: "active",
+      },
+    ]);
+    mocks.getA2pBrand.mockResolvedValue({ identityStatus: "VERIFIED" });
+    mocks.getA2pCampaign.mockResolvedValue({ status: "ACTIVE" });
+    mocks.getA2pNumberAssignment.mockResolvedValue({
+      phoneNumber: "+15555550101",
+      campaignId: "campaign-123",
+      assignmentStatus: "ASSIGNED",
+    });
+    mocks.updateMessagingProfileEnabled.mockResolvedValue({
+      ...providerProfile(true),
+      id: "profile-current",
+    });
+
+    await expect(
+      caller().setMessagingProfileEnabled({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        enabled: true,
+        confirmProviderMutation: true,
+      }),
+    ).resolves.toMatchObject({ enabled: true, clinicEnabled: false });
+
+    expect(mocks.updateMessagingProfileEnabled).toHaveBeenCalledWith({
+      profileId: "profile-current",
+      enabled: true,
+    });
+    expect(mocks.getMessagingProfile).toHaveBeenNthCalledWith(
+      2,
+      "profile-current",
+    );
+  });
+
+  it("blocks provider-profile mutations before reads while the kill-switch is off", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "false");
+
+    await expect(
+      caller().setMessagingProfileEnabled({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        enabled: true,
+        confirmProviderMutation: true,
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+    expect(mocks.withSystem).not.toHaveBeenCalled();
+    expect(mocks.updateMessagingProfileEnabled).not.toHaveBeenCalled();
+  });
+
+  it("refuses provider activation when exact profile safety checks fail", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    mocks.selectResults.push(
+      [activeSender()],
+      [activeRegistration()],
+      [activeSender()],
+    );
+    mocks.getMessagingProfile.mockResolvedValue(providerProfile(false));
+    mocks.findOwnedPhoneNumbers.mockResolvedValue([
+      {
+        id: "number-123",
+        phoneNumber: "+15555550100",
+        messagingProfileId: "profile-123",
+        status: "active",
+      },
+    ]);
+    mocks.getA2pBrand.mockResolvedValue({
+      brandId: "brand-123",
+      identityStatus: "VERIFIED",
+    });
+    mocks.getA2pCampaign.mockResolvedValue({
+      campaignId: "campaign-123",
+      status: "ACTIVE",
+    });
+    mocks.getA2pNumberAssignment.mockResolvedValue({
+      phoneNumber: "+15555550100",
+      campaignId: "campaign-123",
+      assignmentStatus: "ASSIGNED",
+    });
+    mocks.messagingProfileSafetyIssues.mockReturnValueOnce([
+      "webhook URL mismatch",
+    ]);
+
+    await expect(
+      caller().setMessagingProfileEnabled({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        enabled: true,
+        confirmProviderMutation: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("webhook URL mismatch"),
+    });
+    expect(mocks.updateMessagingProfileEnabled).not.toHaveBeenCalled();
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        providerProfileReady: false,
+        providerProfileSyncedAt: null,
+      }),
+    );
+  });
+
+  it("keeps readiness cleared when provider activation readback is unsafe", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://app.openvpm.com");
+    mocks.selectResults.push(
+      [activeSender()],
+      [activeRegistration()],
+      [activeSender()],
+    );
+    mocks.getMessagingProfile
+      .mockResolvedValueOnce(providerProfile(false))
+      .mockResolvedValueOnce(providerProfile(true));
+    mocks.findOwnedPhoneNumbers.mockResolvedValue([
+      {
+        id: "number-123",
+        phoneNumber: "+15555550100",
+        messagingProfileId: "profile-123",
+        status: "active",
+      },
+    ]);
+    mocks.getA2pBrand.mockResolvedValue({
+      brandId: "brand-123",
+      identityStatus: "VERIFIED",
+    });
+    mocks.getA2pCampaign.mockResolvedValue({
+      campaignId: "campaign-123",
+      status: "ACTIVE",
+    });
+    mocks.getA2pNumberAssignment.mockResolvedValue({
+      phoneNumber: "+15555550100",
+      campaignId: "campaign-123",
+      assignmentStatus: "ASSIGNED",
+    });
+    mocks.messagingProfileSafetyIssues
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce(["daily spend limit is not enabled"]);
+
+    await expect(
+      caller().setMessagingProfileEnabled({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        enabled: true,
+        confirmProviderMutation: true,
+      }),
+    ).rejects.toMatchObject({ code: "BAD_GATEWAY" });
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        providerProfileReady: false,
+        providerProfileSyncedAt: null,
+      }),
+    );
+    expect(mocks.updateSet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ providerProfileReady: true }),
+    );
+  });
+
+  it("turns off the clinic gate before disabling the provider profile", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    mocks.selectResults.push([activeSender()], [activeSender()]);
+    mocks.getMessagingProfile
+      .mockResolvedValueOnce(providerProfile(true))
+      .mockResolvedValueOnce(providerProfile(false));
+    mocks.updateMessagingProfileEnabled.mockResolvedValue(
+      providerProfile(false),
+    );
+
+    await expect(
+      caller().setMessagingProfileEnabled({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        enabled: false,
+        confirmProviderMutation: true,
+      }),
+    ).resolves.toMatchObject({ enabled: false, clinicEnabled: false });
+
+    expect(mocks.updateSet.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.updateMessagingProfileEnabled.mock.invocationCallOrder[0]!,
+    );
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        providerProfileReady: false,
+      }),
+    );
+  });
+
+  it("targets the freshly read sender identity during provider deactivation", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+    vi.stubEnv("MESSAGING_PROVISIONING_ENABLED", "true");
+    mocks.selectResults.push(
+      [activeSender()],
+      [
+        {
+          ...activeSender(),
+          messagingProfileId: "profile-current",
+          senderE164: "+15555550101",
+        },
+      ],
+    );
+    mocks.getMessagingProfile
+      .mockResolvedValueOnce({
+        ...providerProfile(true),
+        id: "profile-current",
+      })
+      .mockResolvedValueOnce({
+        ...providerProfile(false),
+        id: "profile-current",
+      });
+    mocks.updateMessagingProfileEnabled.mockResolvedValue({
+      ...providerProfile(false),
+      id: "profile-current",
+    });
+
+    await expect(
+      caller().setMessagingProfileEnabled({
+        practiceId: PRACTICE_ID,
+        locationId: LOCATION_ID,
+        enabled: false,
+        confirmProviderMutation: true,
+      }),
+    ).resolves.toMatchObject({ enabled: false, clinicEnabled: false });
+
+    expect(mocks.getMessagingProfile).toHaveBeenNthCalledWith(
+      1,
+      "profile-current",
+    );
+    expect(mocks.updateMessagingProfileEnabled).toHaveBeenCalledWith({
+      profileId: "profile-current",
+      enabled: false,
+    });
+  });
+
+  it("invalidates every sender when recovered provider IDs change", async () => {
+    vi.stubEnv("PLATFORM_ADMIN_EMAILS", "ops@example.com");
+
+    await expect(
+      caller().attachMessagingProviderIds({
+        practiceId: PRACTICE_ID,
+        providerBrandId: "brand-recovered",
+        providerCampaignId: "campaign-recovered",
+        confirmProviderPortalReviewed: true,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerBrandId: "brand-recovered",
+        providerBrandStatus: null,
+        providerCampaignId: "campaign-recovered",
+        providerCampaignStatus: null,
+        status: "pending",
+        lastSyncedAt: null,
+      }),
+    );
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        registrationStatus: "pending",
+        providerProfileReady: false,
+        providerProfileSyncedAt: null,
+      }),
+    );
   });
 
   it("clears only a portal-reviewed stale lock and keeps every sender disabled", async () => {

--- a/apps/web/server/__tests__/messaging-location-safety.test.ts
+++ b/apps/web/server/__tests__/messaging-location-safety.test.ts
@@ -1377,7 +1377,7 @@ describe("messaging location target safety", () => {
   });
 
   it("rejects enabling SMS before carrier registration is active", async () => {
-    const { db, updateSet } = createDb({
+    const { db, updateSet, updateWhere } = createDb({
       selectResults: [[{ id: LOCATION_ID }], []],
     });
 
@@ -1455,7 +1455,7 @@ describe("messaging location target safety", () => {
     expect(mocks.sendSms).not.toHaveBeenCalled();
   });
 
-  it("allows one explicitly allowlisted active Telnyx hosted location to be enabled", async () => {
+  it("requires a fresh provider-profile attestation for hosted enablement", async () => {
     vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
     vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
     vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", PRACTICE_ID);
@@ -1468,10 +1468,42 @@ describe("messaging location target safety", () => {
           trialEndsAt: null,
         },
       ],
+      selectResults: [[{ id: PRACTICE_ID }], [{ id: LOCATION_ID }], []],
+    });
+
+    await expect(
+      callerWithDb(db).setEnabled({ locationId: LOCATION_ID, enabled: true }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: expect.stringContaining("freshly verify"),
+    });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("allows one explicitly allowlisted active Telnyx hosted location to be enabled", async () => {
+    vi.stubEnv("HOSTED_BILLING_ENABLED", "true");
+    vi.stubEnv("MESSAGING_SENDING_ENABLED", "true");
+    vi.stubEnv("MESSAGING_SENDING_PRACTICE_IDS", PRACTICE_ID);
+    vi.stubEnv("MESSAGING_SENDING_LOCATION_IDS", LOCATION_ID);
+    const { db, updateSet, updateWhere } = createDb({
+      practiceRows: [
+        {
+          tier: "cloud",
+          billingStatus: "active",
+          trialEndsAt: null,
+        },
+      ],
       selectResults: [
         [{ id: PRACTICE_ID }],
         [{ id: LOCATION_ID }],
-        [{ locationId: LOCATION_ID, provider: "telnyx" }],
+        [
+          {
+            locationId: LOCATION_ID,
+            provider: "telnyx",
+            providerProfileReady: true,
+            providerProfileSyncedAt: new Date(),
+          },
+        ],
         [],
       ],
       updateRows: [{ enabled: true }],
@@ -1484,6 +1516,10 @@ describe("messaging location target safety", () => {
       enabled: true,
       updatedAt: expect.any(Date),
     });
+    const condition = updateWhere.mock.calls[0]?.[0];
+    expect(
+      sqlIncludesColumnParamPair(condition, "provider_profile_ready", true),
+    ).toBe(true);
   });
 
   it("rejects test sends when no active registered sender exists", async () => {
@@ -1684,6 +1720,31 @@ describe("messaging location sender join scoping", () => {
     );
     expect(source).toContain(
       "eq(locationMessaging.practiceId, opts.practiceId!)",
+    );
+  });
+
+  it("requires a fresh verified provider profile at both hosted enablement writes", () => {
+    const source = readSource("server/routers/messaging.ts");
+
+    expect(source).toContain(
+      "HOSTED_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS",
+    );
+    expect(source.match(/eq\(locationMessaging\.providerProfileReady, true\)/g)).toHaveLength(
+      2,
+    );
+    expect(
+      source.match(
+        /gte\(\s*locationMessaging\.providerProfileSyncedAt/g,
+      ),
+    ).toHaveLength(2);
+    expect(source).toContain("OpenVPM must freshly verify");
+  });
+
+  it("fails closed for migrated hosted senders until provider readiness is verified", () => {
+    const source = readSource("lib/messaging/index.ts");
+
+    expect(source).toContain(
+      "eq(locationMessaging.providerProfileReady, true)",
     );
   });
 });

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -34,17 +34,22 @@ import {
   onboardingIntentLabel,
   type OnboardingIntent,
 } from "@/lib/onboarding/intent";
-import { normalizeAppBaseUrl } from "@/lib/app-url";
+import { publicTelnyxWebhookUrl } from "@/lib/messaging/public-webhook";
 import {
   createA2pBrand,
   createA2pCampaign,
   ensureA2pNumberAssignment,
   findA2pCampaignByReference,
+  findOwnedPhoneNumbers,
   getA2pBrand,
   getA2pCampaign,
   getA2pNumberAssignment,
+  getMessagingProfile,
+  messagingProfileSafetyIssues,
+  openVpmMessagingProfileName,
   TelnyxError,
   type TelnyxNumberAssignment,
+  updateMessagingProfileEnabled,
 } from "@/lib/messaging/telnyx-provisioning";
 import {
   decryptRegistrationTaxId,
@@ -73,6 +78,7 @@ const platformAdminProcedure = protectedProcedure.use(async ({ ctx, next }) => {
 });
 
 const MESSAGING_SUBMISSION_LOCK_STALE_MS = 15 * 60 * 1000;
+const MESSAGING_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS = 15 * 60 * 1000;
 
 function redactedOperatorIdentity(value: string | null): string | null {
   if (!value) return null;
@@ -95,21 +101,14 @@ function assertMessagingProviderMutationsEnabled() {
 function telnyxRegistrationWebhookUrl(): string {
   const raw =
     process.env.NEXT_PUBLIC_APP_URL?.trim() || process.env.NEXTAUTH_URL?.trim();
-  const normalized = normalizeAppBaseUrl(raw ?? "");
-  if (!normalized) {
+  const webhookUrl = publicTelnyxWebhookUrl(raw);
+  if (!webhookUrl) {
     throw new TRPCError({
       code: "PRECONDITION_FAILED",
       message: "A public HTTPS app URL is required for Telnyx registration.",
     });
   }
-  const base = new URL(normalized);
-  if (base.protocol !== "https:" || base.hostname === "localhost") {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: "A public HTTPS app URL is required for Telnyx registration.",
-    });
-  }
-  return new URL("/api/webhooks/telnyx", base).toString();
+  return webhookUrl;
 }
 
 function providerFailure(error: unknown): TRPCError {
@@ -127,6 +126,307 @@ function providerFailure(error: unknown): TRPCError {
         ? "CONFLICT"
         : "BAD_GATEWAY",
     message,
+  });
+}
+
+async function messagingSenderForOperator(
+  practiceId: string,
+  locationId: string,
+) {
+  return withSystem(db, async (tx) => {
+    const [sender] = await tx
+      .select({
+        practiceId: locationMessaging.practiceId,
+        locationId: locationMessaging.locationId,
+        provider: locationMessaging.provider,
+        messagingProfileId: locationMessaging.messagingProfileId,
+        senderE164: locationMessaging.senderE164,
+        registrationStatus: locationMessaging.registrationStatus,
+        registrationDetail: locationMessaging.registrationDetail,
+        providerProfileReady: locationMessaging.providerProfileReady,
+        providerProfileSyncedAt: locationMessaging.providerProfileSyncedAt,
+        enabled: locationMessaging.enabled,
+      })
+      .from(locationMessaging)
+      .where(
+        and(
+          eq(locationMessaging.practiceId, practiceId),
+          eq(locationMessaging.locationId, locationId),
+          isNull(locationMessaging.deletedAt),
+          sql`exists (
+            select 1
+            from ${locations}
+            where ${locations.id} = ${locationId}
+              and ${locations.practiceId} = ${practiceId}
+              and ${locations.deletedAt} is null
+          )`,
+          sql`exists (
+            select 1
+            from ${practices}
+            where ${practices.id} = ${practiceId}
+              and ${practices.deletedAt} is null
+          )`,
+        ),
+      )
+      .limit(1);
+    if (
+      !sender ||
+      sender.provider !== "telnyx" ||
+      !sender.messagingProfileId ||
+      !sender.senderE164
+    ) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message:
+          "This clinic location does not have a complete Telnyx sender identity.",
+      });
+    }
+    return {
+      ...sender,
+      messagingProfileId: sender.messagingProfileId,
+      senderE164: sender.senderE164,
+    };
+  });
+}
+
+async function inspectMessagingProviderReadiness(input: {
+  practiceId: string;
+  locationId: string;
+}) {
+  const registration = await registrationForOperator(input.practiceId);
+  const sender = await messagingSenderForOperator(
+    input.practiceId,
+    input.locationId,
+  );
+  const providerBrandId = registration.providerBrandId;
+  const providerCampaignId = registration.providerCampaignId;
+  if (!providerBrandId || !providerCampaignId) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "The clinic brand and campaign must be submitted first.",
+    });
+  }
+
+  const webhookUrl = telnyxRegistrationWebhookUrl();
+  const [profile, ownedNumbers, brand, campaign, assignment] =
+    await Promise.all([
+      getMessagingProfile(sender.messagingProfileId),
+      findOwnedPhoneNumbers(sender.senderE164),
+      getA2pBrand(providerBrandId),
+      getA2pCampaign(providerCampaignId),
+      getA2pNumberAssignment(sender.senderE164),
+    ]);
+
+  const blockers = messagingProfileSafetyIssues(profile, {
+    id: sender.messagingProfileId,
+    name: openVpmMessagingProfileName(sender.locationId),
+    webhookUrl,
+  });
+  const ownedNumber =
+    ownedNumbers.length === 1 ? ownedNumbers[0] : undefined;
+  if (
+    !ownedNumber ||
+    ownedNumber.messagingProfileId !== sender.messagingProfileId ||
+    ownedNumber.status?.toLowerCase() !== "active"
+  ) {
+    blockers.push(
+      "phone number is not active on the exact messaging profile",
+    );
+  }
+  if (
+    !new Set(["VERIFIED", "VETTED_VERIFIED"]).has(
+      (brand.identityStatus ?? "").toUpperCase(),
+    )
+  ) {
+    blockers.push("carrier brand is not verified");
+  }
+  if (
+    campaign.status?.toUpperCase() !== "ACTIVE" &&
+    campaign.campaignStatus?.toUpperCase() !== "MNO_PROVISIONED"
+  ) {
+    blockers.push("carrier campaign is not active");
+  }
+  if (
+    !assignment ||
+    assignment.phoneNumber !== sender.senderE164 ||
+    assignment.campaignId !== providerCampaignId ||
+    assignment.assignmentStatus?.toUpperCase() !== "ASSIGNED"
+  ) {
+    blockers.push("phone number is not assigned to the active campaign");
+  }
+  if (
+    registration.status !== "active" ||
+    sender.registrationStatus !== "active"
+  ) {
+    blockers.push("OpenVPM carrier reconciliation is not active");
+  }
+
+  return {
+    profile,
+    sender,
+    blockers,
+    registration: {
+      id: registration.id,
+      practiceId: registration.practiceId,
+      providerBrandId,
+      providerCampaignId,
+      status: registration.status,
+    },
+  };
+}
+
+function expectedMessagingProfileState(
+  inspection: Awaited<ReturnType<typeof inspectMessagingProviderReadiness>>,
+) {
+  return {
+    registrationId: inspection.registration.id,
+    providerBrandId: inspection.registration.providerBrandId,
+    providerCampaignId: inspection.registration.providerCampaignId,
+    messagingProfileId: inspection.sender.messagingProfileId,
+    senderE164: inspection.sender.senderE164,
+    clinicEnabled: inspection.sender.enabled,
+    providerProfileReady: inspection.sender.providerProfileReady,
+    providerProfileSyncedAt: inspection.sender.providerProfileSyncedAt,
+  };
+}
+
+async function updateMessagingSenderDisabled(input: {
+  practiceId: string;
+  locationId: string;
+  detail: string;
+  syncedAt: Date | null;
+}) {
+  await withSystem(db, async (tx) => {
+    await tx
+      .update(locationMessaging)
+      .set({
+        enabled: false,
+        registrationDetail: input.detail,
+        providerProfileReady: false,
+        providerProfileSyncedAt: input.syncedAt,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(locationMessaging.practiceId, input.practiceId),
+          eq(locationMessaging.locationId, input.locationId),
+          eq(locationMessaging.provider, "telnyx"),
+          isNull(locationMessaging.deletedAt),
+        ),
+      );
+  });
+}
+
+async function recordMessagingProfileReady(input: {
+  practiceId: string;
+  locationId: string;
+  detail: string;
+  expected: {
+    registrationId: string;
+    providerBrandId: string;
+    providerCampaignId: string;
+    messagingProfileId: string;
+    senderE164: string;
+    clinicEnabled: boolean;
+    providerProfileReady: boolean;
+    providerProfileSyncedAt: Date | null;
+  };
+}) {
+  await withSystem(db, async (tx) => {
+    const [updated] = await tx
+      .update(locationMessaging)
+      .set({
+        registrationDetail: input.detail,
+        providerProfileReady: true,
+        providerProfileSyncedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(locationMessaging.practiceId, input.practiceId),
+          eq(locationMessaging.locationId, input.locationId),
+          eq(locationMessaging.provider, "telnyx"),
+          eq(
+            locationMessaging.messagingProfileId,
+            input.expected.messagingProfileId,
+          ),
+          eq(locationMessaging.senderE164, input.expected.senderE164),
+          eq(locationMessaging.registrationStatus, "active"),
+          eq(locationMessaging.enabled, input.expected.clinicEnabled),
+          eq(
+            locationMessaging.providerProfileReady,
+            input.expected.providerProfileReady,
+          ),
+          input.expected.providerProfileSyncedAt === null
+            ? isNull(locationMessaging.providerProfileSyncedAt)
+            : eq(
+                locationMessaging.providerProfileSyncedAt,
+                input.expected.providerProfileSyncedAt,
+              ),
+          isNull(locationMessaging.deletedAt),
+          sql`exists (
+            select 1
+            from ${messagingRegistrations}
+            where ${messagingRegistrations.id} = ${input.expected.registrationId}
+              and ${messagingRegistrations.practiceId} = ${input.practiceId}
+              and ${messagingRegistrations.providerBrandId} = ${input.expected.providerBrandId}
+              and ${messagingRegistrations.providerCampaignId} = ${input.expected.providerCampaignId}
+              and ${messagingRegistrations.status} = 'active'
+              and ${messagingRegistrations.deletedAt} is null
+          )`,
+        ),
+      )
+      .returning({ id: locationMessaging.id });
+    if (!updated) {
+      throw new TRPCError({
+        code: "CONFLICT",
+        message:
+          "Messaging lifecycle state changed during provider verification. Refresh and inspect again.",
+      });
+    }
+  });
+}
+
+async function recordMessagingProfileDisabled(input: {
+  practiceId: string;
+  locationId: string;
+  detail: string;
+  expected: {
+    messagingProfileId: string;
+    senderE164: string;
+  };
+}) {
+  await withSystem(db, async (tx) => {
+    const [updated] = await tx
+      .update(locationMessaging)
+      .set({
+        enabled: false,
+        registrationDetail: input.detail,
+        providerProfileReady: false,
+        providerProfileSyncedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(locationMessaging.practiceId, input.practiceId),
+          eq(locationMessaging.locationId, input.locationId),
+          eq(locationMessaging.provider, "telnyx"),
+          eq(
+            locationMessaging.messagingProfileId,
+            input.expected.messagingProfileId,
+          ),
+          eq(locationMessaging.senderE164, input.expected.senderE164),
+          isNull(locationMessaging.deletedAt),
+        ),
+      )
+      .returning({ id: locationMessaging.id });
+    if (!updated) {
+      throw new TRPCError({
+        code: "CONFLICT",
+        message:
+          "Messaging sender identity changed during provider deactivation. Refresh and disable the current profile.",
+      });
+    }
   });
 }
 
@@ -276,6 +576,8 @@ async function failRegistrationOperation(opts: {
       .set({
         enabled: false,
         registrationStatus: "action_required",
+        providerProfileReady: false,
+        providerProfileSyncedAt: null,
         updatedAt: new Date(),
       })
       .where(
@@ -632,20 +934,217 @@ export const adminRouter = createRouter({
       const senders = await tx
         .select({
           practiceId: locationMessaging.practiceId,
+          locationId: locationMessaging.locationId,
+          provider: locationMessaging.provider,
+          messagingProfileId: locationMessaging.messagingProfileId,
           senderE164: locationMessaging.senderE164,
           registrationStatus: locationMessaging.registrationStatus,
+          registrationDetail: locationMessaging.registrationDetail,
+          providerProfileReady: locationMessaging.providerProfileReady,
+          providerProfileSyncedAt: locationMessaging.providerProfileSyncedAt,
           enabled: locationMessaging.enabled,
         })
         .from(locationMessaging)
         .where(isNull(locationMessaging.deletedAt));
       return rows.map((row) => ({
         ...row,
-        senders: senders.filter(
-          (sender) => sender.practiceId === row.practiceId,
-        ),
+        senders: senders
+          .filter((sender) => sender.practiceId === row.practiceId)
+          .map((sender) => ({
+            ...sender,
+            providerProfileReady:
+              sender.providerProfileReady &&
+              sender.providerProfileSyncedAt !== null &&
+              sender.providerProfileSyncedAt.getTime() >=
+                Date.now() -
+                  MESSAGING_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS,
+          })),
       }));
     }),
   ),
+
+  /** Read the exact provider profile and every prerequisite without mutating it. */
+  inspectMessagingProfile: platformAdminProcedure
+    .input(
+      z.object({
+        practiceId: z.string().uuid(),
+        locationId: z.string().uuid(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      try {
+        const inspection = await inspectMessagingProviderReadiness(input);
+        const { profile, blockers } = inspection;
+        const ready = blockers.length === 0 && profile.enabled === true;
+        if (ready) {
+          await recordMessagingProfileReady({
+            ...input,
+            detail:
+              "Provider profile is active and verified. A clinic admin may now enable this approved pilot sender.",
+            expected: expectedMessagingProfileState(inspection),
+          });
+        } else {
+          await updateMessagingSenderDisabled({
+            ...input,
+            detail:
+              blockers.length > 0
+                ? `Provider profile is not ready: ${blockers.join("; ")}.`
+                : "Provider profile is verified but remains disabled. Clinic sending stays off.",
+            syncedAt: new Date(),
+          });
+        }
+        return {
+          locationId: input.locationId,
+          enabled: profile.enabled === true,
+          activationReady: blockers.length === 0,
+          clinicEnableReady: ready,
+          blockers,
+        };
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        throw providerFailure(error);
+      }
+    }),
+
+  /**
+   * Explicit provider-side profile switch. Clinic sending remains disabled
+   * until its own admin performs the final, separately allowlisted enable.
+   */
+  setMessagingProfileEnabled: platformAdminProcedure
+    .input(
+      z.object({
+        practiceId: z.string().uuid(),
+        locationId: z.string().uuid(),
+        enabled: z.boolean(),
+        confirmProviderMutation: z.literal(true),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      assertMessagingProviderMutationsEnabled();
+      const sender = await messagingSenderForOperator(
+        input.practiceId,
+        input.locationId,
+      );
+
+      if (!input.enabled) {
+        await updateMessagingSenderDisabled({
+          ...input,
+          detail:
+            "OpenVPM disabled the provider profile. Clinic sending remains off.",
+          syncedAt: null,
+        });
+        try {
+          const targetSender = await messagingSenderForOperator(
+            input.practiceId,
+            input.locationId,
+          );
+          let profile = await getMessagingProfile(
+            targetSender.messagingProfileId,
+          );
+          const reused = profile.enabled === false;
+          if (!reused) {
+            await updateMessagingProfileEnabled({
+              profileId: targetSender.messagingProfileId,
+              enabled: false,
+            });
+            profile = await getMessagingProfile(
+              targetSender.messagingProfileId,
+            );
+          }
+          if (profile.enabled !== false) {
+            throw new TRPCError({
+              code: "BAD_GATEWAY",
+              message:
+                "Telnyx did not confirm that the messaging profile is disabled.",
+            });
+          }
+          await recordMessagingProfileDisabled({
+            ...input,
+            detail:
+              "OpenVPM disabled the provider profile. Clinic sending remains off.",
+            expected: {
+              messagingProfileId: targetSender.messagingProfileId,
+              senderE164: targetSender.senderE164,
+            },
+          });
+          return {
+            locationId: input.locationId,
+            enabled: false,
+            clinicEnabled: false,
+            reused,
+          };
+        } catch (error) {
+          if (error instanceof TRPCError) throw error;
+          throw providerFailure(error);
+        }
+      }
+
+      if (sender.enabled) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            "Turn off clinic sending before changing its provider profile.",
+        });
+      }
+
+      await updateMessagingSenderDisabled({
+        ...input,
+        detail:
+          "OpenVPM is verifying the provider profile. Clinic sending remains off.",
+        syncedAt: null,
+      });
+
+      try {
+        const inspection = await inspectMessagingProviderReadiness(input);
+        if (inspection.blockers.length > 0) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: `Provider profile is not safe to enable: ${inspection.blockers.join(
+              "; ",
+            )}.`,
+          });
+        }
+        let profile = inspection.profile;
+        const inspectedSender = inspection.sender;
+        const reused = profile.enabled === true;
+        if (!reused) {
+          await updateMessagingProfileEnabled({
+            profileId: inspectedSender.messagingProfileId,
+            enabled: true,
+          });
+          profile = await getMessagingProfile(
+            inspectedSender.messagingProfileId,
+          );
+        }
+        const readbackIssues = messagingProfileSafetyIssues(profile, {
+          id: inspectedSender.messagingProfileId,
+          name: openVpmMessagingProfileName(inspectedSender.locationId),
+          webhookUrl: telnyxRegistrationWebhookUrl(),
+        });
+        if (profile.enabled !== true || readbackIssues.length > 0) {
+          throw new TRPCError({
+            code: "BAD_GATEWAY",
+            message:
+              "Telnyx did not confirm the exact safe messaging-profile state.",
+          });
+        }
+        await recordMessagingProfileReady({
+          ...input,
+          detail:
+            "Provider profile is active and verified. A clinic admin may now enable this approved pilot sender.",
+          expected: expectedMessagingProfileState(inspection),
+        });
+        return {
+          locationId: input.locationId,
+          enabled: true,
+          clinicEnabled: false,
+          reused,
+        };
+      } catch (error) {
+        if (error instanceof TRPCError) throw error;
+        throw providerFailure(error);
+      }
+    }),
 
   /** Fee-bearing TCR brand creation; platform operator only and explicitly confirmed. */
   submitMessagingBrand: platformAdminProcedure
@@ -959,6 +1458,8 @@ export const adminRouter = createRouter({
               next === "active"
                 ? "Carrier registration active. An admin may now enable sending."
                 : "Carrier number assignment is pending.",
+            providerProfileReady: false,
+            providerProfileSyncedAt: null,
             enabled: false,
             updatedAt: new Date(),
           })
@@ -1697,15 +2198,16 @@ export const adminRouter = createRouter({
           .update(messagingRegistrations)
           .set({
             providerBrandId: input.providerBrandId,
-            ...(input.providerCampaignId
-              ? { providerCampaignId: input.providerCampaignId }
-              : {}),
+            providerBrandStatus: null,
+            providerCampaignId: input.providerCampaignId ?? null,
+            providerCampaignStatus: null,
             status: "pending",
             statusDetail:
               "Provider IDs recovered by an OpenVPM operator; refresh status next.",
             submissionLockId: null,
             submissionLockAt: null,
             lastError: null,
+            lastSyncedAt: null,
             updatedAt: new Date(),
           })
           .where(
@@ -1721,6 +2223,24 @@ export const adminRouter = createRouter({
             message: "Registration not found.",
           });
         }
+        await tx
+          .update(locationMessaging)
+          .set({
+            enabled: false,
+            registrationStatus: "pending",
+            registrationDetail:
+              "Provider IDs changed. OpenVPM must reconcile carrier and provider-profile state again.",
+            providerProfileReady: false,
+            providerProfileSyncedAt: null,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(locationMessaging.practiceId, input.practiceId),
+              eq(locationMessaging.provider, "telnyx"),
+              isNull(locationMessaging.deletedAt),
+            ),
+          );
         return { ok: true };
       }),
     ),
@@ -1821,6 +2341,8 @@ export const adminRouter = createRouter({
             enabled: false,
             registrationStatus: "action_required",
             registrationDetail: "Carrier registration needs OpenVPM review.",
+            providerProfileReady: false,
+            providerProfileSyncedAt: null,
             updatedAt: new Date(),
           })
           .where(
@@ -1923,7 +2445,13 @@ export const adminRouter = createRouter({
                       next === "suspended"
                     ? "Carrier registration needs OpenVPM review."
                     : "Carrier registration is pending.",
-              ...(next === "active" ? {} : { enabled: false }),
+              ...(next === "active"
+                ? {}
+                : {
+                    enabled: false,
+                    providerProfileReady: false,
+                    providerProfileSyncedAt: null,
+                  }),
               updatedAt: new Date(),
             })
             .where(

--- a/apps/web/server/routers/messaging.ts
+++ b/apps/web/server/routers/messaging.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, gte, isNull, sql } from "drizzle-orm";
 import { TRPCError } from "@trpc/server";
 import { createRouter, protectedProcedure, requireRole } from "../trpc";
 import {
@@ -36,7 +36,8 @@ import {
   TelnyxMutationUncertainError,
   TelnyxNotConfiguredError,
 } from "@/lib/messaging/telnyx-provisioning";
-import { appBaseUrl, normalizeAppBaseUrl } from "@/lib/app-url";
+import { appBaseUrl } from "@/lib/app-url";
+import { publicTelnyxWebhookUrl } from "@/lib/messaging/public-webhook";
 import {
   encryptRegistrationTaxId,
   MessagingRegistrationEncryptionError,
@@ -62,6 +63,7 @@ const EXISTING_NUMBER_UNAVAILABLE_DETAIL =
   "Texting from your clinic's existing phone number is not supported yet. OpenVPM has not ported or changed that number. Choose a new local texting number instead.";
 const INCONCLUSIVE_ORDER_DETAIL =
   "OpenVPM could not conclusively reconcile the earlier number order. No additional purchase was attempted. Contact OpenVPM support before trying another number.";
+const HOSTED_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS = 15 * 60 * 1000;
 
 const providerPriceInput = z
   .string()
@@ -329,37 +331,15 @@ function telnyxWebhookUrl(): string {
     });
   }
 
-  const normalized = normalizeAppBaseUrl(rawBase);
-  if (!normalized) {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message:
-        "Set NEXT_PUBLIC_APP_URL or NEXTAUTH_URL to a valid public HTTPS app URL before provisioning texting.",
-    });
-  }
-
-  const baseUrl = new URL(normalized);
-  const hostname = baseUrl.hostname.toLowerCase();
-  const localHostnames = new Set([
-    "localhost",
-    "127.0.0.1",
-    "0.0.0.0",
-    "::1",
-    "[::1]",
-  ]);
-  if (
-    baseUrl.protocol !== "https:" ||
-    localHostnames.has(hostname) ||
-    hostname.endsWith(".local")
-  ) {
+  const webhookUrl = publicTelnyxWebhookUrl(rawBase);
+  if (!webhookUrl) {
     throw new TRPCError({
       code: "PRECONDITION_FAILED",
       message:
         "Set NEXT_PUBLIC_APP_URL or NEXTAUTH_URL to your public HTTPS app URL before provisioning texting.",
     });
   }
-
-  return new URL("/api/webhooks/telnyx", baseUrl).toString();
+  return webhookUrl;
 }
 
 function configuredWebhookBaseUrl(): string {
@@ -674,6 +654,8 @@ export const messagingRouter = createRouter({
         numberSource: locationMessaging.numberSource,
         registrationStatus: locationMessaging.registrationStatus,
         registrationDetail: locationMessaging.registrationDetail,
+        providerProfileReady: locationMessaging.providerProfileReady,
+        providerProfileSyncedAt: locationMessaging.providerProfileSyncedAt,
         enabled: locationMessaging.enabled,
       })
       .from(locations)
@@ -747,6 +729,15 @@ export const messagingRouter = createRouter({
               numberSource: l.numberSource,
               registrationStatus: l.registrationStatus,
               registrationDetail: l.registrationDetail,
+              providerProfileReady: l.providerProfileReady,
+              providerProfileSyncedAt: l.providerProfileSyncedAt,
+              providerProfileAttestationFresh:
+                !billingEnforced() ||
+                (l.providerProfileReady === true &&
+                  l.providerProfileSyncedAt !== null &&
+                  l.providerProfileSyncedAt.getTime() >=
+                    Date.now() -
+                      HOSTED_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS),
               enabled: l.enabled,
               launchEligible:
                 launchEligibleLocationIds.has(l.locationId) &&
@@ -1214,6 +1205,8 @@ export const messagingRouter = createRouter({
               numberSource: "purchased",
               registrationStatus: "not_started",
               registrationDetail: MESSAGING_NUMBER_ORDERED_DETAIL,
+              providerProfileReady: false,
+              providerProfileSyncedAt: null,
               enabled: false,
             })
             .onConflictDoUpdate({
@@ -1225,6 +1218,8 @@ export const messagingRouter = createRouter({
                 numberSource: "purchased",
                 registrationStatus: "not_started",
                 registrationDetail: MESSAGING_NUMBER_ORDERED_DETAIL,
+                providerProfileReady: false,
+                providerProfileSyncedAt: null,
                 enabled: false,
                 deletedAt: null,
                 updatedAt: new Date(),
@@ -1335,6 +1330,8 @@ export const messagingRouter = createRouter({
                   numberSource: "purchased",
                   registrationStatus: "failed",
                   registrationDetail: MESSAGING_PROVISIONING_FAILED_DETAIL,
+                  providerProfileReady: false,
+                  providerProfileSyncedAt: null,
                   enabled: false,
                 })
                 .onConflictDoUpdate({
@@ -1346,6 +1343,8 @@ export const messagingRouter = createRouter({
                     numberSource: "purchased",
                     registrationStatus: "failed",
                     registrationDetail: MESSAGING_PROVISIONING_FAILED_DETAIL,
+                    providerProfileReady: false,
+                    providerProfileSyncedAt: null,
                     enabled: false,
                     deletedAt: null,
                     updatedAt: new Date(),
@@ -1392,29 +1391,42 @@ export const messagingRouter = createRouter({
             sql`select pg_advisory_xact_lock(hashtextextended(${`hosted-sms:${ctx.practiceId}`}, 0))`
           );
         }
+        const readySenderConditions = [
+          eq(locationMessaging.locationId, input.locationId),
+          eq(locationMessaging.practiceId, ctx.practiceId),
+          activePracticePredicate(ctx.practiceId),
+          isNull(locationMessaging.deletedAt),
+          eq(locationMessaging.registrationStatus, "active"),
+          hasNonBlankMessagingSender(),
+        ];
+        if (billingEnforced()) {
+          readySenderConditions.push(
+            eq(locationMessaging.provider, "telnyx"),
+            eq(locationMessaging.providerProfileReady, true),
+            gte(
+              locationMessaging.providerProfileSyncedAt,
+              new Date(
+                Date.now() - HOSTED_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS,
+              ),
+            ),
+          );
+        }
         const [readySender] = await ctx.db
           .select({
             locationId: locationMessaging.locationId,
             provider: locationMessaging.provider,
           })
           .from(locationMessaging)
-          .where(
-            and(
-              eq(locationMessaging.locationId, input.locationId),
-              eq(locationMessaging.practiceId, ctx.practiceId),
-              activePracticePredicate(ctx.practiceId),
-              isNull(locationMessaging.deletedAt),
-              eq(locationMessaging.registrationStatus, "active"),
-              hasNonBlankMessagingSender()
-            )
-          )
+          .where(and(...readySenderConditions))
           .limit(1);
 
         if (!readySender) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
             message:
-              "Carrier registration must be active before enabling SMS sending.",
+              billingEnforced()
+                ? "OpenVPM must freshly verify the active provider profile before enabling hosted SMS sending."
+                : "Carrier registration must be active before enabling SMS sending.",
           });
         }
         if (billingEnforced() && readySender.provider !== "telnyx") {
@@ -1465,7 +1477,16 @@ export const messagingRouter = createRouter({
           hasNonBlankMessagingSender()
         );
         if (billingEnforced()) {
-          updateConditions.push(eq(locationMessaging.provider, "telnyx"));
+          updateConditions.push(
+            eq(locationMessaging.provider, "telnyx"),
+            eq(locationMessaging.providerProfileReady, true),
+            gte(
+              locationMessaging.providerProfileSyncedAt,
+              new Date(
+                Date.now() - HOSTED_PROVIDER_PROFILE_ATTESTATION_MAX_AGE_MS,
+              ),
+            ),
+          );
         }
       }
 

--- a/apps/web/server/trpc.ts
+++ b/apps/web/server/trpc.ts
@@ -121,6 +121,8 @@ const HOSTED_READ_ONLY_MUTATION_ALLOWLIST = new Set([
   "admin.submitMessagingBrand",
   "admin.submitMessagingCampaign",
   "admin.assignMessagingNumbers",
+  "admin.inspectMessagingProfile",
+  "admin.setMessagingProfileEnabled",
   "admin.attachMessagingProviderIds",
   "admin.clearStaleMessagingSubmissionLock",
   "admin.reconcileMessagingRegistration",

--- a/docs/hosted-cloud-production.md
+++ b/docs/hosted-cloud-production.md
@@ -121,15 +121,44 @@ expanding beyond a design-partner pilot.
 
 Outbound sending has a separate, default-off launch interlock. Keep
 `MESSAGING_SENDING_ENABLED=false` and both sending allowlists empty until one
-Telnyx location has carrier-active registration, its database sender is enabled,
-and the clinic has passed pilot review. A hosted send requires the practice UUID
-in `MESSAGING_SENDING_PRACTICE_IDS` and the exact location UUID in
-`MESSAGING_SENDING_LOCATION_IDS`; the hosted pilot permits only one enabled
-location per practice. Missing, ambiguous, Twilio, inactive, or partially
-configured state makes no provider call. These three variables are hosted-only
-and do not gate intentional self-host messaging configuration. Arbitrary hosted
-test destinations remain disabled; validate through a current, consented client
-workflow after approval.
+Telnyx location has carrier-active registration, an explicitly activated and
+read-back provider profile, and the clinic has passed pilot review. A hosted
+send requires the practice UUID in `MESSAGING_SENDING_PRACTICE_IDS` and the
+exact location UUID in `MESSAGING_SENDING_LOCATION_IDS`; the hosted pilot
+permits only one enabled location per practice. Missing, ambiguous, Twilio,
+inactive, or partially configured state makes no provider call. These
+three variables are hosted-only and do not gate intentional self-host messaging
+configuration. Arbitrary hosted test destinations remain disabled; validate
+through a current, consented client workflow after approval.
+
+### Controlled texting pilot activation
+
+Provider profiles are created disabled. Never enable one during number
+purchase or carrier submission. Use the platform admin queue in this order:
+
+1. Reconcile the brand as `VERIFIED` or `VETTED_VERIFIED`, the campaign as
+   `ACTIVE` or `MNO_PROVISIONED`, and the exact number assignment as `ASSIGNED`.
+2. Select **Inspect profile**. OpenVPM reads the exact profile, owned number,
+   brand, campaign, and assignment. The profile must have the canonical v2
+   webhook, a US-only destination allowlist, smart encoding, and the enforced
+   `$10.00` daily cap.
+3. Select **Enable provider profile** and confirm the provider mutation. OpenVPM
+   reads the provider state back after the update and deliberately leaves the
+   clinic database sender off.
+4. Add exactly one practice and location to the sending allowlists and set
+   `MESSAGING_SENDING_ENABLED=true`.
+5. Within 15 minutes of the provider readback, have the clinic admin enable the
+   location sender. An expired or failed attestation blocks the database switch;
+   inspect the profile again instead of bypassing the gate.
+6. Validate only with a current, consented client workflow. Confirm outbound
+   accepted-to-delivered evidence, an ordinary inbound reply, HELP, STOP plus a
+   blocked resend, START plus restored consent, one reminder, usage metering,
+   and empty reconciliation queues.
+
+The kill sequence is global sending off first, then clear both sending
+allowlists, disable the clinic database sender, and finally select **Disable
+provider profile**. Provider deactivation always closes the database gate before
+contacting Telnyx, so an uncertain carrier response cannot leave OpenVPM sending.
 
 For a Twilio fallback deployment, set `MESSAGING_PROVIDER=twilio` and provide
 `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_PHONE_NUMBER` instead of

--- a/packages/db/drizzle/0061_majestic_rattler.sql
+++ b/packages/db/drizzle/0061_majestic_rattler.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "location_messaging" ADD COLUMN "provider_profile_ready" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "location_messaging" ADD COLUMN "provider_profile_synced_at" timestamp with time zone;

--- a/packages/db/drizzle/meta/0061_snapshot.json
+++ b/packages/db/drizzle/meta/0061_snapshot.json
@@ -1,0 +1,18699 @@
+{
+  "id": "e369b2d7-3ff4-4bfc-9130-4939c4917686",
+  "prevId": "e03e8fcc-f0ea-4815-83fa-5856d48f19a8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "performed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_operation_id": {
+          "name": "creation_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_payload_hash": {
+          "name": "creation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_note": {
+          "name": "follow_up_note",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_by": {
+          "name": "follow_up_completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_at": {
+          "name": "follow_up_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_outcome": {
+          "name": "follow_up_outcome",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_review_inbox_idx": {
+          "name": "lab_results_review_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_follow_up_inbox_idx": {
+          "name": "lab_results_follow_up_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_record_uq": {
+          "name": "lab_results_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_creation_operation_uq": {
+          "name": "lab_results_creation_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_results_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_completed_by_users_id_fk": {
+          "name": "lab_results_follow_up_completed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_patient_fk": {
+          "name": "lab_results_practice_patient_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_ordered_by_fk": {
+          "name": "lab_results_practice_ordered_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_reviewed_by_fk": {
+          "name": "lab_results_practice_reviewed_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_assigned_fk": {
+          "name": "lab_results_practice_follow_up_assigned_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_completed_fk": {
+          "name": "lab_results_practice_follow_up_completed_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_results_lifecycle_shape_check": {
+          "name": "lab_results_lifecycle_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"completed_at\" is null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'completed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is not null\n          and \"lab_results\".\"reviewed_by\" is not null\n        )"
+        },
+        "lab_results_creation_operation_shape_check": {
+          "name": "lab_results_creation_operation_shape_check",
+          "value": "(\"lab_results\".\"creation_operation_id\" is null and \"lab_results\".\"creation_payload_hash\" is null)\n        or (\"lab_results\".\"creation_operation_id\" is not null and \"lab_results\".\"creation_payload_hash\" ~ '^[0-9a-f]{64}$')"
+        },
+        "lab_results_result_shape_check": {
+          "name": "lab_results_result_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"result_value\" is null\n          and \"lab_results\".\"unit\" is null\n          and \"lab_results\".\"reference_range_low\" is null\n          and \"lab_results\".\"reference_range_high\" is null\n          and \"lab_results\".\"result_flag\" = 'unknown'\n        ) or (\n          \"lab_results\".\"status\" in ('completed', 'reviewed')\n          and length(btrim(coalesce(\"lab_results\".\"result_value\", ''))) > 0\n        )"
+        },
+        "lab_results_follow_up_shape_check": {
+          "name": "lab_results_follow_up_shape_check",
+          "value": "(\"lab_results\".\"status\" <> 'pending' or \"lab_results\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_results\".\"follow_up_due_at\" is null\n        )\n        and ((\n          \"lab_results\".\"follow_up_status\" = 'not_required'\n          and \"lab_results\".\"follow_up_assigned_to\" is null\n          and \"lab_results\".\"follow_up_due_at\" is null\n          and \"lab_results\".\"follow_up_note\" is null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'open'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'completed'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is not null\n          and \"lab_results\".\"follow_up_completed_at\" is not null\n          and length(btrim(coalesce(\"lab_results\".\"follow_up_outcome\", ''))) between 3 and 1000\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_result_events": {
+      "name": "lab_result_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "lab_result_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_events_result_history_idx": {
+          "name": "lab_result_events_result_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_time_idx": {
+          "name": "lab_result_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_operation_uq": {
+          "name": "lab_result_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_created_uq": {
+          "name": "lab_result_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"lab_result_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_events_practice_id_practices_id_fk": {
+          "name": "lab_result_events_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_events_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_id_patients_id_fk": {
+          "name": "lab_result_events_patient_id_patients_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_id_appointments_id_fk": {
+          "name": "lab_result_events_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_result_events_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_id_users_id_fk": {
+          "name": "lab_result_events_actor_id_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_result_tenant_fk": {
+          "name": "lab_result_events_result_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_tenant_fk": {
+          "name": "lab_result_events_patient_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_tenant_fk": {
+          "name": "lab_result_events_appointment_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_tenant_fk": {
+          "name": "lab_result_events_actor_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_assignee_tenant_fk": {
+          "name": "lab_result_events_assignee_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_events_shape_check": {
+          "name": "lab_result_events_shape_check",
+          "value": "length(btrim(\"lab_result_events\".\"actor_name\")) between 1 and 255\n        and \"lab_result_events\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        and (\"lab_result_events\".\"note\" is null or length(\"lab_result_events\".\"note\") <= 1000)\n        and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_result_events\".\"status_after\" = 'reviewed'\n          and \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_result_events\".\"follow_up_due_at\" is null\n        )\n        and (\n          (\"lab_result_events\".\"status_after\" = 'pending'\n            and \"lab_result_events\".\"result_value\" is null\n            and \"lab_result_events\".\"unit\" is null\n            and \"lab_result_events\".\"reference_range_low\" is null\n            and \"lab_result_events\".\"reference_range_high\" is null\n            and \"lab_result_events\".\"result_flag\" = 'unknown')\n          or (\"lab_result_events\".\"status_after\" in ('completed', 'reviewed')\n            and length(btrim(coalesce(\"lab_result_events\".\"result_value\", ''))) between 1 and 128)\n        )\n        and (\n          (\"lab_result_events\".\"follow_up_status\" = 'not_required'\n            and \"lab_result_events\".\"follow_up_assigned_to\" is null\n            and \"lab_result_events\".\"follow_up_due_at\" is null)\n          or (\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n            and \"lab_result_events\".\"follow_up_assigned_to\" is not null)\n        )\n        and (\n          \"lab_result_events\".\"event_type\" = 'created'\n          and \"lab_result_events\".\"status_before\" is null\n          and \"lab_result_events\".\"status_after\" in ('pending', 'completed')\n          and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"result_flag\" = 'unknown')\n        or \"lab_result_events\".\"event_type\" = 'completed'\n          and \"lab_result_events\".\"status_before\" = 'pending'\n          and \"lab_result_events\".\"status_after\" = 'completed'\n        or \"lab_result_events\".\"event_type\" = 'reviewed'\n          and \"lab_result_events\".\"status_before\" = 'completed'\n          and \"lab_result_events\".\"status_after\" = 'reviewed'\n        or \"lab_result_events\".\"event_type\" in ('follow_up_assigned', 'follow_up_reassigned')\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'open'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n        or \"lab_result_events\".\"event_type\" = 'follow_up_completed'\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'completed'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n          and length(btrim(coalesce(\"lab_result_events\".\"note\", ''))) between 3 and 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_lab_result_uq": {
+          "name": "clinical_record_corrections_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"lab_result_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_operation_uq": {
+          "name": "clinical_record_corrections_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_lab_source_uq": {
+          "name": "clinical_record_corrections_practice_record_lab_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_id_lab_results_id_fk": {
+          "name": "clinical_record_corrections_lab_result_id_lab_results_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "practice_id",
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_source_fk": {
+          "name": "clinical_record_corrections_lab_result_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n        and \"clinical_record_corrections\".\"lab_result_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      )"
+        },
+        "clinical_record_corrections_operation_shape_check": {
+          "name": "clinical_record_corrections_operation_shape_check",
+          "value": "(\n          \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is not null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        ) or (\n          \"clinical_record_corrections\".\"record_type\" <> 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" is null\n        )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lab_result_replacements": {
+      "name": "lab_result_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lab_result_id": {
+          "name": "source_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_lab_result_id": {
+          "name": "replacement_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_replacements_source_history_idx": {
+          "name": "lab_result_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_source_uq": {
+          "name": "lab_result_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_replacement_uq": {
+          "name": "lab_result_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_operation_uq": {
+          "name": "lab_result_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_replacements_practice_id_practices_id_fk": {
+          "name": "lab_result_replacements_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "lab_result_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_source_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_id_users_id_fk": {
+          "name": "lab_result_replacements_actor_id_users_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_tenant_fk": {
+          "name": "lab_result_replacements_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_tenant_fk": {
+          "name": "lab_result_replacements_replacement_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_source_tenant_fk": {
+          "name": "lab_result_replacements_correction_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "lab_result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_tenant_fk": {
+          "name": "lab_result_replacements_actor_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_replacements_shape_check": {
+          "name": "lab_result_replacements_shape_check",
+          "value": "\"lab_result_replacements\".\"source_lab_result_id\" <> \"lab_result_replacements\".\"replacement_lab_result_id\"\n        and length(btrim(\"lab_result_replacements\".\"actor_name\")) between 1 and 255\n        and \"lab_result_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ready": {
+          "name": "provider_profile_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_profile_synced_at": {
+          "name": "provider_profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_event_history": {
+      "name": "sms_delivery_event_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivery_event_id": {
+          "name": "delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_history_id": {
+          "name": "reviewed_history_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_delivery_history_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "sms_delivery_history_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_reason_code": {
+          "name": "operator_reason_code",
+          "type": "sms_delivery_reconciliation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_event_history_event_key_uq": {
+          "name": "sms_delivery_event_history_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_idx": {
+          "name": "sms_delivery_event_history_event_idx",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_id_uq": {
+          "name": "sms_delivery_event_history_event_id_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attribution_uq": {
+          "name": "sms_delivery_event_history_attribution_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"result\" = 'attributed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_reviewed_history_uq": {
+          "name": "sms_delivery_event_history_reviewed_history_uq",
+          "columns": [
+            {
+              "expression": "reviewed_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"reviewed_history_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_practice_queue_idx": {
+          "name": "sms_delivery_event_history_practice_queue_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attempt_idx": {
+          "name": "sms_delivery_event_history_attempt_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": [
+            "delivery_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_practice_id_practices_id_fk": {
+          "name": "sms_delivery_event_history_practice_id_practices_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_id_communications_id_fk": {
+          "name": "sms_delivery_event_history_communication_id_communications_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_user_id_users_id_fk": {
+          "name": "sms_delivery_event_history_actor_user_id_users_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_attempt_tenant_fk": {
+          "name": "sms_delivery_event_history_attempt_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_tenant_fk": {
+          "name": "sms_delivery_event_history_communication_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_tenant_fk": {
+          "name": "sms_delivery_event_history_actor_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_reviewed_history_fk": {
+          "name": "sms_delivery_event_history_reviewed_history_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_event_history",
+          "columnsFrom": [
+            "delivery_event_id",
+            "reviewed_history_id"
+          ],
+          "columnsTo": [
+            "delivery_event_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_event_history_event_key_check": {
+          "name": "sms_delivery_event_history_event_key_check",
+          "value": "length(btrim(\"sms_delivery_event_history\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_event_history_detail_check": {
+          "name": "sms_delivery_event_history_detail_check",
+          "value": "\"sms_delivery_event_history\".\"detail\" is null or length(\"sms_delivery_event_history\".\"detail\") <= 2000"
+        },
+        "sms_delivery_event_history_target_shape_check": {
+          "name": "sms_delivery_event_history_target_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous', 'operator_reviewed')\n          and \"sms_delivery_event_history\".\"practice_id\" is null\n          and \"sms_delivery_event_history\".\"attempt_id\" is null\n          and \"sms_delivery_event_history\".\"communication_id\" is null\n          and (\n            (\"sms_delivery_event_history\".\"result\" = 'operator_reviewed' and \"sms_delivery_event_history\".\"reviewed_history_id\" is not null)\n            or (\"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous') and \"sms_delivery_event_history\".\"reviewed_history_id\" is null)\n          )\n        ) or (\n          \"sms_delivery_event_history\".\"result\" in ('attributed', 'projection_miss', 'reconciled')\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"result\" = 'projected'\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"communication_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        )"
+        },
+        "sms_delivery_event_history_actor_shape_check": {
+          "name": "sms_delivery_event_history_actor_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"kind\" = 'automatic'\n          and \"sms_delivery_event_history\".\"result\" in (\n            'unmatched',\n            'ambiguous',\n            'attributed',\n            'projected',\n            'projection_miss'\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" is null\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and \"sms_delivery_event_history\".\"actor_identity\" is null\n          and \"sms_delivery_event_history\".\"actor_name\" is null\n          and \"sms_delivery_event_history\".\"operator_reason_code\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"kind\" = 'operator_reconciliation'\n          and (\n            (\n              \"sms_delivery_event_history\".\"result\" = 'reconciled'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'exact_attribution_retry',\n                'provider_portal_status_review',\n                'projection_repair'\n              )\n            )\n            or (\n              \"sms_delivery_event_history\".\"result\" = 'operator_reviewed'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'identity_conflict_review',\n                'unmatched_evidence_review'\n              )\n            )\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" = 'platform_operator'\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_name\", ''))) between 1 and 255\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_events": {
+      "name": "sms_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint_sha256": {
+          "name": "payload_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_events_provider_event_key_uq": {
+          "name": "sms_delivery_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_provider_message_idx": {
+          "name": "sms_delivery_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_classification_queue_idx": {
+          "name": "sms_delivery_events_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_events_provider_check": {
+          "name": "sms_delivery_events_provider_check",
+          "value": "\"sms_delivery_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_delivery_events_event_type_check": {
+          "name": "sms_delivery_events_event_type_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"provider_event_type\")) between 1 and 80"
+        },
+        "sms_delivery_events_event_key_check": {
+          "name": "sms_delivery_events_event_key_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_events_fingerprint_check": {
+          "name": "sms_delivery_events_fingerprint_check",
+          "value": "\"sms_delivery_events\".\"payload_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_delivery_events_provider_event_id_check": {
+          "name": "sms_delivery_events_provider_event_id_check",
+          "value": "\"sms_delivery_events\".\"provider_event_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_event_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_message_id_check": {
+          "name": "sms_delivery_events_provider_message_id_check",
+          "value": "\"sms_delivery_events\".\"provider_message_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_message_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_status_check": {
+          "name": "sms_delivery_events_provider_status_check",
+          "value": "\"sms_delivery_events\".\"provider_status\" is null or length(btrim(\"sms_delivery_events\".\"provider_status\")) between 1 and 80"
+        },
+        "sms_delivery_events_provider_error_code_check": {
+          "name": "sms_delivery_events_provider_error_code_check",
+          "value": "\"sms_delivery_events\".\"provider_error_code\" is null or length(btrim(\"sms_delivery_events\".\"provider_error_code\")) between 1 and 80"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "resend_of_attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": [
+            "practice_id",
+            "milestone"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_follow_up_status": {
+      "name": "lab_follow_up_status",
+      "schema": "public",
+      "values": [
+        "not_required",
+        "open",
+        "completed"
+      ]
+    },
+    "public.lab_result_flag": {
+      "name": "lab_result_flag",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "normal",
+        "abnormal",
+        "critical"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.lab_result_event_type": {
+      "name": "lab_result_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "completed",
+        "reviewed",
+        "follow_up_assigned",
+        "follow_up_reassigned",
+        "follow_up_completed"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": [
+        "entered_in_error"
+      ]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign",
+        "vaccination_record",
+        "lab_result"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invoiced",
+        "waived"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": [
+        "staff",
+        "client",
+        "system"
+      ]
+    },
+    "public.sms_delivery_classification": {
+      "name": "sms_delivery_classification",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "sent",
+        "failed",
+        "delivered"
+      ]
+    },
+    "public.sms_delivery_history_kind": {
+      "name": "sms_delivery_history_kind",
+      "schema": "public",
+      "values": [
+        "automatic",
+        "operator_reconciliation"
+      ]
+    },
+    "public.sms_delivery_history_result": {
+      "name": "sms_delivery_history_result",
+      "schema": "public",
+      "values": [
+        "unmatched",
+        "ambiguous",
+        "attributed",
+        "projected",
+        "projection_miss",
+        "reconciled",
+        "operator_reviewed"
+      ]
+    },
+    "public.sms_delivery_reconciliation_reason": {
+      "name": "sms_delivery_reconciliation_reason",
+      "schema": "public",
+      "values": [
+        "exact_attribution_retry",
+        "provider_portal_status_review",
+        "projection_repair",
+        "identity_conflict_review",
+        "unmatched_evidence_review"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator"
+      ]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": [
+        "provider_result",
+        "reconciliation"
+      ]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": [
+        "practice_created",
+        "product_records",
+        "stripe_webhook"
+      ]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": [
+        "unresolved",
+        "charged",
+        "no_charge",
+        "voided"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -428,6 +428,13 @@
       "when": 1786274928585,
       "tag": "0060_warm_rawhide_kid",
       "breakpoints": true
+    },
+    {
+      "idx": 61,
+      "version": "7",
+      "when": 1786282239386,
+      "tag": "0061_majestic_rattler",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schema/messaging.ts
+++ b/packages/db/schema/messaging.ts
@@ -161,6 +161,15 @@ export const locationMessaging = pgTable(
       .notNull()
       .default("not_started"),
     registrationDetail: text("registration_detail"),
+    // Short-lived operator attestation that the provider profile, number,
+    // webhook, campaign, destination allowlist, and spend cap all read back in
+    // the safe launch state. Clinic enablement requires a fresh attestation.
+    providerProfileReady: boolean("provider_profile_ready")
+      .notNull()
+      .default(false),
+    providerProfileSyncedAt: timestamp("provider_profile_synced_at", {
+      withTimezone: true,
+    }),
     // Master switch — sending is allowed only when enabled AND registration is active.
     enabled: boolean("enabled").notNull().default(false),
   },


### PR DESCRIPTION
## Summary

- add exact Telnyx messaging-profile readback, activation, deactivation, and operator controls
- require a fresh provider safety attestation before a hosted clinic can enable sending
- fail closed at outbound transport resolution until the provider profile is verified
- invalidate readiness whenever carrier or sender identity state changes
- expose provider blockers and readiness in clinic and platform operator surfaces
- add a public HTTPS callback invariant shared by provisioning and activation
- document the controlled pilot activation and kill sequence

## Safety

- production messaging flags and allowlists remain unchanged
- provider profiles are still created disabled
- activating a provider profile leaves the clinic sender disabled
- no SMS was sent and no provider mutation or spend occurred during development
- migrated rows default to not ready, and hosted outbound resolution rejects them until verified

## Verification

- 312 test files passed, 3,140 tests total
- database and web type checks passed
- optimized production build passed
- migration and targeted provider lifecycle tests passed
- adversarial review findings for stale identities, concurrent state, legacy enabled rows, and local webhook origins were fixed before publication