### PR TITLE
Use clinic name in billing PDFs

### DIFF
--- a/apps/web/app/(dashboard)/billing/page.tsx
+++ b/apps/web/app/(dashboard)/billing/page.tsx
@@ -377,7 +377,7 @@ export default function BillingPage() {
         </div>
       ) : isListLoading ? (
         <TableSkeleton rows={8} cols={7} />
-      ) : data && data.items.length > 0 ? (
+      ) : data && verifiedBillingConfig && data.items.length > 0 ? (
         <>
           <TableScroll className="mt-6 rounded-lg border border-border">
             <table className="w-full text-sm">
@@ -424,6 +424,7 @@ export default function BillingPage() {
                     onStatusChange={handleStatusChange}
                     onConvertEstimate={handleConvertEstimate}
                     onVoidInvoice={handleVoidInvoice}
+                    practiceName={verifiedBillingConfig.practiceName}
                     billingTimeZone={billingTimeZone}
                     canManageBilling={canManageBilling}
                     isMutating={
@@ -968,6 +969,7 @@ function InvoiceRow({
   onStatusChange,
   onConvertEstimate,
   onVoidInvoice,
+  practiceName,
   billingTimeZone,
   canManageBilling,
   isMutating,
@@ -996,6 +998,7 @@ function InvoiceRow({
   ) => void;
   onConvertEstimate: (e: React.MouseEvent, id: string) => void;
   onVoidInvoice: (e: React.MouseEvent, id: string) => void;
+  practiceName: string;
   billingTimeZone?: string | null;
   canManageBilling: boolean;
   isMutating: boolean;
@@ -1146,7 +1149,7 @@ function InvoiceRow({
                             .join(" ");
                           const { generateInvoicePdf } = await import("@/lib/pdf");
                           generateInvoicePdf({
-                            practiceName: "Your Practice",
+                            practiceName,
                             clientName,
                             clientEmail: d.clientEmail ?? undefined,
                             patientName: d.patientName ?? undefined,
@@ -1332,7 +1335,7 @@ function InvoiceRow({
                             .join(" ");
                           const { generateInvoicePdf } = await import("@/lib/pdf");
                           generateInvoicePdf({
-                            practiceName: "Your Practice",
+                            practiceName,
                             clientName,
                             clientEmail: d.clientEmail ?? undefined,
                             patientName: d.patientName ?? undefined,

--- a/apps/web/lib/__tests__/billing-ui.test.ts
+++ b/apps/web/lib/__tests__/billing-ui.test.ts
@@ -347,6 +347,27 @@ describe("billing invoice payment actions", () => {
     );
     expect(source).not.toContain("billingConfig.data?.timezone");
   });
+
+  it("uses the loaded clinic name in both estimate and invoice PDFs", () => {
+    const estimatePdfBlock = source.slice(
+      source.indexOf("{/* Estimate Approval Card */}"),
+      source.indexOf('<div className="flex items-center gap-6 text-sm">')
+    );
+    const invoicePdfBlock = source.slice(
+      source.indexOf("{/* Balance Summary */}"),
+      source.indexOf("{/* Payment History & Record Payment */}")
+    );
+
+    expect(source).toContain(
+      "data && verifiedBillingConfig && data.items.length > 0"
+    );
+    expect(source).toContain(
+      "practiceName={verifiedBillingConfig.practiceName}"
+    );
+    expect(estimatePdfBlock).toContain("practiceName,");
+    expect(invoicePdfBlock).toContain("practiceName,");
+    expect(source).not.toContain('practiceName: "Your Practice"');
+  });
 });
 
 describe("medication dispense billing queue", () => {

--- a/apps/web/server/__tests__/billing-list-inputs.test.ts
+++ b/apps/web/server/__tests__/billing-list-inputs.test.ts
@@ -43,9 +43,10 @@ afterEach(() => {
 });
 
 describe("billing list input validation", () => {
-  it("returns the practice timezone with billing tax config", async () => {
+  it("returns the authenticated practice identity with billing config", async () => {
     const result = [
       {
+        practiceName: "Harbor Veterinary Clinic",
         taxRatePercent: "8.75",
         currency: "cad",
         country: "CA",
@@ -61,6 +62,7 @@ describe("billing list input validation", () => {
     db.select = vi.fn(() => builder);
 
     await expect(callerWithDb(db).getTaxConfig()).resolves.toEqual({
+      practiceName: "Harbor Veterinary Clinic",
       taxRatePercent: "8.75",
       currency: "cad",
       country: "CA",

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -1591,11 +1591,13 @@ async function restoreProductStock(
 }
 
 export const billingRouter = createRouter({
-  // Region-aware billing config for the practice (tax rate + currency).
-  // Available to any authenticated user so invoice forms can preview totals.
+  // Region-aware billing config and display identity for the practice.
+  // Available to any authenticated user so billing screens and client-facing
+  // documents use the authenticated tenant's settings.
   getTaxConfig: protectedProcedure.query(async ({ ctx }) => {
     const [practice] = await ctx.db
       .select({
+        practiceName: practices.name,
         taxRatePercent: practices.taxRatePercent,
         currency: practices.currency,
         country: practices.country,
@@ -1608,6 +1610,7 @@ export const billingRouter = createRouter({
       throw practiceNotFound();
     }
     return {
+      practiceName: practice.practiceName,
       taxRatePercent: practice.taxRatePercent ?? "8.00",
       currency: practice.currency ?? "usd",
       country: practice.country ?? "US",


### PR DESCRIPTION
## Summary
- use the authenticated practice name in estimate PDFs
- use the authenticated practice name in invoice PDFs
- keep document actions gated until tenant billing configuration is loaded
- add regression coverage for both PDF paths and tenant scoping

## Verification
- 23 focused tests
- `pnpm --filter @openpims/web type-check`
- `pnpm --filter @openpims/web build`

No schema changes, external sends, or provider mutations.