### PR TITLE
Track auth email delivery and recovery

### DIFF
--- a/apps/web/app/api/webhooks/resend/route.test.ts
+++ b/apps/web/app/api/webhooks/resend/route.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 const ROUTE_SOURCE = readFileSync(
   fileURLToPath(new URL("./route.ts", import.meta.url)),
-  "utf8"
+  "utf8",
 );
 
 const mocks = vi.hoisted(() => {
@@ -45,15 +45,23 @@ const mocks = vi.hoisted(() => {
     updateWhere,
     verify,
     Resend,
+    recordAuthEmailDeliveryEvent: vi.fn(
+      async (): Promise<{
+        tracked: boolean;
+        duplicate: boolean;
+        attribution: string | null;
+      }> => ({
+        tracked: false,
+        duplicate: false,
+        attribution: null,
+      }),
+    ),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
-      fn(db)
+      fn(db),
     ),
     withTenant: vi.fn(
-      async (
-        _db: unknown,
-        _practiceId: string,
-        fn: (tx: unknown) => unknown
-      ) => fn(db)
+      async (_db: unknown, _practiceId: string, fn: (tx: unknown) => unknown) =>
+        fn(db),
     ),
   };
 });
@@ -71,10 +79,13 @@ vi.mock("@/lib/tenant-db", () => ({
   withTenant: mocks.withTenant,
 }));
 
+vi.mock("@/lib/auth-email-delivery", () => ({
+  recordAuthEmailDeliveryEvent: mocks.recordAuthEmailDeliveryEvent,
+}));
+
 const { POST } = await import("./route");
-const { EMAIL_WEBHOOK_BODY_MAX_BYTES } = await import(
-  "@/lib/email-webhook-limits"
-);
+const { EMAIL_WEBHOOK_BODY_MAX_BYTES } =
+  await import("@/lib/email-webhook-limits");
 
 const PRACTICE_ID = "00000000-0000-0000-0000-0000000000aa";
 const COMMUNICATION_ID = "00000000-0000-0000-0000-0000000000cc";
@@ -95,6 +106,11 @@ function signedRequest(body: string, headers?: Record<string, string>) {
 afterEach(() => {
   vi.clearAllMocks();
   mocks.selectResults.length = 0;
+  mocks.recordAuthEmailDeliveryEvent.mockResolvedValue({
+    tracked: false,
+    duplicate: false,
+    attribution: null,
+  });
   delete process.env.RESEND_WEBHOOK_SECRET;
   delete process.env.RESEND_API_KEY;
 });
@@ -104,7 +120,7 @@ describe("Resend webhook", () => {
     const response = await POST(
       signedRequest("{}", {
         "content-length": String(EMAIL_WEBHOOK_BODY_MAX_BYTES + 1),
-      })
+      }),
     );
 
     expect(response.status).toBe(413);
@@ -118,7 +134,7 @@ describe("Resend webhook", () => {
 
   it("rejects streamed oversized payloads without a content-length header", async () => {
     const response = await POST(
-      signedRequest("x".repeat(EMAIL_WEBHOOK_BODY_MAX_BYTES + 1))
+      signedRequest("x".repeat(EMAIL_WEBHOOK_BODY_MAX_BYTES + 1)),
     );
 
     expect(response.status).toBe(413);
@@ -141,7 +157,7 @@ describe("Resend webhook", () => {
       new Request("https://openvpm.test/api/webhooks/resend", {
         method: "POST",
         body: "{}",
-      })
+      }),
     );
 
     expect(response.status).toBe(401);
@@ -199,7 +215,7 @@ describe("Resend webhook", () => {
     expect(mocks.withTenant).toHaveBeenCalledWith(
       mocks.db,
       PRACTICE_ID,
-      expect.any(Function)
+      expect.any(Function),
     );
     expect(mocks.updateSet).toHaveBeenCalledWith({ status: "delivered" });
     expect(mocks.insertValues).not.toHaveBeenCalled();
@@ -242,6 +258,48 @@ describe("Resend webhook", () => {
     expect(mocks.insertConflict).toHaveBeenCalledTimes(1);
   });
 
+  it("records verification evidence without polluting client suppressions", async () => {
+    process.env.RESEND_WEBHOOK_SECRET = "whsec_test";
+    const event = {
+      type: "email.bounced" as const,
+      created_at: "2026-06-29T12:00:00Z",
+      data: {
+        email_id: "email-auth-1",
+        from: "OpenVPM <noreply@mail.openvpm.com>",
+        to: ["owner@example.com"],
+        subject: "Verify your OpenVPM email",
+        created_at: "2026-06-29T12:00:00Z",
+        tags: {
+          openvpm_email_kind: "auth_verification",
+          openvpm_attempt_id: "00000000-0000-4000-8000-000000000001",
+        },
+        bounce: {
+          message: "Mailbox unavailable",
+          subType: "General",
+          type: "Permanent",
+        },
+      },
+    };
+    mocks.verify.mockReturnValue(event);
+    mocks.recordAuthEmailDeliveryEvent.mockResolvedValue({
+      tracked: true,
+      duplicate: false,
+      attribution: "attempt_tag",
+    });
+
+    const response = await POST(signedRequest("{}"));
+
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(mocks.recordAuthEmailDeliveryEvent).toHaveBeenCalledWith({
+      event,
+      webhookId: "msg_123",
+      db: mocks.db,
+    });
+    expect(mocks.withTenant).not.toHaveBeenCalled();
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+  });
+
   it("acks unmatched provider events without creating suppressions", async () => {
     process.env.RESEND_WEBHOOK_SECRET = "whsec_test";
     mocks.verify.mockReturnValue({
@@ -267,7 +325,7 @@ describe("Resend webhook", () => {
 
   it("matches provider email events only for active practices", () => {
     const matchLookup = ROUTE_SOURCE.match(
-      /const matches = await withSystem[\s\S]+?\.limit\(20\)/
+      /const matches = await withSystem[\s\S]+?\.limit\(20\)/,
     )?.[0];
 
     expect(matchLookup).toContain("innerJoin(");

--- a/apps/web/app/api/webhooks/resend/route.test.ts
+++ b/apps/web/app/api/webhooks/resend/route.test.ts
@@ -49,13 +49,16 @@ const mocks = vi.hoisted(() => {
       async (): Promise<{
         tracked: boolean;
         duplicate: boolean;
+        conflict: boolean;
         attribution: string | null;
       }> => ({
         tracked: false,
         duplicate: false,
+        conflict: false,
         attribution: null,
       }),
     ),
+    authEmailWebhookFingerprint: vi.fn(() => "f".repeat(64)),
     withSystem: vi.fn(async (_db: unknown, fn: (tx: unknown) => unknown) =>
       fn(db),
     ),
@@ -81,6 +84,7 @@ vi.mock("@/lib/tenant-db", () => ({
 
 vi.mock("@/lib/auth-email-delivery", () => ({
   recordAuthEmailDeliveryEvent: mocks.recordAuthEmailDeliveryEvent,
+  authEmailWebhookFingerprint: mocks.authEmailWebhookFingerprint,
 }));
 
 const { POST } = await import("./route");
@@ -109,6 +113,7 @@ afterEach(() => {
   mocks.recordAuthEmailDeliveryEvent.mockResolvedValue({
     tracked: false,
     duplicate: false,
+    conflict: false,
     attribution: null,
   });
   delete process.env.RESEND_WEBHOOK_SECRET;
@@ -284,6 +289,7 @@ describe("Resend webhook", () => {
     mocks.recordAuthEmailDeliveryEvent.mockResolvedValue({
       tracked: true,
       duplicate: false,
+      conflict: false,
       attribution: "attempt_tag",
     });
 
@@ -293,10 +299,42 @@ describe("Resend webhook", () => {
     expect(mocks.recordAuthEmailDeliveryEvent).toHaveBeenCalledWith({
       event,
       webhookId: "msg_123",
+      rawBodyFingerprint: "f".repeat(64),
       db: mocks.db,
     });
     expect(mocks.withTenant).not.toHaveBeenCalled();
     expect(mocks.updateSet).not.toHaveBeenCalled();
+    expect(mocks.insertValues).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a changed-body Svix identity conflict without tenant work", async () => {
+    process.env.RESEND_WEBHOOK_SECRET = "whsec_test";
+    mocks.verify.mockReturnValue({
+      type: "email.delivered",
+      created_at: "2026-06-29T12:00:00Z",
+      data: {
+        email_id: "email-auth-1",
+        from: "OpenVPM <noreply@mail.openvpm.com>",
+        to: ["owner@example.com"],
+        subject: "Verify your OpenVPM email",
+        created_at: "2026-06-29T12:00:00Z",
+        tags: { openvpm_email_kind: "auth_verification" },
+      },
+    });
+    mocks.recordAuthEmailDeliveryEvent.mockResolvedValue({
+      tracked: true,
+      duplicate: false,
+      conflict: true,
+      attribution: "identity_conflict",
+    });
+
+    const response = await POST(signedRequest("changed signed body"));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "webhook identity conflict",
+    });
+    expect(mocks.withTenant).not.toHaveBeenCalled();
     expect(mocks.insertValues).not.toHaveBeenCalled();
   });
 

--- a/apps/web/app/api/webhooks/resend/route.test.ts
+++ b/apps/web/app/api/webhooks/resend/route.test.ts
@@ -307,7 +307,7 @@ describe("Resend webhook", () => {
     expect(mocks.insertValues).not.toHaveBeenCalled();
   });
 
-  it("surfaces a changed-body Svix identity conflict without tenant work", async () => {
+  it("acknowledges a durably quarantined Svix identity conflict without tenant work", async () => {
     process.env.RESEND_WEBHOOK_SECRET = "whsec_test";
     mocks.verify.mockReturnValue({
       type: "email.delivered",
@@ -330,10 +330,8 @@ describe("Resend webhook", () => {
 
     const response = await POST(signedRequest("changed signed body"));
 
-    expect(response.status).toBe(409);
-    await expect(response.json()).resolves.toEqual({
-      error: "webhook identity conflict",
-    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
     expect(mocks.withTenant).not.toHaveBeenCalled();
     expect(mocks.insertValues).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/webhooks/resend/route.ts
+++ b/apps/web/app/api/webhooks/resend/route.ts
@@ -152,13 +152,11 @@ export async function POST(request: Request) {
     rawBodyFingerprint: authEmailWebhookFingerprint(rawBody.text),
     db,
   });
-  if (authDelivery.conflict) {
-    return NextResponse.json(
-      { error: "webhook identity conflict" },
-      { status: 409 },
-    );
-  }
   if (authDelivery.tracked) {
+    // Identity conflicts are acknowledged only after the recorder durably
+    // quarantines safe fingerprint/provider evidence. A database failure
+    // throws above and remains retryable; a committed conflict must not cause
+    // an infinite provider retry loop.
     return NextResponse.json({ ok: true });
   }
 

--- a/apps/web/app/api/webhooks/resend/route.ts
+++ b/apps/web/app/api/webhooks/resend/route.ts
@@ -14,25 +14,26 @@ import {
   type EmailSuppressionReason,
 } from "@/lib/email-suppression";
 import { emailEnv } from "@/lib/email-env";
+import {
+  recordAuthEmailDeliveryEvent,
+  type AuthEmailWebhookEvent,
+} from "@/lib/auth-email-delivery";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type EmailWebhookEvent = Extract<
-  WebhookEventPayload,
-  { data: { email_id: string; to: string[] } }
->;
+type EmailWebhookEvent = AuthEmailWebhookEvent;
 
 function payloadTooLargeResponse() {
   return NextResponse.json(
     { error: "Email webhook payload too large" },
-    { status: 413 }
+    { status: 413 },
   );
 }
 
 function verifiedEvent(
   rawBody: string,
-  headers: Headers
+  headers: Headers,
 ): WebhookEventPayload | null {
   const webhookSecret = emailEnv("RESEND_WEBHOOK_SECRET");
   const id = headers.get("svix-id");
@@ -42,7 +43,9 @@ function verifiedEvent(
   if (!webhookSecret || !id || !timestamp || !signature) return null;
 
   try {
-    const resend = new Resend(emailEnv("RESEND_API_KEY") ?? "re_webhook_verify");
+    const resend = new Resend(
+      emailEnv("RESEND_API_KEY") ?? "re_webhook_verify",
+    );
     return resend.webhooks.verify({
       payload: rawBody,
       webhookSecret,
@@ -54,14 +57,14 @@ function verifiedEvent(
 }
 
 function isEmailWebhookEvent(
-  event: WebhookEventPayload
+  event: WebhookEventPayload,
 ): event is EmailWebhookEvent {
   const data = (event as { data?: { email_id?: unknown; to?: unknown } }).data;
   return typeof data?.email_id === "string" && Array.isArray(data.to);
 }
 
 function communicationStatusForEvent(
-  type: WebhookEventPayload["type"]
+  type: WebhookEventPayload["type"],
 ): "delivered" | "failed" | null {
   if (type === "email.delivered") return "delivered";
   if (
@@ -76,7 +79,7 @@ function communicationStatusForEvent(
 }
 
 function suppressionReasonForEvent(
-  type: WebhookEventPayload["type"]
+  type: WebhookEventPayload["type"],
 ): EmailSuppressionReason | null {
   if (type === "email.bounced") return "bounce";
   if (type === "email.complained") return "complaint";
@@ -89,7 +92,9 @@ function eventDetail(event: EmailWebhookEvent): string {
     return event.data.bounce?.message || "Resend reported a hard bounce.";
   }
   if (event.type === "email.failed") {
-    return event.data.failed?.reason || "Resend reported email delivery failed.";
+    return (
+      event.data.failed?.reason || "Resend reported email delivery failed."
+    );
   }
   if (event.type === "email.suppressed") {
     return (
@@ -103,11 +108,14 @@ function eventDetail(event: EmailWebhookEvent): string {
 }
 
 function groupByPractice(
-  rows: Array<{ id: string; practiceId: string }>
+  rows: Array<{ id: string; practiceId: string }>,
 ): Map<string, string[]> {
   const grouped = new Map<string, string[]>();
   for (const row of rows) {
-    grouped.set(row.practiceId, [...(grouped.get(row.practiceId) ?? []), row.id]);
+    grouped.set(row.practiceId, [
+      ...(grouped.get(row.practiceId) ?? []),
+      row.id,
+    ]);
   }
   return grouped;
 }
@@ -119,7 +127,7 @@ export async function POST(request: Request) {
 
   const rawBody = await readRequestTextWithLimit(
     request,
-    EMAIL_WEBHOOK_BODY_MAX_BYTES
+    EMAIL_WEBHOOK_BODY_MAX_BYTES,
   );
   if (!rawBody.ok) {
     return payloadTooLargeResponse();
@@ -131,6 +139,18 @@ export async function POST(request: Request) {
   }
 
   if (!isEmailWebhookEvent(event)) {
+    return NextResponse.json({ ok: true });
+  }
+
+  // Account-verification mail is system auth traffic, not a clinic-to-client
+  // communication. Claim its redacted evidence first and never turn its
+  // recipient into a clinic email suppression.
+  const authDelivery = await recordAuthEmailDeliveryEvent({
+    event,
+    webhookId: request.headers.get("svix-id")!,
+    db,
+  });
+  if (authDelivery.tracked) {
     return NextResponse.json({ ok: true });
   }
 
@@ -151,26 +171,26 @@ export async function POST(request: Request) {
         practices,
         and(
           eq(practices.id, communications.practiceId),
-          isNull(practices.deletedAt)
-        )
+          isNull(practices.deletedAt),
+        ),
       )
       .where(
         and(
           eq(communications.providerMessageId, event.data.email_id),
           eq(communications.channel, "email"),
           eq(communications.direction, "outbound"),
-          isNull(communications.deletedAt)
-        )
+          isNull(communications.deletedAt),
+        ),
       )
-      .limit(20)
+      .limit(20),
   );
 
   const recipients = Array.from(
     new Set(
       event.data.to
         .map((email) => normalizeEmailSuppressionAddress(email))
-        .filter((email): email is string => Boolean(email))
-    )
+        .filter((email): email is string => Boolean(email)),
+    ),
   );
   const detail = eventDetail(event);
 
@@ -190,10 +210,10 @@ export async function POST(request: Request) {
                 communications.status,
                 status === "delivered"
                   ? ["pending", "sent"]
-                  : ["pending", "sent", "delivered"]
+                  : ["pending", "sent", "delivered"],
               ),
-              isNull(communications.deletedAt)
-            )
+              isNull(communications.deletedAt),
+            ),
           );
       }
 
@@ -206,7 +226,7 @@ export async function POST(request: Request) {
               email,
               reason: suppressionReason,
               detail,
-            }))
+            })),
           )
           .onConflictDoNothing({
             target: [emailSuppressions.practiceId, emailSuppressions.email],

--- a/apps/web/app/api/webhooks/resend/route.ts
+++ b/apps/web/app/api/webhooks/resend/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/email-suppression";
 import { emailEnv } from "@/lib/email-env";
 import {
+  authEmailWebhookFingerprint,
   recordAuthEmailDeliveryEvent,
   type AuthEmailWebhookEvent,
 } from "@/lib/auth-email-delivery";
@@ -148,8 +149,15 @@ export async function POST(request: Request) {
   const authDelivery = await recordAuthEmailDeliveryEvent({
     event,
     webhookId: request.headers.get("svix-id")!,
+    rawBodyFingerprint: authEmailWebhookFingerprint(rawBody.text),
     db,
   });
+  if (authDelivery.conflict) {
+    return NextResponse.json(
+      { error: "webhook identity conflict" },
+      { status: 409 },
+    );
+  }
   if (authDelivery.tracked) {
     return NextResponse.json({ ok: true });
   }

--- a/apps/web/components/layout/verify-email-banner.tsx
+++ b/apps/web/components/layout/verify-email-banner.tsx
@@ -77,9 +77,10 @@ export function VerifyEmailBanner() {
     !resend.isSuccess ||
     Boolean(
       resend.data &&
-        !resend.data.alreadyVerified &&
-        !resend.data.verificationEmailSent &&
-        !resend.data.possiblySent,
+      !resend.data.alreadyVerified &&
+      !resend.data.verificationEmailSent &&
+      !resend.data.verificationEmailPreviewed &&
+      !resend.data.possiblySent,
     );
 
   return (
@@ -89,7 +90,8 @@ export function VerifyEmailBanner() {
       <p className="min-w-0 flex-1 basis-48">
         {resend.isSuccess && resend.data ? (
           <span className="inline-flex items-center gap-1.5">
-            {resend.data.verificationEmailSent ? (
+            {resend.data.verificationEmailSent ||
+            resend.data.verificationEmailPreviewed ? (
               <Check className="h-4 w-4" />
             ) : (
               <AlertTriangle className="h-4 w-4" />
@@ -98,8 +100,8 @@ export function VerifyEmailBanner() {
           </span>
         ) : (
           <>
-            Verify your email{data.email ? ` (${data.email})` : ""} to secure your
-            account and keep reminders deliverable.
+            Verify your email{data.email ? ` (${data.email})` : ""} to secure
+            your account and keep reminders deliverable.
           </>
         )}
         {resend.error ? (
@@ -115,7 +117,9 @@ export function VerifyEmailBanner() {
           onClick={() => resend.mutate()}
           className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-amber-300 bg-white px-2.5 py-1 text-xs font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-50"
         >
-          {resend.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+          {resend.isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : null}
           Resend email
         </button>
       )}

--- a/apps/web/components/layout/verify-email-banner.tsx
+++ b/apps/web/components/layout/verify-email-banner.tsx
@@ -73,14 +73,28 @@ export function VerifyEmailBanner() {
 
   if (!data.verificationEnabled || data.emailVerified) return null;
 
+  const showResendAction =
+    !resend.isSuccess ||
+    Boolean(
+      resend.data &&
+        !resend.data.alreadyVerified &&
+        !resend.data.verificationEmailSent &&
+        !resend.data.possiblySent,
+    );
+
   return (
     // Wraps at phone widths so the resend button never clips off-screen.
     <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-900 sm:px-6">
       <Mail className="hidden h-4 w-4 shrink-0 sm:block" />
       <p className="min-w-0 flex-1 basis-48">
-        {resend.isSuccess ? (
+        {resend.isSuccess && resend.data ? (
           <span className="inline-flex items-center gap-1.5">
-            <Check className="h-4 w-4" /> Verification email sent. Check your inbox (and spam).
+            {resend.data.verificationEmailSent ? (
+              <Check className="h-4 w-4" />
+            ) : (
+              <AlertTriangle className="h-4 w-4" />
+            )}
+            {resend.data.message}
           </span>
         ) : (
           <>
@@ -94,7 +108,7 @@ export function VerifyEmailBanner() {
           </span>
         ) : null}
       </p>
-      {!resend.isSuccess && (
+      {showResendAction && (
         <button
           type="button"
           disabled={resend.isPending}

--- a/apps/web/lib/__tests__/auth-email-delivery.test.ts
+++ b/apps/web/lib/__tests__/auth-email-delivery.test.ts
@@ -6,7 +6,9 @@ const mocks = vi.hoisted(() => {
     get systemDepth() {
       return systemDepth;
     },
+    verificationEmailProvider: vi.fn((): "resend" | "console" => "resend"),
     sendVerificationEmailWithProviderEvidence: vi.fn(),
+    alertOps: vi.fn(async () => undefined),
     withSystem: vi.fn(
       async (database: unknown, fn: (tx: unknown) => Promise<unknown>) => {
         systemDepth += 1;
@@ -20,46 +22,67 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("@openpims/db/client", () => ({ db: {} }));
 vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
+vi.mock("@/lib/alerts", () => ({ alertOps: mocks.alertOps }));
 vi.mock("@/lib/email", () => ({
+  verificationEmailProvider: mocks.verificationEmailProvider,
   sendVerificationEmailWithProviderEvidence:
     mocks.sendVerificationEmailWithProviderEvidence,
 }));
 
 const {
+  AUTH_EMAIL_WEBHOOK_REPAIR_MIN_AGE_MS,
   authEmailDeliveryClassification,
+  authEmailWebhookFingerprint,
   recordAuthEmailDeliveryEvent,
   sendTrackedVerificationEmail,
 } = await import("../auth-email-delivery");
 
+type ScriptValue = unknown[] | Error;
+
 function databaseDouble(options?: {
-  selectResults?: unknown[][];
-  deliveryInsertResults?: unknown[][];
-  updateResults?: unknown[][];
+  selectResults?: ScriptValue[];
+  deliveryInsertResults?: ScriptValue[];
+  updateResults?: ScriptValue[];
+  insertErrorAtCall?: number;
 }) {
   const selectResults = [...(options?.selectResults ?? [])];
-  const deliveryInsertResults = [...(options?.deliveryInsertResults ?? [])];
-  const updateResults = [...(options?.updateResults ?? [[{ id: "recorded" }]])];
+  const deliveryInsertResults = [
+    ...(options?.deliveryInsertResults ?? [[{ id: "event-recorded" }]]),
+  ];
+  const updateResults = [...(options?.updateResults ?? [])];
   const insertedValues: unknown[] = [];
   const updatedValues: unknown[] = [];
 
-  const selectLimit = vi.fn(async () => selectResults.shift() ?? []);
+  const selectLimit = vi.fn(async () => {
+    const next = selectResults.shift() ?? [];
+    if (next instanceof Error) throw next;
+    return next;
+  });
   const selectWhere = vi.fn(() => ({ limit: selectLimit }));
   const selectFrom = vi.fn(() => ({ where: selectWhere }));
   const select = vi.fn(() => ({ from: selectFrom }));
 
-  const insertReturning = vi.fn(
-    async () => deliveryInsertResults.shift() ?? [{ id: "event-recorded" }],
-  );
+  const insertReturning = vi.fn(async () => {
+    const next = deliveryInsertResults.shift() ?? [];
+    if (next instanceof Error) throw next;
+    return next;
+  });
   const onConflictDoNothing = vi.fn(() => ({ returning: insertReturning }));
   const insertValues = vi.fn((values: unknown) => {
     insertedValues.push(values);
+    if (insertedValues.length === options?.insertErrorAtCall) {
+      throw new Error("scripted insert failure");
+    }
     return { onConflictDoNothing };
   });
   const insert = vi.fn(() => ({ values: insertValues }));
 
-  const updateReturning = vi.fn(async () => updateResults.shift() ?? []);
+  const updateReturning = vi.fn(async () => {
+    const next = updateResults.shift() ?? [];
+    if (next instanceof Error) throw next;
+    return next;
+  });
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn((values: unknown) => {
     updatedValues.push(values);
@@ -74,6 +97,21 @@ function databaseDouble(options?: {
     updatedValues,
     insertReturning,
     onConflictDoNothing,
+    updateReturning,
+    updateWhere,
+    updateSet,
+  };
+}
+
+function acceptedState(
+  provider: "resend" | "console" = "resend",
+  providerMessageId = "provider-email-1",
+) {
+  return {
+    outcome: "accepted",
+    provider,
+    providerMessageId,
+    failureCode: null,
   };
 }
 
@@ -96,58 +134,66 @@ function webhookEvent(input?: {
   } as never;
 }
 
+function trackedInput(db: unknown) {
+  return {
+    practiceId: "00000000-0000-4000-8000-000000000001",
+    userId: "00000000-0000-4000-8000-000000000002",
+    source: "registration" as const,
+    to: "owner@example.com",
+    name: "Dr Owner",
+    verifyUrl: "https://app.openvpm.com/verify-email?token=never-persist-this",
+    db: db as never,
+  };
+}
+
 afterEach(() => {
   vi.clearAllMocks();
+  mocks.verificationEmailProvider.mockReturnValue("resend");
 });
 
 describe("tracked verification email dispatch", () => {
-  it("reserves before the provider call, sends outside the transaction, and records acceptance", async () => {
-    const { db, insertedValues, updatedValues } = databaseDouble();
+  it("commits reservation, calls the provider outside transactions, and resolves in another transaction", async () => {
+    const { db, insertedValues, updatedValues } = databaseDouble({
+      updateResults: [[acceptedState()]],
+      selectResults: [[]],
+    });
     mocks.sendVerificationEmailWithProviderEvidence.mockImplementation(
       async (payload: Record<string, unknown>) => {
         expect(mocks.systemDepth).toBe(0);
         expect(insertedValues).toHaveLength(1);
-        expect(payload.attemptId).toMatch(/^[0-9a-f-]{36}$/);
         expect(payload.idempotencyKey).toBe(
           `auth-email:${String(payload.attemptId)}`,
         );
         return {
           success: true,
+          provider: "resend",
           id: "provider-email-1",
           outcome: "accepted",
         };
       },
     );
 
-    const result = await sendTrackedVerificationEmail({
-      practiceId: "00000000-0000-4000-8000-000000000001",
-      userId: "00000000-0000-4000-8000-000000000002",
-      source: "registration",
-      to: "owner@example.com",
-      name: "Dr Owner",
-      verifyUrl:
-        "https://app.openvpm.com/verify-email?token=never-persist-this",
-      db: db as never,
-    });
+    const result = await sendTrackedVerificationEmail(trackedInput(db));
 
     expect(result).toMatchObject({
       success: true,
+      provider: "resend",
       outcome: "accepted",
+      possiblySent: false,
+      evidencePersisted: true,
       providerMessageId: "provider-email-1",
     });
     expect(insertedValues[0]).toMatchObject({
-      practiceId: "00000000-0000-4000-8000-000000000001",
-      userId: "00000000-0000-4000-8000-000000000002",
+      provider: "resend",
       source: "registration",
       idempotencyKey: `auth-email:${result.attemptId}`,
     });
-    expect(updatedValues).toEqual([
-      expect.objectContaining({
-        outcome: "accepted",
-        providerMessageId: "provider-email-1",
-        failureCode: null,
-      }),
-    ]);
+    expect(updatedValues[0]).toMatchObject({
+      outcome: "accepted",
+      providerMessageId: "provider-email-1",
+      failureCode: null,
+    });
+    expect(mocks.withSystem).toHaveBeenCalledTimes(3);
 
     const persisted = JSON.stringify({ insertedValues, updatedValues });
     expect(persisted).not.toContain("owner@example.com");
@@ -155,99 +201,208 @@ describe("tracked verification email dispatch", () => {
     expect(persisted).not.toContain("Dr Owner");
   });
 
-  it.each([
-    {
-      outcome: "definite_failure",
-      failureCode: "provider_rejected",
-    },
-    {
-      outcome: "outcome_unknown",
-      failureCode: "send_timeout",
-    },
-  ] as const)(
-    "records $outcome without provider identity",
-    async (expected) => {
-      const { db, updatedValues } = databaseDouble();
-      mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
-        success: false,
-        error: "provider detail shown only to the request",
-        ...expected,
-      });
-
-      const result = await sendTrackedVerificationEmail({
-        practiceId: "00000000-0000-4000-8000-000000000001",
-        userId: "00000000-0000-4000-8000-000000000002",
-        source: "authenticated_resend",
-        to: "owner@example.com",
-        name: "Dr Owner",
-        verifyUrl: "https://app.openvpm.com/verify-email?token=secret",
-        db: db as never,
-      });
-
-      expect(result.outcome).toBe(expected.outcome);
-      expect(updatedValues[0]).toMatchObject({
-        outcome: expected.outcome,
-        providerMessageId: null,
-        failureCode: expected.failureCode,
-      });
-      expect(JSON.stringify(updatedValues)).not.toContain("provider detail");
-    },
-  );
-
-  it("fails loudly when the reserved provider outcome cannot be persisted", async () => {
-    const { db } = databaseDouble({ updateResults: [[]] });
+  it("retries only the CAS after a transient persistence failure", async () => {
+    const { db } = databaseDouble({
+      updateResults: [new Error("transient"), [acceptedState()]],
+      selectResults: [[]],
+    });
     mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
       success: true,
+      provider: "resend",
       id: "provider-email-1",
       outcome: "accepted",
     });
 
     await expect(
-      sendTrackedVerificationEmail({
-        practiceId: "00000000-0000-4000-8000-000000000001",
-        userId: "00000000-0000-4000-8000-000000000002",
-        source: "registration",
-        to: "owner@example.com",
-        name: "Dr Owner",
-        verifyUrl: "https://app.openvpm.com/verify-email?token=secret",
-        db: db as never,
-      }),
-    ).rejects.toThrow(
-      "Verification email provider outcome could not be recorded safely.",
+      sendTrackedVerificationEmail(trackedInput(db)),
+    ).resolves.toMatchObject({ success: true, evidencePersisted: true });
+    expect(
+      mocks.sendVerificationEmailWithProviderEvidence,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns known acceptance and check-inbox semantics when persistence remains unavailable", async () => {
+    const { db } = databaseDouble({
+      updateResults: [new Error("db down"), new Error("db still down")],
+      selectResults: [new Error("read down")],
+    });
+    mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
+      success: true,
+      provider: "resend",
+      id: "provider-email-1",
+      outcome: "accepted",
+    });
+
+    await expect(
+      sendTrackedVerificationEmail(trackedInput(db)),
+    ).resolves.toMatchObject({
+      success: true,
+      outcome: "accepted",
+      possiblySent: false,
+      evidencePersisted: false,
+    });
+    expect(
+      mocks.sendVerificationEmailWithProviderEvidence,
+    ).toHaveBeenCalledTimes(1);
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Auth email outcome persistence failed",
+      expect.not.stringMatching(/owner|token|provider-email-1/i),
+    );
+  });
+
+  it("reports an unknown provider outcome as possibly sent, never retry-now", async () => {
+    const unknownState = {
+      outcome: "outcome_unknown",
+      provider: "resend",
+      providerMessageId: null,
+      failureCode: "send_timeout",
+    };
+    const { db } = databaseDouble({ updateResults: [[unknownState]] });
+    mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
+      success: false,
+      provider: "resend",
+      outcome: "outcome_unknown",
+      failureCode: "send_timeout",
+    });
+
+    const result = await sendTrackedVerificationEmail(trackedInput(db));
+
+    expect(result).toMatchObject({
+      success: false,
+      outcome: "outcome_unknown",
+      possiblySent: true,
+      evidencePersisted: true,
+    });
+    expect(result.error).toMatch(/may have been sent/i);
+    expect(result.error).not.toMatch(/try again|retry/i);
+  });
+
+  it("models local console acceptance without expecting Resend delivery", async () => {
+    mocks.verificationEmailProvider.mockReturnValue("console");
+    const { db, insertedValues } = databaseDouble({
+      updateResults: [[acceptedState("console", "dev-console:attempt")]],
+    });
+    mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
+      success: true,
+      provider: "console",
+      id: "dev-console:attempt",
+      outcome: "accepted",
+    });
+
+    await expect(
+      sendTrackedVerificationEmail(trackedInput(db)),
+    ).resolves.toMatchObject({
+      success: true,
+      provider: "console",
+      evidencePersisted: true,
+    });
+    expect(insertedValues[0]).toMatchObject({ provider: "console" });
+    expect(mocks.withSystem).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not call the provider when reservation commit fails", async () => {
+    const { db } = databaseDouble({ insertErrorAtCall: 1 });
+
+    await expect(
+      sendTrackedVerificationEmail(trackedInput(db)),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      possiblySent: false,
+      evidencePersisted: false,
+    });
+    expect(
+      mocks.sendVerificationEmailWithProviderEvidence,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("surfaces signed delivery evidence that disagrees with the provider result", async () => {
+    const { db } = databaseDouble({
+      updateResults: [[acceptedState()]],
+      selectResults: [[{ id: "mismatch-event" }]],
+    });
+    mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
+      success: true,
+      provider: "resend",
+      id: "provider-email-1",
+      outcome: "accepted",
+    });
+
+    await expect(
+      sendTrackedVerificationEmail(trackedInput(db)),
+    ).resolves.toMatchObject({
+      success: true,
+      identityConflict: true,
+      evidencePersisted: false,
+    });
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Auth email provider identity conflict",
+      expect.any(String),
     );
   });
 });
 
 describe("auth verification delivery evidence", () => {
   const attemptId = "00000000-0000-4000-8000-000000000010";
+  const rawBody = '{"type":"email.delivered"}';
+  const fingerprint = authEmailWebhookFingerprint(rawBody);
 
-  it("attributes an out-of-order callback by its attempt tag", async () => {
-    const { db, insertedValues } = databaseDouble({
-      selectResults: [[{ id: attemptId, providerMessageId: null }], []],
-    });
-
-    const result = await recordAuthEmailDeliveryEvent({
-      event: webhookEvent({
-        tags: {
-          openvpm_attempt_id: attemptId,
-          openvpm_email_kind: "auth_verification",
-        },
-      }),
-      webhookId: "svix-out-of-order",
+  function recordInput(db: unknown, event = webhookEvent()) {
+    return {
+      event,
+      webhookId: "svix-event-1",
+      rawBodyFingerprint: fingerprint,
       db: db as never,
+    };
+  }
+
+  it("computes a lowercase verified-raw-body SHA-256 fingerprint", () => {
+    expect(fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(fingerprint).toBe(
+      "535799124c18a17be0d968d1622289e68ac38bcb476da8a6532d9e4f256b7c0b",
+    );
+  });
+
+  it("links an early out-of-order tag callback without racing provider resolution", async () => {
+    const { db, insertedValues, updateSet } = databaseDouble({
+      selectResults: [
+        [],
+        [
+          {
+            id: attemptId,
+            createdAt: new Date(),
+            outcome: "reserved",
+            provider: "resend",
+            providerMessageId: null,
+          },
+        ],
+        [],
+      ],
     });
+
+    const result = await recordAuthEmailDeliveryEvent(
+      recordInput(
+        db,
+        webhookEvent({
+          tags: {
+            openvpm_attempt_id: attemptId,
+            openvpm_email_kind: "auth_verification",
+          },
+        }),
+      ),
+    );
 
     expect(result).toEqual({
       tracked: true,
       duplicate: false,
+      conflict: false,
       attribution: "attempt_tag",
     });
+    expect(updateSet).not.toHaveBeenCalled();
     expect(insertedValues[0]).toMatchObject({
-      webhookId: "svix-out-of-order",
+      rawBodyFingerprint: fingerprint,
       providerMessageId: "provider-email-1",
       attemptId,
-      eventType: "email.delivered",
-      classification: "delivered",
       attribution: "attempt_tag",
     });
     const persisted = JSON.stringify(insertedValues[0]);
@@ -256,17 +411,50 @@ describe("auth verification delivery evidence", () => {
     expect(persisted).not.toContain("openvpm_attempt_id");
   });
 
-  it("falls back to the exact provider message id when tags are absent", async () => {
+  it("repairs a stale reserved attempt from a consistent signed tag", async () => {
+    const { db, updateSet } = databaseDouble({
+      selectResults: [
+        [],
+        [
+          {
+            id: attemptId,
+            createdAt: new Date(
+              Date.now() - AUTH_EMAIL_WEBHOOK_REPAIR_MIN_AGE_MS - 1_000,
+            ),
+            outcome: "reserved",
+            provider: "resend",
+            providerMessageId: null,
+          },
+        ],
+        [],
+      ],
+    });
+
+    await recordAuthEmailDeliveryEvent(
+      recordInput(
+        db,
+        webhookEvent({
+          tags: { openvpm_attempt_id: attemptId },
+        }),
+      ),
+    );
+
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "accepted",
+        providerMessageId: "provider-email-1",
+        failureCode: null,
+      }),
+    );
+  });
+
+  it("falls back to the exact Resend message id when tags are absent", async () => {
     const { db, insertedValues } = databaseDouble({
-      selectResults: [[{ id: attemptId }]],
+      selectResults: [[], [{ id: attemptId }]],
     });
 
     await expect(
-      recordAuthEmailDeliveryEvent({
-        event: webhookEvent(),
-        webhookId: "svix-provider-fallback",
-        db: db as never,
-      }),
+      recordAuthEmailDeliveryEvent(recordInput(db)),
     ).resolves.toMatchObject({
       tracked: true,
       attribution: "provider_message_id",
@@ -277,28 +465,156 @@ describe("auth verification delivery evidence", () => {
     });
   });
 
+  it("deduplicates only the exact same Svix id and fingerprint", async () => {
+    const existing = {
+      rawBodyFingerprint: fingerprint,
+      provider: "resend",
+      providerMessageId: "provider-email-1",
+      eventType: "email.delivered",
+      attribution: "attempt_tag",
+    };
+    const { db, insertedValues } = databaseDouble({
+      selectResults: [[existing]],
+    });
+
+    await expect(
+      recordAuthEmailDeliveryEvent(recordInput(db)),
+    ).resolves.toEqual({
+      tracked: true,
+      duplicate: true,
+      conflict: false,
+      attribution: "attempt_tag",
+    });
+    expect(insertedValues).toEqual([]);
+  });
+
+  it("surfaces the same Svix id with a changed fingerprint as a PHI-free conflict", async () => {
+    const existing = {
+      rawBodyFingerprint: "0".repeat(64),
+      provider: "resend",
+      providerMessageId: "provider-email-1",
+      eventType: "email.delivered",
+      attribution: "attempt_tag",
+    };
+    const { db } = databaseDouble({ selectResults: [[existing]] });
+
+    await expect(
+      recordAuthEmailDeliveryEvent(recordInput(db)),
+    ).resolves.toEqual({
+      tracked: true,
+      duplicate: false,
+      conflict: true,
+      attribution: "identity_conflict",
+    });
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Auth email webhook identity conflict",
+      expect.not.stringMatching(/owner|provider-email-1|subject/i),
+    );
+  });
+
+  it("race-safely re-reads a winning exact insert before claiming duplicate", async () => {
+    const existing = {
+      rawBodyFingerprint: fingerprint,
+      provider: "resend",
+      providerMessageId: "provider-email-1",
+      eventType: "email.delivered",
+      attribution: "attempt_tag",
+    };
+    const { db } = databaseDouble({
+      selectResults: [
+        [],
+        [
+          {
+            id: attemptId,
+            createdAt: new Date(),
+            outcome: "reserved",
+            provider: "resend",
+            providerMessageId: null,
+          },
+        ],
+        [],
+        [existing],
+      ],
+      deliveryInsertResults: [[]],
+    });
+
+    await expect(
+      recordAuthEmailDeliveryEvent(
+        recordInput(
+          db,
+          webhookEvent({ tags: { openvpm_attempt_id: attemptId } }),
+        ),
+      ),
+    ).resolves.toMatchObject({ duplicate: true, conflict: false });
+  });
+
+  it("race-safely reports a winning insert with changed identity as conflict", async () => {
+    const racedIdentity = {
+      rawBodyFingerprint: "0".repeat(64),
+      provider: "resend",
+      providerMessageId: "different-provider-message",
+      eventType: "email.failed",
+      attribution: "attempt_tag",
+    };
+    const { db } = databaseDouble({
+      selectResults: [
+        [],
+        [
+          {
+            id: attemptId,
+            createdAt: new Date(),
+            outcome: "reserved",
+            provider: "resend",
+            providerMessageId: null,
+          },
+        ],
+        [],
+        [racedIdentity],
+      ],
+      deliveryInsertResults: [[]],
+    });
+
+    await expect(
+      recordAuthEmailDeliveryEvent(
+        recordInput(
+          db,
+          webhookEvent({ tags: { openvpm_attempt_id: attemptId } }),
+        ),
+      ),
+    ).resolves.toMatchObject({ duplicate: false, conflict: true });
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Auth email webhook identity conflict",
+      expect.any(String),
+    );
+  });
+
   it("quarantines conflicting tag and provider identities", async () => {
     const { db, insertedValues } = databaseDouble({
       selectResults: [
-        [{ id: attemptId, providerMessageId: "different-provider-id" }],
+        [],
+        [
+          {
+            id: attemptId,
+            createdAt: new Date(),
+            outcome: "accepted",
+            provider: "resend",
+            providerMessageId: "different-provider-id",
+          },
+        ],
         [],
       ],
     });
 
     await expect(
-      recordAuthEmailDeliveryEvent({
-        event: webhookEvent({
-          tags: {
-            openvpm_attempt_id: attemptId,
-            openvpm_email_kind: "auth_verification",
-          },
-        }),
-        webhookId: "svix-conflict",
-        db: db as never,
-      }),
-    ).resolves.toEqual({
+      recordAuthEmailDeliveryEvent(
+        recordInput(
+          db,
+          webhookEvent({ tags: { openvpm_attempt_id: attemptId } }),
+        ),
+      ),
+    ).resolves.toMatchObject({
       tracked: true,
-      duplicate: false,
+      conflict: true,
       attribution: "identity_conflict",
     });
     expect(insertedValues[0]).toMatchObject({
@@ -307,54 +623,26 @@ describe("auth verification delivery evidence", () => {
     });
   });
 
-  it("deduplicates redelivery by the signed Svix id", async () => {
-    const { db, onConflictDoNothing } = databaseDouble({
-      selectResults: [[{ id: attemptId, providerMessageId: null }], []],
-      deliveryInsertResults: [[]],
-    });
+  it("leaves ordinary client-email events to the communication path", async () => {
+    const { db, insertedValues } = databaseDouble({ selectResults: [[], []] });
 
     await expect(
-      recordAuthEmailDeliveryEvent({
-        event: webhookEvent({
-          tags: { openvpm_attempt_id: attemptId },
-        }),
-        webhookId: "svix-duplicate",
-        db: db as never,
-      }),
-    ).resolves.toMatchObject({ tracked: true, duplicate: true });
-    expect(onConflictDoNothing).toHaveBeenCalledWith(
-      expect.objectContaining({ target: expect.anything() }),
-    );
-  });
-
-  it("leaves ordinary client-email events to the existing communication path", async () => {
-    const { db, insertedValues } = databaseDouble({ selectResults: [[]] });
-
-    await expect(
-      recordAuthEmailDeliveryEvent({
-        event: webhookEvent(),
-        webhookId: "svix-client-email",
-        db: db as never,
-      }),
+      recordAuthEmailDeliveryEvent(recordInput(db)),
     ).resolves.toEqual({
       tracked: false,
       duplicate: false,
+      conflict: false,
       attribution: null,
     });
     expect(insertedValues).toEqual([]);
   });
 
-  it("classifies delivery events independently of arrival order", () => {
+  it("classifies redacted events without treating opens/clicks as verification", () => {
     expect(authEmailDeliveryClassification("email.delivered")).toBe(
       "delivered",
     );
-    expect(authEmailDeliveryClassification("email.sent")).toBe("sent");
-    expect(authEmailDeliveryClassification("email.delivery_delayed")).toBe(
-      "delayed",
-    );
+    expect(authEmailDeliveryClassification("email.opened")).toBe("opened");
+    expect(authEmailDeliveryClassification("email.clicked")).toBe("clicked");
     expect(authEmailDeliveryClassification("email.bounced")).toBe("failed");
-    expect(authEmailDeliveryClassification("email.complained")).toBe(
-      "complained",
-    );
   });
 });

--- a/apps/web/lib/__tests__/auth-email-delivery.test.ts
+++ b/apps/web/lib/__tests__/auth-email-delivery.test.ts
@@ -372,6 +372,93 @@ describe("tracked verification email dispatch", () => {
       expect.any(String),
     );
   });
+
+  it("durably records callback id A versus accepted API id B", async () => {
+    const { db, insertedValues } = databaseDouble({
+      updateResults: [[]],
+      selectResults: [[acceptedState("resend", "callback-id-a")]],
+    });
+    mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
+      success: true,
+      provider: "resend",
+      id: "api-id-b",
+      outcome: "accepted",
+    });
+
+    await expect(
+      sendTrackedVerificationEmail(trackedInput(db)),
+    ).resolves.toMatchObject({
+      success: true,
+      outcome: "accepted",
+      identityConflict: true,
+      evidencePersisted: false,
+      providerMessageId: "api-id-b",
+    });
+    expect(insertedValues[1]).toMatchObject({
+      provider: "resend",
+      source: "registration",
+      durableProviderMessageId: "callback-id-a",
+      conflictingProviderMessageId: "api-id-b",
+    });
+    expect(JSON.stringify(insertedValues[1])).not.toMatch(
+      /owner@example|token|subject|body/i,
+    );
+    expect(mocks.alertOps).toHaveBeenCalledTimes(1);
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Auth email provider identity conflict",
+      expect.any(String),
+    );
+  });
+
+  it("keeps accepted UX and emits a separate alert if identity conflict persistence fails", async () => {
+    const { db } = databaseDouble({
+      updateResults: [[]],
+      selectResults: [[acceptedState("resend", "callback-id-a")]],
+      insertErrorAtCall: 2,
+    });
+    mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
+      success: true,
+      provider: "resend",
+      id: "api-id-b",
+      outcome: "accepted",
+    });
+
+    await expect(
+      sendTrackedVerificationEmail(trackedInput(db)),
+    ).resolves.toMatchObject({
+      success: true,
+      outcome: "accepted",
+      identityConflict: true,
+      evidencePersisted: false,
+    });
+    expect(mocks.alertOps).toHaveBeenCalledTimes(1);
+    expect(mocks.alertOps).toHaveBeenCalledWith(
+      "Auth email provider identity conflict persistence failed",
+      expect.not.stringMatching(/callback-id-a|api-id-b|owner|token/i),
+    );
+    expect(
+      mocks.sendVerificationEmailWithProviderEvidence,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not alert again when the same provider identity conflict already exists", async () => {
+    const { db } = databaseDouble({
+      updateResults: [[]],
+      selectResults: [[acceptedState("resend", "callback-id-a")]],
+      deliveryInsertResults: [[]],
+    });
+    mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
+      success: true,
+      provider: "resend",
+      id: "api-id-b",
+      outcome: "accepted",
+    });
+
+    await expect(
+      sendTrackedVerificationEmail(trackedInput(db)),
+    ).resolves.toMatchObject({ success: true, identityConflict: true });
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
 });
 
 describe("auth verification delivery evidence", () => {

--- a/apps/web/lib/__tests__/auth-email-delivery.test.ts
+++ b/apps/web/lib/__tests__/auth-email-delivery.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  let systemDepth = 0;
+  return {
+    get systemDepth() {
+      return systemDepth;
+    },
+    sendVerificationEmailWithProviderEvidence: vi.fn(),
+    withSystem: vi.fn(
+      async (database: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        systemDepth += 1;
+        try {
+          return await fn(database);
+        } finally {
+          systemDepth -= 1;
+        }
+      },
+    ),
+  };
+});
+
+vi.mock("@openpims/db/client", () => ({ db: {} }));
+vi.mock("@/lib/tenant-db", () => ({ withSystem: mocks.withSystem }));
+vi.mock("@/lib/email", () => ({
+  sendVerificationEmailWithProviderEvidence:
+    mocks.sendVerificationEmailWithProviderEvidence,
+}));
+
+const {
+  authEmailDeliveryClassification,
+  recordAuthEmailDeliveryEvent,
+  sendTrackedVerificationEmail,
+} = await import("../auth-email-delivery");
+
+function databaseDouble(options?: {
+  selectResults?: unknown[][];
+  deliveryInsertResults?: unknown[][];
+  updateResults?: unknown[][];
+}) {
+  const selectResults = [...(options?.selectResults ?? [])];
+  const deliveryInsertResults = [...(options?.deliveryInsertResults ?? [])];
+  const updateResults = [...(options?.updateResults ?? [[{ id: "recorded" }]])];
+  const insertedValues: unknown[] = [];
+  const updatedValues: unknown[] = [];
+
+  const selectLimit = vi.fn(async () => selectResults.shift() ?? []);
+  const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+  const selectFrom = vi.fn(() => ({ where: selectWhere }));
+  const select = vi.fn(() => ({ from: selectFrom }));
+
+  const insertReturning = vi.fn(
+    async () => deliveryInsertResults.shift() ?? [{ id: "event-recorded" }],
+  );
+  const onConflictDoNothing = vi.fn(() => ({ returning: insertReturning }));
+  const insertValues = vi.fn((values: unknown) => {
+    insertedValues.push(values);
+    return { onConflictDoNothing };
+  });
+  const insert = vi.fn(() => ({ values: insertValues }));
+
+  const updateReturning = vi.fn(async () => updateResults.shift() ?? []);
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const updateSet = vi.fn((values: unknown) => {
+    updatedValues.push(values);
+    return { where: updateWhere };
+  });
+  const update = vi.fn(() => ({ set: updateSet }));
+
+  const db = { select, insert, update };
+  return {
+    db,
+    insertedValues,
+    updatedValues,
+    insertReturning,
+    onConflictDoNothing,
+  };
+}
+
+function webhookEvent(input?: {
+  type?: string;
+  tags?: Record<string, string>;
+  providerMessageId?: string;
+}) {
+  return {
+    type: input?.type ?? "email.delivered",
+    created_at: "2026-08-09T12:00:00.000Z",
+    data: {
+      email_id: input?.providerMessageId ?? "provider-email-1",
+      created_at: "2026-08-09T11:59:59.000Z",
+      from: "OpenVPM <noreply@mail.openvpm.com>",
+      to: ["owner@example.com"],
+      subject: "Verify your OpenVPM email",
+      ...(input?.tags ? { tags: input.tags } : {}),
+    },
+  } as never;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("tracked verification email dispatch", () => {
+  it("reserves before the provider call, sends outside the transaction, and records acceptance", async () => {
+    const { db, insertedValues, updatedValues } = databaseDouble();
+    mocks.sendVerificationEmailWithProviderEvidence.mockImplementation(
+      async (payload: Record<string, unknown>) => {
+        expect(mocks.systemDepth).toBe(0);
+        expect(insertedValues).toHaveLength(1);
+        expect(payload.attemptId).toMatch(/^[0-9a-f-]{36}$/);
+        expect(payload.idempotencyKey).toBe(
+          `auth-email:${String(payload.attemptId)}`,
+        );
+        return {
+          success: true,
+          id: "provider-email-1",
+          outcome: "accepted",
+        };
+      },
+    );
+
+    const result = await sendTrackedVerificationEmail({
+      practiceId: "00000000-0000-4000-8000-000000000001",
+      userId: "00000000-0000-4000-8000-000000000002",
+      source: "registration",
+      to: "owner@example.com",
+      name: "Dr Owner",
+      verifyUrl:
+        "https://app.openvpm.com/verify-email?token=never-persist-this",
+      db: db as never,
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      outcome: "accepted",
+      providerMessageId: "provider-email-1",
+    });
+    expect(insertedValues[0]).toMatchObject({
+      practiceId: "00000000-0000-4000-8000-000000000001",
+      userId: "00000000-0000-4000-8000-000000000002",
+      source: "registration",
+      idempotencyKey: `auth-email:${result.attemptId}`,
+    });
+    expect(updatedValues).toEqual([
+      expect.objectContaining({
+        outcome: "accepted",
+        providerMessageId: "provider-email-1",
+        failureCode: null,
+      }),
+    ]);
+
+    const persisted = JSON.stringify({ insertedValues, updatedValues });
+    expect(persisted).not.toContain("owner@example.com");
+    expect(persisted).not.toContain("never-persist-this");
+    expect(persisted).not.toContain("Dr Owner");
+  });
+
+  it.each([
+    {
+      outcome: "definite_failure",
+      failureCode: "provider_rejected",
+    },
+    {
+      outcome: "outcome_unknown",
+      failureCode: "send_timeout",
+    },
+  ] as const)(
+    "records $outcome without provider identity",
+    async (expected) => {
+      const { db, updatedValues } = databaseDouble();
+      mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
+        success: false,
+        error: "provider detail shown only to the request",
+        ...expected,
+      });
+
+      const result = await sendTrackedVerificationEmail({
+        practiceId: "00000000-0000-4000-8000-000000000001",
+        userId: "00000000-0000-4000-8000-000000000002",
+        source: "authenticated_resend",
+        to: "owner@example.com",
+        name: "Dr Owner",
+        verifyUrl: "https://app.openvpm.com/verify-email?token=secret",
+        db: db as never,
+      });
+
+      expect(result.outcome).toBe(expected.outcome);
+      expect(updatedValues[0]).toMatchObject({
+        outcome: expected.outcome,
+        providerMessageId: null,
+        failureCode: expected.failureCode,
+      });
+      expect(JSON.stringify(updatedValues)).not.toContain("provider detail");
+    },
+  );
+
+  it("fails loudly when the reserved provider outcome cannot be persisted", async () => {
+    const { db } = databaseDouble({ updateResults: [[]] });
+    mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
+      success: true,
+      id: "provider-email-1",
+      outcome: "accepted",
+    });
+
+    await expect(
+      sendTrackedVerificationEmail({
+        practiceId: "00000000-0000-4000-8000-000000000001",
+        userId: "00000000-0000-4000-8000-000000000002",
+        source: "registration",
+        to: "owner@example.com",
+        name: "Dr Owner",
+        verifyUrl: "https://app.openvpm.com/verify-email?token=secret",
+        db: db as never,
+      }),
+    ).rejects.toThrow(
+      "Verification email provider outcome could not be recorded safely.",
+    );
+  });
+});
+
+describe("auth verification delivery evidence", () => {
+  const attemptId = "00000000-0000-4000-8000-000000000010";
+
+  it("attributes an out-of-order callback by its attempt tag", async () => {
+    const { db, insertedValues } = databaseDouble({
+      selectResults: [[{ id: attemptId, providerMessageId: null }], []],
+    });
+
+    const result = await recordAuthEmailDeliveryEvent({
+      event: webhookEvent({
+        tags: {
+          openvpm_attempt_id: attemptId,
+          openvpm_email_kind: "auth_verification",
+        },
+      }),
+      webhookId: "svix-out-of-order",
+      db: db as never,
+    });
+
+    expect(result).toEqual({
+      tracked: true,
+      duplicate: false,
+      attribution: "attempt_tag",
+    });
+    expect(insertedValues[0]).toMatchObject({
+      webhookId: "svix-out-of-order",
+      providerMessageId: "provider-email-1",
+      attemptId,
+      eventType: "email.delivered",
+      classification: "delivered",
+      attribution: "attempt_tag",
+    });
+    const persisted = JSON.stringify(insertedValues[0]);
+    expect(persisted).not.toContain("owner@example.com");
+    expect(persisted).not.toContain("Verify your OpenVPM email");
+    expect(persisted).not.toContain("openvpm_attempt_id");
+  });
+
+  it("falls back to the exact provider message id when tags are absent", async () => {
+    const { db, insertedValues } = databaseDouble({
+      selectResults: [[{ id: attemptId }]],
+    });
+
+    await expect(
+      recordAuthEmailDeliveryEvent({
+        event: webhookEvent(),
+        webhookId: "svix-provider-fallback",
+        db: db as never,
+      }),
+    ).resolves.toMatchObject({
+      tracked: true,
+      attribution: "provider_message_id",
+    });
+    expect(insertedValues[0]).toMatchObject({
+      attemptId,
+      attribution: "provider_message_id",
+    });
+  });
+
+  it("quarantines conflicting tag and provider identities", async () => {
+    const { db, insertedValues } = databaseDouble({
+      selectResults: [
+        [{ id: attemptId, providerMessageId: "different-provider-id" }],
+        [],
+      ],
+    });
+
+    await expect(
+      recordAuthEmailDeliveryEvent({
+        event: webhookEvent({
+          tags: {
+            openvpm_attempt_id: attemptId,
+            openvpm_email_kind: "auth_verification",
+          },
+        }),
+        webhookId: "svix-conflict",
+        db: db as never,
+      }),
+    ).resolves.toEqual({
+      tracked: true,
+      duplicate: false,
+      attribution: "identity_conflict",
+    });
+    expect(insertedValues[0]).toMatchObject({
+      attemptId: null,
+      attribution: "identity_conflict",
+    });
+  });
+
+  it("deduplicates redelivery by the signed Svix id", async () => {
+    const { db, onConflictDoNothing } = databaseDouble({
+      selectResults: [[{ id: attemptId, providerMessageId: null }], []],
+      deliveryInsertResults: [[]],
+    });
+
+    await expect(
+      recordAuthEmailDeliveryEvent({
+        event: webhookEvent({
+          tags: { openvpm_attempt_id: attemptId },
+        }),
+        webhookId: "svix-duplicate",
+        db: db as never,
+      }),
+    ).resolves.toMatchObject({ tracked: true, duplicate: true });
+    expect(onConflictDoNothing).toHaveBeenCalledWith(
+      expect.objectContaining({ target: expect.anything() }),
+    );
+  });
+
+  it("leaves ordinary client-email events to the existing communication path", async () => {
+    const { db, insertedValues } = databaseDouble({ selectResults: [[]] });
+
+    await expect(
+      recordAuthEmailDeliveryEvent({
+        event: webhookEvent(),
+        webhookId: "svix-client-email",
+        db: db as never,
+      }),
+    ).resolves.toEqual({
+      tracked: false,
+      duplicate: false,
+      attribution: null,
+    });
+    expect(insertedValues).toEqual([]);
+  });
+
+  it("classifies delivery events independently of arrival order", () => {
+    expect(authEmailDeliveryClassification("email.delivered")).toBe(
+      "delivered",
+    );
+    expect(authEmailDeliveryClassification("email.sent")).toBe("sent");
+    expect(authEmailDeliveryClassification("email.delivery_delayed")).toBe(
+      "delayed",
+    );
+    expect(authEmailDeliveryClassification("email.bounced")).toBe("failed");
+    expect(authEmailDeliveryClassification("email.complained")).toBe(
+      "complained",
+    );
+  });
+});

--- a/apps/web/lib/__tests__/auth-email-delivery.test.ts
+++ b/apps/web/lib/__tests__/auth-email-delivery.test.ts
@@ -31,7 +31,6 @@ vi.mock("@/lib/email", () => ({
 }));
 
 const {
-  AUTH_EMAIL_WEBHOOK_REPAIR_MIN_AGE_MS,
   authEmailDeliveryClassification,
   authEmailWebhookFingerprint,
   recordAuthEmailDeliveryEvent,
@@ -52,6 +51,7 @@ function databaseDouble(options?: {
   ];
   const updateResults = [...(options?.updateResults ?? [])];
   const insertedValues: unknown[] = [];
+  const insertTargets: unknown[] = [];
   const updatedValues: unknown[] = [];
 
   const selectLimit = vi.fn(async () => {
@@ -76,7 +76,10 @@ function databaseDouble(options?: {
     }
     return { onConflictDoNothing };
   });
-  const insert = vi.fn(() => ({ values: insertValues }));
+  const insert = vi.fn((target: unknown) => {
+    insertTargets.push(target);
+    return { values: insertValues };
+  });
 
   const updateReturning = vi.fn(async () => {
     const next = updateResults.shift() ?? [];
@@ -94,6 +97,7 @@ function databaseDouble(options?: {
   return {
     db,
     insertedValues,
+    insertTargets,
     updatedValues,
     insertReturning,
     onConflictDoNothing,
@@ -277,6 +281,34 @@ describe("tracked verification email dispatch", () => {
     expect(result.error).not.toMatch(/try again|retry/i);
   });
 
+  it("returns accepted when matching signed tagged evidence wins a timeout race", async () => {
+    const { db } = databaseDouble({
+      updateResults: [[]],
+      selectResults: [
+        [acceptedState("resend", "provider-email-from-webhook")],
+        [{ id: "signed-tagged-evidence" }],
+      ],
+    });
+    mocks.sendVerificationEmailWithProviderEvidence.mockResolvedValue({
+      success: false,
+      provider: "resend",
+      outcome: "outcome_unknown",
+      failureCode: "send_timeout",
+    });
+
+    await expect(
+      sendTrackedVerificationEmail(trackedInput(db)),
+    ).resolves.toMatchObject({
+      success: true,
+      provider: "resend",
+      outcome: "accepted",
+      possiblySent: false,
+      evidencePersisted: true,
+      providerMessageId: "provider-email-from-webhook",
+    });
+    expect(mocks.alertOps).not.toHaveBeenCalled();
+  });
+
   it("models local console acceptance without expecting Resend delivery", async () => {
     mocks.verificationEmailProvider.mockReturnValue("console");
     const { db, insertedValues } = databaseDouble({
@@ -363,14 +395,13 @@ describe("auth verification delivery evidence", () => {
     );
   });
 
-  it("links an early out-of-order tag callback without racing provider resolution", async () => {
+  it("immediately repairs an early reserved attempt from exact signed tags", async () => {
     const { db, insertedValues, updateSet } = databaseDouble({
       selectResults: [
         [],
         [
           {
             id: attemptId,
-            createdAt: new Date(),
             outcome: "reserved",
             provider: "resend",
             providerMessageId: null,
@@ -398,7 +429,13 @@ describe("auth verification delivery evidence", () => {
       conflict: false,
       attribution: "attempt_tag",
     });
-    expect(updateSet).not.toHaveBeenCalled();
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "accepted",
+        providerMessageId: "provider-email-1",
+        failureCode: null,
+      }),
+    );
     expect(insertedValues[0]).toMatchObject({
       rawBodyFingerprint: fingerprint,
       providerMessageId: "provider-email-1",
@@ -411,17 +448,14 @@ describe("auth verification delivery evidence", () => {
     expect(persisted).not.toContain("openvpm_attempt_id");
   });
 
-  it("repairs a stale reserved attempt from a consistent signed tag", async () => {
+  it("repairs a persisted unknown Resend outcome from exact signed tags", async () => {
     const { db, updateSet } = databaseDouble({
       selectResults: [
         [],
         [
           {
             id: attemptId,
-            createdAt: new Date(
-              Date.now() - AUTH_EMAIL_WEBHOOK_REPAIR_MIN_AGE_MS - 1_000,
-            ),
-            outcome: "reserved",
+            outcome: "outcome_unknown",
             provider: "resend",
             providerMessageId: null,
           },
@@ -434,7 +468,10 @@ describe("auth verification delivery evidence", () => {
       recordInput(
         db,
         webhookEvent({
-          tags: { openvpm_attempt_id: attemptId },
+          tags: {
+            openvpm_attempt_id: attemptId,
+            openvpm_email_kind: "auth_verification",
+          },
         }),
       ),
     );
@@ -471,6 +508,7 @@ describe("auth verification delivery evidence", () => {
       provider: "resend",
       providerMessageId: "provider-email-1",
       eventType: "email.delivered",
+      attemptId,
       attribution: "attempt_tag",
     };
     const { db, insertedValues } = databaseDouble({
@@ -488,15 +526,63 @@ describe("auth verification delivery evidence", () => {
     expect(insertedValues).toEqual([]);
   });
 
-  it("surfaces the same Svix id with a changed fingerprint as a PHI-free conflict", async () => {
+  it("re-enters repair when exact tagged evidence is redelivered", async () => {
+    const existing = {
+      rawBodyFingerprint: fingerprint,
+      provider: "resend",
+      providerMessageId: "provider-email-1",
+      eventType: "email.delivered",
+      attemptId,
+      attribution: "attempt_tag",
+    };
+    const { db, insertedValues, updateSet } = databaseDouble({
+      selectResults: [
+        [existing],
+        [
+          {
+            id: attemptId,
+            outcome: "reserved",
+            provider: "resend",
+            providerMessageId: null,
+          },
+        ],
+      ],
+    });
+
+    await expect(
+      recordAuthEmailDeliveryEvent(
+        recordInput(
+          db,
+          webhookEvent({
+            tags: {
+              openvpm_attempt_id: attemptId,
+              openvpm_email_kind: "auth_verification",
+            },
+          }),
+        ),
+      ),
+    ).resolves.toMatchObject({ duplicate: true, conflict: false });
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "accepted",
+        providerMessageId: "provider-email-1",
+      }),
+    );
+    expect(insertedValues).toEqual([]);
+  });
+
+  it("durably quarantines a changed body under the same Svix id", async () => {
     const existing = {
       rawBodyFingerprint: "0".repeat(64),
       provider: "resend",
       providerMessageId: "provider-email-1",
       eventType: "email.delivered",
+      attemptId,
       attribution: "attempt_tag",
     };
-    const { db } = databaseDouble({ selectResults: [[existing]] });
+    const { db, insertedValues } = databaseDouble({
+      selectResults: [[existing]],
+    });
 
     await expect(
       recordAuthEmailDeliveryEvent(recordInput(db)),
@@ -506,10 +592,62 @@ describe("auth verification delivery evidence", () => {
       conflict: true,
       attribution: "identity_conflict",
     });
+    expect(insertedValues).toHaveLength(1);
+    expect(insertedValues[0]).toEqual({
+      originalWebhookId: "svix-event-1",
+      incomingRawBodyFingerprint: fingerprint,
+      provider: "resend",
+      incomingProviderMessageId: "provider-email-1",
+      incomingEventType: "email.delivered",
+    });
+    expect(JSON.stringify(insertedValues[0])).not.toMatch(
+      /owner@example|verify|subject|token/i,
+    );
     expect(mocks.alertOps).toHaveBeenCalledWith(
       "Auth email webhook identity conflict",
       expect.not.stringMatching(/owner|provider-email-1|subject/i),
     );
+  });
+
+  it("idempotently records repeated changed-body conflict evidence without alert storms", async () => {
+    const existing = {
+      rawBodyFingerprint: "0".repeat(64),
+      provider: "resend",
+      providerMessageId: "provider-email-1",
+      eventType: "email.delivered",
+      attemptId,
+      attribution: "attempt_tag",
+    };
+    const { db, insertedValues } = databaseDouble({
+      selectResults: [[existing], [existing]],
+      deliveryInsertResults: [[{ id: "new-conflict" }], []],
+    });
+
+    await recordAuthEmailDeliveryEvent(recordInput(db));
+    await recordAuthEmailDeliveryEvent(recordInput(db));
+
+    expect(insertedValues).toHaveLength(2);
+    expect(mocks.alertOps).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails retryably when changed-body conflict evidence cannot be committed", async () => {
+    const existing = {
+      rawBodyFingerprint: "0".repeat(64),
+      provider: "resend",
+      providerMessageId: "provider-email-1",
+      eventType: "email.delivered",
+      attemptId,
+      attribution: "attempt_tag",
+    };
+    const { db } = databaseDouble({
+      selectResults: [[existing]],
+      deliveryInsertResults: [new Error("conflict ledger unavailable")],
+    });
+
+    await expect(recordAuthEmailDeliveryEvent(recordInput(db))).rejects.toThrow(
+      "conflict ledger unavailable",
+    );
+    expect(mocks.alertOps).not.toHaveBeenCalled();
   });
 
   it("race-safely re-reads a winning exact insert before claiming duplicate", async () => {
@@ -518,6 +656,7 @@ describe("auth verification delivery evidence", () => {
       provider: "resend",
       providerMessageId: "provider-email-1",
       eventType: "email.delivered",
+      attemptId,
       attribution: "attempt_tag",
     };
     const { db } = databaseDouble({
@@ -526,7 +665,6 @@ describe("auth verification delivery evidence", () => {
         [
           {
             id: attemptId,
-            createdAt: new Date(),
             outcome: "reserved",
             provider: "resend",
             providerMessageId: null,
@@ -554,6 +692,7 @@ describe("auth verification delivery evidence", () => {
       provider: "resend",
       providerMessageId: "different-provider-message",
       eventType: "email.failed",
+      attemptId,
       attribution: "attempt_tag",
     };
     const { db } = databaseDouble({
@@ -562,7 +701,6 @@ describe("auth verification delivery evidence", () => {
         [
           {
             id: attemptId,
-            createdAt: new Date(),
             outcome: "reserved",
             provider: "resend",
             providerMessageId: null,
@@ -571,7 +709,7 @@ describe("auth verification delivery evidence", () => {
         [],
         [racedIdentity],
       ],
-      deliveryInsertResults: [[]],
+      deliveryInsertResults: [[], [{ id: "quarantined-conflict" }]],
     });
 
     await expect(
@@ -595,7 +733,6 @@ describe("auth verification delivery evidence", () => {
         [
           {
             id: attemptId,
-            createdAt: new Date(),
             outcome: "accepted",
             provider: "resend",
             providerMessageId: "different-provider-id",

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -995,6 +995,9 @@ describe("committed Drizzle migrations", () => {
     expect(sql).toContain('CREATE TABLE "auth_email_attempts"');
     expect(sql).toContain('CREATE TABLE "auth_email_delivery_events"');
     expect(sql).toContain('CREATE TABLE "auth_email_webhook_conflicts"');
+    expect(sql).toContain(
+      'CREATE TABLE "auth_email_provider_identity_conflicts"',
+    );
     expect(sql).toContain("auth_email_attempts_outcome_shape_check");
     expect(sql).toContain("auth_email_attempts_state_guard");
     expect(sql).toContain("guard_auth_email_attempt_mutation");
@@ -1016,10 +1019,17 @@ describe("committed Drizzle migrations", () => {
     expect(sql).toContain("'^[0-9a-f]{64}$'");
     expect(sql).toContain("auth_email_delivery_events_immutable");
     expect(sql).toContain("auth_email_webhook_conflicts_identity_uq");
-    expect(
-      sql.indexOf("auth_email_delivery_events_webhook_uq"),
-    ).toBeLessThan(sql.indexOf("auth_email_webhook_conflicts_webhook_fk"));
+    expect(sql.indexOf("auth_email_delivery_events_webhook_uq")).toBeLessThan(
+      sql.indexOf("auth_email_webhook_conflicts_webhook_fk"),
+    );
     expect(sql).toContain("auth_email_webhook_conflicts_immutable");
+    expect(sql).toContain("auth_email_provider_identity_conflicts_immutable");
+    expect(sql).toContain(
+      "auth_email_provider_identity_conflicts_distinct_id_check",
+    );
+    expect(sql).toContain(
+      "auth_email_provider_identity_conflicts_id_shape_check",
+    );
     expect(sql).toContain(
       "auth_email_webhook_conflicts_raw_body_fingerprint_check",
     );
@@ -1033,10 +1043,13 @@ describe("committed Drizzle migrations", () => {
       "ALTER TABLE auth_email_webhook_conflicts ENABLE ROW LEVEL SECURITY",
     );
     expect(sql).toContain(
+      "ALTER TABLE auth_email_provider_identity_conflicts ENABLE ROW LEVEL SECURITY",
+    );
+    expect(sql).toContain(
       "GRANT SELECT, INSERT, UPDATE ON auth_email_attempts TO openpims_app",
     );
     expect(sql).toContain(
-      "GRANT SELECT, INSERT ON auth_email_delivery_events, auth_email_webhook_conflicts TO openpims_app",
+      "GRANT SELECT, INSERT ON auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts TO openpims_app",
     );
     expect(sql).not.toMatch(
       /recipient|verify_url|auth_token|subject|html|\bto\b varchar/i,
@@ -1045,6 +1058,7 @@ describe("committed Drizzle migrations", () => {
     const reset = readRepoFile("packages/db/reset.ts");
     expect(reset).toContain('"auth_email_delivery_events"');
     expect(reset).toContain('"auth_email_webhook_conflicts"');
+    expect(reset).toContain('"auth_email_provider_identity_conflicts"');
     expect(reset).toContain('"auth_email_attempts"');
     expect(reset.indexOf('"auth_email_webhook_conflicts"')).toBeLessThan(
       reset.indexOf('"auth_email_delivery_events"'),
@@ -1062,7 +1076,10 @@ describe("committed Drizzle migrations", () => {
       "CREATE POLICY system_only ON auth_email_webhook_conflicts",
     );
     expect(rls).toContain(
-      "REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts FROM openpims_app",
+      "CREATE POLICY system_only ON auth_email_provider_identity_conflicts",
+    );
+    expect(rls).toContain(
+      "REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts FROM openpims_app",
     );
   });
 });

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -995,7 +995,22 @@ describe("committed Drizzle migrations", () => {
     expect(sql).toContain('CREATE TABLE "auth_email_attempts"');
     expect(sql).toContain('CREATE TABLE "auth_email_delivery_events"');
     expect(sql).toContain("auth_email_attempts_outcome_shape_check");
+    expect(sql).toContain("auth_email_attempts_state_guard");
+    expect(sql).toContain("guard_auth_email_attempt_mutation");
+    expect(sql).toContain("Auth email attempt identity is immutable");
+    expect(sql).toContain("Auth email attempt state may resolve exactly once");
+    expect(sql).toContain(
+      "Auth email attempts may only be deleted during owner maintenance",
+    );
+    expect(sql).toContain(
+      '"provider" in (\'resend\', \'console\')',
+    );
     expect(sql).toContain("auth_email_delivery_events_attribution_shape_check");
+    expect(sql).toContain(
+      "auth_email_delivery_events_raw_body_fingerprint_check",
+    );
+    expect(sql).toContain('"raw_body_fingerprint" varchar(64) NOT NULL');
+    expect(sql).toContain("'^[0-9a-f]{64}$'");
     expect(sql).toContain("auth_email_delivery_events_immutable");
     expect(sql).toContain(
       "ALTER TABLE auth_email_attempts ENABLE ROW LEVEL SECURITY",
@@ -1010,7 +1025,7 @@ describe("committed Drizzle migrations", () => {
       "GRANT SELECT, INSERT ON auth_email_delivery_events TO openpims_app",
     );
     expect(sql).not.toMatch(
-      /recipient|verify_url|token|subject|body|html|\bto\b varchar/i,
+      /recipient|verify_url|auth_token|subject|html|\bto\b varchar/i,
     );
 
     const reset = readRepoFile("packages/db/reset.ts");

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -980,4 +980,53 @@ describe("committed Drizzle migrations", () => {
       "REVOKE ALL ON lab_result_replacements FROM authenticated",
     );
   });
+
+  it("creates system-only verification email attempts and immutable delivery evidence", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries?: Array<{ tag?: string }> };
+    expect(journal.entries?.map((entry) => entry.tag)).toContain(
+      "0062_ambitious_moon_knight",
+    );
+
+    const sql = readRepoFile(
+      "packages/db/drizzle/0062_ambitious_moon_knight.sql",
+    );
+    expect(sql).toContain('CREATE TABLE "auth_email_attempts"');
+    expect(sql).toContain('CREATE TABLE "auth_email_delivery_events"');
+    expect(sql).toContain("auth_email_attempts_outcome_shape_check");
+    expect(sql).toContain("auth_email_delivery_events_attribution_shape_check");
+    expect(sql).toContain("auth_email_delivery_events_immutable");
+    expect(sql).toContain(
+      "ALTER TABLE auth_email_attempts ENABLE ROW LEVEL SECURITY",
+    );
+    expect(sql).toContain(
+      "ALTER TABLE auth_email_delivery_events ENABLE ROW LEVEL SECURITY",
+    );
+    expect(sql).toContain(
+      "GRANT SELECT, INSERT, UPDATE ON auth_email_attempts TO openpims_app",
+    );
+    expect(sql).toContain(
+      "GRANT SELECT, INSERT ON auth_email_delivery_events TO openpims_app",
+    );
+    expect(sql).not.toMatch(
+      /recipient|verify_url|token|subject|body|html|\bto\b varchar/i,
+    );
+
+    const reset = readRepoFile("packages/db/reset.ts");
+    expect(reset).toContain('"auth_email_delivery_events"');
+    expect(reset).toContain('"auth_email_attempts"');
+    expect(reset.indexOf('"auth_email_delivery_events"')).toBeLessThan(
+      reset.indexOf('"auth_email_attempts"'),
+    );
+
+    const rls = readRepoFile("packages/db/rls/enable-rls.sql");
+    expect(rls).toContain("CREATE POLICY system_only ON auth_email_attempts");
+    expect(rls).toContain(
+      "CREATE POLICY system_only ON auth_email_delivery_events",
+    );
+    expect(rls).toContain(
+      "REVOKE ALL ON auth_email_attempts, auth_email_delivery_events FROM openpims_app",
+    );
+  });
 });

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -994,17 +994,20 @@ describe("committed Drizzle migrations", () => {
     );
     expect(sql).toContain('CREATE TABLE "auth_email_attempts"');
     expect(sql).toContain('CREATE TABLE "auth_email_delivery_events"');
+    expect(sql).toContain('CREATE TABLE "auth_email_webhook_conflicts"');
     expect(sql).toContain("auth_email_attempts_outcome_shape_check");
     expect(sql).toContain("auth_email_attempts_state_guard");
     expect(sql).toContain("guard_auth_email_attempt_mutation");
     expect(sql).toContain("Auth email attempt identity is immutable");
-    expect(sql).toContain("Auth email attempt state may resolve exactly once");
+    expect(sql).toContain(
+      "Auth email attempt state transition is not permitted",
+    );
+    expect(sql).toContain("OLD.outcome = 'outcome_unknown'");
+    expect(sql).toContain("NEW.outcome = 'accepted'");
     expect(sql).toContain(
       "Auth email attempts may only be deleted during owner maintenance",
     );
-    expect(sql).toContain(
-      '"provider" in (\'resend\', \'console\')',
-    );
+    expect(sql).toContain("\"provider\" in ('resend', 'console')");
     expect(sql).toContain("auth_email_delivery_events_attribution_shape_check");
     expect(sql).toContain(
       "auth_email_delivery_events_raw_body_fingerprint_check",
@@ -1012,6 +1015,14 @@ describe("committed Drizzle migrations", () => {
     expect(sql).toContain('"raw_body_fingerprint" varchar(64) NOT NULL');
     expect(sql).toContain("'^[0-9a-f]{64}$'");
     expect(sql).toContain("auth_email_delivery_events_immutable");
+    expect(sql).toContain("auth_email_webhook_conflicts_identity_uq");
+    expect(
+      sql.indexOf("auth_email_delivery_events_webhook_uq"),
+    ).toBeLessThan(sql.indexOf("auth_email_webhook_conflicts_webhook_fk"));
+    expect(sql).toContain("auth_email_webhook_conflicts_immutable");
+    expect(sql).toContain(
+      "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+    );
     expect(sql).toContain(
       "ALTER TABLE auth_email_attempts ENABLE ROW LEVEL SECURITY",
     );
@@ -1019,10 +1030,13 @@ describe("committed Drizzle migrations", () => {
       "ALTER TABLE auth_email_delivery_events ENABLE ROW LEVEL SECURITY",
     );
     expect(sql).toContain(
+      "ALTER TABLE auth_email_webhook_conflicts ENABLE ROW LEVEL SECURITY",
+    );
+    expect(sql).toContain(
       "GRANT SELECT, INSERT, UPDATE ON auth_email_attempts TO openpims_app",
     );
     expect(sql).toContain(
-      "GRANT SELECT, INSERT ON auth_email_delivery_events TO openpims_app",
+      "GRANT SELECT, INSERT ON auth_email_delivery_events, auth_email_webhook_conflicts TO openpims_app",
     );
     expect(sql).not.toMatch(
       /recipient|verify_url|auth_token|subject|html|\bto\b varchar/i,
@@ -1030,7 +1044,11 @@ describe("committed Drizzle migrations", () => {
 
     const reset = readRepoFile("packages/db/reset.ts");
     expect(reset).toContain('"auth_email_delivery_events"');
+    expect(reset).toContain('"auth_email_webhook_conflicts"');
     expect(reset).toContain('"auth_email_attempts"');
+    expect(reset.indexOf('"auth_email_webhook_conflicts"')).toBeLessThan(
+      reset.indexOf('"auth_email_delivery_events"'),
+    );
     expect(reset.indexOf('"auth_email_delivery_events"')).toBeLessThan(
       reset.indexOf('"auth_email_attempts"'),
     );
@@ -1041,7 +1059,10 @@ describe("committed Drizzle migrations", () => {
       "CREATE POLICY system_only ON auth_email_delivery_events",
     );
     expect(rls).toContain(
-      "REVOKE ALL ON auth_email_attempts, auth_email_delivery_events FROM openpims_app",
+      "CREATE POLICY system_only ON auth_email_webhook_conflicts",
+    );
+    expect(rls).toContain(
+      "REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts FROM openpims_app",
     );
   });
 });

--- a/apps/web/lib/__tests__/email.test.ts
+++ b/apps/web/lib/__tests__/email.test.ts
@@ -269,6 +269,7 @@ describe("sendEmail", () => {
       }),
     ).resolves.toEqual({
       success: true,
+      provider: "resend",
       id: "email-verify-1",
       outcome: "accepted",
     });
@@ -300,6 +301,7 @@ describe("sendEmail", () => {
       }),
     ).resolves.toMatchObject({
       success: true,
+      provider: "console",
       id: "dev-console:auth-email:00000000-0000-4000-8000-000000000001",
       outcome: "accepted",
     });
@@ -311,6 +313,27 @@ describe("sendEmail", () => {
       "private-owner@example.com",
     );
     consoleLog.mockRestore();
+  });
+
+  it("models hosted missing configuration as a definite Resend failure", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    const { sendVerificationEmailWithProviderEvidence } = await loadEmail();
+
+    await expect(
+      sendVerificationEmailWithProviderEvidence({
+        to: "private-owner@example.com",
+        name: "Dr Admin",
+        verifyUrl: "https://app.openvpm.com/verify-email?token=safe-token",
+        attemptId: "00000000-0000-4000-8000-000000000001",
+        idempotencyKey: "auth-email:00000000-0000-4000-8000-000000000001",
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      provider: "resend",
+      outcome: "definite_failure",
+      failureCode: "provider_not_configured",
+    });
+    expect(mocks.resendSend).not.toHaveBeenCalled();
   });
 
   it("redacts auth verification provider rejection detail from logs", async () => {

--- a/apps/web/lib/__tests__/email.test.ts
+++ b/apps/web/lib/__tests__/email.test.ts
@@ -43,7 +43,9 @@ afterEach(() => {
 
 describe("sendEmail", () => {
   it("logs to console in self-hosted/dev mode without Resend", async () => {
-    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
     const { sendEmail } = await loadEmail();
 
     await expect(
@@ -51,11 +53,11 @@ describe("sendEmail", () => {
         to: "client@example.com",
         subject: "Reminder",
         html: "<p>Hello</p>",
-      })
+      }),
     ).resolves.toEqual({ success: true, id: "dev-console" });
 
     expect(consoleLog).toHaveBeenCalledWith(
-      "[Email] No RESEND_API_KEY configured – logging email to console"
+      "[Email] No RESEND_API_KEY configured – logging email to console",
     );
     expect(mocks.Resend).not.toHaveBeenCalled();
     consoleLog.mockRestore();
@@ -63,7 +65,9 @@ describe("sendEmail", () => {
 
   it("fails closed in hosted mode without Resend", async () => {
     mocks.billingEnforced.mockReturnValue(true);
-    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
     const { sendEmail } = await loadEmail();
 
     await expect(
@@ -71,7 +75,7 @@ describe("sendEmail", () => {
         to: "client@example.com",
         subject: "Reminder",
         html: "<p>Hello</p>",
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error: "Email provider is not configured for hosted sending.",
@@ -85,7 +89,9 @@ describe("sendEmail", () => {
   it("treats a blank Resend API key as missing in hosted mode", async () => {
     vi.stubEnv("RESEND_API_KEY", "   ");
     mocks.billingEnforced.mockReturnValue(true);
-    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
     const { sendEmail } = await loadEmail();
 
     await expect(
@@ -93,7 +99,7 @@ describe("sendEmail", () => {
         to: "client@example.com",
         subject: "Reminder",
         html: "<p>Hello</p>",
-      })
+      }),
     ).resolves.toEqual({
       success: false,
       error: "Email provider is not configured for hosted sending.",
@@ -107,7 +113,9 @@ describe("sendEmail", () => {
   it("keeps the console fallback available in demo mode", async () => {
     vi.stubEnv("NEXT_PUBLIC_DEMO_MODE", " true ");
     mocks.billingEnforced.mockReturnValue(true);
-    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
     const { sendEmail } = await loadEmail();
 
     await expect(
@@ -115,7 +123,7 @@ describe("sendEmail", () => {
         to: "client@example.com",
         subject: "Reminder",
         html: "<p>Hello</p>",
-      })
+      }),
     ).resolves.toEqual({ success: true, id: "dev-console" });
 
     expect(consoleLog).toHaveBeenCalled();
@@ -134,7 +142,7 @@ describe("sendEmail", () => {
         to: "client@example.com",
         subject: "Reminder",
         html: "<p>Hello</p>",
-      })
+      }),
     ).resolves.toEqual({ success: true, id: "email-1" });
 
     expect(mocks.Resend).toHaveBeenCalledWith("re_test");
@@ -146,7 +154,7 @@ describe("sendEmail", () => {
       }),
       expect.objectContaining({
         signal: expect.any(AbortSignal),
-      })
+      }),
     );
     expect(EMAIL_SEND_TIMEOUT_MS).toBe(10_000);
   });
@@ -164,7 +172,7 @@ describe("sendEmail", () => {
         replyTo: " ",
         subject: "Reminder",
         html: "<p>Hello</p>",
-      })
+      }),
     ).resolves.toEqual({ success: true, id: "email-1" });
 
     const [payload] = mocks.resendSend.mock.calls[0] ?? [];
@@ -196,7 +204,7 @@ describe("sendEmail", () => {
         appointmentDate: "July 2",
         appointmentTime: "9:00 AM",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).resolves.toMatchObject({ success: true, id: "email-appt-1" });
 
     await expect(
@@ -207,7 +215,7 @@ describe("sendEmail", () => {
         vaccineName: "Rabies",
         dueDate: "July 2",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).resolves.toMatchObject({ success: true, id: "email-vax-1" });
 
     await expect(
@@ -216,7 +224,7 @@ describe("sendEmail", () => {
         clientName: "Ada Lovelace",
         invoiceTotal: "$123.45",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).resolves.toMatchObject({ success: true, id: "email-invoice-1" });
   });
 
@@ -230,7 +238,7 @@ describe("sendEmail", () => {
         to: "admin@example.com",
         name: "Dr Admin",
         verifyUrl: "https://app.openvpm.com/verify-email?token=safe-token",
-      })
+      }),
     ).resolves.toEqual({ success: true, id: "email-verify-1" });
 
     const [payload] = mocks.resendSend.mock.calls[0] ?? [];
@@ -240,7 +248,128 @@ describe("sendEmail", () => {
     });
     expect(payload.html).toContain("Your trial is already active.");
     expect(payload.html).toContain("Confirm email");
-    expect(payload.html).not.toMatch(/activate your account|start your free trial/i);
+    expect(payload.html).not.toMatch(
+      /activate your account|start your free trial/i,
+    );
+  });
+
+  it("attaches a durable attempt tag and Resend idempotency key to tracked verification", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    mocks.resendSend.mockResolvedValue({ data: { id: "email-verify-1" } });
+    const { sendVerificationEmailWithProviderEvidence } = await loadEmail();
+    const attemptId = "00000000-0000-4000-8000-000000000001";
+
+    await expect(
+      sendVerificationEmailWithProviderEvidence({
+        to: "admin@example.com",
+        name: "Dr Admin",
+        verifyUrl: "https://app.openvpm.com/verify-email?token=safe-token",
+        attemptId,
+        idempotencyKey: `auth-email:${attemptId}`,
+      }),
+    ).resolves.toEqual({
+      success: true,
+      id: "email-verify-1",
+      outcome: "accepted",
+    });
+
+    expect(mocks.resendSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: [
+          { name: "openvpm_attempt_id", value: attemptId },
+          { name: "openvpm_email_kind", value: "auth_verification" },
+        ],
+      }),
+      expect.objectContaining({ idempotencyKey: `auth-email:${attemptId}` }),
+    );
+  });
+
+  it("redacts the auth recipient from development fallback logs", async () => {
+    const consoleLog = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    const { sendVerificationEmailWithProviderEvidence } = await loadEmail();
+
+    await expect(
+      sendVerificationEmailWithProviderEvidence({
+        to: "private-owner@example.com",
+        name: "Dr Admin",
+        verifyUrl: "https://app.openvpm.com/verify-email?token=safe-token",
+        attemptId: "00000000-0000-4000-8000-000000000001",
+        idempotencyKey: "auth-email:00000000-0000-4000-8000-000000000001",
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+      id: "dev-console:auth-email:00000000-0000-4000-8000-000000000001",
+      outcome: "accepted",
+    });
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "  To:      [redacted auth recipient]",
+    );
+    expect(JSON.stringify(consoleLog.mock.calls)).not.toContain(
+      "private-owner@example.com",
+    );
+    consoleLog.mockRestore();
+  });
+
+  it("redacts auth verification provider rejection detail from logs", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mocks.resendSend.mockResolvedValue({
+      data: null,
+      error: {
+        message: "Rejected private-owner@example.com",
+        name: "validation_error",
+        statusCode: 422,
+      },
+    });
+    const { sendVerificationEmailWithProviderEvidence } = await loadEmail();
+
+    await expect(
+      sendVerificationEmailWithProviderEvidence({
+        to: "private-owner@example.com",
+        name: "Dr Admin",
+        verifyUrl: "https://app.openvpm.com/verify-email?token=safe-token",
+        attemptId: "00000000-0000-4000-8000-000000000001",
+        idempotencyKey: "auth-email:00000000-0000-4000-8000-000000000001",
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "definite_failure",
+      failureCode: "provider_rejected",
+    });
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[Email] Resend error:",
+      "auth verification provider rejection",
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(
+      "private-owner@example.com",
+    );
+    consoleError.mockRestore();
+  });
+
+  it("classifies a missing provider id as an unknown outcome", async () => {
+    vi.stubEnv("RESEND_API_KEY", "re_test");
+    mocks.resendSend.mockResolvedValue({ data: null, error: null });
+    const { sendVerificationEmailWithProviderEvidence } = await loadEmail();
+
+    await expect(
+      sendVerificationEmailWithProviderEvidence({
+        to: "admin@example.com",
+        name: "Dr Admin",
+        verifyUrl: "https://app.openvpm.com/verify-email?token=safe-token",
+        attemptId: "00000000-0000-4000-8000-000000000001",
+        idempotencyKey: "auth-email:00000000-0000-4000-8000-000000000001",
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      outcome: "outcome_unknown",
+      failureCode: "missing_provider_id",
+    });
   });
 
   it("aborts hung Resend sends and returns a timeout error", async () => {
@@ -251,22 +380,20 @@ describe("sendEmail", () => {
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
     mocks.resendSend.mockImplementation(
-      (
-        _payload: unknown,
-        options?: { signal?: AbortSignal }
-      ) =>
+      (_payload: unknown, options?: { signal?: AbortSignal }) =>
         new Promise((resolve) => {
           options?.signal?.addEventListener("abort", () => {
             resolve({
               data: null,
               error: {
-                message: "Unable to fetch data. The request could not be resolved.",
+                message:
+                  "Unable to fetch data. The request could not be resolved.",
                 statusCode: null,
                 name: "application_error",
               },
             });
           });
-        })
+        }),
     );
     const { EMAIL_SEND_TIMEOUT_MS, sendEmail } = await loadEmail();
 
@@ -283,7 +410,7 @@ describe("sendEmail", () => {
     });
     expect(consoleError).toHaveBeenCalledWith(
       "[Email] Resend error:",
-      expect.objectContaining({ name: "application_error" })
+      expect.objectContaining({ name: "application_error" }),
     );
   });
 });
@@ -337,7 +464,7 @@ describe("lifecycle email branding", () => {
         to: "owner@example.com",
         practiceName: "Neighborhood Veterinary",
         trialDays: 14,
-      })
+      }),
     ).resolves.toEqual({ success: true, id: "email-1" });
 
     const [payload] = mocks.resendSend.mock.calls[0] ?? [];
@@ -345,7 +472,7 @@ describe("lifecycle email branding", () => {
       expect.objectContaining({
         replyTo: "support@example.com",
         to: "owner@example.com",
-      })
+      }),
     );
   });
 
@@ -361,7 +488,7 @@ describe("lifecycle email branding", () => {
         practiceName: "Neighborhood Veterinary",
         amount: "$79.00",
         periodLabel: "July 2026",
-      })
+      }),
     ).resolves.toEqual({ success: true, id: "email-1" });
 
     const [payload] = mocks.resendSend.mock.calls[0] ?? [];
@@ -369,7 +496,7 @@ describe("lifecycle email branding", () => {
       expect.objectContaining({
         replyTo: "support@openvpm.com",
         to: "owner@example.com",
-      })
+      }),
     );
   });
 });

--- a/apps/web/lib/__tests__/schema-indexes.test.ts
+++ b/apps/web/lib/__tests__/schema-indexes.test.ts
@@ -5,6 +5,8 @@ import {
   appointmentTypes,
   appointmentWaitlist,
   appointments,
+  authEmailAttempts,
+  authEmailDeliveryEvents,
   authTokens,
   cases,
   caseEntries,
@@ -50,14 +52,14 @@ import {
 } from "@openpims/db";
 
 function indexNames(table: PgTable): string[] {
-  return getTableConfig(table).indexes
-    .map((idx) => idx.config.name)
+  return getTableConfig(table)
+    .indexes.map((idx) => idx.config.name)
     .filter((name): name is string => typeof name === "string");
 }
 
 function indexColumnNames(table: PgTable, name: string): string[] {
   const index = getTableConfig(table).indexes.find(
-    (idx) => idx.config.name === name
+    (idx) => idx.config.name === name,
   );
 
   expect(index, `${name} should be registered`).toBeDefined();
@@ -88,11 +90,7 @@ describe("hot table indexes", () => {
       controlledSubstanceLog,
       ["cs_log_practice_drug_date_idx", "cs_log_practice_date_idx"],
     ],
-    [
-      "webhooks",
-      webhooks,
-      ["webhooks_practice_active_idx"],
-    ],
+    ["webhooks", webhooks, ["webhooks_practice_active_idx"]],
     [
       "email_suppressions",
       emailSuppressions,
@@ -145,11 +143,7 @@ describe("hot table indexes", () => {
         "vital_signs_appointment_idx",
       ],
     ],
-    [
-      "patient_allergies",
-      patientAllergies,
-      ["patient_allergies_patient_idx"],
-    ],
+    ["patient_allergies", patientAllergies, ["patient_allergies_patient_idx"]],
     [
       "procedures",
       procedures,
@@ -175,16 +169,8 @@ describe("hot table indexes", () => {
       problemList,
       ["problem_list_patient_status_idx", "problem_list_practice_status_idx"],
     ],
-    [
-      "cases",
-      cases,
-      ["cases_patient_status_idx", "cases_practice_status_idx"],
-    ],
-    [
-      "case_entries",
-      caseEntries,
-      ["case_entries_case_idx"],
-    ],
+    ["cases", cases, ["cases_patient_status_idx", "cases_practice_status_idx"]],
+    ["case_entries", caseEntries, ["case_entries_case_idx"]],
     [
       "treatment_plan_items",
       treatmentPlanItems,
@@ -241,11 +227,7 @@ describe("hot table indexes", () => {
         "waitlist_patient_status_idx",
       ],
     ],
-    [
-      "rooms",
-      rooms,
-      ["rooms_practice_name_idx", "rooms_location_idx"],
-    ],
+    ["rooms", rooms, ["rooms_practice_name_idx", "rooms_location_idx"]],
     [
       "staff_schedules",
       staffSchedules,
@@ -263,16 +245,8 @@ describe("hot table indexes", () => {
         "products_stock_alert_idx",
       ],
     ],
-    [
-      "services",
-      services,
-      ["services_practice_name_idx"],
-    ],
-    [
-      "suppliers",
-      suppliers,
-      ["suppliers_practice_name_idx"],
-    ],
+    ["services", services, ["services_practice_name_idx"]],
+    ["suppliers", suppliers, ["suppliers_practice_name_idx"]],
     [
       "invoices",
       invoices,
@@ -304,11 +278,7 @@ describe("hot table indexes", () => {
         "invoice_adjustments_operation_key_uq",
       ],
     ],
-    [
-      "payments",
-      payments,
-      ["payments_invoice_idx", "payments_external_id_uq"],
-    ],
+    ["payments", payments, ["payments_invoice_idx", "payments_external_id_uq"]],
     [
       "prescriptions",
       prescriptions,
@@ -366,15 +336,31 @@ describe("hot table indexes", () => {
         "wellness_enrollments_target_idx",
       ],
     ],
-    [
-      "wellness_plans",
-      wellnessPlans,
-      ["wellness_plans_practice_created_idx"],
-    ],
+    ["wellness_plans", wellnessPlans, ["wellness_plans_practice_created_idx"]],
     [
       "auth_tokens",
       authTokens,
       ["auth_tokens_hash_idx", "auth_tokens_expires_idx"],
+    ],
+    [
+      "auth_email_attempts",
+      authEmailAttempts,
+      [
+        "auth_email_attempts_idempotency_uq",
+        "auth_email_attempts_provider_message_uq",
+        "auth_email_attempts_recovery_idx",
+        "auth_email_attempts_practice_created_idx",
+      ],
+    ],
+    [
+      "auth_email_delivery_events",
+      authEmailDeliveryEvents,
+      [
+        "auth_email_delivery_events_webhook_uq",
+        "auth_email_delivery_events_attempt_timeline_idx",
+        "auth_email_delivery_events_provider_timeline_idx",
+        "auth_email_delivery_events_attribution_queue_idx",
+      ],
     ],
     ["sessions", sessions, ["sessions_expires_idx"]],
     [
@@ -411,60 +397,55 @@ describe("hot table indexes", () => {
 
   it("matches communications indexes to active inbox query shapes", () => {
     expect(
-      indexColumnNames(communications, "communications_practice_list_idx")
+      indexColumnNames(communications, "communications_practice_list_idx"),
     ).toEqual(["practice_id", "deleted_at", "created_at"]);
     expect(
-      indexColumnNames(communications, "communications_client_timeline_idx")
+      indexColumnNames(communications, "communications_client_timeline_idx"),
     ).toEqual(["practice_id", "client_id", "deleted_at", "created_at"]);
     expect(
-      indexColumnNames(communications, "communications_inbox_status_idx")
+      indexColumnNames(communications, "communications_inbox_status_idx"),
     ).toEqual(["practice_id", "direction", "status", "deleted_at"]);
     expect(
-      indexColumnNames(communications, "communications_assigned_idx")
+      indexColumnNames(communications, "communications_assigned_idx"),
     ).toEqual(["practice_id", "assigned_to", "deleted_at"]);
     expect(
-      indexColumnNames(communications, "communications_provider_message_idx")
+      indexColumnNames(communications, "communications_provider_message_idx"),
     ).toEqual(["practice_id", "provider_message_id", "channel", "direction"]);
   });
 
   it("matches controlled-substance ledger indexes to list and summary query shapes", () => {
     expect(
-      indexColumnNames(
-        controlledSubstanceLog,
-        "cs_log_practice_drug_date_idx"
-      )
+      indexColumnNames(controlledSubstanceLog, "cs_log_practice_drug_date_idx"),
     ).toEqual(["practice_id", "drug_name", "performed_at"]);
     expect(
-      indexColumnNames(controlledSubstanceLog, "cs_log_practice_date_idx")
+      indexColumnNames(controlledSubstanceLog, "cs_log_practice_date_idx"),
     ).toEqual(["practice_id", "deleted_at", "performed_at"]);
   });
 
   it("matches email suppression indexes to send-gate and restore query shapes", () => {
     expect(
-      indexColumnNames(emailSuppressions, "email_suppressions_practice_email_uq")
+      indexColumnNames(
+        emailSuppressions,
+        "email_suppressions_practice_email_uq",
+      ),
     ).toEqual(["practice_id", "email"]);
     expect(
-      indexColumnNames(emailSuppressions, "email_suppressions_practice_idx")
+      indexColumnNames(emailSuppressions, "email_suppressions_practice_idx"),
     ).toEqual(["practice_id", "deleted_at"]);
   });
 
   it("matches SMS suppression indexes to send-gate and export query shapes", () => {
     expect(
-      indexColumnNames(smsSuppressions, "sms_suppressions_practice_phone_uq")
+      indexColumnNames(smsSuppressions, "sms_suppressions_practice_phone_uq"),
     ).toEqual(["practice_id", "phone"]);
     expect(
-      indexColumnNames(smsSuppressions, "sms_suppressions_practice_idx")
+      indexColumnNames(smsSuppressions, "sms_suppressions_practice_idx"),
     ).toEqual(["practice_id", "deleted_at"]);
   });
 
   it("matches visit-vitals indexing to the tenant appointment timeline query", () => {
-    expect(
-      indexColumnNames(vitalSigns, "vital_signs_appointment_idx")
-    ).toEqual([
-      "practice_id",
-      "appointment_id",
-      "deleted_at",
-      "recorded_at",
-    ]);
+    expect(indexColumnNames(vitalSigns, "vital_signs_appointment_idx")).toEqual(
+      ["practice_id", "appointment_id", "deleted_at", "recorded_at"],
+    );
   });
 });

--- a/apps/web/lib/__tests__/schema-indexes.test.ts
+++ b/apps/web/lib/__tests__/schema-indexes.test.ts
@@ -7,6 +7,7 @@ import {
   appointments,
   authEmailAttempts,
   authEmailDeliveryEvents,
+  authEmailProviderIdentityConflicts,
   authEmailWebhookConflicts,
   authTokens,
   cases,
@@ -369,6 +370,14 @@ describe("hot table indexes", () => {
       [
         "auth_email_webhook_conflicts_identity_uq",
         "auth_email_webhook_conflicts_recovery_idx",
+      ],
+    ],
+    [
+      "auth_email_provider_identity_conflicts",
+      authEmailProviderIdentityConflicts,
+      [
+        "auth_email_provider_identity_conflicts_identity_uq",
+        "auth_email_provider_identity_conflicts_recovery_idx",
       ],
     ],
     ["sessions", sessions, ["sessions_expires_idx"]],

--- a/apps/web/lib/__tests__/schema-indexes.test.ts
+++ b/apps/web/lib/__tests__/schema-indexes.test.ts
@@ -7,6 +7,7 @@ import {
   appointments,
   authEmailAttempts,
   authEmailDeliveryEvents,
+  authEmailWebhookConflicts,
   authTokens,
   cases,
   caseEntries,
@@ -360,6 +361,14 @@ describe("hot table indexes", () => {
         "auth_email_delivery_events_attempt_timeline_idx",
         "auth_email_delivery_events_provider_timeline_idx",
         "auth_email_delivery_events_attribution_queue_idx",
+      ],
+    ],
+    [
+      "auth_email_webhook_conflicts",
+      authEmailWebhookConflicts,
+      [
+        "auth_email_webhook_conflicts_identity_uq",
+        "auth_email_webhook_conflicts_recovery_idx",
       ],
     ],
     ["sessions", sessions, ["sessions_expires_idx"]],

--- a/apps/web/lib/__tests__/verify-email-banner-ui.test.ts
+++ b/apps/web/lib/__tests__/verify-email-banner-ui.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("verify email banner UI", () => {
-  const source = readFileSync("components/layout/verify-email-banner.tsx", "utf8");
+  const source = readFileSync(
+    "components/layout/verify-email-banner.tsx",
+    "utf8",
+  );
 
   it("surfaces loading and failures before hiding the verification banner", () => {
     expect(source).toContain("const { data, isLoading, error, refetch }");
@@ -10,14 +13,20 @@ describe("verify email banner UI", () => {
     expect(source).toContain("Unable to check email verification status.");
     expect(source).toContain("onClick={() => void refetch()}");
     expect(source).toContain("if (error || !data)");
-    expect(source).toContain("if (!data.verificationEnabled || data.emailVerified) return null");
+    expect(source).toContain(
+      "if (!data.verificationEnabled || data.emailVerified) return null",
+    );
     expect(source.indexOf("if (isLoading)")).toBeLessThan(
-      source.indexOf("if (error || !data)")
+      source.indexOf("if (error || !data)"),
     );
     expect(source.indexOf("if (error || !data)")).toBeLessThan(
-      source.indexOf("if (!data.verificationEnabled || data.emailVerified) return null")
+      source.indexOf(
+        "if (!data.verificationEnabled || data.emailVerified) return null",
+      ),
     );
-    expect(source).not.toContain("if (!data?.verificationEnabled || data.emailVerified)");
+    expect(source).not.toContain(
+      "if (!data?.verificationEnabled || data.emailVerified)",
+    );
   });
 
   it("uses the authenticated inputless resend and renders real failures", () => {
@@ -26,8 +35,10 @@ describe("verify email banner UI", () => {
     expect(source).not.toContain("resend.mutate({ email:");
     expect(source).toContain("resend.error.message");
     expect(source).toContain("resend.data.verificationEmailSent");
+    expect(source).toContain("resend.data.verificationEmailPreviewed");
     expect(source).toContain("!resend.data.alreadyVerified");
     expect(source).toContain("!resend.data.possiblySent");
+    expect(source).toContain("!resend.data.verificationEmailPreviewed");
     expect(source).toContain("{showResendAction && (");
     expect(source).toContain("resend.data.message");
   });

--- a/apps/web/lib/__tests__/verify-email-banner-ui.test.ts
+++ b/apps/web/lib/__tests__/verify-email-banner-ui.test.ts
@@ -25,6 +25,10 @@ describe("verify email banner UI", () => {
     expect(source).toContain("onClick={() => resend.mutate()}");
     expect(source).not.toContain("resend.mutate({ email:");
     expect(source).toContain("resend.error.message");
-    expect(source).toContain("Verification email sent. Check your inbox (and spam).");
+    expect(source).toContain("resend.data.verificationEmailSent");
+    expect(source).toContain("!resend.data.alreadyVerified");
+    expect(source).toContain("!resend.data.possiblySent");
+    expect(source).toContain("{showResendAction && (");
+    expect(source).toContain("resend.data.message");
   });
 });

--- a/apps/web/lib/auth-email-delivery.ts
+++ b/apps/web/lib/auth-email-delivery.ts
@@ -5,6 +5,7 @@ import type { Database } from "@openpims/db/client";
 import {
   authEmailAttempts,
   authEmailDeliveryEvents,
+  authEmailProviderIdentityConflicts,
   authEmailWebhookConflicts,
 } from "@openpims/db";
 import { alertOps } from "@/lib/alerts";
@@ -201,6 +202,44 @@ async function hasSignedTaggedAcceptance(input: {
   }
 }
 
+async function persistProviderIdentityConflict(input: {
+  database: Database;
+  attemptId: string;
+  source: AuthEmailSource;
+  durableProviderMessageId: string;
+  conflictingProviderMessageId: string;
+}): Promise<"inserted" | "duplicate" | "failed"> {
+  try {
+    const [inserted] = await withSystem(input.database, (tx) =>
+      tx
+        .insert(authEmailProviderIdentityConflicts)
+        .values({
+          attemptId: input.attemptId,
+          provider: "resend",
+          source: input.source,
+          durableProviderMessageId: input.durableProviderMessageId,
+          conflictingProviderMessageId: input.conflictingProviderMessageId,
+        })
+        .onConflictDoNothing({
+          target: [
+            authEmailProviderIdentityConflicts.attemptId,
+            authEmailProviderIdentityConflicts.provider,
+            authEmailProviderIdentityConflicts.durableProviderMessageId,
+            authEmailProviderIdentityConflicts.conflictingProviderMessageId,
+          ],
+        })
+        .returning({ id: authEmailProviderIdentityConflicts.id }),
+    );
+    return inserted ? "inserted" : "duplicate";
+  } catch {
+    await safeAuthEmailAlert(
+      "Auth email provider identity conflict persistence failed",
+      "Conflicting verification provider identities could not be written to the durable ledger. Review auth email operations.",
+    );
+    return "failed";
+  }
+}
+
 /**
  * Reserve, dispatch, and record one verification email. Callers must invoke
  * this from a tRPC post-commit effect with the root pool. Reservation and
@@ -301,33 +340,62 @@ export async function sendTrackedVerificationEmail(input: {
     }));
   consistentState = consistentState || signedAcceptedState;
 
-  let identityConflict = providerIdentityConflict;
+  const resolutionIdentityConflict = Boolean(
+    recordedOutcome === "accepted" &&
+    provider === "resend" &&
+    providerMessageId &&
+    resolution.state?.outcome === "accepted" &&
+    resolution.state.providerMessageId &&
+    resolution.state.providerMessageId !== providerMessageId,
+  );
+  const conflictPersistence = resolutionIdentityConflict
+    ? await persistProviderIdentityConflict({
+        database: input.db,
+        attemptId,
+        source: input.source,
+        durableProviderMessageId: resolution.state?.providerMessageId ?? "",
+        conflictingProviderMessageId: providerMessageId ?? "",
+      })
+    : null;
+
+  let deliveryIdentityConflict = false;
   if (
+    !resolutionIdentityConflict &&
     recordedOutcome === "accepted" &&
     provider === "resend" &&
     providerMessageId
   ) {
-    identityConflict =
-      identityConflict ||
-      (resolution.state?.outcome === "accepted" &&
-        resolution.state.providerMessageId !== providerMessageId) ||
-      (await hasDeliveryIdentityMismatch({
-        database: input.db,
-        attemptId,
-        providerMessageId,
-      }));
+    deliveryIdentityConflict = await hasDeliveryIdentityMismatch({
+      database: input.db,
+      attemptId,
+      providerMessageId,
+    });
   }
+
+  const identityConflict =
+    providerIdentityConflict ||
+    resolutionIdentityConflict ||
+    deliveryIdentityConflict;
+  const shouldAlertIdentityConflict =
+    providerIdentityConflict ||
+    deliveryIdentityConflict ||
+    conflictPersistence === "inserted";
 
   const evidencePersisted = consistentState && !identityConflict;
   if (!evidencePersisted) {
-    await safeAuthEmailAlert(
-      identityConflict
-        ? "Auth email provider identity conflict"
-        : "Auth email outcome persistence failed",
-      identityConflict
-        ? "Provider acceptance disagrees with durable signed verification evidence. Review the recovery queue."
-        : "A verification provider outcome could not be confirmed in the durable ledger. Review the recovery queue.",
-    );
+    if (identityConflict) {
+      if (shouldAlertIdentityConflict) {
+        await safeAuthEmailAlert(
+          "Auth email provider identity conflict",
+          "Provider acceptance disagrees with durable signed verification evidence. Review the recovery queue.",
+        );
+      }
+    } else {
+      await safeAuthEmailAlert(
+        "Auth email outcome persistence failed",
+        "A verification provider outcome could not be confirmed in the durable ledger. Review the recovery queue.",
+      );
+    }
   }
 
   if (signedAcceptedState && resolution.state?.providerMessageId) {

--- a/apps/web/lib/auth-email-delivery.ts
+++ b/apps/web/lib/auth-email-delivery.ts
@@ -1,0 +1,273 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import type { WebhookEventPayload } from "resend";
+import { db as defaultDb } from "@openpims/db/client";
+import type { Database } from "@openpims/db/client";
+import { authEmailAttempts, authEmailDeliveryEvents } from "@openpims/db";
+import { withSystem } from "@/lib/tenant-db";
+import {
+  sendVerificationEmailWithProviderEvidence,
+  type EmailProviderOutcome,
+} from "@/lib/email";
+
+export type AuthEmailSource = "registration" | "authenticated_resend";
+
+export interface TrackedVerificationEmailResult {
+  success: boolean;
+  attemptId: string;
+  outcome: EmailProviderOutcome;
+  providerMessageId?: string;
+  error?: string;
+}
+
+/**
+ * Reserve, dispatch, and record one verification email. The provider call is
+ * intentionally outside every database transaction. No recipient or auth-link
+ * content is copied into the operational ledger.
+ */
+export async function sendTrackedVerificationEmail(input: {
+  practiceId: string;
+  userId: string;
+  source: AuthEmailSource;
+  to: string;
+  name: string;
+  verifyUrl: string;
+  db?: Database;
+}): Promise<TrackedVerificationEmailResult> {
+  const database = input.db ?? defaultDb;
+  const attemptId = randomUUID();
+  const idempotencyKey = `auth-email:${attemptId}`;
+
+  await withSystem(database, async (tx) => {
+    await tx.insert(authEmailAttempts).values({
+      id: attemptId,
+      practiceId: input.practiceId,
+      userId: input.userId,
+      source: input.source,
+      idempotencyKey,
+    });
+  });
+
+  const providerResult = await sendVerificationEmailWithProviderEvidence({
+    to: input.to,
+    name: input.name,
+    verifyUrl: input.verifyUrl,
+    attemptId,
+    idempotencyKey,
+  });
+  const recordedOutcome: EmailProviderOutcome =
+    providerResult.outcome === "accepted" && !providerResult.id
+      ? "outcome_unknown"
+      : providerResult.outcome;
+  const resolvedAt = new Date();
+  const [recorded] = await withSystem(database, (tx) =>
+    tx
+      .update(authEmailAttempts)
+      .set({
+        outcome: recordedOutcome,
+        resolvedAt,
+        providerMessageId:
+          recordedOutcome === "accepted" ? providerResult.id : null,
+        failureCode:
+          recordedOutcome === "accepted"
+            ? null
+            : (providerResult.failureCode ??
+              (providerResult.outcome === "accepted"
+                ? "missing_provider_id"
+                : "provider_exception")),
+      })
+      .where(
+        and(
+          eq(authEmailAttempts.id, attemptId),
+          eq(authEmailAttempts.outcome, "reserved"),
+        ),
+      )
+      .returning({ id: authEmailAttempts.id }),
+  );
+
+  if (!recorded) {
+    throw new Error(
+      "Verification email provider outcome could not be recorded safely.",
+    );
+  }
+
+  return {
+    success: providerResult.success && recordedOutcome === "accepted",
+    attemptId,
+    outcome: recordedOutcome,
+    ...(recordedOutcome === "accepted" && providerResult.id
+      ? { providerMessageId: providerResult.id }
+      : {}),
+    ...(recordedOutcome === "definite_failure"
+      ? { error: "Email provider did not accept the verification message." }
+      : recordedOutcome === "outcome_unknown"
+        ? {
+            error:
+              "Email provider outcome is unknown; do not retry automatically.",
+          }
+        : {}),
+  };
+}
+
+export type AuthEmailWebhookEvent = Extract<
+  WebhookEventPayload,
+  { data: { email_id: string; to: string[] } }
+>;
+
+type AuthEmailDeliveryClassification =
+  | "sent"
+  | "delivered"
+  | "delayed"
+  | "failed"
+  | "complained"
+  | "opened"
+  | "clicked"
+  | "unknown";
+
+export function authEmailDeliveryClassification(
+  eventType: WebhookEventPayload["type"],
+): AuthEmailDeliveryClassification {
+  switch (eventType) {
+    case "email.sent":
+    case "email.scheduled":
+      return "sent";
+    case "email.delivered":
+      return "delivered";
+    case "email.delivery_delayed":
+      return "delayed";
+    case "email.bounced":
+    case "email.failed":
+    case "email.suppressed":
+      return "failed";
+    case "email.complained":
+      return "complained";
+    case "email.opened":
+      return "opened";
+    case "email.clicked":
+      return "clicked";
+    default:
+      return "unknown";
+  }
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function providerOccurredAt(event: AuthEmailWebhookEvent): Date {
+  const candidates = [event.created_at, event.data.created_at];
+  for (const candidate of candidates) {
+    const parsed = new Date(candidate);
+    if (!Number.isNaN(parsed.getTime())) return parsed;
+  }
+  return new Date();
+}
+
+export interface AuthEmailDeliveryRecordResult {
+  tracked: boolean;
+  duplicate: boolean;
+  attribution:
+    | "attempt_tag"
+    | "provider_message_id"
+    | "unmatched"
+    | "identity_conflict"
+    | null;
+}
+
+/**
+ * Claim a signed Resend delivery event without retaining its recipient,
+ * subject, tags, or payload. Attempt tags are authoritative when consistent;
+ * provider-message identity is the exact fallback. Every event is append-only.
+ */
+export async function recordAuthEmailDeliveryEvent(input: {
+  event: AuthEmailWebhookEvent;
+  webhookId: string;
+  db?: Database;
+}): Promise<AuthEmailDeliveryRecordResult> {
+  const database = input.db ?? defaultDb;
+  const providerMessageId = input.event.data.email_id.trim();
+  const webhookId = input.webhookId.trim();
+  if (
+    !providerMessageId ||
+    providerMessageId.length > 128 ||
+    !webhookId ||
+    webhookId.length > 128
+  ) {
+    return { tracked: false, duplicate: false, attribution: null };
+  }
+
+  const tags =
+    (input.event.data as { tags?: Record<string, string> }).tags ?? {};
+  const taggedAttemptValue = tags.openvpm_attempt_id?.trim();
+  const hasAuthTag =
+    tags.openvpm_email_kind === "auth_verification" ||
+    Boolean(taggedAttemptValue);
+
+  return withSystem(database, async (tx) => {
+    const [taggedAttempt] =
+      taggedAttemptValue && UUID_PATTERN.test(taggedAttemptValue)
+        ? await tx
+            .select({
+              id: authEmailAttempts.id,
+              providerMessageId: authEmailAttempts.providerMessageId,
+            })
+            .from(authEmailAttempts)
+            .where(eq(authEmailAttempts.id, taggedAttemptValue))
+            .limit(1)
+        : [];
+    const [providerAttempt] = await tx
+      .select({ id: authEmailAttempts.id })
+      .from(authEmailAttempts)
+      .where(
+        and(
+          eq(authEmailAttempts.provider, "resend"),
+          eq(authEmailAttempts.providerMessageId, providerMessageId),
+        ),
+      )
+      .limit(1);
+
+    if (!hasAuthTag && !providerAttempt) {
+      return { tracked: false, duplicate: false, attribution: null };
+    }
+
+    let attemptId: string | null = null;
+    let attribution: Exclude<
+      AuthEmailDeliveryRecordResult["attribution"],
+      null
+    >;
+    const tagProviderMismatch =
+      taggedAttempt?.providerMessageId !== null &&
+      taggedAttempt?.providerMessageId !== undefined &&
+      taggedAttempt.providerMessageId !== providerMessageId;
+    if (
+      taggedAttempt &&
+      (tagProviderMismatch ||
+        (providerAttempt && providerAttempt.id !== taggedAttempt.id))
+    ) {
+      attribution = "identity_conflict";
+    } else if (taggedAttempt) {
+      attemptId = taggedAttempt.id;
+      attribution = "attempt_tag";
+    } else if (providerAttempt) {
+      attemptId = providerAttempt.id;
+      attribution = "provider_message_id";
+    } else {
+      attribution = "unmatched";
+    }
+
+    const [inserted] = await tx
+      .insert(authEmailDeliveryEvents)
+      .values({
+        webhookId,
+        providerMessageId,
+        attemptId,
+        eventType: input.event.type,
+        classification: authEmailDeliveryClassification(input.event.type),
+        attribution,
+        occurredAt: providerOccurredAt(input.event),
+      })
+      .onConflictDoNothing({ target: authEmailDeliveryEvents.webhookId })
+      .returning({ id: authEmailDeliveryEvents.id });
+
+    return { tracked: true, duplicate: !inserted, attribution };
+  });
+}

--- a/apps/web/lib/auth-email-delivery.ts
+++ b/apps/web/lib/auth-email-delivery.ts
@@ -1,8 +1,12 @@
 import { createHash, randomUUID } from "node:crypto";
-import { and, eq, isNull, lte, ne } from "drizzle-orm";
+import { and, eq, isNull, ne, or } from "drizzle-orm";
 import type { WebhookEventPayload } from "resend";
 import type { Database } from "@openpims/db/client";
-import { authEmailAttempts, authEmailDeliveryEvents } from "@openpims/db";
+import {
+  authEmailAttempts,
+  authEmailDeliveryEvents,
+  authEmailWebhookConflicts,
+} from "@openpims/db";
 import { alertOps } from "@/lib/alerts";
 import { withSystem } from "@/lib/tenant-db";
 import {
@@ -168,6 +172,35 @@ async function hasDeliveryIdentityMismatch(input: {
   }
 }
 
+async function hasSignedTaggedAcceptance(input: {
+  database: Database;
+  attemptId: string;
+  providerMessageId: string;
+}): Promise<boolean> {
+  try {
+    const [evidence] = await withSystem(input.database, (tx) =>
+      tx
+        .select({ id: authEmailDeliveryEvents.id })
+        .from(authEmailDeliveryEvents)
+        .where(
+          and(
+            eq(authEmailDeliveryEvents.attemptId, input.attemptId),
+            eq(authEmailDeliveryEvents.provider, "resend"),
+            eq(
+              authEmailDeliveryEvents.providerMessageId,
+              input.providerMessageId,
+            ),
+            eq(authEmailDeliveryEvents.attribution, "attempt_tag"),
+          ),
+        )
+        .limit(1),
+    );
+    return Boolean(evidence);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Reserve, dispatch, and record one verification email. Callers must invoke
  * this from a tRPC post-commit effect with the root pool. Reservation and
@@ -246,12 +279,27 @@ export async function sendTrackedVerificationEmail(input: {
     providerMessageId,
     failureCode,
   });
-  const consistentState = stateMatchesOutcome(resolution.state, {
+  let consistentState = stateMatchesOutcome(resolution.state, {
     provider,
     outcome: recordedOutcome,
     providerMessageId,
     failureCode,
   });
+
+  // A signed tagged callback can win the race after a provider timeout but
+  // before this resolver observes the ledger. Treat that stronger durable
+  // evidence as acceptance instead of telling the user the result is unknown.
+  const signedAcceptedState =
+    provider === "resend" &&
+    recordedOutcome === "outcome_unknown" &&
+    resolution.state?.outcome === "accepted" &&
+    Boolean(resolution.state.providerMessageId) &&
+    (await hasSignedTaggedAcceptance({
+      database: input.db,
+      attemptId,
+      providerMessageId: resolution.state?.providerMessageId ?? "",
+    }));
+  consistentState = consistentState || signedAcceptedState;
 
   let identityConflict = providerIdentityConflict;
   if (
@@ -280,6 +328,18 @@ export async function sendTrackedVerificationEmail(input: {
         ? "Provider acceptance disagrees with durable signed verification evidence. Review the recovery queue."
         : "A verification provider outcome could not be confirmed in the durable ledger. Review the recovery queue.",
     );
+  }
+
+  if (signedAcceptedState && resolution.state?.providerMessageId) {
+    return {
+      success: true,
+      attemptId,
+      provider,
+      outcome: "accepted",
+      possiblySent: false,
+      evidencePersisted: true,
+      providerMessageId: resolution.state.providerMessageId,
+    };
   }
 
   // Once the provider is known to have accepted a message, persistence trouble
@@ -371,7 +431,6 @@ export function authEmailDeliveryClassification(
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
-export const AUTH_EMAIL_WEBHOOK_REPAIR_MIN_AGE_MS = 15_000;
 
 export function authEmailWebhookFingerprint(rawBody: string): string {
   return createHash("sha256").update(rawBody, "utf8").digest("hex");
@@ -407,6 +466,7 @@ type ExistingWebhookIdentity = {
   provider: string;
   providerMessageId: string;
   eventType: string;
+  attemptId: string | null;
   attribution:
     | "attempt_tag"
     | "provider_message_id"
@@ -438,10 +498,10 @@ function duplicateResult(
 /**
  * Claim a signed Resend delivery event without retaining its recipient,
  * subject, tags, or payload. The SHA-256 fingerprint proves whether a repeated
- * Svix id carried the exact same verified raw body. Early tagged callbacks are
- * linked immediately but repair a reserved attempt only after the API timeout
- * window, preventing an out-of-order callback from racing a different provider
- * result. Opens/clicks are redacted evidence only and never verify a user.
+ * Svix id carried the exact same verified raw body. Signed callbacks carrying
+ * both OpenVPM verification tags may repair a reserved or unknown Resend
+ * attempt immediately; a conflicting provider identity is quarantined instead.
+ * Opens/clicks are redacted evidence only and never verify a user.
  */
 export async function recordAuthEmailDeliveryEvent(input: {
   event: AuthEmailWebhookEvent;
@@ -473,8 +533,21 @@ export async function recordAuthEmailDeliveryEvent(input: {
   const hasAuthTag =
     tags.openvpm_email_kind === "auth_verification" ||
     Boolean(taggedAttemptValue);
+  const hasExactAuthAttemptTag =
+    tags.openvpm_email_kind === "auth_verification" &&
+    Boolean(taggedAttemptValue && UUID_PATTERN.test(taggedAttemptValue));
 
   const result = await withSystem(input.db, async (tx) => {
+    type TaggedAttempt = {
+      id: string;
+      outcome: AttemptState["outcome"];
+      provider: EmailProvider;
+      providerMessageId: string | null;
+    };
+    type InternalResult = AuthEmailDeliveryRecordResult & {
+      alertConflict: boolean;
+    };
+
     const selectExistingWebhook = async () => {
       const [existing] = await tx
         .select({
@@ -482,6 +555,7 @@ export async function recordAuthEmailDeliveryEvent(input: {
           provider: authEmailDeliveryEvents.provider,
           providerMessageId: authEmailDeliveryEvents.providerMessageId,
           eventType: authEmailDeliveryEvents.eventType,
+          attemptId: authEmailDeliveryEvents.attemptId,
           attribution: authEmailDeliveryEvents.attribution,
         })
         .from(authEmailDeliveryEvents)
@@ -490,29 +564,118 @@ export async function recordAuthEmailDeliveryEvent(input: {
       return existing as ExistingWebhookIdentity | undefined;
     };
 
-    const existing = await selectExistingWebhook();
-    if (existing) {
-      return duplicateResult(existing, {
+    const selectTaggedAttempt = async (): Promise<
+      TaggedAttempt | undefined
+    > => {
+      if (!taggedAttemptValue || !UUID_PATTERN.test(taggedAttemptValue)) {
+        return undefined;
+      }
+      const [attempt] = await tx
+        .select({
+          id: authEmailAttempts.id,
+          outcome: authEmailAttempts.outcome,
+          provider: authEmailAttempts.provider,
+          providerMessageId: authEmailAttempts.providerMessageId,
+        })
+        .from(authEmailAttempts)
+        .where(eq(authEmailAttempts.id, taggedAttemptValue))
+        .limit(1);
+      return attempt as TaggedAttempt | undefined;
+    };
+
+    const repairSignedTaggedAttempt = async (
+      attempt: TaggedAttempt | undefined,
+      expectedAttemptId?: string | null,
+    ) => {
+      if (
+        !hasExactAuthAttemptTag ||
+        !isOutboundAuthEmailEvent(input.event.type) ||
+        !attempt ||
+        (expectedAttemptId !== undefined &&
+          expectedAttemptId !== taggedAttemptValue) ||
+        attempt.provider !== "resend" ||
+        (attempt.providerMessageId !== null &&
+          attempt.providerMessageId !== providerMessageId)
+      ) {
+        return;
+      }
+      if (
+        attempt.outcome !== "reserved" &&
+        attempt.outcome !== "outcome_unknown"
+      ) {
+        return;
+      }
+      await tx
+        .update(authEmailAttempts)
+        .set({
+          outcome: "accepted",
+          resolvedAt: new Date(),
+          providerMessageId,
+          failureCode: null,
+        })
+        .where(
+          and(
+            eq(authEmailAttempts.id, attempt.id),
+            eq(authEmailAttempts.provider, "resend"),
+            isNull(authEmailAttempts.providerMessageId),
+            or(
+              eq(authEmailAttempts.outcome, "reserved"),
+              eq(authEmailAttempts.outcome, "outcome_unknown"),
+            ),
+          ),
+        );
+    };
+
+    const quarantineChangedWebhook = async (
+      existing: ExistingWebhookIdentity,
+    ): Promise<InternalResult> => {
+      const conflict = duplicateResult(existing, {
         rawBodyFingerprint,
         providerMessageId,
         eventType: input.event.type,
       });
+      const [inserted] = await tx
+        .insert(authEmailWebhookConflicts)
+        .values({
+          originalWebhookId: webhookId,
+          incomingRawBodyFingerprint: rawBodyFingerprint,
+          provider: "resend",
+          incomingProviderMessageId: providerMessageId,
+          incomingEventType: input.event.type,
+        })
+        .onConflictDoNothing({
+          target: [
+            authEmailWebhookConflicts.originalWebhookId,
+            authEmailWebhookConflicts.incomingRawBodyFingerprint,
+          ],
+        })
+        .returning({ id: authEmailWebhookConflicts.id });
+      return { ...conflict, alertConflict: Boolean(inserted) };
+    };
+
+    const existing = await selectExistingWebhook();
+    if (existing) {
+      const duplicate = duplicateResult(existing, {
+        rawBodyFingerprint,
+        providerMessageId,
+        eventType: input.event.type,
+      });
+      if (duplicate.duplicate) {
+        if (
+          existing.attribution === "attempt_tag" &&
+          existing.attemptId === taggedAttemptValue
+        ) {
+          await repairSignedTaggedAttempt(
+            await selectTaggedAttempt(),
+            existing.attemptId,
+          );
+        }
+        return { ...duplicate, alertConflict: false };
+      }
+      return quarantineChangedWebhook(existing);
     }
 
-    const [taggedAttempt] =
-      taggedAttemptValue && UUID_PATTERN.test(taggedAttemptValue)
-        ? await tx
-            .select({
-              id: authEmailAttempts.id,
-              createdAt: authEmailAttempts.createdAt,
-              outcome: authEmailAttempts.outcome,
-              provider: authEmailAttempts.provider,
-              providerMessageId: authEmailAttempts.providerMessageId,
-            })
-            .from(authEmailAttempts)
-            .where(eq(authEmailAttempts.id, taggedAttemptValue))
-            .limit(1)
-        : [];
+    const taggedAttempt = await selectTaggedAttempt();
     const [providerAttempt] = await tx
       .select({ id: authEmailAttempts.id })
       .from(authEmailAttempts)
@@ -530,7 +693,8 @@ export async function recordAuthEmailDeliveryEvent(input: {
         duplicate: false,
         conflict: false,
         attribution: null,
-      } satisfies AuthEmailDeliveryRecordResult;
+        alertConflict: false,
+      } satisfies InternalResult;
     }
 
     let attemptId: string | null = null;
@@ -576,48 +740,35 @@ export async function recordAuthEmailDeliveryEvent(input: {
 
     if (!inserted) {
       const racedExisting = await selectExistingWebhook();
-      return racedExisting
-        ? duplicateResult(racedExisting, {
-            rawBodyFingerprint,
-            providerMessageId,
-            eventType: input.event.type,
-          })
-        : {
-            tracked: true,
-            duplicate: false,
-            conflict: true,
-            attribution: "identity_conflict" as const,
-          };
+      if (!racedExisting) {
+        throw new Error("Webhook identity winner could not be read.");
+      }
+      const racedDuplicate = duplicateResult(racedExisting, {
+        rawBodyFingerprint,
+        providerMessageId,
+        eventType: input.event.type,
+      });
+      if (racedDuplicate.duplicate) {
+        if (
+          racedExisting.attribution === "attempt_tag" &&
+          racedExisting.attemptId === taggedAttemptValue
+        ) {
+          await repairSignedTaggedAttempt(
+            taggedAttempt,
+            racedExisting.attemptId,
+          );
+        }
+        return { ...racedDuplicate, alertConflict: false };
+      }
+      return quarantineChangedWebhook(racedExisting);
     }
 
     if (
       taggedAttempt &&
       attribution === "attempt_tag" &&
-      taggedAttempt.outcome === "reserved" &&
-      taggedAttempt.createdAt.getTime() <=
-        Date.now() - AUTH_EMAIL_WEBHOOK_REPAIR_MIN_AGE_MS &&
-      isOutboundAuthEmailEvent(input.event.type)
+      hasExactAuthAttemptTag
     ) {
-      await tx
-        .update(authEmailAttempts)
-        .set({
-          outcome: "accepted",
-          resolvedAt: new Date(),
-          providerMessageId,
-          failureCode: null,
-        })
-        .where(
-          and(
-            eq(authEmailAttempts.id, taggedAttempt.id),
-            eq(authEmailAttempts.provider, "resend"),
-            eq(authEmailAttempts.outcome, "reserved"),
-            isNull(authEmailAttempts.providerMessageId),
-            lte(
-              authEmailAttempts.createdAt,
-              new Date(Date.now() - AUTH_EMAIL_WEBHOOK_REPAIR_MIN_AGE_MS),
-            ),
-          ),
-        );
+      await repairSignedTaggedAttempt(taggedAttempt, taggedAttempt.id);
     }
 
     return {
@@ -625,14 +776,16 @@ export async function recordAuthEmailDeliveryEvent(input: {
       duplicate: false,
       conflict: attribution === "identity_conflict",
       attribution,
-    } satisfies AuthEmailDeliveryRecordResult;
+      alertConflict: attribution === "identity_conflict",
+    } satisfies InternalResult;
   });
 
-  if (result.conflict) {
+  if (result.alertConflict) {
     await safeAuthEmailAlert(
       "Auth email webhook identity conflict",
       "A signed verification callback disagreed with immutable provider evidence. Review the recovery queue.",
     );
   }
-  return result;
+  const { alertConflict: _alertConflict, ...publicResult } = result;
+  return publicResult;
 }

--- a/apps/web/lib/auth-email-delivery.ts
+++ b/apps/web/lib/auth-email-delivery.ts
@@ -1,12 +1,14 @@
-import { randomUUID } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { createHash, randomUUID } from "node:crypto";
+import { and, eq, isNull, lte, ne } from "drizzle-orm";
 import type { WebhookEventPayload } from "resend";
-import { db as defaultDb } from "@openpims/db/client";
 import type { Database } from "@openpims/db/client";
 import { authEmailAttempts, authEmailDeliveryEvents } from "@openpims/db";
+import { alertOps } from "@/lib/alerts";
 import { withSystem } from "@/lib/tenant-db";
 import {
   sendVerificationEmailWithProviderEvidence,
+  verificationEmailProvider,
+  type EmailProvider,
   type EmailProviderOutcome,
 } from "@/lib/email";
 
@@ -15,15 +17,163 @@ export type AuthEmailSource = "registration" | "authenticated_resend";
 export interface TrackedVerificationEmailResult {
   success: boolean;
   attemptId: string;
+  provider: EmailProvider;
   outcome: EmailProviderOutcome;
+  possiblySent: boolean;
+  evidencePersisted: boolean;
   providerMessageId?: string;
+  identityConflict?: boolean;
   error?: string;
 }
 
+type AttemptState = {
+  outcome: EmailProviderOutcome | "reserved";
+  provider: EmailProvider;
+  providerMessageId: string | null;
+  failureCode: string | null;
+};
+
+async function safeAuthEmailAlert(subject: string, detail: string) {
+  // Both arguments are constants chosen by this module. Never pass provider
+  // errors, recipient data, URLs, tokens, or message identifiers here.
+  await alertOps(subject, detail).catch(() => undefined);
+}
+
+async function readAttemptState(
+  database: Database,
+  attemptId: string,
+): Promise<AttemptState | null> {
+  const [state] = await withSystem(database, (tx) =>
+    tx
+      .select({
+        outcome: authEmailAttempts.outcome,
+        provider: authEmailAttempts.provider,
+        providerMessageId: authEmailAttempts.providerMessageId,
+        failureCode: authEmailAttempts.failureCode,
+      })
+      .from(authEmailAttempts)
+      .where(eq(authEmailAttempts.id, attemptId))
+      .limit(1),
+  );
+  return (state as AttemptState | undefined) ?? null;
+}
+
+async function persistAttemptOutcome(input: {
+  database: Database;
+  attemptId: string;
+  outcome: EmailProviderOutcome;
+  providerMessageId: string | null;
+  failureCode: string | null;
+}): Promise<{ persisted: boolean; state: AttemptState | null }> {
+  // Each iteration is an independent top-level transaction. This safely
+  // handles both a transient failure and the ambiguous "commit succeeded but
+  // acknowledgement was lost" case without ever replaying the provider call.
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const [recorded] = await withSystem(input.database, (tx) =>
+        tx
+          .update(authEmailAttempts)
+          .set({
+            outcome: input.outcome,
+            resolvedAt: new Date(),
+            providerMessageId: input.providerMessageId,
+            failureCode: input.failureCode,
+          })
+          .where(
+            and(
+              eq(authEmailAttempts.id, input.attemptId),
+              eq(authEmailAttempts.outcome, "reserved"),
+            ),
+          )
+          .returning({
+            outcome: authEmailAttempts.outcome,
+            provider: authEmailAttempts.provider,
+            providerMessageId: authEmailAttempts.providerMessageId,
+            failureCode: authEmailAttempts.failureCode,
+          }),
+      );
+      if (recorded) {
+        return { persisted: true, state: recorded as AttemptState };
+      }
+
+      // A signed webhook may have repaired the reservation while the provider
+      // result was in flight. Read it rather than attempting to rewrite a
+      // resolved, immutable state.
+      return {
+        persisted: false,
+        state: await readAttemptState(input.database, input.attemptId),
+      };
+    } catch {
+      // Retry only the idempotent CAS; the provider call is never repeated.
+    }
+  }
+
+  try {
+    return {
+      persisted: false,
+      state: await readAttemptState(input.database, input.attemptId),
+    };
+  } catch {
+    return { persisted: false, state: null };
+  }
+}
+
+function stateMatchesOutcome(
+  state: AttemptState | null,
+  input: {
+    provider: EmailProvider;
+    outcome: EmailProviderOutcome;
+    providerMessageId: string | null;
+    failureCode: string | null;
+  },
+): boolean {
+  return Boolean(
+    state &&
+    state.provider === input.provider &&
+    state.outcome === input.outcome &&
+    state.providerMessageId === input.providerMessageId &&
+    state.failureCode === input.failureCode,
+  );
+}
+
+async function hasDeliveryIdentityMismatch(input: {
+  database: Database;
+  attemptId: string;
+  providerMessageId: string;
+}): Promise<boolean> {
+  try {
+    const [mismatch] = await withSystem(input.database, (tx) =>
+      tx
+        .select({ id: authEmailDeliveryEvents.id })
+        .from(authEmailDeliveryEvents)
+        .where(
+          and(
+            eq(authEmailDeliveryEvents.attemptId, input.attemptId),
+            eq(authEmailDeliveryEvents.provider, "resend"),
+            ne(
+              authEmailDeliveryEvents.providerMessageId,
+              input.providerMessageId,
+            ),
+          ),
+        )
+        .limit(1),
+    );
+    return Boolean(mismatch);
+  } catch {
+    await safeAuthEmailAlert(
+      "Auth email identity revalidation failed",
+      "A verification provider result could not be compared with signed delivery evidence. Review the recovery queue.",
+    );
+    return false;
+  }
+}
+
 /**
- * Reserve, dispatch, and record one verification email. The provider call is
- * intentionally outside every database transaction. No recipient or auth-link
- * content is copied into the operational ledger.
+ * Reserve, dispatch, and record one verification email. Callers must invoke
+ * this from a tRPC post-commit effect with the root pool. Reservation and
+ * resolution each use their own top-level system transaction; the provider
+ * call occurs between them, outside every database transaction. No recipient
+ * or auth-link content is copied into the ledger or operational alerts.
  */
 export async function sendTrackedVerificationEmail(input: {
   practiceId: string;
@@ -32,21 +182,39 @@ export async function sendTrackedVerificationEmail(input: {
   to: string;
   name: string;
   verifyUrl: string;
-  db?: Database;
+  db: Database;
 }): Promise<TrackedVerificationEmailResult> {
-  const database = input.db ?? defaultDb;
   const attemptId = randomUUID();
   const idempotencyKey = `auth-email:${attemptId}`;
+  const provider = verificationEmailProvider();
 
-  await withSystem(database, async (tx) => {
-    await tx.insert(authEmailAttempts).values({
-      id: attemptId,
-      practiceId: input.practiceId,
-      userId: input.userId,
-      source: input.source,
-      idempotencyKey,
+  try {
+    await withSystem(input.db, async (tx) => {
+      await tx.insert(authEmailAttempts).values({
+        id: attemptId,
+        practiceId: input.practiceId,
+        userId: input.userId,
+        source: input.source,
+        provider,
+        idempotencyKey,
+      });
     });
-  });
+  } catch {
+    await safeAuthEmailAlert(
+      "Auth email reservation failed",
+      "A verification dispatch was not attempted because its durable reservation could not be committed.",
+    );
+    return {
+      success: false,
+      attemptId,
+      provider,
+      outcome: "definite_failure",
+      possiblySent: false,
+      evidencePersisted: false,
+      error:
+        "Verification email could not be prepared. Please try again later.",
+    };
+  }
 
   const providerResult = await sendVerificationEmailWithProviderEvidence({
     to: input.to,
@@ -55,57 +223,107 @@ export async function sendTrackedVerificationEmail(input: {
     attemptId,
     idempotencyKey,
   });
+  const providerIdentityConflict = providerResult.provider !== provider;
   const recordedOutcome: EmailProviderOutcome =
-    providerResult.outcome === "accepted" && !providerResult.id
+    providerIdentityConflict ||
+    (providerResult.outcome === "accepted" && !providerResult.id)
       ? "outcome_unknown"
       : providerResult.outcome;
-  const resolvedAt = new Date();
-  const [recorded] = await withSystem(database, (tx) =>
-    tx
-      .update(authEmailAttempts)
-      .set({
-        outcome: recordedOutcome,
-        resolvedAt,
-        providerMessageId:
-          recordedOutcome === "accepted" ? providerResult.id : null,
-        failureCode:
-          recordedOutcome === "accepted"
-            ? null
-            : (providerResult.failureCode ??
-              (providerResult.outcome === "accepted"
-                ? "missing_provider_id"
-                : "provider_exception")),
-      })
-      .where(
-        and(
-          eq(authEmailAttempts.id, attemptId),
-          eq(authEmailAttempts.outcome, "reserved"),
-        ),
-      )
-      .returning({ id: authEmailAttempts.id }),
-  );
+  const providerMessageId =
+    recordedOutcome === "accepted" ? (providerResult.id ?? null) : null;
+  const failureCode =
+    recordedOutcome === "accepted"
+      ? null
+      : (providerResult.failureCode ??
+        (providerResult.outcome === "accepted"
+          ? "missing_provider_id"
+          : "provider_exception"));
 
-  if (!recorded) {
-    throw new Error(
-      "Verification email provider outcome could not be recorded safely.",
+  const resolution = await persistAttemptOutcome({
+    database: input.db,
+    attemptId,
+    outcome: recordedOutcome,
+    providerMessageId,
+    failureCode,
+  });
+  const consistentState = stateMatchesOutcome(resolution.state, {
+    provider,
+    outcome: recordedOutcome,
+    providerMessageId,
+    failureCode,
+  });
+
+  let identityConflict = providerIdentityConflict;
+  if (
+    recordedOutcome === "accepted" &&
+    provider === "resend" &&
+    providerMessageId
+  ) {
+    identityConflict =
+      identityConflict ||
+      (resolution.state?.outcome === "accepted" &&
+        resolution.state.providerMessageId !== providerMessageId) ||
+      (await hasDeliveryIdentityMismatch({
+        database: input.db,
+        attemptId,
+        providerMessageId,
+      }));
+  }
+
+  const evidencePersisted = consistentState && !identityConflict;
+  if (!evidencePersisted) {
+    await safeAuthEmailAlert(
+      identityConflict
+        ? "Auth email provider identity conflict"
+        : "Auth email outcome persistence failed",
+      identityConflict
+        ? "Provider acceptance disagrees with durable signed verification evidence. Review the recovery queue."
+        : "A verification provider outcome could not be confirmed in the durable ledger. Review the recovery queue.",
     );
   }
 
+  // Once the provider is known to have accepted a message, persistence trouble
+  // must never encourage an immediate duplicate. The signed tagged webhook can
+  // still repair an old reserved attempt to this accepted identity.
+  if (
+    providerResult.outcome === "accepted" &&
+    providerResult.id &&
+    !providerIdentityConflict
+  ) {
+    return {
+      success: true,
+      attemptId,
+      provider,
+      outcome: "accepted",
+      possiblySent: false,
+      evidencePersisted,
+      providerMessageId: providerResult.id,
+      ...(identityConflict ? { identityConflict: true } : {}),
+    };
+  }
+
+  if (recordedOutcome === "outcome_unknown") {
+    return {
+      success: false,
+      attemptId,
+      provider,
+      outcome: "outcome_unknown",
+      possiblySent: true,
+      evidencePersisted,
+      ...(identityConflict ? { identityConflict: true } : {}),
+      error:
+        "Verification email may have been sent. Check your inbox before requesting another.",
+    };
+  }
+
   return {
-    success: providerResult.success && recordedOutcome === "accepted",
+    success: false,
     attemptId,
-    outcome: recordedOutcome,
-    ...(recordedOutcome === "accepted" && providerResult.id
-      ? { providerMessageId: providerResult.id }
-      : {}),
-    ...(recordedOutcome === "definite_failure"
-      ? { error: "Email provider did not accept the verification message." }
-      : recordedOutcome === "outcome_unknown"
-        ? {
-            error:
-              "Email provider outcome is unknown; do not retry automatically.",
-          }
-        : {}),
+    provider,
+    outcome: "definite_failure",
+    possiblySent: false,
+    evidencePersisted,
+    error: "Email provider did not accept the verification message.",
   };
 }
 
@@ -152,6 +370,12 @@ export function authEmailDeliveryClassification(
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+export const AUTH_EMAIL_WEBHOOK_REPAIR_MIN_AGE_MS = 15_000;
+
+export function authEmailWebhookFingerprint(rawBody: string): string {
+  return createHash("sha256").update(rawBody, "utf8").digest("hex");
+}
 
 function providerOccurredAt(event: AuthEmailWebhookEvent): Date {
   const candidates = [event.created_at, event.data.created_at];
@@ -162,9 +386,14 @@ function providerOccurredAt(event: AuthEmailWebhookEvent): Date {
   return new Date();
 }
 
+function isOutboundAuthEmailEvent(type: WebhookEventPayload["type"]): boolean {
+  return type.startsWith("email.") && type !== "email.received";
+}
+
 export interface AuthEmailDeliveryRecordResult {
   tracked: boolean;
   duplicate: boolean;
+  conflict: boolean;
   attribution:
     | "attempt_tag"
     | "provider_message_id"
@@ -173,26 +402,69 @@ export interface AuthEmailDeliveryRecordResult {
     | null;
 }
 
+type ExistingWebhookIdentity = {
+  rawBodyFingerprint: string;
+  provider: string;
+  providerMessageId: string;
+  eventType: string;
+  attribution:
+    | "attempt_tag"
+    | "provider_message_id"
+    | "unmatched"
+    | "identity_conflict";
+};
+
+function duplicateResult(
+  existing: ExistingWebhookIdentity,
+  input: {
+    rawBodyFingerprint: string;
+    providerMessageId: string;
+    eventType: string;
+  },
+): AuthEmailDeliveryRecordResult {
+  const exact =
+    existing.rawBodyFingerprint === input.rawBodyFingerprint &&
+    existing.provider === "resend" &&
+    existing.providerMessageId === input.providerMessageId &&
+    existing.eventType === input.eventType;
+  return {
+    tracked: true,
+    duplicate: exact,
+    conflict: !exact,
+    attribution: exact ? existing.attribution : "identity_conflict",
+  };
+}
+
 /**
  * Claim a signed Resend delivery event without retaining its recipient,
- * subject, tags, or payload. Attempt tags are authoritative when consistent;
- * provider-message identity is the exact fallback. Every event is append-only.
+ * subject, tags, or payload. The SHA-256 fingerprint proves whether a repeated
+ * Svix id carried the exact same verified raw body. Early tagged callbacks are
+ * linked immediately but repair a reserved attempt only after the API timeout
+ * window, preventing an out-of-order callback from racing a different provider
+ * result. Opens/clicks are redacted evidence only and never verify a user.
  */
 export async function recordAuthEmailDeliveryEvent(input: {
   event: AuthEmailWebhookEvent;
   webhookId: string;
-  db?: Database;
+  rawBodyFingerprint: string;
+  db: Database;
 }): Promise<AuthEmailDeliveryRecordResult> {
-  const database = input.db ?? defaultDb;
   const providerMessageId = input.event.data.email_id.trim();
   const webhookId = input.webhookId.trim();
+  const rawBodyFingerprint = input.rawBodyFingerprint.trim();
   if (
     !providerMessageId ||
     providerMessageId.length > 128 ||
     !webhookId ||
-    webhookId.length > 128
+    webhookId.length > 128 ||
+    !SHA256_PATTERN.test(rawBodyFingerprint)
   ) {
-    return { tracked: false, duplicate: false, attribution: null };
+    return {
+      tracked: false,
+      duplicate: false,
+      conflict: false,
+      attribution: null,
+    };
   }
 
   const tags =
@@ -202,12 +474,39 @@ export async function recordAuthEmailDeliveryEvent(input: {
     tags.openvpm_email_kind === "auth_verification" ||
     Boolean(taggedAttemptValue);
 
-  return withSystem(database, async (tx) => {
+  const result = await withSystem(input.db, async (tx) => {
+    const selectExistingWebhook = async () => {
+      const [existing] = await tx
+        .select({
+          rawBodyFingerprint: authEmailDeliveryEvents.rawBodyFingerprint,
+          provider: authEmailDeliveryEvents.provider,
+          providerMessageId: authEmailDeliveryEvents.providerMessageId,
+          eventType: authEmailDeliveryEvents.eventType,
+          attribution: authEmailDeliveryEvents.attribution,
+        })
+        .from(authEmailDeliveryEvents)
+        .where(eq(authEmailDeliveryEvents.webhookId, webhookId))
+        .limit(1);
+      return existing as ExistingWebhookIdentity | undefined;
+    };
+
+    const existing = await selectExistingWebhook();
+    if (existing) {
+      return duplicateResult(existing, {
+        rawBodyFingerprint,
+        providerMessageId,
+        eventType: input.event.type,
+      });
+    }
+
     const [taggedAttempt] =
       taggedAttemptValue && UUID_PATTERN.test(taggedAttemptValue)
         ? await tx
             .select({
               id: authEmailAttempts.id,
+              createdAt: authEmailAttempts.createdAt,
+              outcome: authEmailAttempts.outcome,
+              provider: authEmailAttempts.provider,
               providerMessageId: authEmailAttempts.providerMessageId,
             })
             .from(authEmailAttempts)
@@ -226,7 +525,12 @@ export async function recordAuthEmailDeliveryEvent(input: {
       .limit(1);
 
     if (!hasAuthTag && !providerAttempt) {
-      return { tracked: false, duplicate: false, attribution: null };
+      return {
+        tracked: false,
+        duplicate: false,
+        conflict: false,
+        attribution: null,
+      } satisfies AuthEmailDeliveryRecordResult;
     }
 
     let attemptId: string | null = null;
@@ -235,9 +539,10 @@ export async function recordAuthEmailDeliveryEvent(input: {
       null
     >;
     const tagProviderMismatch =
-      taggedAttempt?.providerMessageId !== null &&
-      taggedAttempt?.providerMessageId !== undefined &&
-      taggedAttempt.providerMessageId !== providerMessageId;
+      taggedAttempt?.provider !== undefined &&
+      (taggedAttempt.provider !== "resend" ||
+        (taggedAttempt.providerMessageId !== null &&
+          taggedAttempt.providerMessageId !== providerMessageId));
     if (
       taggedAttempt &&
       (tagProviderMismatch ||
@@ -258,6 +563,7 @@ export async function recordAuthEmailDeliveryEvent(input: {
       .insert(authEmailDeliveryEvents)
       .values({
         webhookId,
+        rawBodyFingerprint,
         providerMessageId,
         attemptId,
         eventType: input.event.type,
@@ -268,6 +574,65 @@ export async function recordAuthEmailDeliveryEvent(input: {
       .onConflictDoNothing({ target: authEmailDeliveryEvents.webhookId })
       .returning({ id: authEmailDeliveryEvents.id });
 
-    return { tracked: true, duplicate: !inserted, attribution };
+    if (!inserted) {
+      const racedExisting = await selectExistingWebhook();
+      return racedExisting
+        ? duplicateResult(racedExisting, {
+            rawBodyFingerprint,
+            providerMessageId,
+            eventType: input.event.type,
+          })
+        : {
+            tracked: true,
+            duplicate: false,
+            conflict: true,
+            attribution: "identity_conflict" as const,
+          };
+    }
+
+    if (
+      taggedAttempt &&
+      attribution === "attempt_tag" &&
+      taggedAttempt.outcome === "reserved" &&
+      taggedAttempt.createdAt.getTime() <=
+        Date.now() - AUTH_EMAIL_WEBHOOK_REPAIR_MIN_AGE_MS &&
+      isOutboundAuthEmailEvent(input.event.type)
+    ) {
+      await tx
+        .update(authEmailAttempts)
+        .set({
+          outcome: "accepted",
+          resolvedAt: new Date(),
+          providerMessageId,
+          failureCode: null,
+        })
+        .where(
+          and(
+            eq(authEmailAttempts.id, taggedAttempt.id),
+            eq(authEmailAttempts.provider, "resend"),
+            eq(authEmailAttempts.outcome, "reserved"),
+            isNull(authEmailAttempts.providerMessageId),
+            lte(
+              authEmailAttempts.createdAt,
+              new Date(Date.now() - AUTH_EMAIL_WEBHOOK_REPAIR_MIN_AGE_MS),
+            ),
+          ),
+        );
+    }
+
+    return {
+      tracked: true,
+      duplicate: false,
+      conflict: attribution === "identity_conflict",
+      attribution,
+    } satisfies AuthEmailDeliveryRecordResult;
   });
+
+  if (result.conflict) {
+    await safeAuthEmailAlert(
+      "Auth email webhook identity conflict",
+      "A signed verification callback disagreed with immutable provider evidence. Review the recovery queue.",
+    );
+  }
+  return result;
 }

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -281,6 +281,8 @@ describe("summarizePracticeExport", () => {
     expect(sections).not.toContain("practiceConversionMilestones");
     expect(sections).not.toContain("rateLimitBuckets");
     expect(sections).not.toContain("messagingRegistrations");
+    expect(sections).not.toContain("authEmailAttempts");
+    expect(sections).not.toContain("authEmailDeliveryEvents");
     expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.usageRecords).toContain("billing");
     expect(
       PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.practiceConversionMilestones,
@@ -293,6 +295,12 @@ describe("summarizePracticeExport", () => {
     );
     expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.messagingRegistrations).toContain(
       "operational database disaster recovery",
+    );
+    expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.authEmailAttempts).toContain(
+      "provider identity",
+    );
+    expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.authEmailDeliveryEvents).toContain(
+      "immutable",
     );
   });
 
@@ -1761,9 +1769,14 @@ describe("restorePracticeData", () => {
       referenceRangeHigh: "18.000",
       actorName: "Clinician",
     });
-    expect(rows.filter((candidate) =>
-      typeof candidate.id === "string" && candidate.id.startsWith("lab-") && candidate.id.endsWith("event"),
-    )).toHaveLength(5);
+    expect(
+      rows.filter(
+        (candidate) =>
+          typeof candidate.id === "string" &&
+          candidate.id.startsWith("lab-") &&
+          candidate.id.endsWith("event"),
+      ),
+    ).toHaveLength(5);
     expect(row("lab-created-event")).toMatchObject({
       statusAfter: "pending",
       resultValue: null,

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -283,6 +283,7 @@ describe("summarizePracticeExport", () => {
     expect(sections).not.toContain("messagingRegistrations");
     expect(sections).not.toContain("authEmailAttempts");
     expect(sections).not.toContain("authEmailDeliveryEvents");
+    expect(sections).not.toContain("authEmailWebhookConflicts");
     expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.usageRecords).toContain("billing");
     expect(
       PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.practiceConversionMilestones,
@@ -302,6 +303,9 @@ describe("summarizePracticeExport", () => {
     expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.authEmailDeliveryEvents).toContain(
       "immutable",
     );
+    expect(
+      PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.authEmailWebhookConflicts,
+    ).toContain("conflict evidence");
   });
 
   it("counts present sections and reports missing sections", () => {

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -284,6 +284,7 @@ describe("summarizePracticeExport", () => {
     expect(sections).not.toContain("authEmailAttempts");
     expect(sections).not.toContain("authEmailDeliveryEvents");
     expect(sections).not.toContain("authEmailWebhookConflicts");
+    expect(sections).not.toContain("authEmailProviderIdentityConflicts");
     expect(PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.usageRecords).toContain("billing");
     expect(
       PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.practiceConversionMilestones,
@@ -306,6 +307,9 @@ describe("summarizePracticeExport", () => {
     expect(
       PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.authEmailWebhookConflicts,
     ).toContain("conflict evidence");
+    expect(
+      PRACTICE_EXPORT_SYSTEM_EXCLUSIONS.authEmailProviderIdentityConflicts,
+    ).toContain("provider identity conflict evidence");
   });
 
   it("counts present sections and reports missing sections", () => {

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -92,6 +92,8 @@ export const PRACTICE_EXPORT_SYSTEM_EXCLUSIONS = {
     "System verification-email dispatch evidence; it contains live provider identity and is recovered only through operational database disaster recovery.",
   authEmailDeliveryEvents:
     "Global immutable verification-email provider callback evidence; it is not clinic-owned restore data.",
+  authEmailWebhookConflicts:
+    "Global immutable verification-email callback conflict evidence; it is not clinic-owned restore data.",
   captureSessions:
     "Expiring QR photo-capture link tokens; restoring them would resurrect old capture URLs. The photos themselves are in the files section.",
   consentRequests:

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -94,6 +94,8 @@ export const PRACTICE_EXPORT_SYSTEM_EXCLUSIONS = {
     "Global immutable verification-email provider callback evidence; it is not clinic-owned restore data.",
   authEmailWebhookConflicts:
     "Global immutable verification-email callback conflict evidence; it is not clinic-owned restore data.",
+  authEmailProviderIdentityConflicts:
+    "Global immutable verification-email provider identity conflict evidence; it is not clinic-owned restore data.",
   captureSessions:
     "Expiring QR photo-capture link tokens; restoring them would resurrect old capture URLs. The photos themselves are in the files section.",
   consentRequests:

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -88,6 +88,10 @@ export const PRACTICE_EXPORT_SYSTEM_EXCLUSIONS = {
   verificationTokens: "Transient authentication verification tokens.",
   authTokens:
     "Expiring pre-tenant email verification and password-reset tokens.",
+  authEmailAttempts:
+    "System verification-email dispatch evidence; it contains live provider identity and is recovered only through operational database disaster recovery.",
+  authEmailDeliveryEvents:
+    "Global immutable verification-email provider callback evidence; it is not clinic-owned restore data.",
   captureSessions:
     "Expiring QR photo-capture link tokens; restoring them would resurrect old capture URLs. The photos themselves are in the files section.",
   consentRequests:

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -36,6 +36,24 @@ type ResendEmailSendOptions = NonNullable<
   signal?: AbortSignal;
 };
 
+export type EmailProviderOutcome =
+  | "accepted"
+  | "definite_failure"
+  | "outcome_unknown";
+
+export interface EmailProviderEvidence {
+  success: boolean;
+  id?: string;
+  error?: string;
+  outcome: EmailProviderOutcome;
+  failureCode?:
+    | "provider_not_configured"
+    | "provider_rejected"
+    | "send_timeout"
+    | "provider_exception"
+    | "missing_provider_id";
+}
+
 function emailSendTimeoutMessage(): string {
   return `Email send timed out after ${EMAIL_SEND_TIMEOUT_MS}ms`;
 }
@@ -105,14 +123,21 @@ function ctaButton(label: string, url: string): string {
 // Core send function
 // ---------------------------------------------------------------------------
 
-export async function sendEmail(options: {
+interface EmailDispatchOptions {
   to: string;
   subject: string;
   html: string;
   from?: string;
   replyTo?: string;
   headers?: Record<string, string>;
-}): Promise<{ success: boolean; id?: string; error?: string }> {
+  tags?: Array<{ name: string; value: string }>;
+  idempotencyKey?: string;
+  redactRecipientInLogs?: boolean;
+}
+
+async function dispatchEmail(
+  options: EmailDispatchOptions,
+): Promise<EmailProviderEvidence> {
   const client = getResend();
   const from = defaultEmailFrom(options.from);
   const replyTo = nonBlankEmailValue(options.replyTo);
@@ -122,18 +147,30 @@ export async function sendEmail(options: {
       return {
         success: false,
         error: "Email provider is not configured for hosted sending.",
+        outcome: "definite_failure",
+        failureCode: "provider_not_configured",
       };
     }
 
     // Development fallback – log to console instead of sending
     console.log("──────────────────────────────────────────");
-    console.log("[Email] No RESEND_API_KEY configured – logging email to console");
-    console.log(`  To:      ${options.to}`);
+    console.log(
+      "[Email] No RESEND_API_KEY configured – logging email to console",
+    );
+    console.log(
+      `  To:      ${options.redactRecipientInLogs ? "[redacted auth recipient]" : options.to}`,
+    );
     console.log(`  From:    ${from}`);
     console.log(`  Subject: ${options.subject}`);
     console.log("  HTML:    (omitted – check server logs for full content)");
     console.log("──────────────────────────────────────────");
-    return { success: true, id: "dev-console" };
+    return {
+      success: true,
+      id: options.idempotencyKey
+        ? `dev-console:${options.idempotencyKey}`.slice(0, 128)
+        : "dev-console",
+      outcome: "accepted",
+    };
   }
 
   const controller = new AbortController();
@@ -143,37 +180,84 @@ export async function sendEmail(options: {
     const sendOptions: ResendEmailSendOptions = {
       signal: controller.signal,
     };
-    const { data, error } = await client.emails.send({
-      from,
-      to: options.to,
-      subject: options.subject,
-      html: options.html,
-      ...(replyTo ? { replyTo } : {}),
-      ...(options.headers ? { headers: options.headers } : {}),
-    }, sendOptions);
+    const { data, error } = await client.emails.send(
+      {
+        from,
+        to: options.to,
+        subject: options.subject,
+        html: options.html,
+        ...(replyTo ? { replyTo } : {}),
+        ...(options.headers ? { headers: options.headers } : {}),
+        ...(options.tags ? { tags: options.tags } : {}),
+      },
+      {
+        ...sendOptions,
+        ...(options.idempotencyKey
+          ? { idempotencyKey: options.idempotencyKey }
+          : {}),
+      },
+    );
 
     if (error) {
-      console.error("[Email] Resend error:", error);
+      console.error(
+        "[Email] Resend error:",
+        options.redactRecipientInLogs
+          ? "auth verification provider rejection"
+          : error,
+      );
+      const timedOut = controller.signal.aborted;
       return {
         success: false,
-        error: controller.signal.aborted
-          ? emailSendTimeoutMessage()
-          : error.message,
+        error: timedOut ? emailSendTimeoutMessage() : error.message,
+        outcome: timedOut ? "outcome_unknown" : "definite_failure",
+        failureCode: timedOut ? "send_timeout" : "provider_rejected",
       };
     }
 
-    return { success: true, id: data?.id };
+    if (!data?.id) {
+      return {
+        success: false,
+        error: "Email provider response did not include a message id.",
+        outcome: "outcome_unknown",
+        failureCode: "missing_provider_id",
+      };
+    }
+
+    return { success: true, id: data.id, outcome: "accepted" };
   } catch (err) {
     const message = controller.signal.aborted
       ? emailSendTimeoutMessage()
       : err instanceof Error
         ? err.message
         : "Unknown email error";
-    console.error("[Email] Exception:", message);
-    return { success: false, error: message };
+    console.error(
+      "[Email] Exception:",
+      options.redactRecipientInLogs
+        ? "auth verification provider exception"
+        : message,
+    );
+    return {
+      success: false,
+      error: message,
+      outcome: "outcome_unknown",
+      failureCode: controller.signal.aborted
+        ? "send_timeout"
+        : "provider_exception",
+    };
   } finally {
     clearTimeout(timeout);
   }
+}
+
+export async function sendEmail(
+  options: EmailDispatchOptions,
+): Promise<{ success: boolean; id?: string; error?: string }> {
+  const { success, id, error } = await dispatchEmail(options);
+  return {
+    success,
+    ...(id ? { id } : {}),
+    ...(error ? { error } : {}),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -383,11 +467,13 @@ export async function sendClientPaymentReceiptEmail(data: {
 // Account: email verification + password reset (hosted auth)
 // ---------------------------------------------------------------------------
 
-export async function sendVerificationEmail(data: {
+interface VerificationEmailData {
   to: string;
   name: string;
   verifyUrl: string;
-}): Promise<{ success: boolean; id?: string; error?: string }> {
+}
+
+function verificationEmailContent(data: VerificationEmailData) {
   const body = `
     <p style="margin:0 0 16px;color:#111827;font-size:15px;line-height:1.6;">Hi ${data.name},</p>
     <p style="margin:0 0 8px;color:#111827;font-size:15px;line-height:1.6;">Welcome to OpenVPM! Your trial is already active. Please confirm your email address to secure your workspace and keep important account messages deliverable.</p>
@@ -395,12 +481,37 @@ export async function sendVerificationEmail(data: {
     <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.5;">This link expires in 24 hours. If you didn't create an OpenVPM account, you can ignore this email.</p>
   `;
   const html = emailLayout("OpenVPM", body);
-  const result = await sendEmail({
+  return { subject: "Verify your OpenVPM email", html };
+}
+
+export async function sendVerificationEmail(
+  data: VerificationEmailData,
+): Promise<{ success: boolean; id?: string; error?: string }> {
+  const content = verificationEmailContent(data);
+  return sendEmail({
     to: data.to,
-    subject: "Verify your OpenVPM email",
-    html,
+    ...content,
   });
-  return result;
+}
+
+/** Provider-evidence variant used only by the durable auth-email dispatcher. */
+export async function sendVerificationEmailWithProviderEvidence(
+  data: VerificationEmailData & {
+    attemptId: string;
+    idempotencyKey: string;
+  },
+): Promise<EmailProviderEvidence> {
+  const content = verificationEmailContent(data);
+  return dispatchEmail({
+    to: data.to,
+    ...content,
+    idempotencyKey: data.idempotencyKey,
+    redactRecipientInLogs: true,
+    tags: [
+      { name: "openvpm_attempt_id", value: data.attemptId },
+      { name: "openvpm_email_kind", value: "auth_verification" },
+    ],
+  });
 }
 
 export async function sendPasswordResetEmail(data: {

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -40,9 +40,11 @@ export type EmailProviderOutcome =
   | "accepted"
   | "definite_failure"
   | "outcome_unknown";
+export type EmailProvider = "resend" | "console";
 
 export interface EmailProviderEvidence {
   success: boolean;
+  provider: EmailProvider;
   id?: string;
   error?: string;
   outcome: EmailProviderOutcome;
@@ -139,6 +141,8 @@ async function dispatchEmail(
   options: EmailDispatchOptions,
 ): Promise<EmailProviderEvidence> {
   const client = getResend();
+  const provider: EmailProvider =
+    client || (billingEnforced() && !emailDemoMode()) ? "resend" : "console";
   const from = defaultEmailFrom(options.from);
   const replyTo = nonBlankEmailValue(options.replyTo);
 
@@ -146,6 +150,7 @@ async function dispatchEmail(
     if (billingEnforced() && !emailDemoMode()) {
       return {
         success: false,
+        provider,
         error: "Email provider is not configured for hosted sending.",
         outcome: "definite_failure",
         failureCode: "provider_not_configured",
@@ -166,6 +171,7 @@ async function dispatchEmail(
     console.log("──────────────────────────────────────────");
     return {
       success: true,
+      provider,
       id: options.idempotencyKey
         ? `dev-console:${options.idempotencyKey}`.slice(0, 128)
         : "dev-console",
@@ -208,6 +214,7 @@ async function dispatchEmail(
       const timedOut = controller.signal.aborted;
       return {
         success: false,
+        provider,
         error: timedOut ? emailSendTimeoutMessage() : error.message,
         outcome: timedOut ? "outcome_unknown" : "definite_failure",
         failureCode: timedOut ? "send_timeout" : "provider_rejected",
@@ -217,13 +224,14 @@ async function dispatchEmail(
     if (!data?.id) {
       return {
         success: false,
+        provider,
         error: "Email provider response did not include a message id.",
         outcome: "outcome_unknown",
         failureCode: "missing_provider_id",
       };
     }
 
-    return { success: true, id: data.id, outcome: "accepted" };
+    return { success: true, provider, id: data.id, outcome: "accepted" };
   } catch (err) {
     const message = controller.signal.aborted
       ? emailSendTimeoutMessage()
@@ -238,6 +246,7 @@ async function dispatchEmail(
     );
     return {
       success: false,
+      provider,
       error: message,
       outcome: "outcome_unknown",
       failureCode: controller.signal.aborted
@@ -247,6 +256,16 @@ async function dispatchEmail(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+/**
+ * Resolve the durable provider identity before reserving a tracked attempt.
+ * Hosted mode without credentials still models Resend (as a definite
+ * configuration failure); only the explicit local/demo fallback is console.
+ */
+export function verificationEmailProvider(): EmailProvider {
+  if (getResend()) return "resend";
+  return billingEnforced() && !emailDemoMode() ? "resend" : "console";
 }
 
 export async function sendEmail(

--- a/apps/web/server/__tests__/admin-auth-email-recovery.test.ts
+++ b/apps/web/server/__tests__/admin-auth-email-recovery.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync("server/routers/admin.ts", "utf8");
+const queue = source.slice(
+  source.indexOf("authEmailRecoveryQueue:"),
+  source.indexOf("overview:", source.indexOf("authEmailRecoveryQueue:")),
+);
+
+describe("auth verification email recovery queue", () => {
+  it("surfaces missing and uncertain provider outcomes", () => {
+    expect(queue).toContain("provider_outcome_missing");
+    expect(queue).toContain("provider_outcome_unknown");
+    expect(queue).toContain("provider_definite_failure");
+    expect(queue).toContain("attempt.outcome = 'reserved'");
+    expect(queue).toContain(
+      "attempt.outcome in ('outcome_unknown', 'definite_failure')",
+    );
+    expect(queue).toContain("interval '15 minutes'");
+  });
+
+  it("derives out-of-order delivery matches without rewriting evidence", () => {
+    expect(queue).toContain("delivery.attempt_id = attempt.id");
+    expect(queue).toContain("delivery.attempt_id is null");
+    expect(queue).toContain(
+      "delivery.provider_message_id = attempt.provider_message_id",
+    );
+    expect(queue).toContain("delivery_confirmation_missing");
+    expect(queue).toContain("interval '60 minutes'");
+  });
+
+  it("keeps the operator result bounded, no-store, and recipient-free", () => {
+    expect(queue).toContain("noStore()");
+    expect(queue).toContain("limit ${input.limit}");
+    expect(queue).toContain('cacheControl: "no-store" as const');
+    expect(queue).toContain("providerMessageHint: null");
+    expect(queue).not.toContain("users.email");
+    expect(queue).not.toContain("recipient");
+    expect(queue).not.toContain("verifyUrl");
+    expect(queue).not.toContain("token");
+    expect(queue).not.toContain("subject");
+    expect(queue).not.toContain("body");
+  });
+});

--- a/apps/web/server/__tests__/admin-auth-email-recovery.test.ts
+++ b/apps/web/server/__tests__/admin-auth-email-recovery.test.ts
@@ -9,6 +9,12 @@ const queue = source.slice(
 
 describe("auth verification email recovery queue", () => {
   it("surfaces missing and uncertain provider outcomes", () => {
+    expect(queue).toContain("latest_attempts as");
+    expect(queue).toContain(
+      "distinct on (attempt.practice_id, attempt.user_id)",
+    );
+    expect(queue).toContain("attempt.created_at desc");
+    expect(queue).toContain("from latest_attempts attempt");
     expect(queue).toContain("provider_outcome_missing");
     expect(queue).toContain("provider_outcome_unknown");
     expect(queue).toContain("provider_definite_failure");
@@ -20,6 +26,18 @@ describe("auth verification email recovery queue", () => {
     expect(queue).toContain("attempt.provider = 'resend'");
     expect(queue).toContain("'delivered', 'failed', 'complained'");
     expect(queue).not.toContain("'opened', 'clicked'");
+  });
+
+  it("surfaces the latest terminal failed or complained delivery incident", () => {
+    expect(queue).toContain("delivery_incidents as");
+    expect(queue).toContain("delivery_failed");
+    expect(queue).toContain("delivery_complained");
+    expect(queue).toContain(
+      "terminal.classification in ('failed', 'complained')",
+    );
+    expect(queue).toContain("delivery.occurred_at desc");
+    expect(queue).toContain("limit 1");
+    expect(queue).toContain("select * from delivery_incidents");
   });
 
   it("derives out-of-order delivery matches without rewriting evidence", () => {
@@ -35,6 +53,12 @@ describe("auth verification email recovery queue", () => {
     expect(queue).toContain(
       "delivery.provider_message_id <> attempt.provider_message_id",
     );
+    expect(queue).toContain("webhook_conflicts as");
+    expect(queue).toContain("from auth_email_webhook_conflicts quarantine");
+    expect(queue).toContain(
+      "original.webhook_id = quarantine.original_webhook_id",
+    );
+    expect(queue).toContain("webhook_payload_conflict");
   });
 
   it("keeps the operator result bounded, no-store, and recipient-free", () => {

--- a/apps/web/server/__tests__/admin-auth-email-recovery.test.ts
+++ b/apps/web/server/__tests__/admin-auth-email-recovery.test.ts
@@ -59,6 +59,12 @@ describe("auth verification email recovery queue", () => {
       "original.webhook_id = quarantine.original_webhook_id",
     );
     expect(queue).toContain("webhook_payload_conflict");
+    expect(queue).toContain("provider_identity_conflicts as");
+    expect(queue).toContain(
+      "from auth_email_provider_identity_conflicts conflict",
+    );
+    expect(queue).toContain("attempt.id = conflict.attempt_id");
+    expect(queue).toContain("provider_identity_conflict");
   });
 
   it("keeps the operator result bounded, no-store, and recipient-free", () => {

--- a/apps/web/server/__tests__/admin-auth-email-recovery.test.ts
+++ b/apps/web/server/__tests__/admin-auth-email-recovery.test.ts
@@ -17,6 +17,9 @@ describe("auth verification email recovery queue", () => {
       "attempt.outcome in ('outcome_unknown', 'definite_failure')",
     );
     expect(queue).toContain("interval '15 minutes'");
+    expect(queue).toContain("attempt.provider = 'resend'");
+    expect(queue).toContain("'delivered', 'failed', 'complained'");
+    expect(queue).not.toContain("'opened', 'clicked'");
   });
 
   it("derives out-of-order delivery matches without rewriting evidence", () => {
@@ -27,6 +30,11 @@ describe("auth verification email recovery queue", () => {
     );
     expect(queue).toContain("delivery_confirmation_missing");
     expect(queue).toContain("interval '60 minutes'");
+    expect(queue).toContain("identity_mismatches as");
+    expect(queue).toContain("delivery.provider <> attempt.provider");
+    expect(queue).toContain(
+      "delivery.provider_message_id <> attempt.provider_message_id",
+    );
   });
 
   it("keeps the operator result bounded, no-store, and recipient-free", () => {
@@ -40,5 +48,6 @@ describe("auth verification email recovery queue", () => {
     expect(queue).not.toContain("token");
     expect(queue).not.toContain("subject");
     expect(queue).not.toContain("body");
+    expect(queue).toContain("account.email_verified_at is null");
   });
 });

--- a/apps/web/server/__tests__/auth-router.test.ts
+++ b/apps/web/server/__tests__/auth-router.test.ts
@@ -600,6 +600,8 @@ describe("auth router input validation", () => {
       verificationRequired: true,
       verificationEmailSent: true,
       verificationEmailPossiblySent: false,
+      verificationEmailPreviewed: false,
+      verificationEmailProvider: "resend",
       onboardingRequired: true,
       checkoutUrl: undefined,
     });
@@ -624,6 +626,33 @@ describe("auth router input validation", () => {
       name: "Dr Owner",
       verifyUrl: "http://localhost:3000/verify-email?token=token-123",
       db,
+    });
+  });
+
+  it("reports a console verification preview without claiming registration email delivery", async () => {
+    mocks.billingEnforced.mockReturnValue(true);
+    mocks.noCardTrialEnabled.mockReturnValue(true);
+    const { db } = createRegistrationDb();
+    mocks.sendTrackedVerificationEmail.mockResolvedValueOnce({
+      success: true,
+      provider: "console",
+      outcome: "accepted",
+      possiblySent: false,
+      evidencePersisted: true,
+    });
+
+    await expect(
+      callerWithDb(db).register({
+        email: "owner@example.com",
+        password: "password123",
+        practiceName: "Neighborhood Veterinary",
+      }),
+    ).resolves.toMatchObject({
+      verificationRequired: true,
+      verificationEmailSent: false,
+      verificationEmailPossiblySent: false,
+      verificationEmailPreviewed: true,
+      verificationEmailProvider: "console",
     });
   });
 
@@ -751,6 +780,8 @@ describe("authenticated verification resend", () => {
       alreadyVerified: false,
       verificationEmailSent: true,
       possiblySent: false,
+      verificationEmailPreviewed: false,
+      verificationEmailProvider: "resend",
       message: "Verification email sent. Check your inbox and spam folder.",
     });
 
@@ -795,6 +826,8 @@ describe("authenticated verification resend", () => {
       alreadyVerified: true,
       verificationEmailSent: false,
       possiblySent: false,
+      verificationEmailPreviewed: false,
+      verificationEmailProvider: null,
       message: "Your email is already verified.",
     });
     expect(mocks.rateLimit).not.toHaveBeenCalled();
@@ -817,6 +850,8 @@ describe("authenticated verification resend", () => {
       alreadyVerified: false,
       verificationEmailSent: false,
       possiblySent: false,
+      verificationEmailPreviewed: false,
+      verificationEmailProvider: "resend",
       message:
         "The email provider did not accept the verification email. Please try again later.",
     });
@@ -837,9 +872,32 @@ describe("authenticated verification resend", () => {
     expect(result).toMatchObject({
       verificationEmailSent: false,
       possiblySent: true,
+      verificationEmailProvider: "resend",
     });
     expect(result.message).toMatch(/may have been sent/i);
     expect(result.message).not.toMatch(/try again|retry/i);
+  });
+
+  it("reports console preview semantics without claiming an email was sent", async () => {
+    const { db } = createSelectDb([[unverifiedUser]]);
+    mocks.sendTrackedVerificationEmail.mockResolvedValueOnce({
+      success: true,
+      provider: "console",
+      outcome: "accepted",
+      possiblySent: false,
+      evidencePersisted: true,
+    });
+
+    await expect(callerWithSession(db).resendVerification()).resolves.toEqual({
+      ok: true,
+      alreadyVerified: false,
+      verificationEmailSent: false,
+      possiblySent: false,
+      verificationEmailPreviewed: true,
+      verificationEmailProvider: "console",
+      message:
+        "Verification email preview generated in the server console. No email was sent.",
+    });
   });
 
   it("fails closed when the resend limiter is unavailable", async () => {

--- a/apps/web/server/__tests__/auth-router.test.ts
+++ b/apps/web/server/__tests__/auth-router.test.ts
@@ -11,8 +11,18 @@ const mocks = vi.hoisted(() => ({
   consumeAuthToken: vi.fn(),
   sendPasswordResetEmail: vi.fn(async () => ({ success: true })),
   sendTrackedVerificationEmail: vi.fn(
-    async (): Promise<{ success: boolean; id?: string; error?: string }> => ({
+    async (): Promise<{
+      success: boolean;
+      provider: "resend" | "console";
+      outcome: "accepted" | "definite_failure" | "outcome_unknown";
+      possiblySent: boolean;
+      evidencePersisted: boolean;
+    }> => ({
       success: true,
+      provider: "resend",
+      outcome: "accepted",
+      possiblySent: false,
+      evidencePersisted: true,
     }),
   ),
   sendWelcomeEmail: vi.fn(async () => ({ success: true })),
@@ -137,13 +147,25 @@ function createSelectDb(selectResults: unknown[][]) {
   const selectFrom = vi.fn(() => ({ where: selectWhere }));
   const select = vi.fn(() => ({ from: selectFrom }));
 
+  let transactionDepth = 0;
   const db: Record<string, unknown> = {
-    transaction: async (fn: (tx: unknown) => unknown) => fn(db),
+    transaction: async (fn: (tx: unknown) => unknown) => {
+      transactionDepth += 1;
+      try {
+        return await fn(db);
+      } finally {
+        transactionDepth -= 1;
+      }
+    },
     execute: vi.fn(async () => undefined),
     select,
   };
 
-  return { db, selectWhere };
+  return {
+    db,
+    selectWhere,
+    isInTransaction: () => transactionDepth > 0,
+  };
 }
 
 function createRegistrationDb(opts?: { insertRows?: unknown[] }) {
@@ -168,13 +190,13 @@ function createRegistrationDb(opts?: { insertRows?: unknown[] }) {
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
 
-  let inTransaction = false;
+  let transactionDepth = 0;
   const transaction = vi.fn(async (fn: (tx: unknown) => unknown) => {
-    inTransaction = true;
+    transactionDepth += 1;
     try {
       return await fn(db);
     } finally {
-      inTransaction = false;
+      transactionDepth -= 1;
     }
   });
   const db: Record<string, unknown> = {
@@ -190,7 +212,7 @@ function createRegistrationDb(opts?: { insertRows?: unknown[] }) {
     insertValues,
     updateSet,
     transaction,
-    isInTransaction: () => inTransaction,
+    isInTransaction: () => transactionDepth > 0,
   };
 }
 
@@ -229,7 +251,13 @@ afterEach(() => {
   mocks.billingEnforced.mockReturnValue(false);
   mocks.noCardTrialEnabled.mockReturnValue(false);
   mocks.createAuthToken.mockResolvedValue("token-123");
-  mocks.sendTrackedVerificationEmail.mockResolvedValue({ success: true });
+  mocks.sendTrackedVerificationEmail.mockResolvedValue({
+    success: true,
+    provider: "resend",
+    outcome: "accepted",
+    possiblySent: false,
+    evidencePersisted: true,
+  });
   mocks.createSubscriptionCheckoutSession.mockResolvedValue({
     url: "https://stripe.example/signup-checkout",
   });
@@ -540,7 +568,25 @@ describe("auth router input validation", () => {
     vi.stubEnv("STRIPE_PRICE_CLOUD_LOCATION", "price_location");
     mocks.billingEnforced.mockReturnValue(true);
     mocks.noCardTrialEnabled.mockReturnValue(true);
-    const { db, insertValues } = createRegistrationDb();
+    const { db, insertValues, isInTransaction } = createRegistrationDb();
+    mocks.createAuthToken.mockImplementationOnce(async () => {
+      expect(isInTransaction()).toBe(true);
+      return "token-123";
+    });
+    mocks.sendTrackedVerificationEmail.mockImplementationOnce(async () => {
+      expect(isInTransaction()).toBe(false);
+      return {
+        success: true,
+        provider: "resend",
+        outcome: "accepted",
+        possiblySent: false,
+        evidencePersisted: true,
+      };
+    });
+    mocks.sendWelcomeEmail.mockImplementationOnce(async () => {
+      expect(isInTransaction()).toBe(false);
+      return { success: true };
+    });
 
     await expect(
       callerWithDb(db).register({
@@ -552,6 +598,8 @@ describe("auth router input validation", () => {
       id: "user-1",
       email: "owner@example.com",
       verificationRequired: true,
+      verificationEmailSent: true,
+      verificationEmailPossiblySent: false,
       onboardingRequired: true,
       checkoutUrl: undefined,
     });
@@ -680,11 +728,30 @@ describe("authenticated verification resend", () => {
   });
 
   it("binds resend to the signed-in account and reports provider acceptance", async () => {
-    const { db, selectWhere } = createSelectDb([[unverifiedUser]]);
+    const { db, selectWhere, isInTransaction } = createSelectDb([
+      [unverifiedUser],
+    ]);
+    mocks.createAuthToken.mockImplementationOnce(async () => {
+      expect(isInTransaction()).toBe(true);
+      return "token-123";
+    });
+    mocks.sendTrackedVerificationEmail.mockImplementationOnce(async () => {
+      expect(isInTransaction()).toBe(false);
+      return {
+        success: true,
+        provider: "resend",
+        outcome: "accepted",
+        possiblySent: false,
+        evidencePersisted: true,
+      };
+    });
 
     await expect(callerWithSession(db).resendVerification()).resolves.toEqual({
       ok: true,
       alreadyVerified: false,
+      verificationEmailSent: true,
+      possiblySent: false,
+      message: "Verification email sent. Check your inbox and spam folder.",
     });
 
     const condition = selectWhere.mock.calls[0]?.[0];
@@ -726,37 +793,53 @@ describe("authenticated verification resend", () => {
     await expect(callerWithSession(db).resendVerification()).resolves.toEqual({
       ok: true,
       alreadyVerified: true,
+      verificationEmailSent: false,
+      possiblySent: false,
+      message: "Your email is already verified.",
     });
     expect(mocks.rateLimit).not.toHaveBeenCalled();
     expect(mocks.createAuthToken).not.toHaveBeenCalled();
     expect(mocks.sendTrackedVerificationEmail).not.toHaveBeenCalled();
   });
 
-  it("reports provider rejection instead of claiming the email was sent", async () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => undefined);
+  it("reports provider rejection without claiming the email was sent", async () => {
     const { db } = createSelectDb([[unverifiedUser]]);
     mocks.sendTrackedVerificationEmail.mockResolvedValueOnce({
       success: false,
-      error: "provider unavailable",
+      provider: "resend",
+      outcome: "definite_failure",
+      possiblySent: false,
+      evidencePersisted: true,
     });
 
-    try {
-      await expect(
-        callerWithSession(db).resendVerification(),
-      ).rejects.toMatchObject({
-        code: "INTERNAL_SERVER_ERROR",
-        message:
-          "We couldn't send the verification email. Please try again in a moment.",
-      });
-      expect(consoleError).toHaveBeenCalledWith(
-        "[resendVerification] email failed:",
-        expect.any(Error),
-      );
-    } finally {
-      consoleError.mockRestore();
-    }
+    await expect(callerWithSession(db).resendVerification()).resolves.toEqual({
+      ok: true,
+      alreadyVerified: false,
+      verificationEmailSent: false,
+      possiblySent: false,
+      message:
+        "The email provider did not accept the verification email. Please try again later.",
+    });
+  });
+
+  it("tells users to check their inbox when the provider outcome is unknown", async () => {
+    const { db } = createSelectDb([[unverifiedUser]]);
+    mocks.sendTrackedVerificationEmail.mockResolvedValueOnce({
+      success: false,
+      provider: "resend",
+      outcome: "outcome_unknown",
+      possiblySent: true,
+      evidencePersisted: true,
+    });
+
+    const result = await callerWithSession(db).resendVerification();
+
+    expect(result).toMatchObject({
+      verificationEmailSent: false,
+      possiblySent: true,
+    });
+    expect(result.message).toMatch(/may have been sent/i);
+    expect(result.message).not.toMatch(/try again|retry/i);
   });
 
   it("fails closed when the resend limiter is unavailable", async () => {

--- a/apps/web/server/__tests__/auth-router.test.ts
+++ b/apps/web/server/__tests__/auth-router.test.ts
@@ -2,14 +2,18 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { users } from "@openpims/db";
 
 const mocks = vi.hoisted(() => ({
-  rateLimit: vi.fn(async () => ({ success: true, remaining: 4, resetAt: new Date() })),
+  rateLimit: vi.fn(async () => ({
+    success: true,
+    remaining: 4,
+    resetAt: new Date(),
+  })),
   createAuthToken: vi.fn(async () => "token-123"),
   consumeAuthToken: vi.fn(),
   sendPasswordResetEmail: vi.fn(async () => ({ success: true })),
-  sendVerificationEmail: vi.fn(
+  sendTrackedVerificationEmail: vi.fn(
     async (): Promise<{ success: boolean; id?: string; error?: string }> => ({
       success: true,
-    })
+    }),
   ),
   sendWelcomeEmail: vi.fn(async () => ({ success: true })),
   createSubscriptionCheckoutSession: vi.fn(async () => ({
@@ -33,8 +37,11 @@ vi.mock("@/lib/auth-tokens", () => ({
 
 vi.mock("@/lib/email", () => ({
   sendPasswordResetEmail: mocks.sendPasswordResetEmail,
-  sendVerificationEmail: mocks.sendVerificationEmail,
   sendWelcomeEmail: mocks.sendWelcomeEmail,
+}));
+
+vi.mock("@/lib/auth-email-delivery", () => ({
+  sendTrackedVerificationEmail: mocks.sendTrackedVerificationEmail,
 }));
 
 vi.mock("@/lib/onboarding/defaults", () => ({
@@ -70,7 +77,7 @@ const { authRouter } = await import("../routers/auth");
 function sqlIncludesValue(
   value: unknown,
   needle: unknown,
-  seen = new WeakSet<object>()
+  seen = new WeakSet<object>(),
 ): boolean {
   if (Object.is(value, needle)) {
     return true;
@@ -95,12 +102,12 @@ function sqlIncludesValue(
   }
   if (Array.isArray(candidate.queryChunks)) {
     return candidate.queryChunks.some((item) =>
-      sqlIncludesValue(item, needle, seen)
+      sqlIncludesValue(item, needle, seen),
     );
   }
 
   return Object.values(value as Record<string, unknown>).some((item) =>
-    sqlIncludesValue(item, needle, seen)
+    sqlIncludesValue(item, needle, seen),
   );
 }
 
@@ -222,7 +229,7 @@ afterEach(() => {
   mocks.billingEnforced.mockReturnValue(false);
   mocks.noCardTrialEnabled.mockReturnValue(false);
   mocks.createAuthToken.mockResolvedValue("token-123");
-  mocks.sendVerificationEmail.mockResolvedValue({ success: true });
+  mocks.sendTrackedVerificationEmail.mockResolvedValue({ success: true });
   mocks.createSubscriptionCheckoutSession.mockResolvedValue({
     url: "https://stripe.example/signup-checkout",
   });
@@ -240,7 +247,7 @@ describe("auth router input validation", () => {
         email: "owner@example.com",
         password: "password123",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -248,7 +255,7 @@ describe("auth router input validation", () => {
         email: "owner@example.com",
         password: "p".repeat(129),
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -256,7 +263,7 @@ describe("auth router input validation", () => {
         email: `${"a".repeat(250)}@example.com`,
         password: "password123",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -264,7 +271,7 @@ describe("auth router input validation", () => {
         email: "owner@example.com",
         password: "password123",
         practiceName: " ".repeat(4),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -275,7 +282,7 @@ describe("auth router input validation", () => {
         onboardingDraft: {
           logoName: "l".repeat(121),
         },
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
@@ -284,20 +291,20 @@ describe("auth router input validation", () => {
         password: "password123",
         practiceName: "Neighborhood Veterinary",
         acquisition: { source: "<script>" },
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       caller.requestPasswordReset({
         email: `${"b".repeat(250)}@example.com`,
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     await expect(
       caller.resetPassword({
         token: "a".repeat(64),
         password: "p".repeat(129),
-      })
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(db.select).not.toHaveBeenCalled();
@@ -331,7 +338,7 @@ describe("auth router input validation", () => {
           medium: "website",
           campaign: "summer_launch",
         },
-      })
+      }),
     ).resolves.toMatchObject({
       id: "user-1",
       email: "owner@example.com",
@@ -343,14 +350,14 @@ describe("auth router input validation", () => {
       expect.objectContaining({
         name: "Neighborhood Veterinary",
         email: "owner@example.com",
-      })
+      }),
     );
     expect(insertValues).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         practiceId: "practice-1",
         name: "North Clinic",
-      })
+      }),
     );
     expect(insertValues).toHaveBeenNthCalledWith(
       3,
@@ -359,7 +366,7 @@ describe("auth router input validation", () => {
         name: "Dr Owner",
         role: "admin",
         practiceId: "practice-1",
-      })
+      }),
     );
     expect(updateSet).toHaveBeenCalledWith({
       settings: {
@@ -386,11 +393,7 @@ describe("auth router input validation", () => {
 
   it("fails signup before setup side effects when core account bootstrap returns no user", async () => {
     const { db, insertValues, transaction, updateSet } = createRegistrationDb({
-      insertRows: [
-        { id: "practice-1" },
-        { id: "location-1" },
-        undefined,
-      ],
+      insertRows: [{ id: "practice-1" }, { id: "location-1" }, undefined],
     });
 
     await expect(
@@ -398,7 +401,7 @@ describe("auth router input validation", () => {
         email: "owner@example.com",
         password: "password123",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "INTERNAL_SERVER_ERROR",
       message: "Account setup failed.",
@@ -409,7 +412,7 @@ describe("auth router input validation", () => {
     expect(mocks.seedPractice).not.toHaveBeenCalled();
     expect(mocks.seedDemoData).not.toHaveBeenCalled();
     expect(mocks.createAuthToken).not.toHaveBeenCalled();
-    expect(mocks.sendVerificationEmail).not.toHaveBeenCalled();
+    expect(mocks.sendTrackedVerificationEmail).not.toHaveBeenCalled();
     expect(mocks.sendWelcomeEmail).not.toHaveBeenCalled();
     expect(mocks.createSubscriptionCheckoutSession).not.toHaveBeenCalled();
     expect(updateSet).not.toHaveBeenCalled();
@@ -424,7 +427,7 @@ describe("auth router input validation", () => {
         email: "owner@example.com",
         password: "password123",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "SERVICE_UNAVAILABLE",
       message:
@@ -457,7 +460,7 @@ describe("auth router input validation", () => {
         email: "owner@example.com",
         password: "password123",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "SERVICE_UNAVAILABLE",
       message: "Could not start hosted billing checkout. Please try again.",
@@ -470,16 +473,16 @@ describe("auth router input validation", () => {
         lineItems: [{ priceId: "price_location", quantity: 1 }],
         practiceId: "practice-1",
         customerEmail: "owner@example.com",
-      })
+      }),
     );
     expect(mocks.seedPractice).not.toHaveBeenCalled();
     expect(mocks.seedDemoData).not.toHaveBeenCalled();
     expect(mocks.createAuthToken).not.toHaveBeenCalled();
-    expect(mocks.sendVerificationEmail).not.toHaveBeenCalled();
+    expect(mocks.sendTrackedVerificationEmail).not.toHaveBeenCalled();
     expect(mocks.sendWelcomeEmail).not.toHaveBeenCalled();
     expect(consoleError).toHaveBeenCalledWith(
       "[register] subscription checkout failed:",
-      expect.any(Error)
+      expect.any(Error),
     );
     consoleError.mockRestore();
     expect(updateSet).not.toHaveBeenCalled();
@@ -500,7 +503,7 @@ describe("auth router input validation", () => {
         email: "owner@example.com",
         password: "password123",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).resolves.toMatchObject({
       id: "user-1",
       email: "owner@example.com",
@@ -529,7 +532,7 @@ describe("auth router input validation", () => {
         trialPeriodDays: 14,
         successUrl: "http://localhost:3000/login?checkout=success",
         cancelUrl: "http://localhost:3000/login?checkout=cancelled",
-      })
+      }),
     );
   });
 
@@ -544,7 +547,7 @@ describe("auth router input validation", () => {
         email: "owner@example.com",
         password: "password123",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).resolves.toMatchObject({
       id: "user-1",
       email: "owner@example.com",
@@ -565,6 +568,15 @@ describe("auth router input validation", () => {
     expect(practiceInsert.trialEndsAt).toBeInstanceOf(Date);
     // Card-free trial never touches Stripe Checkout.
     expect(mocks.createSubscriptionCheckoutSession).not.toHaveBeenCalled();
+    expect(mocks.sendTrackedVerificationEmail).toHaveBeenCalledWith({
+      practiceId: "practice-1",
+      userId: "user-1",
+      source: "registration",
+      to: "owner@example.com",
+      name: "Dr Owner",
+      verifyUrl: "http://localhost:3000/verify-email?token=token-123",
+      db,
+    });
   });
 
   it("rejects hosted signup when Stripe returns an unsafe checkout URL", async () => {
@@ -580,7 +592,7 @@ describe("auth router input validation", () => {
         email: "owner@example.com",
         password: "password123",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "SERVICE_UNAVAILABLE",
       message: "Could not start hosted billing checkout. Please try again.",
@@ -605,7 +617,7 @@ describe("auth router email normalization", () => {
         email: "Admin@Example.COM",
         password: "password123",
         practiceName: "Neighborhood Veterinary",
-      })
+      }),
     ).rejects.toMatchObject({
       code: "CONFLICT",
       message: "Email already registered",
@@ -616,9 +628,9 @@ describe("auth router email normalization", () => {
       limit: 5,
       windowMs: 3600000,
     });
-    expect(sqlIncludesValue(selectWhere.mock.calls[0]?.[0], "admin@example.com")).toBe(
-      true
-    );
+    expect(
+      sqlIncludesValue(selectWhere.mock.calls[0]?.[0], "admin@example.com"),
+    ).toBe(true);
   });
 
   it("normalizes password-reset rate-limit keys and account lookups", async () => {
@@ -627,7 +639,7 @@ describe("auth router email normalization", () => {
     ]);
 
     await expect(
-      callerWithDb(db).requestPasswordReset({ email: "Admin@Example.COM" })
+      callerWithDb(db).requestPasswordReset({ email: "Admin@Example.COM" }),
     ).resolves.toEqual({ ok: true });
 
     expect(mocks.rateLimit).toHaveBeenCalledWith({
@@ -635,12 +647,12 @@ describe("auth router email normalization", () => {
       limit: 5,
       windowMs: 3600000,
     });
-    expect(sqlIncludesValue(selectWhere.mock.calls[0]?.[0], "admin@example.com")).toBe(
-      true
-    );
-    expect(sqlIncludesValue(selectWhere.mock.calls[0]?.[0], users.deletedAt)).toBe(
-      true
-    );
+    expect(
+      sqlIncludesValue(selectWhere.mock.calls[0]?.[0], "admin@example.com"),
+    ).toBe(true);
+    expect(
+      sqlIncludesValue(selectWhere.mock.calls[0]?.[0], users.deletedAt),
+    ).toBe(true);
     expect(mocks.createAuthToken).toHaveBeenCalledWith({
       userId: "user-1",
       email: "admin@example.com",
@@ -648,7 +660,6 @@ describe("auth router email normalization", () => {
       db,
     });
   });
-
 });
 
 describe("authenticated verification resend", () => {
@@ -691,16 +702,25 @@ describe("authenticated verification resend", () => {
       type: "email_verify",
       db,
     });
-    expect(mocks.sendVerificationEmail).toHaveBeenCalledWith({
+    expect(mocks.sendTrackedVerificationEmail).toHaveBeenCalledWith({
+      practiceId: "practice-1",
+      userId: "user-1",
+      source: "authenticated_resend",
       to: "admin@example.com",
       name: "Admin",
       verifyUrl: "http://localhost:3000/verify-email?token=token-123",
+      db,
     });
   });
 
   it("does not send another message after the account is verified", async () => {
     const { db } = createSelectDb([
-      [{ ...unverifiedUser, emailVerifiedAt: new Date("2026-08-09T12:00:00Z") }],
+      [
+        {
+          ...unverifiedUser,
+          emailVerifiedAt: new Date("2026-08-09T12:00:00Z"),
+        },
+      ],
     ]);
 
     await expect(callerWithSession(db).resendVerification()).resolves.toEqual({
@@ -709,7 +729,7 @@ describe("authenticated verification resend", () => {
     });
     expect(mocks.rateLimit).not.toHaveBeenCalled();
     expect(mocks.createAuthToken).not.toHaveBeenCalled();
-    expect(mocks.sendVerificationEmail).not.toHaveBeenCalled();
+    expect(mocks.sendTrackedVerificationEmail).not.toHaveBeenCalled();
   });
 
   it("reports provider rejection instead of claiming the email was sent", async () => {
@@ -717,20 +737,22 @@ describe("authenticated verification resend", () => {
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
     const { db } = createSelectDb([[unverifiedUser]]);
-    mocks.sendVerificationEmail.mockResolvedValueOnce({
+    mocks.sendTrackedVerificationEmail.mockResolvedValueOnce({
       success: false,
       error: "provider unavailable",
     });
 
     try {
-      await expect(callerWithSession(db).resendVerification()).rejects.toMatchObject({
+      await expect(
+        callerWithSession(db).resendVerification(),
+      ).rejects.toMatchObject({
         code: "INTERNAL_SERVER_ERROR",
         message:
           "We couldn't send the verification email. Please try again in a moment.",
       });
       expect(consoleError).toHaveBeenCalledWith(
         "[resendVerification] email failed:",
-        expect.any(Error)
+        expect.any(Error),
       );
     } finally {
       consoleError.mockRestore();
@@ -745,16 +767,18 @@ describe("authenticated verification resend", () => {
     mocks.rateLimit.mockRejectedValueOnce(new Error("rate limiter down"));
 
     try {
-      await expect(callerWithSession(db).resendVerification()).rejects.toMatchObject({
+      await expect(
+        callerWithSession(db).resendVerification(),
+      ).rejects.toMatchObject({
         code: "TOO_MANY_REQUESTS",
         message: "Too many requests. Please try again later.",
       });
       expect(consoleError).toHaveBeenCalledWith(
         "[auth.resendVerification] rate limit failed:",
-        expect.any(Error)
+        expect.any(Error),
       );
       expect(mocks.createAuthToken).not.toHaveBeenCalled();
-      expect(mocks.sendVerificationEmail).not.toHaveBeenCalled();
+      expect(mocks.sendTrackedVerificationEmail).not.toHaveBeenCalled();
     } finally {
       consoleError.mockRestore();
     }
@@ -799,18 +823,18 @@ describe("auth router rate-limit failure guards", () => {
 
         expect(consoleError).toHaveBeenCalledWith(
           `[auth.${logContext}] rate limit failed:`,
-          expect.any(Error)
+          expect.any(Error),
         );
         expect(db.select).not.toHaveBeenCalled();
         expect(mocks.createAuthToken).not.toHaveBeenCalled();
-        expect(mocks.sendVerificationEmail).not.toHaveBeenCalled();
+        expect(mocks.sendTrackedVerificationEmail).not.toHaveBeenCalled();
         expect(mocks.sendPasswordResetEmail).not.toHaveBeenCalled();
         expect(mocks.sendWelcomeEmail).not.toHaveBeenCalled();
         expect(mocks.createSubscriptionCheckoutSession).not.toHaveBeenCalled();
       } finally {
         consoleError.mockRestore();
       }
-    }
+    },
   );
 });
 
@@ -821,14 +845,19 @@ describe("auth router token validation", () => {
     const { db } = createSelectDb([]);
     const caller = callerWithDb(db);
 
-    await expect(caller.verifyEmail({ token: "not-a-token" })).rejects.toMatchObject({
+    await expect(
+      caller.verifyEmail({ token: "not-a-token" }),
+    ).rejects.toMatchObject({
       code: "BAD_REQUEST",
     });
     await expect(
-      caller.resetPassword({ token: "b".repeat(65), password: "password123" })
+      caller.resetPassword({ token: "b".repeat(65), password: "password123" }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     await expect(
-      caller.acceptInvite({ token: "../".repeat(1024), password: "password123" })
+      caller.acceptInvite({
+        token: "../".repeat(1024),
+        password: "password123",
+      }),
     ).rejects.toMatchObject({ code: "BAD_REQUEST" });
 
     expect(mocks.consumeAuthToken).not.toHaveBeenCalled();
@@ -836,7 +865,11 @@ describe("auth router token validation", () => {
 
   it("accepts issued 64-hex tokens for verification, reset, and invite flows", async () => {
     const { db, updateWhere } = createAuthUpdateDb({
-      returningRows: [[{ id: "user-1" }], [{ id: "user-1" }], [{ id: "user-1" }]],
+      returningRows: [
+        [{ id: "user-1" }],
+        [{ id: "user-1" }],
+        [{ id: "user-1" }],
+      ],
     });
     mocks.consumeAuthToken.mockResolvedValue({
       userId: "user-1",
@@ -848,21 +881,21 @@ describe("auth router token validation", () => {
       ok: true,
     });
     await expect(
-      caller.resetPassword({ token: validToken, password: "password123" })
+      caller.resetPassword({ token: validToken, password: "password123" }),
     ).resolves.toEqual({ ok: true });
     await expect(
-      caller.acceptInvite({ token: validToken, password: "password123" })
+      caller.acceptInvite({ token: validToken, password: "password123" }),
     ).resolves.toEqual({ ok: true });
 
     expect(mocks.consumeAuthToken).toHaveBeenCalledWith(
       validToken,
       "email_verify",
-      { db }
+      { db },
     );
     expect(mocks.consumeAuthToken).toHaveBeenCalledWith(
       validToken,
       "password_reset",
-      { db }
+      { db },
     );
     expect(mocks.consumeAuthToken).toHaveBeenCalledWith(validToken, "invite", {
       db,
@@ -882,18 +915,20 @@ describe("auth router token validation", () => {
     });
     const caller = callerWithDb(db);
 
-    await expect(caller.verifyEmail({ token: validToken })).rejects.toMatchObject({
+    await expect(
+      caller.verifyEmail({ token: validToken }),
+    ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "This verification link is invalid or has expired.",
     });
     await expect(
-      caller.resetPassword({ token: validToken, password: "password123" })
+      caller.resetPassword({ token: validToken, password: "password123" }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "This reset link is invalid or has expired.",
     });
     await expect(
-      caller.acceptInvite({ token: validToken, password: "password123" })
+      caller.acceptInvite({ token: validToken, password: "password123" }),
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "This invite link is invalid or has expired.",

--- a/apps/web/server/__tests__/trpc-post-commit.test.ts
+++ b/apps/web/server/__tests__/trpc-post-commit.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  let systemDepth = 0;
+  let tenantDepth = 0;
+  const events: string[] = [];
+  return {
+    events,
+    get systemDepth() {
+      return systemDepth;
+    },
+    get tenantDepth() {
+      return tenantDepth;
+    },
+    withSystem: vi.fn(
+      async (database: unknown, fn: (tx: unknown) => Promise<unknown>) => {
+        systemDepth += 1;
+        events.push("system:begin");
+        try {
+          return await fn({ scope: "system", root: database });
+        } finally {
+          events.push("system:commit");
+          systemDepth -= 1;
+        }
+      },
+    ),
+    withTenant: vi.fn(
+      async (
+        database: unknown,
+        _practiceId: string,
+        fn: (tx: unknown) => Promise<unknown>,
+      ) => {
+        tenantDepth += 1;
+        events.push("tenant:begin");
+        try {
+          return await fn({ scope: "tenant", root: database });
+        } finally {
+          events.push("tenant:commit");
+          tenantDepth -= 1;
+        }
+      },
+    ),
+    recordAuditLog: vi.fn(async () => undefined),
+    db: {},
+  };
+});
+
+vi.mock("@/lib/tenant-db", () => ({
+  withSystem: mocks.withSystem,
+  withTenant: mocks.withTenant,
+}));
+vi.mock("@/lib/audit", () => ({ recordAuditLog: mocks.recordAuditLog }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/auth-secret", () => ({
+  hasBlankConfiguredNextAuthSecret: () => true,
+}));
+vi.mock("@/lib/rls-assertion", () => ({
+  assertHostedRlsRoleOnce: vi.fn(async () => undefined),
+}));
+vi.mock("@/lib/billing/plans", () => ({
+  billingEnforced: () => false,
+  hasHostedFullAccess: () => true,
+  isEntitled: () => true,
+  effectiveTier: () => "cloud",
+}));
+vi.mock("@openpims/db/client", () => ({ db: mocks.db }));
+
+const { createRouter, protectedProcedure, publicProcedure } =
+  await import("../trpc");
+
+const router = createRouter({
+  publicEffect: publicProcedure.mutation(({ ctx }) => {
+    mocks.events.push("public:handler");
+    ctx.postCommitEffect?.(async (rootDb) => {
+      expect(rootDb).toBe((ctx.db as unknown as { root: unknown }).root);
+      expect(mocks.systemDepth).toBe(0);
+      mocks.events.push("public:effect");
+    });
+    return { ok: true };
+  }),
+  protectedEffect: protectedProcedure.mutation(({ ctx }) => {
+    mocks.events.push("protected:handler");
+    ctx.postCommitEffect?.(async (rootDb) => {
+      expect(rootDb).toBe((ctx.db as unknown as { root: unknown }).root);
+      expect(mocks.tenantDepth).toBe(0);
+      mocks.events.push("protected:effect");
+    });
+    return { ok: true };
+  }),
+});
+
+afterEach(() => {
+  mocks.events.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("tRPC post-commit effects", () => {
+  it("runs public mutation effects after the outer system transaction commits", async () => {
+    const rootDb = { kind: "root-public" };
+    const caller = router.createCaller({ db: rootDb, session: null } as never);
+
+    await expect(caller.publicEffect()).resolves.toEqual({ ok: true });
+
+    expect(mocks.events).toEqual([
+      "system:begin",
+      "public:handler",
+      "system:commit",
+      "public:effect",
+    ]);
+  });
+
+  it("runs protected mutation effects after the outer tenant transaction commits", async () => {
+    const rootDb = { kind: "root-tenant" };
+    const caller = router.createCaller({
+      db: rootDb,
+      session: {
+        user: {
+          id: "user-1",
+          email: "owner@example.com",
+          name: "Owner",
+          role: "admin",
+          practiceId: "practice-1",
+        },
+      },
+    } as never);
+
+    await expect(caller.protectedEffect()).resolves.toEqual({ ok: true });
+
+    const commitIndex = mocks.events.indexOf("tenant:commit");
+    const effectIndex = mocks.events.indexOf("protected:effect");
+    expect(commitIndex).toBeGreaterThan(-1);
+    expect(effectIndex).toBeGreaterThan(commitIndex);
+  });
+});

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -66,6 +66,7 @@ import {
 import { messagingProgramUrls } from "@/lib/messaging/public-program";
 import { reconcileSmsSendAttempt, resendSmsAttempt } from "@/lib/sms-dispatch";
 import { reconcileSmsDeliveryEvent } from "@/lib/messaging/sms-delivery-ledger";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
 
 /**
  * Platform-operator only. Crosses tenant boundaries deliberately, so it is
@@ -621,6 +622,139 @@ export const adminRouter = createRouter({
   isPlatformAdmin: protectedProcedure.query(({ ctx }) => {
     return isPlatformAdmin(ctx.session?.user?.email);
   }),
+
+  /** Bounded, recipient-free verification-email recovery queue. */
+  authEmailRecoveryQueue: platformAdminProcedure
+    .input(
+      z
+        .object({ limit: z.number().int().min(1).max(100).default(50) })
+        .default({}),
+    )
+    .query(({ input }) => {
+      noStore();
+      return withSystem(db, async (tx) => {
+        const result = await tx.execute(sql`
+          with attempt_issues as (
+            select
+              attempt.created_at as "occurredAt",
+              practice.name as "practiceName",
+              attempt.source::text as source,
+              attempt.outcome::text as outcome,
+              case
+                when attempt.outcome = 'reserved'
+                  then 'provider_outcome_missing'
+                when attempt.outcome = 'outcome_unknown'
+                  then 'provider_outcome_unknown'
+                when attempt.outcome = 'definite_failure'
+                  then 'provider_definite_failure'
+                else 'delivery_confirmation_missing'
+              end as reason
+            from auth_email_attempts attempt
+            join practices practice
+              on practice.id = attempt.practice_id
+             and practice.deleted_at is null
+            join users account
+              on account.id = attempt.user_id
+             and account.practice_id = attempt.practice_id
+             and account.deleted_at is null
+             and account.email_verified_at is null
+            where (
+              attempt.outcome = 'reserved'
+              and attempt.created_at <= now() - interval '15 minutes'
+            ) or attempt.outcome in ('outcome_unknown', 'definite_failure')
+              or (
+                attempt.outcome = 'accepted'
+                and attempt.resolved_at <= now() - interval '60 minutes'
+                and not exists (
+                  select 1
+                  from auth_email_delivery_events delivery
+                  where (
+                    delivery.attempt_id = attempt.id
+                    or (
+                      delivery.attempt_id is null
+                      and delivery.provider = attempt.provider
+                      and delivery.provider_message_id = attempt.provider_message_id
+                    )
+                  )
+                  and delivery.classification in (
+                    'delivered', 'failed', 'complained', 'opened', 'clicked'
+                  )
+                )
+              )
+          ), attribution_issues as (
+            select
+              delivery.received_at as "occurredAt",
+              coalesce(practice.name, 'Unattributed auth email') as "practiceName",
+              null::text as source,
+              null::text as outcome,
+              case
+                when delivery.attribution = 'identity_conflict'
+                  then 'delivery_identity_conflict'
+                else 'delivery_attribution_unmatched'
+              end as reason
+            from auth_email_delivery_events delivery
+            left join auth_email_attempts attempt
+              on attempt.id = delivery.attempt_id
+              or (
+                delivery.attempt_id is null
+                and attempt.provider = delivery.provider
+                and attempt.provider_message_id = delivery.provider_message_id
+              )
+            left join practices practice
+              on practice.id = attempt.practice_id
+             and practice.deleted_at is null
+            where delivery.attribution = 'identity_conflict'
+              or (
+                delivery.attribution = 'unmatched'
+                and attempt.id is null
+              )
+          ), queue as (
+            select * from attempt_issues
+            union all
+            select * from attribution_issues
+          )
+          select
+            "occurredAt",
+            "practiceName",
+            source,
+            outcome,
+            reason,
+            greatest(
+              0,
+              floor(extract(epoch from (now() - "occurredAt")) / 60)
+            )::int as "ageMinutes"
+          from queue
+          order by "occurredAt" asc, reason asc
+          limit ${input.limit}
+        `);
+
+        return {
+          cacheControl: "no-store" as const,
+          items: rowsFromExecute<{
+            occurredAt: Date;
+            practiceName: string;
+            source: "registration" | "authenticated_resend" | null;
+            outcome:
+              | "reserved"
+              | "accepted"
+              | "definite_failure"
+              | "outcome_unknown"
+              | null;
+            reason:
+              | "provider_outcome_missing"
+              | "provider_outcome_unknown"
+              | "provider_definite_failure"
+              | "delivery_confirmation_missing"
+              | "delivery_identity_conflict"
+              | "delivery_attribution_unmatched";
+            ageMinutes: number;
+          }>(result).map((row) => ({
+            ...row,
+            providerMessageHint: null,
+          })),
+        };
+      });
+    }),
 
   /** Cross-tenant operations overview: practices, plans, status, usage, MRR. */
   overview: platformAdminProcedure.query(async () =>

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -797,6 +797,19 @@ export const adminRouter = createRouter({
             left join practices practice
               on practice.id = attempt.practice_id
              and practice.deleted_at is null
+          ), provider_identity_conflicts as (
+            select
+              conflict.occurred_at as "occurredAt",
+              practice.name as "practiceName",
+              conflict.source::text as source,
+              attempt.outcome::text as outcome,
+              'provider_identity_conflict'::text as reason
+            from auth_email_provider_identity_conflicts conflict
+            join auth_email_attempts attempt
+              on attempt.id = conflict.attempt_id
+            join practices practice
+              on practice.id = attempt.practice_id
+             and practice.deleted_at is null
           ), queue as (
             select * from attempt_issues
             union all
@@ -807,6 +820,8 @@ export const adminRouter = createRouter({
             select * from identity_mismatches
             union all
             select * from webhook_conflicts
+            union all
+            select * from provider_identity_conflicts
           )
           select
             "occurredAt",
@@ -844,7 +859,8 @@ export const adminRouter = createRouter({
               | "delivery_complained"
               | "delivery_identity_conflict"
               | "delivery_attribution_unmatched"
-              | "webhook_payload_conflict";
+              | "webhook_payload_conflict"
+              | "provider_identity_conflict";
             ageMinutes: number;
           }>(result).map((row) => ({
             ...row,

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -659,28 +659,31 @@ export const adminRouter = createRouter({
              and account.deleted_at is null
              and account.email_verified_at is null
             where (
-              attempt.outcome = 'reserved'
-              and attempt.created_at <= now() - interval '15 minutes'
-            ) or attempt.outcome in ('outcome_unknown', 'definite_failure')
-              or (
-                attempt.outcome = 'accepted'
-                and attempt.resolved_at <= now() - interval '60 minutes'
-                and not exists (
-                  select 1
-                  from auth_email_delivery_events delivery
-                  where (
-                    delivery.attempt_id = attempt.id
-                    or (
-                      delivery.attempt_id is null
-                      and delivery.provider = attempt.provider
-                      and delivery.provider_message_id = attempt.provider_message_id
+              (
+                attempt.outcome = 'reserved'
+                and attempt.created_at <= now() - interval '15 minutes'
+              ) or attempt.outcome in ('outcome_unknown', 'definite_failure')
+                or (
+                  attempt.provider = 'resend'
+                  and attempt.outcome = 'accepted'
+                  and attempt.resolved_at <= now() - interval '60 minutes'
+                  and not exists (
+                    select 1
+                    from auth_email_delivery_events delivery
+                    where (
+                      delivery.attempt_id = attempt.id
+                      or (
+                        delivery.attempt_id is null
+                        and delivery.provider = attempt.provider
+                        and delivery.provider_message_id = attempt.provider_message_id
+                      )
+                    )
+                    and delivery.classification in (
+                      'delivered', 'failed', 'complained'
                     )
                   )
-                  and delivery.classification in (
-                    'delivered', 'failed', 'complained', 'opened', 'clicked'
-                  )
                 )
-              )
+            )
           ), attribution_issues as (
             select
               delivery.received_at as "occurredAt",
@@ -708,10 +711,30 @@ export const adminRouter = createRouter({
                 delivery.attribution = 'unmatched'
                 and attempt.id is null
               )
+          ), identity_mismatches as (
+            select
+              delivery.received_at as "occurredAt",
+              practice.name as "practiceName",
+              attempt.source::text as source,
+              attempt.outcome::text as outcome,
+              'delivery_identity_conflict'::text as reason
+            from auth_email_delivery_events delivery
+            join auth_email_attempts attempt
+              on attempt.id = delivery.attempt_id
+            join practices practice
+              on practice.id = attempt.practice_id
+             and practice.deleted_at is null
+            where delivery.provider <> attempt.provider
+               or (
+                 attempt.provider_message_id is not null
+                 and delivery.provider_message_id <> attempt.provider_message_id
+               )
           ), queue as (
             select * from attempt_issues
             union all
             select * from attribution_issues
+            union all
+            select * from identity_mismatches
           )
           select
             "occurredAt",

--- a/apps/web/server/routers/admin.ts
+++ b/apps/web/server/routers/admin.ts
@@ -634,7 +634,21 @@ export const adminRouter = createRouter({
       noStore();
       return withSystem(db, async (tx) => {
         const result = await tx.execute(sql`
-          with attempt_issues as (
+          with latest_attempts as (
+            select distinct on (attempt.practice_id, attempt.user_id)
+              attempt.*
+            from auth_email_attempts attempt
+            join users account
+              on account.id = attempt.user_id
+             and account.practice_id = attempt.practice_id
+             and account.deleted_at is null
+             and account.email_verified_at is null
+            order by
+              attempt.practice_id,
+              attempt.user_id,
+              attempt.created_at desc,
+              attempt.id desc
+          ), attempt_issues as (
             select
               attempt.created_at as "occurredAt",
               practice.name as "practiceName",
@@ -649,15 +663,10 @@ export const adminRouter = createRouter({
                   then 'provider_definite_failure'
                 else 'delivery_confirmation_missing'
               end as reason
-            from auth_email_attempts attempt
+            from latest_attempts attempt
             join practices practice
               on practice.id = attempt.practice_id
              and practice.deleted_at is null
-            join users account
-              on account.id = attempt.user_id
-             and account.practice_id = attempt.practice_id
-             and account.deleted_at is null
-             and account.email_verified_at is null
             where (
               (
                 attempt.outcome = 'reserved'
@@ -684,6 +693,45 @@ export const adminRouter = createRouter({
                   )
                 )
             )
+          ), delivery_incidents as (
+            select
+              terminal.received_at as "occurredAt",
+              practice.name as "practiceName",
+              attempt.source::text as source,
+              attempt.outcome::text as outcome,
+              case
+                when terminal.classification = 'complained'
+                  then 'delivery_complained'
+                else 'delivery_failed'
+              end as reason
+            from latest_attempts attempt
+            join practices practice
+              on practice.id = attempt.practice_id
+             and practice.deleted_at is null
+            join lateral (
+              select
+                delivery.received_at,
+                delivery.classification
+              from auth_email_delivery_events delivery
+              where (
+                delivery.attempt_id = attempt.id
+                or (
+                  delivery.attempt_id is null
+                  and delivery.provider = attempt.provider
+                  and delivery.provider_message_id = attempt.provider_message_id
+                )
+              )
+                and delivery.classification in (
+                  'delivered', 'failed', 'complained'
+                )
+              order by
+                delivery.occurred_at desc,
+                delivery.received_at desc,
+                delivery.id desc
+              limit 1
+            ) terminal on true
+            where attempt.outcome = 'accepted'
+              and terminal.classification in ('failed', 'complained')
           ), attribution_issues as (
             select
               delivery.received_at as "occurredAt",
@@ -729,12 +777,36 @@ export const adminRouter = createRouter({
                  attempt.provider_message_id is not null
                  and delivery.provider_message_id <> attempt.provider_message_id
                )
+          ), webhook_conflicts as (
+            select
+              quarantine.received_at as "occurredAt",
+              coalesce(practice.name, 'Unattributed auth email') as "practiceName",
+              attempt.source::text as source,
+              attempt.outcome::text as outcome,
+              'webhook_payload_conflict'::text as reason
+            from auth_email_webhook_conflicts quarantine
+            join auth_email_delivery_events original
+              on original.webhook_id = quarantine.original_webhook_id
+            left join auth_email_attempts attempt
+              on attempt.id = original.attempt_id
+              or (
+                original.attempt_id is null
+                and attempt.provider = original.provider
+                and attempt.provider_message_id = original.provider_message_id
+              )
+            left join practices practice
+              on practice.id = attempt.practice_id
+             and practice.deleted_at is null
           ), queue as (
             select * from attempt_issues
+            union all
+            select * from delivery_incidents
             union all
             select * from attribution_issues
             union all
             select * from identity_mismatches
+            union all
+            select * from webhook_conflicts
           )
           select
             "occurredAt",
@@ -768,8 +840,11 @@ export const adminRouter = createRouter({
               | "provider_outcome_unknown"
               | "provider_definite_failure"
               | "delivery_confirmation_missing"
+              | "delivery_failed"
+              | "delivery_complained"
               | "delivery_identity_conflict"
-              | "delivery_attribution_unmatched";
+              | "delivery_attribution_unmatched"
+              | "webhook_payload_conflict";
             ageMinutes: number;
           }>(result).map((row) => ({
             ...row,

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -384,7 +384,9 @@ export const authRouter = createRouter({
       // Non-fatal: signup still succeeds. Self-host skips this.
       let verificationRequired = false;
       let verificationUrl: string | undefined;
-      let verificationEmailSent: boolean | undefined;
+      let verificationDispatch:
+        | { to: string; name: string; verifyUrl: string }
+        | undefined;
       if (hostedBilling) {
         verificationRequired = true;
         try {
@@ -395,47 +397,67 @@ export const authRouter = createRouter({
             db: ctx.db,
           });
           verificationUrl = `${appBaseUrl()}/verify-email?token=${token}`;
-          const result = await sendTrackedVerificationEmail({
-            practiceId: practice.id,
-            userId: user.id,
-            source: "registration",
+          verificationDispatch = {
             to: user.email,
             name: user.name,
             verifyUrl: verificationUrl,
-            db: ctx.db,
-          });
-          verificationEmailSent = result.success;
-        } catch (err) {
-          console.error("[register] verification email failed:", err);
-          verificationEmailSent = false;
+          };
+        } catch {
+          console.error("[register] verification token preparation failed");
         }
       }
 
-      // Send a branded welcome email (hosted only). Non-fatal — signup succeeds
-      // regardless of delivery.
-      if (hostedBilling) {
-        try {
-          await sendWelcomeEmail({
-            to: user.email,
-            practiceName: input.practiceName.trim(),
-            trialDays: TRIAL_DAYS,
-          });
-        } catch (err) {
-          console.error("[register] welcome email failed:", err);
-        }
-      }
-
-      return {
+      const response = {
         id: user.id,
         email: user.email,
         verificationRequired,
-        verificationEmailSent,
+        verificationEmailSent: hostedBilling ? false : undefined,
+        verificationEmailPossiblySent: hostedBilling ? false : undefined,
         verificationUrl: exposeAuthLinksForPreview() ? verificationUrl : undefined,
         checkoutUrl,
         // Hosted signups (no-card trial) land in the first-run onboarding wizard
         // instead of the bare dashboard.
         onboardingRequired: noCardTrial,
       };
+
+      if (verificationDispatch && ctx.postCommitEffect) {
+        ctx.postCommitEffect(async (rootDb) => {
+          try {
+            const result = await sendTrackedVerificationEmail({
+              practiceId: practice.id,
+              userId: user.id,
+              source: "registration",
+              ...verificationDispatch,
+              db: rootDb,
+            });
+            response.verificationEmailSent = result.outcome === "accepted";
+            response.verificationEmailPossiblySent =
+              result.outcome === "outcome_unknown";
+          } catch {
+            // Signup is already committed. Keep verification soft and do not
+            // log the auth link or recipient embedded in the closure.
+            console.error("[register] post-commit verification dispatch failed");
+          }
+        });
+      }
+
+      // Welcome mail is external I/O as well, so it shares the same strict
+      // post-commit boundary. It remains non-fatal and untracked.
+      if (hostedBilling && ctx.postCommitEffect) {
+        ctx.postCommitEffect(async () => {
+          try {
+            await sendWelcomeEmail({
+              to: user.email,
+              practiceName: input.practiceName.trim(),
+              trialDays: TRIAL_DAYS,
+            });
+          } catch {
+            console.error("[register] post-commit welcome email failed");
+          }
+        });
+      }
+
+      return response;
     }),
 
   /** Confirm an email-verification token (hosted). */
@@ -492,7 +514,13 @@ export const authRouter = createRouter({
       throw new TRPCError({ code: "NOT_FOUND", message: "Account not found." });
     }
     if (user.emailVerifiedAt) {
-      return { ok: true, alreadyVerified: true };
+      return {
+        ok: true,
+        alreadyVerified: true,
+        verificationEmailSent: false,
+        possiblySent: false,
+        message: "Your email is already verified.",
+      };
     }
 
     await assertPreAuthRateLimit({
@@ -503,37 +531,60 @@ export const authRouter = createRouter({
       logContext: "resendVerification",
     });
 
-    try {
-      const token = await createAuthToken({
-        userId: user.id,
-        email: user.email,
-        type: "email_verify",
-        db: ctx.db,
-      });
-      const result = await sendTrackedVerificationEmail({
-        practiceId: ctx.practiceId,
-        userId: user.id,
-        source: "authenticated_resend",
-        to: user.email,
-        name: user.name,
-        verifyUrl: `${appBaseUrl()}/verify-email?token=${token}`,
-        db: ctx.db,
-      });
-      if (!result.success) {
-        throw new Error(
-          result.error || "Email provider did not accept the verification message."
-        );
-      }
-    } catch (err) {
-      console.error("[resendVerification] email failed:", err);
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message:
-          "We couldn't send the verification email. Please try again in a moment.",
-      });
+    const token = await createAuthToken({
+      userId: user.id,
+      email: user.email,
+      type: "email_verify",
+      db: ctx.db,
+    });
+    const response = {
+      ok: true,
+      alreadyVerified: false,
+      verificationEmailSent: false,
+      possiblySent: false,
+      message: "Verification email is being prepared.",
+    };
+
+    if (!ctx.postCommitEffect) {
+      response.message =
+        "We couldn't prepare the verification email. Please try again later.";
+      return response;
     }
 
-    return { ok: true, alreadyVerified: false };
+    ctx.postCommitEffect(async (rootDb) => {
+      try {
+        const result = await sendTrackedVerificationEmail({
+          practiceId: ctx.practiceId,
+          userId: user.id,
+          source: "authenticated_resend",
+          to: user.email,
+          name: user.name,
+          verifyUrl: `${appBaseUrl()}/verify-email?token=${token}`,
+          db: rootDb,
+        });
+        if (result.outcome === "accepted") {
+          response.verificationEmailSent = true;
+          response.message =
+            "Verification email sent. Check your inbox and spam folder.";
+        } else if (result.outcome === "outcome_unknown") {
+          response.possiblySent = true;
+          response.message =
+            "The verification email may have been sent. Check your inbox and spam folder before requesting another.";
+        } else {
+          response.message =
+            "The email provider did not accept the verification email. Please try again later.";
+        }
+      } catch {
+        // A post-provider failure is conservatively reported as possibly sent
+        // so the user is never encouraged to create an immediate duplicate.
+        response.possiblySent = true;
+        response.message =
+          "The verification email may have been sent. Check your inbox and spam folder before requesting another.";
+        console.error("[resendVerification] post-commit dispatch failed");
+      }
+    });
+
+    return response;
   }),
 
   /** Request a password-reset email. Always succeeds (no account enumeration). */

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -17,11 +17,8 @@ import {
 import { createAuthToken, consumeAuthToken } from "@/lib/auth-tokens";
 import { PASSWORD_HASH_COST } from "@/lib/auth-hashing";
 import { authPasswordInput } from "@/lib/auth-password";
-import {
-  sendVerificationEmail,
-  sendPasswordResetEmail,
-  sendWelcomeEmail,
-} from "@/lib/email";
+import { sendPasswordResetEmail, sendWelcomeEmail } from "@/lib/email";
+import { sendTrackedVerificationEmail } from "@/lib/auth-email-delivery";
 import { appBaseUrl, exposeAuthLinksForPreview } from "@/lib/app-url";
 import { isSafeCheckoutRedirectUrl } from "@/lib/checkout-redirect";
 import { createSubscriptionCheckoutSession } from "@/lib/stripe";
@@ -398,10 +395,14 @@ export const authRouter = createRouter({
             db: ctx.db,
           });
           verificationUrl = `${appBaseUrl()}/verify-email?token=${token}`;
-          const result = await sendVerificationEmail({
+          const result = await sendTrackedVerificationEmail({
+            practiceId: practice.id,
+            userId: user.id,
+            source: "registration",
             to: user.email,
             name: user.name,
             verifyUrl: verificationUrl,
+            db: ctx.db,
           });
           verificationEmailSent = result.success;
         } catch (err) {
@@ -509,10 +510,14 @@ export const authRouter = createRouter({
         type: "email_verify",
         db: ctx.db,
       });
-      const result = await sendVerificationEmail({
+      const result = await sendTrackedVerificationEmail({
+        practiceId: ctx.practiceId,
+        userId: user.id,
+        source: "authenticated_resend",
         to: user.email,
         name: user.name,
         verifyUrl: `${appBaseUrl()}/verify-email?token=${token}`,
+        db: ctx.db,
       });
       if (!result.success) {
         throw new Error(

--- a/apps/web/server/routers/auth.ts
+++ b/apps/web/server/routers/auth.ts
@@ -17,7 +17,11 @@ import {
 import { createAuthToken, consumeAuthToken } from "@/lib/auth-tokens";
 import { PASSWORD_HASH_COST } from "@/lib/auth-hashing";
 import { authPasswordInput } from "@/lib/auth-password";
-import { sendPasswordResetEmail, sendWelcomeEmail } from "@/lib/email";
+import {
+  sendPasswordResetEmail,
+  sendWelcomeEmail,
+  type EmailProvider,
+} from "@/lib/email";
 import { sendTrackedVerificationEmail } from "@/lib/auth-email-delivery";
 import { appBaseUrl, exposeAuthLinksForPreview } from "@/lib/app-url";
 import { isSafeCheckoutRedirectUrl } from "@/lib/checkout-redirect";
@@ -101,7 +105,7 @@ const onboardingDraftSchema = z.object({
   logoName: authTextInput(
     "Logo name",
     1,
-    AUTH_ONBOARDING_LOGO_NAME_MAX_LENGTH
+    AUTH_ONBOARDING_LOGO_NAME_MAX_LENGTH,
   ).optional(),
   brandColor: z.string().regex(/^#[0-9a-fA-F]{6}$/).optional(),
   teamMembers: z.array(onboardingTeamMemberSchema).max(8).optional(),
@@ -413,7 +417,13 @@ export const authRouter = createRouter({
         verificationRequired,
         verificationEmailSent: hostedBilling ? false : undefined,
         verificationEmailPossiblySent: hostedBilling ? false : undefined,
-        verificationUrl: exposeAuthLinksForPreview() ? verificationUrl : undefined,
+        verificationEmailPreviewed: hostedBilling ? false : undefined,
+        verificationEmailProvider: hostedBilling
+          ? (null as EmailProvider | null)
+          : undefined,
+        verificationUrl: exposeAuthLinksForPreview()
+          ? verificationUrl
+          : undefined,
         checkoutUrl,
         // Hosted signups (no-card trial) land in the first-run onboarding wizard
         // instead of the bare dashboard.
@@ -430,9 +440,13 @@ export const authRouter = createRouter({
               ...verificationDispatch,
               db: rootDb,
             });
-            response.verificationEmailSent = result.outcome === "accepted";
+            response.verificationEmailProvider = result.provider;
+            response.verificationEmailSent =
+              result.outcome === "accepted" && result.provider === "resend";
             response.verificationEmailPossiblySent =
               result.outcome === "outcome_unknown";
+            response.verificationEmailPreviewed =
+              result.outcome === "accepted" && result.provider === "console";
           } catch {
             // Signup is already committed. Keep verification soft and do not
             // log the auth link or recipient embedded in the closure.
@@ -519,6 +533,8 @@ export const authRouter = createRouter({
         alreadyVerified: true,
         verificationEmailSent: false,
         possiblySent: false,
+        verificationEmailPreviewed: false,
+        verificationEmailProvider: null as EmailProvider | null,
         message: "Your email is already verified.",
       };
     }
@@ -542,6 +558,8 @@ export const authRouter = createRouter({
       alreadyVerified: false,
       verificationEmailSent: false,
       possiblySent: false,
+      verificationEmailPreviewed: false,
+      verificationEmailProvider: null as EmailProvider | null,
       message: "Verification email is being prepared.",
     };
 
@@ -562,10 +580,17 @@ export const authRouter = createRouter({
           verifyUrl: `${appBaseUrl()}/verify-email?token=${token}`,
           db: rootDb,
         });
+        response.verificationEmailProvider = result.provider;
         if (result.outcome === "accepted") {
-          response.verificationEmailSent = true;
-          response.message =
-            "Verification email sent. Check your inbox and spam folder.";
+          if (result.provider === "console") {
+            response.verificationEmailPreviewed = true;
+            response.message =
+              "Verification email preview generated in the server console. No email was sent.";
+          } else {
+            response.verificationEmailSent = true;
+            response.message =
+              "Verification email sent. Check your inbox and spam folder.";
+          }
         } else if (result.outcome === "outcome_unknown") {
           response.possiblySent = true;
           response.message =

--- a/apps/web/server/trpc.ts
+++ b/apps/web/server/trpc.ts
@@ -42,7 +42,32 @@ export type TRPCContext = {
   db: Database;
   session: AppSession | null;
   ip?: string | null;
+  /**
+   * Queue a mutation side effect that must begin only after the procedure's
+   * outer RLS transaction commits. The callback receives the root pool, not
+   * the transaction handle; it must establish its own tenant/system scope for
+   * every database operation. Effects run before the tRPC result is returned.
+   */
+  postCommitEffect?: (effect: (rootDb: Database) => Promise<void>) => void;
 };
+
+type PostCommitEffect = (rootDb: Database) => Promise<void>;
+
+async function runPostCommitEffects(
+  rootDb: Database,
+  effects: PostCommitEffect[],
+  path: string,
+): Promise<void> {
+  for (const effect of effects) {
+    try {
+      await effect(rootDb);
+    } catch {
+      // Do not log the thrown value: effects may handle auth links or contact
+      // data. The route path is sufficient for a PHI-free operational signal.
+      console.error(`[trpc post-commit] effect failed for ${path}`);
+    }
+  }
+}
 
 function clientIp(req?: Request): string | null {
   if (!req) return null;
@@ -140,8 +165,26 @@ function practiceNotFound(): TRPCError {
  * They have no tenant session and do their own scoping (tokens, email, rate
  * limits), so they run in a system DB context that bypasses tenant RLS.
  */
-export const publicProcedure = t.procedure.use(async ({ ctx, next }) => {
-  return withSystem(ctx.db, (tx) => next({ ctx: { ...ctx, db: tx } }));
+export const publicProcedure = t.procedure.use(async ({ ctx, next, type, path }) => {
+  const effects: PostCommitEffect[] = [];
+  const result = await withSystem(ctx.db, (tx) =>
+    next({
+      ctx: {
+        ...ctx,
+        db: tx,
+        postCommitEffect: (effect: PostCommitEffect) => {
+          if (type !== "mutation") {
+            throw new Error("Post-commit effects are mutation-only.");
+          }
+          effects.push(effect);
+        },
+      },
+    }),
+  );
+  if (result.ok) {
+    await runPostCommitEffects(ctx.db, effects, path);
+  }
+  return result;
 });
 
 /** Requires an authenticated session */
@@ -161,7 +204,8 @@ export const protectedProcedure = t.procedure.use(
     const user = ctx.session.user;
     // Run the whole request in a tenant DB context so Postgres RLS scopes every
     // query to this practice (defense-in-depth behind the app-layer filters).
-    return withTenant(ctx.db, user.practiceId, async (tx) => {
+    const effects: PostCommitEffect[] = [];
+    const result = await withTenant(ctx.db, user.practiceId, async (tx) => {
       // Hosted read-only guard: block mutations unless the practice has an
       // active trial or subscription. This MUST run inside withTenant (via tx),
       // not on the raw connection — under the least-privilege production role
@@ -208,6 +252,12 @@ export const protectedProcedure = t.procedure.use(
           user,
           practiceId: user.practiceId,
           db: tx,
+          postCommitEffect: (effect: PostCommitEffect) => {
+            if (type !== "mutation") {
+              throw new Error("Post-commit effects are mutation-only.");
+            }
+            effects.push(effect);
+          },
         },
       });
 
@@ -230,6 +280,10 @@ export const protectedProcedure = t.procedure.use(
 
       return result;
     });
+    if (result.ok) {
+      await runPostCommitEffects(ctx.db, effects, path);
+    }
+    return result;
   },
 );
 

--- a/packages/db/drizzle/0062_ambitious_moon_knight.sql
+++ b/packages/db/drizzle/0062_ambitious_moon_knight.sql
@@ -14,7 +14,7 @@ CREATE TABLE "auth_email_attempts" (
 	"provider_message_id" varchar(128),
 	"outcome" "auth_email_attempt_outcome" DEFAULT 'reserved' NOT NULL,
 	"failure_code" varchar(64),
-	CONSTRAINT "auth_email_attempts_provider_check" CHECK ("auth_email_attempts"."provider" = 'resend'),
+	CONSTRAINT "auth_email_attempts_provider_check" CHECK ("auth_email_attempts"."provider" in ('resend', 'console')),
 	CONSTRAINT "auth_email_attempts_outcome_shape_check" CHECK ((
         "auth_email_attempts"."outcome" = 'reserved'
         and "auth_email_attempts"."resolved_at" is null
@@ -37,6 +37,7 @@ CREATE TABLE "auth_email_delivery_events" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"received_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"webhook_id" varchar(128) NOT NULL,
+	"raw_body_fingerprint" varchar(64) NOT NULL,
 	"provider" varchar(16) DEFAULT 'resend' NOT NULL,
 	"provider_message_id" varchar(128) NOT NULL,
 	"attempt_id" uuid,
@@ -46,6 +47,7 @@ CREATE TABLE "auth_email_delivery_events" (
 	"occurred_at" timestamp with time zone NOT NULL,
 	CONSTRAINT "auth_email_delivery_events_provider_check" CHECK ("auth_email_delivery_events"."provider" = 'resend'),
 	CONSTRAINT "auth_email_delivery_events_event_type_check" CHECK ("auth_email_delivery_events"."event_type" ~ '^email\.'),
+	CONSTRAINT "auth_email_delivery_events_raw_body_fingerprint_check" CHECK ("auth_email_delivery_events"."raw_body_fingerprint" ~ '^[0-9a-f]{64}$'),
 	CONSTRAINT "auth_email_delivery_events_attribution_shape_check" CHECK ((
         "auth_email_delivery_events"."attribution" in ('attempt_tag', 'provider_message_id')
         and "auth_email_delivery_events"."attempt_id" is not null
@@ -66,6 +68,59 @@ CREATE UNIQUE INDEX "auth_email_delivery_events_webhook_uq" ON "auth_email_deliv
 CREATE INDEX "auth_email_delivery_events_attempt_timeline_idx" ON "auth_email_delivery_events" USING btree ("attempt_id","occurred_at","id");--> statement-breakpoint
 CREATE INDEX "auth_email_delivery_events_provider_timeline_idx" ON "auth_email_delivery_events" USING btree ("provider","provider_message_id","occurred_at","id");--> statement-breakpoint
 CREATE INDEX "auth_email_delivery_events_attribution_queue_idx" ON "auth_email_delivery_events" USING btree ("attribution","received_at","id");--> statement-breakpoint
+CREATE OR REPLACE FUNCTION guard_auth_email_attempt_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+	is_owner boolean;
+BEGIN
+	is_owner := current_user = (
+		SELECT pg_catalog.pg_get_userbyid(class.relowner)
+		FROM pg_catalog.pg_class class
+		JOIN pg_catalog.pg_namespace namespace
+			ON namespace.oid = class.relnamespace
+		WHERE namespace.nspname = TG_TABLE_SCHEMA
+			AND class.relname = TG_TABLE_NAME
+	);
+
+	IF TG_OP = 'DELETE' THEN
+		IF is_owner
+			AND coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+		THEN
+			RETURN OLD;
+		END IF;
+		RAISE EXCEPTION USING
+			ERRCODE = '55000',
+			MESSAGE = 'Auth email attempts may only be deleted during owner maintenance.';
+	END IF;
+
+	IF NEW.id IS DISTINCT FROM OLD.id
+		OR NEW.created_at IS DISTINCT FROM OLD.created_at
+		OR NEW.practice_id IS DISTINCT FROM OLD.practice_id
+		OR NEW.user_id IS DISTINCT FROM OLD.user_id
+		OR NEW.source IS DISTINCT FROM OLD.source
+		OR NEW.provider IS DISTINCT FROM OLD.provider
+		OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+	THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '55000',
+			MESSAGE = 'Auth email attempt identity is immutable.';
+	END IF;
+
+	IF OLD.outcome <> 'reserved' OR NEW.outcome = 'reserved' THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '55000',
+			MESSAGE = 'Auth email attempt state may resolve exactly once.';
+	END IF;
+
+	RETURN NEW;
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER auth_email_attempts_state_guard
+	BEFORE UPDATE OR DELETE ON auth_email_attempts
+	FOR EACH ROW EXECUTE FUNCTION guard_auth_email_attempt_mutation();--> statement-breakpoint
 CREATE OR REPLACE FUNCTION reject_auth_email_delivery_event_mutation()
 RETURNS trigger
 LANGUAGE plpgsql

--- a/packages/db/drizzle/0062_ambitious_moon_knight.sql
+++ b/packages/db/drizzle/0062_ambitious_moon_knight.sql
@@ -57,6 +57,19 @@ CREATE TABLE "auth_email_delivery_events" (
       ))
 );
 --> statement-breakpoint
+CREATE TABLE "auth_email_webhook_conflicts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"received_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"original_webhook_id" varchar(128) NOT NULL,
+	"incoming_raw_body_fingerprint" varchar(64) NOT NULL,
+	"provider" varchar(16) DEFAULT 'resend' NOT NULL,
+	"incoming_provider_message_id" varchar(128) NOT NULL,
+	"incoming_event_type" varchar(64) NOT NULL,
+	CONSTRAINT "auth_email_webhook_conflicts_provider_check" CHECK ("auth_email_webhook_conflicts"."provider" = 'resend'),
+	CONSTRAINT "auth_email_webhook_conflicts_event_type_check" CHECK ("auth_email_webhook_conflicts"."incoming_event_type" ~ '^email\.'),
+	CONSTRAINT "auth_email_webhook_conflicts_raw_body_fingerprint_check" CHECK ("auth_email_webhook_conflicts"."incoming_raw_body_fingerprint" ~ '^[0-9a-f]{64}$')
+);
+--> statement-breakpoint
 ALTER TABLE "auth_email_attempts" ADD CONSTRAINT "auth_email_attempts_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "auth_email_attempts" ADD CONSTRAINT "auth_email_attempts_user_tenant_fk" FOREIGN KEY ("practice_id","user_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "auth_email_delivery_events" ADD CONSTRAINT "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk" FOREIGN KEY ("attempt_id") REFERENCES "public"."auth_email_attempts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
@@ -65,9 +78,12 @@ CREATE UNIQUE INDEX "auth_email_attempts_provider_message_uq" ON "auth_email_att
 CREATE INDEX "auth_email_attempts_recovery_idx" ON "auth_email_attempts" USING btree ("outcome","created_at","id");--> statement-breakpoint
 CREATE INDEX "auth_email_attempts_practice_created_idx" ON "auth_email_attempts" USING btree ("practice_id","created_at","id");--> statement-breakpoint
 CREATE UNIQUE INDEX "auth_email_delivery_events_webhook_uq" ON "auth_email_delivery_events" USING btree ("webhook_id");--> statement-breakpoint
+ALTER TABLE "auth_email_webhook_conflicts" ADD CONSTRAINT "auth_email_webhook_conflicts_webhook_fk" FOREIGN KEY ("original_webhook_id") REFERENCES "public"."auth_email_delivery_events"("webhook_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "auth_email_delivery_events_attempt_timeline_idx" ON "auth_email_delivery_events" USING btree ("attempt_id","occurred_at","id");--> statement-breakpoint
 CREATE INDEX "auth_email_delivery_events_provider_timeline_idx" ON "auth_email_delivery_events" USING btree ("provider","provider_message_id","occurred_at","id");--> statement-breakpoint
 CREATE INDEX "auth_email_delivery_events_attribution_queue_idx" ON "auth_email_delivery_events" USING btree ("attribution","received_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "auth_email_webhook_conflicts_identity_uq" ON "auth_email_webhook_conflicts" USING btree ("original_webhook_id","incoming_raw_body_fingerprint");--> statement-breakpoint
+CREATE INDEX "auth_email_webhook_conflicts_recovery_idx" ON "auth_email_webhook_conflicts" USING btree ("received_at","id");--> statement-breakpoint
 CREATE OR REPLACE FUNCTION guard_auth_email_attempt_mutation()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -109,10 +125,18 @@ BEGIN
 			MESSAGE = 'Auth email attempt identity is immutable.';
 	END IF;
 
-	IF OLD.outcome <> 'reserved' OR NEW.outcome = 'reserved' THEN
+	IF NOT (
+		(OLD.outcome = 'reserved' AND NEW.outcome <> 'reserved')
+		OR (
+			OLD.outcome = 'outcome_unknown'
+			AND NEW.outcome = 'accepted'
+			AND OLD.provider = 'resend'
+			AND OLD.provider_message_id IS NULL
+		)
+	) THEN
 		RAISE EXCEPTION USING
 			ERRCODE = '55000',
-			MESSAGE = 'Auth email attempt state may resolve exactly once.';
+			MESSAGE = 'Auth email attempt state transition is not permitted.';
 	END IF;
 
 	RETURN NEW;
@@ -148,6 +172,9 @@ $$;--> statement-breakpoint
 CREATE TRIGGER auth_email_delivery_events_immutable
 	BEFORE UPDATE OR DELETE ON auth_email_delivery_events
 	FOR EACH ROW EXECUTE FUNCTION reject_auth_email_delivery_event_mutation();--> statement-breakpoint
+CREATE TRIGGER auth_email_webhook_conflicts_immutable
+	BEFORE UPDATE OR DELETE ON auth_email_webhook_conflicts
+	FOR EACH ROW EXECUTE FUNCTION reject_auth_email_delivery_event_mutation();--> statement-breakpoint
 ALTER TABLE auth_email_attempts ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 CREATE POLICY system_only ON auth_email_attempts
 	USING (coalesce(current_setting('app.rls_bypass', true), '') = 'on')
@@ -156,18 +183,22 @@ ALTER TABLE auth_email_delivery_events ENABLE ROW LEVEL SECURITY;--> statement-b
 CREATE POLICY system_only ON auth_email_delivery_events
 	USING (coalesce(current_setting('app.rls_bypass', true), '') = 'on')
 	WITH CHECK (coalesce(current_setting('app.rls_bypass', true), '') = 'on');--> statement-breakpoint
+ALTER TABLE auth_email_webhook_conflicts ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY system_only ON auth_email_webhook_conflicts
+	USING (coalesce(current_setting('app.rls_bypass', true), '') = 'on')
+	WITH CHECK (coalesce(current_setting('app.rls_bypass', true), '') = 'on');--> statement-breakpoint
 DO $$
 BEGIN
 	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'openpims_app') THEN
-		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events FROM openpims_app;
+		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts FROM openpims_app;
 		GRANT SELECT, INSERT, UPDATE ON auth_email_attempts TO openpims_app;
-		GRANT SELECT, INSERT ON auth_email_delivery_events TO openpims_app;
+		GRANT SELECT, INSERT ON auth_email_delivery_events, auth_email_webhook_conflicts TO openpims_app;
 	END IF;
 	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
-		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events FROM anon;
+		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts FROM anon;
 	END IF;
 	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events FROM authenticated;
+		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts FROM authenticated;
 	END IF;
 END
 $$;

--- a/packages/db/drizzle/0062_ambitious_moon_knight.sql
+++ b/packages/db/drizzle/0062_ambitious_moon_knight.sql
@@ -1,0 +1,118 @@
+CREATE TYPE "public"."auth_email_attempt_outcome" AS ENUM('reserved', 'accepted', 'definite_failure', 'outcome_unknown');--> statement-breakpoint
+CREATE TYPE "public"."auth_email_delivery_attribution" AS ENUM('attempt_tag', 'provider_message_id', 'unmatched', 'identity_conflict');--> statement-breakpoint
+CREATE TYPE "public"."auth_email_delivery_classification" AS ENUM('sent', 'delivered', 'delayed', 'failed', 'complained', 'opened', 'clicked', 'unknown');--> statement-breakpoint
+CREATE TYPE "public"."auth_email_source" AS ENUM('registration', 'authenticated_resend');--> statement-breakpoint
+CREATE TABLE "auth_email_attempts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"resolved_at" timestamp with time zone,
+	"practice_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"source" "auth_email_source" NOT NULL,
+	"provider" varchar(16) DEFAULT 'resend' NOT NULL,
+	"idempotency_key" varchar(200) NOT NULL,
+	"provider_message_id" varchar(128),
+	"outcome" "auth_email_attempt_outcome" DEFAULT 'reserved' NOT NULL,
+	"failure_code" varchar(64),
+	CONSTRAINT "auth_email_attempts_provider_check" CHECK ("auth_email_attempts"."provider" = 'resend'),
+	CONSTRAINT "auth_email_attempts_outcome_shape_check" CHECK ((
+        "auth_email_attempts"."outcome" = 'reserved'
+        and "auth_email_attempts"."resolved_at" is null
+        and "auth_email_attempts"."provider_message_id" is null
+        and "auth_email_attempts"."failure_code" is null
+      ) or (
+        "auth_email_attempts"."outcome" = 'accepted'
+        and "auth_email_attempts"."resolved_at" is not null
+        and length(btrim(coalesce("auth_email_attempts"."provider_message_id", ''))) > 0
+        and "auth_email_attempts"."failure_code" is null
+      ) or (
+        "auth_email_attempts"."outcome" in ('definite_failure', 'outcome_unknown')
+        and "auth_email_attempts"."resolved_at" is not null
+        and "auth_email_attempts"."provider_message_id" is null
+        and length(btrim(coalesce("auth_email_attempts"."failure_code", ''))) > 0
+      ))
+);
+--> statement-breakpoint
+CREATE TABLE "auth_email_delivery_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"received_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"webhook_id" varchar(128) NOT NULL,
+	"provider" varchar(16) DEFAULT 'resend' NOT NULL,
+	"provider_message_id" varchar(128) NOT NULL,
+	"attempt_id" uuid,
+	"event_type" varchar(64) NOT NULL,
+	"classification" "auth_email_delivery_classification" NOT NULL,
+	"attribution" "auth_email_delivery_attribution" NOT NULL,
+	"occurred_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "auth_email_delivery_events_provider_check" CHECK ("auth_email_delivery_events"."provider" = 'resend'),
+	CONSTRAINT "auth_email_delivery_events_event_type_check" CHECK ("auth_email_delivery_events"."event_type" ~ '^email\.'),
+	CONSTRAINT "auth_email_delivery_events_attribution_shape_check" CHECK ((
+        "auth_email_delivery_events"."attribution" in ('attempt_tag', 'provider_message_id')
+        and "auth_email_delivery_events"."attempt_id" is not null
+      ) or (
+        "auth_email_delivery_events"."attribution" in ('unmatched', 'identity_conflict')
+        and "auth_email_delivery_events"."attempt_id" is null
+      ))
+);
+--> statement-breakpoint
+ALTER TABLE "auth_email_attempts" ADD CONSTRAINT "auth_email_attempts_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "auth_email_attempts" ADD CONSTRAINT "auth_email_attempts_user_tenant_fk" FOREIGN KEY ("practice_id","user_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "auth_email_delivery_events" ADD CONSTRAINT "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk" FOREIGN KEY ("attempt_id") REFERENCES "public"."auth_email_attempts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "auth_email_attempts_idempotency_uq" ON "auth_email_attempts" USING btree ("idempotency_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "auth_email_attempts_provider_message_uq" ON "auth_email_attempts" USING btree ("provider","provider_message_id") WHERE "auth_email_attempts"."provider_message_id" is not null;--> statement-breakpoint
+CREATE INDEX "auth_email_attempts_recovery_idx" ON "auth_email_attempts" USING btree ("outcome","created_at","id");--> statement-breakpoint
+CREATE INDEX "auth_email_attempts_practice_created_idx" ON "auth_email_attempts" USING btree ("practice_id","created_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "auth_email_delivery_events_webhook_uq" ON "auth_email_delivery_events" USING btree ("webhook_id");--> statement-breakpoint
+CREATE INDEX "auth_email_delivery_events_attempt_timeline_idx" ON "auth_email_delivery_events" USING btree ("attempt_id","occurred_at","id");--> statement-breakpoint
+CREATE INDEX "auth_email_delivery_events_provider_timeline_idx" ON "auth_email_delivery_events" USING btree ("provider","provider_message_id","occurred_at","id");--> statement-breakpoint
+CREATE INDEX "auth_email_delivery_events_attribution_queue_idx" ON "auth_email_delivery_events" USING btree ("attribution","received_at","id");--> statement-breakpoint
+CREATE OR REPLACE FUNCTION reject_auth_email_delivery_event_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+	IF coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+		AND current_user = (
+			SELECT pg_catalog.pg_get_userbyid(class.relowner)
+			FROM pg_catalog.pg_class class
+			JOIN pg_catalog.pg_namespace namespace
+				ON namespace.oid = class.relnamespace
+			WHERE namespace.nspname = TG_TABLE_SCHEMA
+				AND class.relname = TG_TABLE_NAME
+		)
+	THEN
+		IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+		RETURN NEW;
+	END IF;
+	RAISE EXCEPTION USING
+		ERRCODE = '55000',
+		MESSAGE = 'Auth email delivery evidence is immutable.';
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER auth_email_delivery_events_immutable
+	BEFORE UPDATE OR DELETE ON auth_email_delivery_events
+	FOR EACH ROW EXECUTE FUNCTION reject_auth_email_delivery_event_mutation();--> statement-breakpoint
+ALTER TABLE auth_email_attempts ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY system_only ON auth_email_attempts
+	USING (coalesce(current_setting('app.rls_bypass', true), '') = 'on')
+	WITH CHECK (coalesce(current_setting('app.rls_bypass', true), '') = 'on');--> statement-breakpoint
+ALTER TABLE auth_email_delivery_events ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY system_only ON auth_email_delivery_events
+	USING (coalesce(current_setting('app.rls_bypass', true), '') = 'on')
+	WITH CHECK (coalesce(current_setting('app.rls_bypass', true), '') = 'on');--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'openpims_app') THEN
+		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events FROM openpims_app;
+		GRANT SELECT, INSERT, UPDATE ON auth_email_attempts TO openpims_app;
+		GRANT SELECT, INSERT ON auth_email_delivery_events TO openpims_app;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events FROM anon;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events FROM authenticated;
+	END IF;
+END
+$$;

--- a/packages/db/drizzle/0062_ambitious_moon_knight.sql
+++ b/packages/db/drizzle/0062_ambitious_moon_knight.sql
@@ -33,6 +33,19 @@ CREATE TABLE "auth_email_attempts" (
       ))
 );
 --> statement-breakpoint
+CREATE TABLE "auth_email_provider_identity_conflicts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"occurred_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"attempt_id" uuid NOT NULL,
+	"provider" varchar(16) DEFAULT 'resend' NOT NULL,
+	"source" "auth_email_source" NOT NULL,
+	"durable_provider_message_id" varchar(128) NOT NULL,
+	"conflicting_provider_message_id" varchar(128) NOT NULL,
+	CONSTRAINT "auth_email_provider_identity_conflicts_provider_check" CHECK ("auth_email_provider_identity_conflicts"."provider" = 'resend'),
+	CONSTRAINT "auth_email_provider_identity_conflicts_distinct_id_check" CHECK ("auth_email_provider_identity_conflicts"."durable_provider_message_id" <> "auth_email_provider_identity_conflicts"."conflicting_provider_message_id"),
+	CONSTRAINT "auth_email_provider_identity_conflicts_id_shape_check" CHECK (length(btrim("auth_email_provider_identity_conflicts"."durable_provider_message_id")) > 0 and length(btrim("auth_email_provider_identity_conflicts"."conflicting_provider_message_id")) > 0)
+);
+--> statement-breakpoint
 CREATE TABLE "auth_email_delivery_events" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"received_at" timestamp with time zone DEFAULT now() NOT NULL,
@@ -72,11 +85,14 @@ CREATE TABLE "auth_email_webhook_conflicts" (
 --> statement-breakpoint
 ALTER TABLE "auth_email_attempts" ADD CONSTRAINT "auth_email_attempts_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "auth_email_attempts" ADD CONSTRAINT "auth_email_attempts_user_tenant_fk" FOREIGN KEY ("practice_id","user_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "auth_email_provider_identity_conflicts" ADD CONSTRAINT "auth_email_provider_identity_conflicts_attempt_fk" FOREIGN KEY ("attempt_id") REFERENCES "public"."auth_email_attempts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "auth_email_delivery_events" ADD CONSTRAINT "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk" FOREIGN KEY ("attempt_id") REFERENCES "public"."auth_email_attempts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "auth_email_attempts_idempotency_uq" ON "auth_email_attempts" USING btree ("idempotency_key");--> statement-breakpoint
 CREATE UNIQUE INDEX "auth_email_attempts_provider_message_uq" ON "auth_email_attempts" USING btree ("provider","provider_message_id") WHERE "auth_email_attempts"."provider_message_id" is not null;--> statement-breakpoint
 CREATE INDEX "auth_email_attempts_recovery_idx" ON "auth_email_attempts" USING btree ("outcome","created_at","id");--> statement-breakpoint
 CREATE INDEX "auth_email_attempts_practice_created_idx" ON "auth_email_attempts" USING btree ("practice_id","created_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "auth_email_provider_identity_conflicts_identity_uq" ON "auth_email_provider_identity_conflicts" USING btree ("attempt_id","provider","durable_provider_message_id","conflicting_provider_message_id");--> statement-breakpoint
+CREATE INDEX "auth_email_provider_identity_conflicts_recovery_idx" ON "auth_email_provider_identity_conflicts" USING btree ("occurred_at","id");--> statement-breakpoint
 CREATE UNIQUE INDEX "auth_email_delivery_events_webhook_uq" ON "auth_email_delivery_events" USING btree ("webhook_id");--> statement-breakpoint
 ALTER TABLE "auth_email_webhook_conflicts" ADD CONSTRAINT "auth_email_webhook_conflicts_webhook_fk" FOREIGN KEY ("original_webhook_id") REFERENCES "public"."auth_email_delivery_events"("webhook_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "auth_email_delivery_events_attempt_timeline_idx" ON "auth_email_delivery_events" USING btree ("attempt_id","occurred_at","id");--> statement-breakpoint
@@ -175,6 +191,9 @@ CREATE TRIGGER auth_email_delivery_events_immutable
 CREATE TRIGGER auth_email_webhook_conflicts_immutable
 	BEFORE UPDATE OR DELETE ON auth_email_webhook_conflicts
 	FOR EACH ROW EXECUTE FUNCTION reject_auth_email_delivery_event_mutation();--> statement-breakpoint
+CREATE TRIGGER auth_email_provider_identity_conflicts_immutable
+	BEFORE UPDATE OR DELETE ON auth_email_provider_identity_conflicts
+	FOR EACH ROW EXECUTE FUNCTION reject_auth_email_delivery_event_mutation();--> statement-breakpoint
 ALTER TABLE auth_email_attempts ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 CREATE POLICY system_only ON auth_email_attempts
 	USING (coalesce(current_setting('app.rls_bypass', true), '') = 'on')
@@ -187,18 +206,22 @@ ALTER TABLE auth_email_webhook_conflicts ENABLE ROW LEVEL SECURITY;--> statement
 CREATE POLICY system_only ON auth_email_webhook_conflicts
 	USING (coalesce(current_setting('app.rls_bypass', true), '') = 'on')
 	WITH CHECK (coalesce(current_setting('app.rls_bypass', true), '') = 'on');--> statement-breakpoint
+ALTER TABLE auth_email_provider_identity_conflicts ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY system_only ON auth_email_provider_identity_conflicts
+	USING (coalesce(current_setting('app.rls_bypass', true), '') = 'on')
+	WITH CHECK (coalesce(current_setting('app.rls_bypass', true), '') = 'on');--> statement-breakpoint
 DO $$
 BEGIN
 	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'openpims_app') THEN
-		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts FROM openpims_app;
+		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts FROM openpims_app;
 		GRANT SELECT, INSERT, UPDATE ON auth_email_attempts TO openpims_app;
-		GRANT SELECT, INSERT ON auth_email_delivery_events, auth_email_webhook_conflicts TO openpims_app;
+		GRANT SELECT, INSERT ON auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts TO openpims_app;
 	END IF;
 	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
-		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts FROM anon;
+		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts FROM anon;
 	END IF;
 	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
-		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts FROM authenticated;
+		REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts FROM authenticated;
 	END IF;
 END
 $$;

--- a/packages/db/drizzle/meta/0062_snapshot.json
+++ b/packages/db/drizzle/meta/0062_snapshot.json
@@ -12790,6 +12790,143 @@
       },
       "isRLSEnabled": false
     },
+    "public.auth_email_provider_identity_conflicts": {
+      "name": "auth_email_provider_identity_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_provider_message_id": {
+          "name": "durable_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflicting_provider_message_id": {
+          "name": "conflicting_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_provider_identity_conflicts_identity_uq": {
+          "name": "auth_email_provider_identity_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "durable_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conflicting_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_provider_identity_conflicts_recovery_idx": {
+          "name": "auth_email_provider_identity_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_provider_identity_conflicts_attempt_fk": {
+          "name": "auth_email_provider_identity_conflicts_attempt_fk",
+          "tableFrom": "auth_email_provider_identity_conflicts",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": ["attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_provider_identity_conflicts_provider_check": {
+          "name": "auth_email_provider_identity_conflicts_provider_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_provider_identity_conflicts_distinct_id_check": {
+          "name": "auth_email_provider_identity_conflicts_distinct_id_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\" <> \"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\""
+        },
+        "auth_email_provider_identity_conflicts_id_shape_check": {
+          "name": "auth_email_provider_identity_conflicts_id_shape_check",
+          "value": "length(btrim(\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\")) > 0\n        and length(btrim(\"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
     "public.auth_email_delivery_events": {
       "name": "auth_email_delivery_events",
       "schema": "",

--- a/packages/db/drizzle/meta/0062_snapshot.json
+++ b/packages/db/drizzle/meta/0062_snapshot.json
@@ -1,0 +1,17639 @@
+{
+  "id": "6e681576-4a9e-47eb-8a36-3074f9ecc813",
+  "prevId": "e369b2d7-3ff4-4bfc-9130-4939c4917686",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["access_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": ["noted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": ["recorded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["source_patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["target_patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "source_patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "target_patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": ["practice_id", "client_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "performed_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": ["type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": ["type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": ["doctor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": ["room_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": ["recurring_series_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": ["case_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": ["primary_vet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_operation_id": {
+          "name": "creation_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_payload_hash": {
+          "name": "creation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_note": {
+          "name": "follow_up_note",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_by": {
+          "name": "follow_up_completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_at": {
+          "name": "follow_up_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_outcome": {
+          "name": "follow_up_outcome",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_review_inbox_idx": {
+          "name": "lab_results_review_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_follow_up_inbox_idx": {
+          "name": "lab_results_follow_up_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_record_uq": {
+          "name": "lab_results_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_creation_operation_uq": {
+          "name": "lab_results_creation_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["ordered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_results_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_completed_by_users_id_fk": {
+          "name": "lab_results_follow_up_completed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_completed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_patient_fk": {
+          "name": "lab_results_practice_patient_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_ordered_by_fk": {
+          "name": "lab_results_practice_ordered_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "ordered_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_reviewed_by_fk": {
+          "name": "lab_results_practice_reviewed_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "reviewed_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_assigned_fk": {
+          "name": "lab_results_practice_follow_up_assigned_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "follow_up_assigned_to"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_completed_fk": {
+          "name": "lab_results_practice_follow_up_completed_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "follow_up_completed_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_results_lifecycle_shape_check": {
+          "name": "lab_results_lifecycle_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"completed_at\" is null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'completed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is not null\n          and \"lab_results\".\"reviewed_by\" is not null\n        )"
+        },
+        "lab_results_creation_operation_shape_check": {
+          "name": "lab_results_creation_operation_shape_check",
+          "value": "(\"lab_results\".\"creation_operation_id\" is null and \"lab_results\".\"creation_payload_hash\" is null)\n        or (\"lab_results\".\"creation_operation_id\" is not null and \"lab_results\".\"creation_payload_hash\" ~ '^[0-9a-f]{64}$')"
+        },
+        "lab_results_result_shape_check": {
+          "name": "lab_results_result_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"result_value\" is null\n          and \"lab_results\".\"unit\" is null\n          and \"lab_results\".\"reference_range_low\" is null\n          and \"lab_results\".\"reference_range_high\" is null\n          and \"lab_results\".\"result_flag\" = 'unknown'\n        ) or (\n          \"lab_results\".\"status\" in ('completed', 'reviewed')\n          and length(btrim(coalesce(\"lab_results\".\"result_value\", ''))) > 0\n        )"
+        },
+        "lab_results_follow_up_shape_check": {
+          "name": "lab_results_follow_up_shape_check",
+          "value": "(\"lab_results\".\"status\" <> 'pending' or \"lab_results\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_results\".\"follow_up_due_at\" is null\n        )\n        and ((\n          \"lab_results\".\"follow_up_status\" = 'not_required'\n          and \"lab_results\".\"follow_up_assigned_to\" is null\n          and \"lab_results\".\"follow_up_due_at\" is null\n          and \"lab_results\".\"follow_up_note\" is null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'open'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'completed'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is not null\n          and \"lab_results\".\"follow_up_completed_at\" is not null\n          and length(btrim(coalesce(\"lab_results\".\"follow_up_outcome\", ''))) between 3 and 1000\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": ["problem_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": ["administered_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": ["recorded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_result_events": {
+      "name": "lab_result_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "lab_result_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_events_result_history_idx": {
+          "name": "lab_result_events_result_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_time_idx": {
+          "name": "lab_result_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_operation_uq": {
+          "name": "lab_result_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_created_uq": {
+          "name": "lab_result_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"lab_result_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_events_practice_id_practices_id_fk": {
+          "name": "lab_result_events_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_events_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": ["lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_id_patients_id_fk": {
+          "name": "lab_result_events_patient_id_patients_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_id_appointments_id_fk": {
+          "name": "lab_result_events_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_result_events_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_id_users_id_fk": {
+          "name": "lab_result_events_actor_id_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_result_tenant_fk": {
+          "name": "lab_result_events_result_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_tenant_fk": {
+          "name": "lab_result_events_patient_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_tenant_fk": {
+          "name": "lab_result_events_appointment_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_tenant_fk": {
+          "name": "lab_result_events_actor_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_assignee_tenant_fk": {
+          "name": "lab_result_events_assignee_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "follow_up_assigned_to"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_events_shape_check": {
+          "name": "lab_result_events_shape_check",
+          "value": "length(btrim(\"lab_result_events\".\"actor_name\")) between 1 and 255\n        and \"lab_result_events\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        and (\"lab_result_events\".\"note\" is null or length(\"lab_result_events\".\"note\") <= 1000)\n        and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_result_events\".\"status_after\" = 'reviewed'\n          and \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_result_events\".\"follow_up_due_at\" is null\n        )\n        and (\n          (\"lab_result_events\".\"status_after\" = 'pending'\n            and \"lab_result_events\".\"result_value\" is null\n            and \"lab_result_events\".\"unit\" is null\n            and \"lab_result_events\".\"reference_range_low\" is null\n            and \"lab_result_events\".\"reference_range_high\" is null\n            and \"lab_result_events\".\"result_flag\" = 'unknown')\n          or (\"lab_result_events\".\"status_after\" in ('completed', 'reviewed')\n            and length(btrim(coalesce(\"lab_result_events\".\"result_value\", ''))) between 1 and 128)\n        )\n        and (\n          (\"lab_result_events\".\"follow_up_status\" = 'not_required'\n            and \"lab_result_events\".\"follow_up_assigned_to\" is null\n            and \"lab_result_events\".\"follow_up_due_at\" is null)\n          or (\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n            and \"lab_result_events\".\"follow_up_assigned_to\" is not null)\n        )\n        and (\n          \"lab_result_events\".\"event_type\" = 'created'\n          and \"lab_result_events\".\"status_before\" is null\n          and \"lab_result_events\".\"status_after\" in ('pending', 'completed')\n          and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"result_flag\" = 'unknown')\n        or \"lab_result_events\".\"event_type\" = 'completed'\n          and \"lab_result_events\".\"status_before\" = 'pending'\n          and \"lab_result_events\".\"status_after\" = 'completed'\n        or \"lab_result_events\".\"event_type\" = 'reviewed'\n          and \"lab_result_events\".\"status_before\" = 'completed'\n          and \"lab_result_events\".\"status_after\" = 'reviewed'\n        or \"lab_result_events\".\"event_type\" in ('follow_up_assigned', 'follow_up_reassigned')\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'open'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n        or \"lab_result_events\".\"event_type\" = 'follow_up_completed'\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'completed'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n          and length(btrim(coalesce(\"lab_result_events\".\"note\", ''))) between 3 and 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_lab_result_uq": {
+          "name": "clinical_record_corrections_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"lab_result_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_operation_uq": {
+          "name": "clinical_record_corrections_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_lab_source_uq": {
+          "name": "clinical_record_corrections_practice_record_lab_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["soap_note_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": ["vital_sign_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": ["vaccination_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_id_lab_results_id_fk": {
+          "name": "clinical_record_corrections_lab_result_id_lab_results_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": ["lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": ["corrected_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id", "patient_id"],
+          "columnsTo": ["practice_id", "id", "patient_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "corrected_by"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": ["practice_id", "soap_note_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": ["practice_id", "vital_sign_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": ["practice_id", "vaccination_record_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_source_fk": {
+          "name": "clinical_record_corrections_lab_result_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n        and \"clinical_record_corrections\".\"lab_result_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      )"
+        },
+        "clinical_record_corrections_operation_shape_check": {
+          "name": "clinical_record_corrections_operation_shape_check",
+          "value": "(\n          \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is not null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        ) or (\n          \"clinical_record_corrections\".\"record_type\" <> 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" is null\n        )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lab_result_replacements": {
+      "name": "lab_result_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lab_result_id": {
+          "name": "source_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_lab_result_id": {
+          "name": "replacement_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_replacements_source_history_idx": {
+          "name": "lab_result_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_source_uq": {
+          "name": "lab_result_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_replacement_uq": {
+          "name": "lab_result_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_operation_uq": {
+          "name": "lab_result_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_replacements_practice_id_practices_id_fk": {
+          "name": "lab_result_replacements_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "lab_result_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": ["correction_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_source_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["source_lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["replacement_lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_id_users_id_fk": {
+          "name": "lab_result_replacements_actor_id_users_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_tenant_fk": {
+          "name": "lab_result_replacements_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "source_lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_tenant_fk": {
+          "name": "lab_result_replacements_replacement_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "replacement_lab_result_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_source_tenant_fk": {
+          "name": "lab_result_replacements_correction_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": ["practice_id", "id", "lab_result_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_tenant_fk": {
+          "name": "lab_result_replacements_actor_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_replacements_shape_check": {
+          "name": "lab_result_replacements_shape_check",
+          "value": "\"lab_result_replacements\".\"source_lab_result_id\" <> \"lab_result_replacements\".\"replacement_lab_result_id\"\n        and length(btrim(\"lab_result_replacements\".\"actor_name\")) between 1 and 255\n        and \"lab_result_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": ["prescribed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["practice_id", "prescription_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": ["practice_id", "product_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["source_prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": ["received_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": ["prescription_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": ["practice_id", "prescription_event_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["practice_id", "prescription_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": ["practice_id", "patient_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": ["practice_id", "product_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_id", "invoice_item_id"],
+          "columnsTo": ["invoice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": ["assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["session_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": ["identifier", "token"]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": ["performed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": ["witnessed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": ["form_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": ["template_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": ["policy_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": ["plan_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": ["patient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": ["event_id", "endpoint"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_email_attempts": {
+      "name": "auth_email_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "auth_email_attempt_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_email_attempts_idempotency_uq": {
+          "name": "auth_email_attempts_idempotency_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_provider_message_uq": {
+          "name": "auth_email_attempts_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_email_attempts\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_recovery_idx": {
+          "name": "auth_email_attempts_recovery_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_practice_created_idx": {
+          "name": "auth_email_attempts_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_attempts_practice_id_practices_id_fk": {
+          "name": "auth_email_attempts_practice_id_practices_id_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_email_attempts_user_tenant_fk": {
+          "name": "auth_email_attempts_user_tenant_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_attempts_provider_check": {
+          "name": "auth_email_attempts_provider_check",
+          "value": "\"auth_email_attempts\".\"provider\" = 'resend'"
+        },
+        "auth_email_attempts_outcome_shape_check": {
+          "name": "auth_email_attempts_outcome_shape_check",
+          "value": "(\n        \"auth_email_attempts\".\"outcome\" = 'reserved'\n        and \"auth_email_attempts\".\"resolved_at\" is null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" = 'accepted'\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"provider_message_id\", ''))) > 0\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"failure_code\", ''))) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_delivery_events": {
+      "name": "auth_email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "auth_email_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "auth_email_delivery_attribution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_delivery_events_webhook_uq": {
+          "name": "auth_email_delivery_events_webhook_uq",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attempt_timeline_idx": {
+          "name": "auth_email_delivery_events_attempt_timeline_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_provider_timeline_idx": {
+          "name": "auth_email_delivery_events_provider_timeline_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attribution_queue_idx": {
+          "name": "auth_email_delivery_events_attribution_queue_idx",
+          "columns": [
+            {
+              "expression": "attribution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk": {
+          "name": "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk",
+          "tableFrom": "auth_email_delivery_events",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": ["attempt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_delivery_events_provider_check": {
+          "name": "auth_email_delivery_events_provider_check",
+          "value": "\"auth_email_delivery_events\".\"provider\" = 'resend'"
+        },
+        "auth_email_delivery_events_event_type_check": {
+          "name": "auth_email_delivery_events_event_type_check",
+          "value": "\"auth_email_delivery_events\".\"event_type\" ~ '^email\\.'"
+        },
+        "auth_email_delivery_events_attribution_shape_check": {
+          "name": "auth_email_delivery_events_attribution_shape_check",
+          "value": "(\n        \"auth_email_delivery_events\".\"attribution\" in ('attempt_tag', 'provider_message_id')\n        and \"auth_email_delivery_events\".\"attempt_id\" is not null\n      ) or (\n        \"auth_email_delivery_events\".\"attribution\" in ('unmatched', 'identity_conflict')\n        and \"auth_email_delivery_events\".\"attempt_id\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ready": {
+          "name": "provider_profile_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_profile_synced_at": {
+          "name": "provider_profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["location_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": ["compliance_attested_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": ["practice_id", "client_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_event_history": {
+      "name": "sms_delivery_event_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivery_event_id": {
+          "name": "delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_history_id": {
+          "name": "reviewed_history_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_delivery_history_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "sms_delivery_history_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_reason_code": {
+          "name": "operator_reason_code",
+          "type": "sms_delivery_reconciliation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_event_history_event_key_uq": {
+          "name": "sms_delivery_event_history_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_idx": {
+          "name": "sms_delivery_event_history_event_idx",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_id_uq": {
+          "name": "sms_delivery_event_history_event_id_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attribution_uq": {
+          "name": "sms_delivery_event_history_attribution_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"result\" = 'attributed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_reviewed_history_uq": {
+          "name": "sms_delivery_event_history_reviewed_history_uq",
+          "columns": [
+            {
+              "expression": "reviewed_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"reviewed_history_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_practice_queue_idx": {
+          "name": "sms_delivery_event_history_practice_queue_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attempt_idx": {
+          "name": "sms_delivery_event_history_attempt_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": ["delivery_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_practice_id_practices_id_fk": {
+          "name": "sms_delivery_event_history_practice_id_practices_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_id_communications_id_fk": {
+          "name": "sms_delivery_event_history_communication_id_communications_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": ["communication_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_user_id_users_id_fk": {
+          "name": "sms_delivery_event_history_actor_user_id_users_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_attempt_tenant_fk": {
+          "name": "sms_delivery_event_history_attempt_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": ["practice_id", "attempt_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_tenant_fk": {
+          "name": "sms_delivery_event_history_communication_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": ["practice_id", "communication_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_tenant_fk": {
+          "name": "sms_delivery_event_history_actor_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_reviewed_history_fk": {
+          "name": "sms_delivery_event_history_reviewed_history_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_event_history",
+          "columnsFrom": ["delivery_event_id", "reviewed_history_id"],
+          "columnsTo": ["delivery_event_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_event_history_event_key_check": {
+          "name": "sms_delivery_event_history_event_key_check",
+          "value": "length(btrim(\"sms_delivery_event_history\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_event_history_detail_check": {
+          "name": "sms_delivery_event_history_detail_check",
+          "value": "\"sms_delivery_event_history\".\"detail\" is null or length(\"sms_delivery_event_history\".\"detail\") <= 2000"
+        },
+        "sms_delivery_event_history_target_shape_check": {
+          "name": "sms_delivery_event_history_target_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous', 'operator_reviewed')\n          and \"sms_delivery_event_history\".\"practice_id\" is null\n          and \"sms_delivery_event_history\".\"attempt_id\" is null\n          and \"sms_delivery_event_history\".\"communication_id\" is null\n          and (\n            (\"sms_delivery_event_history\".\"result\" = 'operator_reviewed' and \"sms_delivery_event_history\".\"reviewed_history_id\" is not null)\n            or (\"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous') and \"sms_delivery_event_history\".\"reviewed_history_id\" is null)\n          )\n        ) or (\n          \"sms_delivery_event_history\".\"result\" in ('attributed', 'projection_miss', 'reconciled')\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"result\" = 'projected'\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"communication_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        )"
+        },
+        "sms_delivery_event_history_actor_shape_check": {
+          "name": "sms_delivery_event_history_actor_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"kind\" = 'automatic'\n          and \"sms_delivery_event_history\".\"result\" in (\n            'unmatched',\n            'ambiguous',\n            'attributed',\n            'projected',\n            'projection_miss'\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" is null\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and \"sms_delivery_event_history\".\"actor_identity\" is null\n          and \"sms_delivery_event_history\".\"actor_name\" is null\n          and \"sms_delivery_event_history\".\"operator_reason_code\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"kind\" = 'operator_reconciliation'\n          and (\n            (\n              \"sms_delivery_event_history\".\"result\" = 'reconciled'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'exact_attribution_retry',\n                'provider_portal_status_review',\n                'projection_repair'\n              )\n            )\n            or (\n              \"sms_delivery_event_history\".\"result\" = 'operator_reviewed'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'identity_conflict_review',\n                'unmatched_evidence_review'\n              )\n            )\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" = 'platform_operator'\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_name\", ''))) between 1 and 255\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_events": {
+      "name": "sms_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint_sha256": {
+          "name": "payload_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_events_provider_event_key_uq": {
+          "name": "sms_delivery_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_provider_message_idx": {
+          "name": "sms_delivery_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_classification_queue_idx": {
+          "name": "sms_delivery_events_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_events_provider_check": {
+          "name": "sms_delivery_events_provider_check",
+          "value": "\"sms_delivery_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_delivery_events_event_type_check": {
+          "name": "sms_delivery_events_event_type_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"provider_event_type\")) between 1 and 80"
+        },
+        "sms_delivery_events_event_key_check": {
+          "name": "sms_delivery_events_event_key_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_events_fingerprint_check": {
+          "name": "sms_delivery_events_fingerprint_check",
+          "value": "\"sms_delivery_events\".\"payload_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_delivery_events_provider_event_id_check": {
+          "name": "sms_delivery_events_provider_event_id_check",
+          "value": "\"sms_delivery_events\".\"provider_event_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_event_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_message_id_check": {
+          "name": "sms_delivery_events_provider_message_id_check",
+          "value": "\"sms_delivery_events\".\"provider_message_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_message_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_status_check": {
+          "name": "sms_delivery_events_provider_status_check",
+          "value": "\"sms_delivery_events\".\"provider_status\" is null or length(btrim(\"sms_delivery_events\".\"provider_status\")) between 1 and 80"
+        },
+        "sms_delivery_events_provider_error_code_check": {
+          "name": "sms_delivery_events_provider_error_code_check",
+          "value": "\"sms_delivery_events\".\"provider_error_code\" is null or length(btrim(\"sms_delivery_events\".\"provider_error_code\")) between 1 and 80"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": ["practice_id", "attempt_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "actor_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": ["communication_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": ["requested_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": ["practice_id", "resend_of_attempt_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": ["practice_id", "client_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": ["practice_id", "location_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": ["practice_id", "communication_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": ["practice_id", "requested_by_user_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": ["practice_id", "milestone"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": ["committed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": ["follow_up_appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_assigned_to"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["follow_up_resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["clinical_finalized_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": ["completed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": ["follow_up_resolution_appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": ["practice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": ["appointment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": ["vaccination_record_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": ["lab_result_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": ["procedure_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["prescription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": ["resolved_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": ["practice_id", "appointment_id"],
+          "columnsTo": ["practice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": ["practice_id", "appointment_id", "lab_result_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": ["practice_id", "appointment_id", "procedure_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": ["practice_id", "appointment_id", "prescription_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["practice_id", "appointment_id", "invoice_id"],
+          "columnsTo": ["practice_id", "appointment_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": ["invoice_id", "invoice_item_id"],
+          "columnsTo": ["invoice_id", "id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": ["admin", "veterinarian", "technician", "front_desk", "viewer"]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": ["phone", "email", "sms", "portal"]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": ["mild", "moderate", "severe"]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": ["active", "inactive", "deceased"]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": ["male", "female", "male_neutered", "female_spayed"]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": ["weekly", "monthly", "annual"]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": ["exam", "surgery", "treatment", "boarding"]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": ["waiting", "scheduled", "cancelled"]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": ["open", "closed"]
+    },
+    "public.lab_follow_up_status": {
+      "name": "lab_follow_up_status",
+      "schema": "public",
+      "values": ["not_required", "open", "completed"]
+    },
+    "public.lab_result_flag": {
+      "name": "lab_result_flag",
+      "schema": "public",
+      "values": ["unknown", "normal", "abnormal", "critical"]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": ["pending", "completed", "reviewed"]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": ["general", "follow_up", "phone_call"]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": ["active", "resolved", "chronic"]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": ["pending", "in_progress", "done", "skipped"]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": ["active", "completed", "discontinued"]
+    },
+    "public.lab_result_event_type": {
+      "name": "lab_result_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "completed",
+        "reviewed",
+        "follow_up_assigned",
+        "follow_up_reassigned",
+        "follow_up_completed"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": ["entered_in_error"]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": ["soap_note", "vital_sign", "vaccination_record", "lab_result"]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": ["minor", "moderate", "major"]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": ["active", "completed", "cancelled", "expired"]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": ["credit", "write_off"]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": ["service", "product"]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": ["draft", "sent", "paid", "overdue", "void"]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": ["pending", "active", "action_required", "disabled"]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": ["draft", "ordered", "received"]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": ["pending", "invoiced", "waived"]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": ["phone", "sms", "email", "portal"]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": ["pending", "sent", "delivered", "read", "failed"]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": ["inbound", "outbound"]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": ["received", "administered", "wasted", "returned"]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": ["monthly", "annual"]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": ["active", "cancelled"]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.auth_email_attempt_outcome": {
+      "name": "auth_email_attempt_outcome",
+      "schema": "public",
+      "values": ["reserved", "accepted", "definite_failure", "outcome_unknown"]
+    },
+    "public.auth_email_delivery_attribution": {
+      "name": "auth_email_delivery_attribution",
+      "schema": "public",
+      "values": [
+        "attempt_tag",
+        "provider_message_id",
+        "unmatched",
+        "identity_conflict"
+      ]
+    },
+    "public.auth_email_delivery_classification": {
+      "name": "auth_email_delivery_classification",
+      "schema": "public",
+      "values": [
+        "sent",
+        "delivered",
+        "delayed",
+        "failed",
+        "complained",
+        "opened",
+        "clicked",
+        "unknown"
+      ]
+    },
+    "public.auth_email_source": {
+      "name": "auth_email_source",
+      "schema": "public",
+      "values": ["registration", "authenticated_resend"]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": ["manual", "bounce", "complaint", "suppressed"]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": ["PRIVATE_PROFIT", "NON_PROFIT"]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": ["hosted", "purchased", "toll_free"]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": ["stop", "manual", "bounce", "complaint"]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": ["granted", "revoked"]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": ["staff", "client", "system"]
+    },
+    "public.sms_delivery_classification": {
+      "name": "sms_delivery_classification",
+      "schema": "public",
+      "values": ["unknown", "sent", "failed", "delivered"]
+    },
+    "public.sms_delivery_history_kind": {
+      "name": "sms_delivery_history_kind",
+      "schema": "public",
+      "values": ["automatic", "operator_reconciliation"]
+    },
+    "public.sms_delivery_history_result": {
+      "name": "sms_delivery_history_result",
+      "schema": "public",
+      "values": [
+        "unmatched",
+        "ambiguous",
+        "attributed",
+        "projected",
+        "projection_miss",
+        "reconciled",
+        "operator_reviewed"
+      ]
+    },
+    "public.sms_delivery_reconciliation_reason": {
+      "name": "sms_delivery_reconciliation_reason",
+      "schema": "public",
+      "values": [
+        "exact_attribution_retry",
+        "provider_portal_status_review",
+        "projection_repair",
+        "identity_conflict_review",
+        "unmatched_evidence_review"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": ["clinic_user", "platform_operator"]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": ["provider_result", "reconciliation"]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": ["accepted", "definite_failure", "outcome_unknown"]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": ["practice_created", "product_records", "stripe_webhook"]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": ["clients", "patients", "vaccinations", "soap_notes"]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": ["previewed", "superseded", "committing", "committed"]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": ["paid", "accounts_receivable", "no_charge"]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": ["draft", "clinical_finalized", "completed"]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": ["none", "needed", "scheduled"]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": ["scheduled", "completed", "not_needed"]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": ["print", "verbal", "declined"]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": ["prescribed", "not_needed"]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": ["unresolved", "charged", "no_charge", "voided"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0062_snapshot.json
+++ b/packages/db/drizzle/meta/0062_snapshot.json
@@ -12781,7 +12781,7 @@
       "checkConstraints": {
         "auth_email_attempts_provider_check": {
           "name": "auth_email_attempts_provider_check",
-          "value": "\"auth_email_attempts\".\"provider\" = 'resend'"
+          "value": "\"auth_email_attempts\".\"provider\" in ('resend', 'console')"
         },
         "auth_email_attempts_outcome_shape_check": {
           "name": "auth_email_attempts_outcome_shape_check",
@@ -12811,6 +12811,12 @@
         "webhook_id": {
           "name": "webhook_id",
           "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint": {
+          "name": "raw_body_fingerprint",
+          "type": "varchar(64)",
           "primaryKey": false,
           "notNull": true
         },
@@ -12986,6 +12992,10 @@
         "auth_email_delivery_events_event_type_check": {
           "name": "auth_email_delivery_events_event_type_check",
           "value": "\"auth_email_delivery_events\".\"event_type\" ~ '^email\\.'"
+        },
+        "auth_email_delivery_events_raw_body_fingerprint_check": {
+          "name": "auth_email_delivery_events_raw_body_fingerprint_check",
+          "value": "\"auth_email_delivery_events\".\"raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
         },
         "auth_email_delivery_events_attribution_shape_check": {
           "name": "auth_email_delivery_events_attribution_shape_check",

--- a/packages/db/drizzle/meta/0062_snapshot.json
+++ b/packages/db/drizzle/meta/0062_snapshot.json
@@ -13004,6 +13004,130 @@
       },
       "isRLSEnabled": false
     },
+    "public.auth_email_webhook_conflicts": {
+      "name": "auth_email_webhook_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "original_webhook_id": {
+          "name": "original_webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint": {
+          "name": "incoming_raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_event_type": {
+          "name": "incoming_event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_webhook_conflicts_identity_uq": {
+          "name": "auth_email_webhook_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_webhook_conflicts_recovery_idx": {
+          "name": "auth_email_webhook_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_webhook_conflicts_webhook_fk": {
+          "name": "auth_email_webhook_conflicts_webhook_fk",
+          "tableFrom": "auth_email_webhook_conflicts",
+          "tableTo": "auth_email_delivery_events",
+          "columnsFrom": ["original_webhook_id"],
+          "columnsTo": ["webhook_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_webhook_conflicts_provider_check": {
+          "name": "auth_email_webhook_conflicts_provider_check",
+          "value": "\"auth_email_webhook_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_webhook_conflicts_event_type_check": {
+          "name": "auth_email_webhook_conflicts_event_type_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_event_type\" ~ '^email\\.'"
+        },
+        "auth_email_webhook_conflicts_raw_body_fingerprint_check": {
+          "name": "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
     "public.email_suppressions": {
       "name": "email_suppressions",
       "schema": "",

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1786282239386,
       "tag": "0061_majestic_rattler",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1786289519527,
+      "tag": "0062_ambitious_moon_knight",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -12,6 +12,7 @@ const TABLES = [
   "stripe_events",
   "practice_conversion_milestones",
   "auth_email_webhook_conflicts",
+  "auth_email_provider_identity_conflicts",
   "auth_email_delivery_events",
   "auth_email_attempts",
   "usage_records",

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -11,6 +11,7 @@ const TABLES = [
   "rate_limit_buckets",
   "stripe_events",
   "practice_conversion_milestones",
+  "auth_email_webhook_conflicts",
   "auth_email_delivery_events",
   "auth_email_attempts",
   "usage_records",

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -11,6 +11,8 @@ const TABLES = [
   "rate_limit_buckets",
   "stripe_events",
   "practice_conversion_milestones",
+  "auth_email_delivery_events",
+  "auth_email_attempts",
   "usage_records",
   "controlled_substance_log",
   "payments",

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -151,6 +151,25 @@ CREATE POLICY delivery_history_insert ON sms_delivery_event_history
 REVOKE ALL ON sms_delivery_events, sms_delivery_event_history FROM openpims_app;
 GRANT SELECT, INSERT ON sms_delivery_events, sms_delivery_event_history TO openpims_app;
 
+-- Verification-email dispatch and delivery evidence is global auth operations
+-- state. A clinic session must not read another user's verification history or
+-- forge provider outcomes. Delivery callbacks are immutable once inserted.
+ALTER TABLE auth_email_attempts ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS system_only ON auth_email_attempts;
+CREATE POLICY system_only ON auth_email_attempts
+  USING (app_rls_bypass())
+  WITH CHECK (app_rls_bypass());
+
+ALTER TABLE auth_email_delivery_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS system_only ON auth_email_delivery_events;
+CREATE POLICY system_only ON auth_email_delivery_events
+  USING (app_rls_bypass())
+  WITH CHECK (app_rls_bypass());
+
+REVOKE ALL ON auth_email_attempts, auth_email_delivery_events FROM openpims_app;
+GRANT SELECT, INSERT, UPDATE ON auth_email_attempts TO openpims_app;
+GRANT SELECT, INSERT ON auth_email_delivery_events TO openpims_app;
+
 -- Dispense charge snapshots are durable revenue work. The app may advance or
 -- reopen their attributed workflow status, while database triggers prevent
 -- snapshot changes and all deletion.
@@ -250,7 +269,7 @@ BEGIN
   FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
       EXECUTE format(
-        'REVOKE ALL ON auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, lab_result_events, lab_result_replacements, patient_merge_events, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
+        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, lab_result_events, lab_result_replacements, patient_merge_events, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
       );
     END IF;
   END LOOP;

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -172,9 +172,15 @@ CREATE POLICY system_only ON auth_email_webhook_conflicts
   USING (app_rls_bypass())
   WITH CHECK (app_rls_bypass());
 
-REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts FROM openpims_app;
+ALTER TABLE auth_email_provider_identity_conflicts ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS system_only ON auth_email_provider_identity_conflicts;
+CREATE POLICY system_only ON auth_email_provider_identity_conflicts
+  USING (app_rls_bypass())
+  WITH CHECK (app_rls_bypass());
+
+REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts FROM openpims_app;
 GRANT SELECT, INSERT, UPDATE ON auth_email_attempts TO openpims_app;
-GRANT SELECT, INSERT ON auth_email_delivery_events, auth_email_webhook_conflicts TO openpims_app;
+GRANT SELECT, INSERT ON auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts TO openpims_app;
 
 -- Dispense charge snapshots are durable revenue work. The app may advance or
 -- reopen their attributed workflow status, while database triggers prevent
@@ -275,7 +281,7 @@ BEGIN
   FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
       EXECUTE format(
-        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, lab_result_events, lab_result_replacements, patient_merge_events, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
+        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts, auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, lab_result_events, lab_result_replacements, patient_merge_events, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
       );
     END IF;
   END LOOP;

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -166,9 +166,15 @@ CREATE POLICY system_only ON auth_email_delivery_events
   USING (app_rls_bypass())
   WITH CHECK (app_rls_bypass());
 
-REVOKE ALL ON auth_email_attempts, auth_email_delivery_events FROM openpims_app;
+ALTER TABLE auth_email_webhook_conflicts ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS system_only ON auth_email_webhook_conflicts;
+CREATE POLICY system_only ON auth_email_webhook_conflicts
+  USING (app_rls_bypass())
+  WITH CHECK (app_rls_bypass());
+
+REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts FROM openpims_app;
 GRANT SELECT, INSERT, UPDATE ON auth_email_attempts TO openpims_app;
-GRANT SELECT, INSERT ON auth_email_delivery_events TO openpims_app;
+GRANT SELECT, INSERT ON auth_email_delivery_events, auth_email_webhook_conflicts TO openpims_app;
 
 -- Dispense charge snapshots are durable revenue work. The app may advance or
 -- reopen their attributed workflow status, while database triggers prevent
@@ -269,7 +275,7 @@ BEGIN
   FOREACH r IN ARRAY ARRAY['anon', 'authenticated'] LOOP
     IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = r) THEN
       EXECUTE format(
-        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, lab_result_events, lab_result_replacements, patient_merge_events, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
+        'REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_tokens, clinical_record_corrections, demo_accesses, dispense_charge_queue, funnel_events, lab_result_events, lab_result_replacements, patient_merge_events, practice_conversion_milestones, prescription_events, sessions, sms_delivery_event_history, sms_delivery_events, sms_send_attempt_events, sms_send_attempts, stripe_events, verification_tokens FROM %I', r
       );
     END IF;
   END LOOP;

--- a/packages/db/schema/auth-email-observability.ts
+++ b/packages/db/schema/auth-email-observability.ts
@@ -92,7 +92,7 @@ export const authEmailAttempts = pgTable(
     ),
     providerCheck: check(
       "auth_email_attempts_provider_check",
-      sql`${table.provider} = 'resend'`,
+      sql`${table.provider} in ('resend', 'console')`,
     ),
     outcomeShapeCheck: check(
       "auth_email_attempts_outcome_shape_check",
@@ -129,6 +129,9 @@ export const authEmailDeliveryEvents = pgTable(
       .notNull()
       .defaultNow(),
     webhookId: varchar("webhook_id", { length: 128 }).notNull(),
+    rawBodyFingerprint: varchar("raw_body_fingerprint", {
+      length: 64,
+    }).notNull(),
     provider: varchar("provider", { length: 16 }).notNull().default("resend"),
     providerMessageId: varchar("provider_message_id", {
       length: 128,
@@ -160,6 +163,10 @@ export const authEmailDeliveryEvents = pgTable(
     eventTypeCheck: check(
       "auth_email_delivery_events_event_type_check",
       sql`${table.eventType} ~ '^email\\.'`,
+    ),
+    rawBodyFingerprintCheck: check(
+      "auth_email_delivery_events_raw_body_fingerprint_check",
+      sql`${table.rawBodyFingerprint} ~ '^[0-9a-f]{64}$'`,
     ),
     attributionShapeCheck: check(
       "auth_email_delivery_events_attribution_shape_check",

--- a/packages/db/schema/auth-email-observability.ts
+++ b/packages/db/schema/auth-email-observability.ts
@@ -116,6 +116,54 @@ export const authEmailAttempts = pgTable(
   }),
 );
 
+/** Append-only evidence that the API and signed callback observed two ids. */
+export const authEmailProviderIdentityConflicts = pgTable(
+  "auth_email_provider_identity_conflicts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    occurredAt: timestamp("occurred_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    attemptId: uuid("attempt_id")
+      .notNull()
+      .references(() => authEmailAttempts.id),
+    provider: varchar("provider", { length: 16 }).notNull().default("resend"),
+    source: authEmailSourceEnum("source").notNull(),
+    durableProviderMessageId: varchar("durable_provider_message_id", {
+      length: 128,
+    }).notNull(),
+    conflictingProviderMessageId: varchar("conflicting_provider_message_id", {
+      length: 128,
+    }).notNull(),
+  },
+  (table) => ({
+    identityUq: uniqueIndex(
+      "auth_email_provider_identity_conflicts_identity_uq",
+    ).on(
+      table.attemptId,
+      table.provider,
+      table.durableProviderMessageId,
+      table.conflictingProviderMessageId,
+    ),
+    recoveryIdx: index(
+      "auth_email_provider_identity_conflicts_recovery_idx",
+    ).on(table.occurredAt, table.id),
+    providerCheck: check(
+      "auth_email_provider_identity_conflicts_provider_check",
+      sql`${table.provider} = 'resend'`,
+    ),
+    distinctIdentityCheck: check(
+      "auth_email_provider_identity_conflicts_distinct_id_check",
+      sql`${table.durableProviderMessageId} <> ${table.conflictingProviderMessageId}`,
+    ),
+    identityShapeCheck: check(
+      "auth_email_provider_identity_conflicts_id_shape_check",
+      sql`length(btrim(${table.durableProviderMessageId})) > 0
+        and length(btrim(${table.conflictingProviderMessageId})) > 0`,
+    ),
+  }),
+);
+
 /**
  * Immutable, redacted evidence from a signed Resend webhook. Events may arrive
  * before the send result is persisted, so attribution can be absent while the

--- a/packages/db/schema/auth-email-observability.ts
+++ b/packages/db/schema/auth-email-observability.ts
@@ -180,3 +180,56 @@ export const authEmailDeliveryEvents = pgTable(
     ),
   }),
 );
+
+/**
+ * Append-only quarantine for a signed callback that reuses an existing Svix
+ * id with a different verified body. Only safe provider identity and SHA-256
+ * evidence is retained; message content and recipients are never copied.
+ */
+export const authEmailWebhookConflicts = pgTable(
+  "auth_email_webhook_conflicts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    receivedAt: timestamp("received_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    originalWebhookId: varchar("original_webhook_id", {
+      length: 128,
+    }).notNull(),
+    incomingRawBodyFingerprint: varchar("incoming_raw_body_fingerprint", {
+      length: 64,
+    }).notNull(),
+    provider: varchar("provider", { length: 16 }).notNull().default("resend"),
+    incomingProviderMessageId: varchar("incoming_provider_message_id", {
+      length: 128,
+    }).notNull(),
+    incomingEventType: varchar("incoming_event_type", { length: 64 }).notNull(),
+  },
+  (table) => ({
+    originalWebhookFk: foreignKey({
+      columns: [table.originalWebhookId],
+      foreignColumns: [authEmailDeliveryEvents.webhookId],
+      name: "auth_email_webhook_conflicts_webhook_fk",
+    }),
+    identityUq: uniqueIndex("auth_email_webhook_conflicts_identity_uq").on(
+      table.originalWebhookId,
+      table.incomingRawBodyFingerprint,
+    ),
+    recoveryIdx: index("auth_email_webhook_conflicts_recovery_idx").on(
+      table.receivedAt,
+      table.id,
+    ),
+    providerCheck: check(
+      "auth_email_webhook_conflicts_provider_check",
+      sql`${table.provider} = 'resend'`,
+    ),
+    eventTypeCheck: check(
+      "auth_email_webhook_conflicts_event_type_check",
+      sql`${table.incomingEventType} ~ '^email\\.'`,
+    ),
+    rawBodyFingerprintCheck: check(
+      "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+      sql`${table.incomingRawBodyFingerprint} ~ '^[0-9a-f]{64}$'`,
+    ),
+  }),
+);

--- a/packages/db/schema/auth-email-observability.ts
+++ b/packages/db/schema/auth-email-observability.ts
@@ -124,9 +124,7 @@ export const authEmailProviderIdentityConflicts = pgTable(
     occurredAt: timestamp("occurred_at", { withTimezone: true })
       .notNull()
       .defaultNow(),
-    attemptId: uuid("attempt_id")
-      .notNull()
-      .references(() => authEmailAttempts.id),
+    attemptId: uuid("attempt_id").notNull(),
     provider: varchar("provider", { length: 16 }).notNull().default("resend"),
     source: authEmailSourceEnum("source").notNull(),
     durableProviderMessageId: varchar("durable_provider_message_id", {
@@ -137,6 +135,11 @@ export const authEmailProviderIdentityConflicts = pgTable(
     }).notNull(),
   },
   (table) => ({
+    attemptFk: foreignKey({
+      columns: [table.attemptId],
+      foreignColumns: [authEmailAttempts.id],
+      name: "auth_email_provider_identity_conflicts_attempt_fk",
+    }),
     identityUq: uniqueIndex(
       "auth_email_provider_identity_conflicts_identity_uq",
     ).on(

--- a/packages/db/schema/auth-email-observability.ts
+++ b/packages/db/schema/auth-email-observability.ts
@@ -1,0 +1,175 @@
+import { sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  pgEnum,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { practices } from "./practices";
+import { users } from "./users";
+
+export const authEmailSourceEnum = pgEnum("auth_email_source", [
+  "registration",
+  "authenticated_resend",
+]);
+
+export const authEmailAttemptOutcomeEnum = pgEnum(
+  "auth_email_attempt_outcome",
+  ["reserved", "accepted", "definite_failure", "outcome_unknown"],
+);
+
+export const authEmailDeliveryClassificationEnum = pgEnum(
+  "auth_email_delivery_classification",
+  [
+    "sent",
+    "delivered",
+    "delayed",
+    "failed",
+    "complained",
+    "opened",
+    "clicked",
+    "unknown",
+  ],
+);
+
+export const authEmailDeliveryAttributionEnum = pgEnum(
+  "auth_email_delivery_attribution",
+  ["attempt_tag", "provider_message_id", "unmatched", "identity_conflict"],
+);
+
+/**
+ * One reserved verification-email dispatch. The reservation is committed
+ * before the provider call and then advanced to an explicit provider outcome.
+ * It intentionally contains no recipient, token, URL, subject, or body copy.
+ */
+export const authEmailAttempts = pgTable(
+  "auth_email_attempts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    userId: uuid("user_id").notNull(),
+    source: authEmailSourceEnum("source").notNull(),
+    provider: varchar("provider", { length: 16 }).notNull().default("resend"),
+    idempotencyKey: varchar("idempotency_key", { length: 200 }).notNull(),
+    providerMessageId: varchar("provider_message_id", { length: 128 }),
+    outcome: authEmailAttemptOutcomeEnum("outcome")
+      .notNull()
+      .default("reserved"),
+    failureCode: varchar("failure_code", { length: 64 }),
+  },
+  (table) => ({
+    userTenantFk: foreignKey({
+      columns: [table.practiceId, table.userId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "auth_email_attempts_user_tenant_fk",
+    }),
+    idempotencyUq: uniqueIndex("auth_email_attempts_idempotency_uq").on(
+      table.idempotencyKey,
+    ),
+    providerMessageUq: uniqueIndex("auth_email_attempts_provider_message_uq")
+      .on(table.provider, table.providerMessageId)
+      .where(sql`${table.providerMessageId} is not null`),
+    recoveryIdx: index("auth_email_attempts_recovery_idx").on(
+      table.outcome,
+      table.createdAt,
+      table.id,
+    ),
+    practiceCreatedIdx: index("auth_email_attempts_practice_created_idx").on(
+      table.practiceId,
+      table.createdAt,
+      table.id,
+    ),
+    providerCheck: check(
+      "auth_email_attempts_provider_check",
+      sql`${table.provider} = 'resend'`,
+    ),
+    outcomeShapeCheck: check(
+      "auth_email_attempts_outcome_shape_check",
+      sql`(
+        ${table.outcome} = 'reserved'
+        and ${table.resolvedAt} is null
+        and ${table.providerMessageId} is null
+        and ${table.failureCode} is null
+      ) or (
+        ${table.outcome} = 'accepted'
+        and ${table.resolvedAt} is not null
+        and length(btrim(coalesce(${table.providerMessageId}, ''))) > 0
+        and ${table.failureCode} is null
+      ) or (
+        ${table.outcome} in ('definite_failure', 'outcome_unknown')
+        and ${table.resolvedAt} is not null
+        and ${table.providerMessageId} is null
+        and length(btrim(coalesce(${table.failureCode}, ''))) > 0
+      )`,
+    ),
+  }),
+);
+
+/**
+ * Immutable, redacted evidence from a signed Resend webhook. Events may arrive
+ * before the send result is persisted, so attribution can be absent while the
+ * provider message id still permits a later exact derived match.
+ */
+export const authEmailDeliveryEvents = pgTable(
+  "auth_email_delivery_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    receivedAt: timestamp("received_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    webhookId: varchar("webhook_id", { length: 128 }).notNull(),
+    provider: varchar("provider", { length: 16 }).notNull().default("resend"),
+    providerMessageId: varchar("provider_message_id", {
+      length: 128,
+    }).notNull(),
+    attemptId: uuid("attempt_id").references(() => authEmailAttempts.id),
+    eventType: varchar("event_type", { length: 64 }).notNull(),
+    classification:
+      authEmailDeliveryClassificationEnum("classification").notNull(),
+    attribution: authEmailDeliveryAttributionEnum("attribution").notNull(),
+    occurredAt: timestamp("occurred_at", { withTimezone: true }).notNull(),
+  },
+  (table) => ({
+    webhookUq: uniqueIndex("auth_email_delivery_events_webhook_uq").on(
+      table.webhookId,
+    ),
+    attemptTimelineIdx: index(
+      "auth_email_delivery_events_attempt_timeline_idx",
+    ).on(table.attemptId, table.occurredAt, table.id),
+    providerTimelineIdx: index(
+      "auth_email_delivery_events_provider_timeline_idx",
+    ).on(table.provider, table.providerMessageId, table.occurredAt, table.id),
+    attributionQueueIdx: index(
+      "auth_email_delivery_events_attribution_queue_idx",
+    ).on(table.attribution, table.receivedAt, table.id),
+    providerCheck: check(
+      "auth_email_delivery_events_provider_check",
+      sql`${table.provider} = 'resend'`,
+    ),
+    eventTypeCheck: check(
+      "auth_email_delivery_events_event_type_check",
+      sql`${table.eventType} ~ '^email\\.'`,
+    ),
+    attributionShapeCheck: check(
+      "auth_email_delivery_events_attribution_shape_check",
+      sql`(
+        ${table.attribution} in ('attempt_tag', 'provider_message_id')
+        and ${table.attemptId} is not null
+      ) or (
+        ${table.attribution} in ('unmatched', 'identity_conflict')
+        and ${table.attemptId} is null
+      )`,
+    ),
+  }),
+);

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -22,6 +22,7 @@ export * from "./insurance";
 export * from "./wellness";
 export * from "./usage";
 export * from "./auth-tokens";
+export * from "./auth-email-observability";
 export * from "./messaging";
 export * from "./sms-consent-events";
 export * from "./sms-send-attempts";

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -89,6 +89,8 @@ const aTransitionAuthEmailAttempt = randomUUID();
 const aRepairAuthEmailAttempt = randomUUID();
 const aAuthEmailDeliveryEvent = randomUUID();
 const aAuthEmailWebhookConflict = randomUUID();
+const aAuthEmailProviderIdentityConflict = randomUUID();
+const aAppAuthEmailProviderIdentityConflict = randomUUID();
 const aSmsDeliveryEvent = randomUUID();
 const bSmsDeliveryEvent = randomUUID();
 const unmatchedSmsDeliveryEvent = randomUUID();
@@ -145,6 +147,13 @@ try {
     (${aAuthEmailWebhookConflict}, ${`svix-${aAuthEmailDeliveryEvent}`},
       ${"b".repeat(64)}, ${`resend-conflict-${aAuthEmailAttempt}`},
       'email.failed')`;
+  await owner`insert into auth_email_provider_identity_conflicts
+    (id, attempt_id, provider, source, durable_provider_message_id,
+     conflicting_provider_message_id)
+    values
+    (${aAuthEmailProviderIdentityConflict}, ${aAuthEmailAttempt}, 'resend',
+      'registration', ${`resend-${aAuthEmailAttempt}`},
+      ${`resend-conflict-${aAuthEmailAttempt}`})`;
   await owner`insert into auth_email_attempts
     (id, practice_id, user_id, source, provider, idempotency_key)
     values
@@ -348,6 +357,14 @@ try {
   check(
     "tenant context cannot read system-only auth email conflict evidence",
     hiddenAuthEmailConflict.length === 0,
+  );
+  const hiddenAuthEmailProviderConflict = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id from auth_email_provider_identity_conflicts where id = ${aAuthEmailProviderIdentityConflict}`;
+  });
+  check(
+    "tenant context cannot read provider identity conflict evidence",
+    hiddenAuthEmailProviderConflict.length === 0,
   );
 
   let tenantAuthEmailInsertBlocked = false;
@@ -1281,6 +1298,73 @@ try {
     "system bypass can read auth email conflict evidence",
     systemAuthEmailConflictRows.length === 1,
   );
+  const systemProviderIdentityConflicts = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`select id from auth_email_provider_identity_conflicts where id = ${aAuthEmailProviderIdentityConflict}`;
+  });
+  check(
+    "system bypass can read provider identity conflict evidence",
+    systemProviderIdentityConflicts.length === 1,
+  );
+  const appInsertedProviderIdentityConflict = await appTransaction(
+    async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      return tx`insert into auth_email_provider_identity_conflicts
+      (id, attempt_id, provider, source, durable_provider_message_id,
+       conflicting_provider_message_id)
+      values
+      (${aAppAuthEmailProviderIdentityConflict}, ${aAuthEmailAttempt}, 'resend',
+       'registration', ${`resend-${aAuthEmailAttempt}`},
+       ${`resend-app-conflict-${aAuthEmailAttempt}`})
+      returning id`;
+    },
+  );
+  check(
+    "system bypass can insert provider identity conflict evidence",
+    appInsertedProviderIdentityConflict.length === 1,
+  );
+  const appSelectedProviderIdentityConflict = await appTransaction(
+    async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      return tx`select id from auth_email_provider_identity_conflicts
+      where id = ${aAppAuthEmailProviderIdentityConflict}`;
+    },
+  );
+  check(
+    "system bypass can select inserted provider identity conflict evidence",
+    appSelectedProviderIdentityConflict.length === 1,
+  );
+
+  let appCannotUpdateProviderIdentityConflict = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`update auth_email_provider_identity_conflicts
+        set occurred_at = occurred_at
+        where id = ${aAppAuthEmailProviderIdentityConflict}`;
+    });
+  } catch {
+    appCannotUpdateProviderIdentityConflict = true;
+  }
+  check(
+    "application role cannot update provider identity conflict evidence",
+    appCannotUpdateProviderIdentityConflict,
+  );
+
+  let appCannotDeleteProviderIdentityConflict = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`delete from auth_email_provider_identity_conflicts
+        where id = ${aAppAuthEmailProviderIdentityConflict}`;
+    });
+  } catch {
+    appCannotDeleteProviderIdentityConflict = true;
+  }
+  check(
+    "application role cannot delete provider identity conflict evidence",
+    appCannotDeleteProviderIdentityConflict,
+  );
 
   const transitionedAuthEmailAttempt = await appTransaction(async (tx) => {
     await tx`select set_config('app.rls_bypass', 'on', true)`;
@@ -1386,6 +1470,30 @@ try {
     "database trigger keeps auth email conflict evidence immutable for the owner",
     ownerCannotRewriteAuthEmailConflict,
   );
+  let ownerCannotRewriteProviderIdentityConflict = false;
+  try {
+    await owner`update auth_email_provider_identity_conflicts
+      set occurred_at = occurred_at where id = ${aAuthEmailProviderIdentityConflict}`;
+  } catch {
+    ownerCannotRewriteProviderIdentityConflict = true;
+  }
+  check(
+    "database trigger keeps provider identity conflict evidence immutable",
+    ownerCannotRewriteProviderIdentityConflict,
+  );
+  const ownerMaintenanceDeletedProviderConflict = await owner.begin(
+    async (tx) => {
+      const maintenance = tx as unknown as typeof owner;
+      await maintenance`select set_config('app.ledger_maintenance', 'on', true)`;
+      return maintenance`delete from auth_email_provider_identity_conflicts
+      where id = ${aAppAuthEmailProviderIdentityConflict}
+      returning id`;
+    },
+  );
+  check(
+    "owner maintenance can delete provider identity conflict evidence",
+    ownerMaintenanceDeletedProviderConflict.length === 1,
+  );
 
   let bypassCannotDeletePrescriptionHistory = false;
   try {
@@ -1468,6 +1576,7 @@ try {
     const cleanup = tx as unknown as typeof owner;
     await cleanup`select set_config('app.ledger_maintenance', 'on', true)`;
     await cleanup`delete from auth_email_webhook_conflicts where id = ${aAuthEmailWebhookConflict}`;
+    await cleanup`delete from auth_email_provider_identity_conflicts where id = ${aAuthEmailProviderIdentityConflict}`;
     await cleanup`delete from auth_email_delivery_events where id = ${aAuthEmailDeliveryEvent}`;
     await cleanup`delete from auth_email_attempts where id in (${aAuthEmailAttempt}, ${aTransitionAuthEmailAttempt}, ${aRepairAuthEmailAttempt})`;
     await cleanup`delete from sms_delivery_event_history where id in (${aSmsDeliveryHistory}, ${bSmsDeliveryHistory}, ${bSmsDeliveryConflictHistory})`;

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -86,7 +86,9 @@ const aAppSmsSendAttempt = randomUUID();
 const aAppSmsSendAttemptEvent = randomUUID();
 const aAuthEmailAttempt = randomUUID();
 const aTransitionAuthEmailAttempt = randomUUID();
+const aRepairAuthEmailAttempt = randomUUID();
 const aAuthEmailDeliveryEvent = randomUUID();
+const aAuthEmailWebhookConflict = randomUUID();
 const aSmsDeliveryEvent = randomUUID();
 const bSmsDeliveryEvent = randomUUID();
 const unmatchedSmsDeliveryEvent = randomUUID();
@@ -136,11 +138,25 @@ try {
       ${"a".repeat(64)},
       ${`resend-${aAuthEmailAttempt}`}, ${aAuthEmailAttempt},
       'email.delivered', 'delivered', 'attempt_tag', now())`;
+  await owner`insert into auth_email_webhook_conflicts
+    (id, original_webhook_id, incoming_raw_body_fingerprint,
+     incoming_provider_message_id, incoming_event_type)
+    values
+    (${aAuthEmailWebhookConflict}, ${`svix-${aAuthEmailDeliveryEvent}`},
+      ${"b".repeat(64)}, ${`resend-conflict-${aAuthEmailAttempt}`},
+      'email.failed')`;
   await owner`insert into auth_email_attempts
     (id, practice_id, user_id, source, provider, idempotency_key)
     values
     (${aTransitionAuthEmailAttempt}, ${aId}, ${aUser}, 'authenticated_resend',
       'console', ${`rls-auth:${aTransitionAuthEmailAttempt}`})`;
+  await owner`insert into auth_email_attempts
+    (id, practice_id, user_id, source, provider, idempotency_key,
+     outcome, resolved_at, failure_code)
+    values
+    (${aRepairAuthEmailAttempt}, ${aId}, ${aUser}, 'authenticated_resend',
+      'resend', ${`rls-auth:${aRepairAuthEmailAttempt}`},
+      'outcome_unknown', now(), 'send_timeout')`;
   await owner`insert into sms_consent_events
     (id, practice_id, client_id, destination_e164, action, source, detail, actor_type, event_key)
     values
@@ -324,6 +340,14 @@ try {
   check(
     "tenant context cannot read system-only auth email delivery evidence",
     hiddenAuthEmailDelivery.length === 0,
+  );
+  const hiddenAuthEmailConflict = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id from auth_email_webhook_conflicts where id = ${aAuthEmailWebhookConflict}`;
+  });
+  check(
+    "tenant context cannot read system-only auth email conflict evidence",
+    hiddenAuthEmailConflict.length === 0,
   );
 
   let tenantAuthEmailInsertBlocked = false;
@@ -1249,6 +1273,14 @@ try {
     "system bypass can read auth email attempts",
     systemAuthEmailRows.length === 1,
   );
+  const systemAuthEmailConflictRows = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`select id from auth_email_webhook_conflicts where id = ${aAuthEmailWebhookConflict}`;
+  });
+  check(
+    "system bypass can read auth email conflict evidence",
+    systemAuthEmailConflictRows.length === 1,
+  );
 
   const transitionedAuthEmailAttempt = await appTransaction(async (tx) => {
     await tx`select set_config('app.rls_bypass', 'on', true)`;
@@ -1262,6 +1294,21 @@ try {
     "system bypass can resolve a reserved auth email attempt exactly once",
     transitionedAuthEmailAttempt.length === 1 &&
       transitionedAuthEmailAttempt[0]!.outcome === "accepted",
+  );
+
+  const repairedUnknownAuthEmailAttempt = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`update auth_email_attempts
+      set outcome = 'accepted', resolved_at = now(),
+          provider_message_id = ${`resend-repaired-${aRepairAuthEmailAttempt}`},
+          failure_code = null
+      where id = ${aRepairAuthEmailAttempt} and outcome = 'outcome_unknown'
+      returning outcome`;
+  });
+  check(
+    "system bypass can repair an unknown Resend outcome to accepted",
+    repairedUnknownAuthEmailAttempt.length === 1 &&
+      repairedUnknownAuthEmailAttempt[0]!.outcome === "accepted",
   );
 
   let appCannotReresolveAuthEmailAttempt = false;
@@ -1327,6 +1374,17 @@ try {
   check(
     "database trigger keeps auth email delivery evidence immutable for the owner",
     ownerCannotRewriteAuthEmailDelivery,
+  );
+  let ownerCannotRewriteAuthEmailConflict = false;
+  try {
+    await owner`update auth_email_webhook_conflicts
+      set received_at = received_at where id = ${aAuthEmailWebhookConflict}`;
+  } catch {
+    ownerCannotRewriteAuthEmailConflict = true;
+  }
+  check(
+    "database trigger keeps auth email conflict evidence immutable for the owner",
+    ownerCannotRewriteAuthEmailConflict,
   );
 
   let bypassCannotDeletePrescriptionHistory = false;
@@ -1409,8 +1467,9 @@ try {
   await owner.begin(async (tx) => {
     const cleanup = tx as unknown as typeof owner;
     await cleanup`select set_config('app.ledger_maintenance', 'on', true)`;
+    await cleanup`delete from auth_email_webhook_conflicts where id = ${aAuthEmailWebhookConflict}`;
     await cleanup`delete from auth_email_delivery_events where id = ${aAuthEmailDeliveryEvent}`;
-    await cleanup`delete from auth_email_attempts where id in (${aAuthEmailAttempt}, ${aTransitionAuthEmailAttempt})`;
+    await cleanup`delete from auth_email_attempts where id in (${aAuthEmailAttempt}, ${aTransitionAuthEmailAttempt}, ${aRepairAuthEmailAttempt})`;
     await cleanup`delete from sms_delivery_event_history where id in (${aSmsDeliveryHistory}, ${bSmsDeliveryHistory}, ${bSmsDeliveryConflictHistory})`;
     await cleanup`delete from sms_delivery_events where id in (${aSmsDeliveryEvent}, ${bSmsDeliveryEvent}, ${unmatchedSmsDeliveryEvent})`;
     await cleanup`delete from lab_result_events where id in (${aLabResultEvent}, ${bLabResultEvent})`;

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -85,6 +85,7 @@ const bLabResultEvent = randomUUID();
 const aAppSmsSendAttempt = randomUUID();
 const aAppSmsSendAttemptEvent = randomUUID();
 const aAuthEmailAttempt = randomUUID();
+const aTransitionAuthEmailAttempt = randomUUID();
 const aAuthEmailDeliveryEvent = randomUUID();
 const aSmsDeliveryEvent = randomUUID();
 const bSmsDeliveryEvent = randomUUID();
@@ -128,12 +129,18 @@ try {
       ${`rls-auth:${aAuthEmailAttempt}`}, ${`resend-${aAuthEmailAttempt}`},
       'accepted')`;
   await owner`insert into auth_email_delivery_events
-    (id, webhook_id, provider_message_id, attempt_id, event_type,
+    (id, webhook_id, raw_body_fingerprint, provider_message_id, attempt_id, event_type,
      classification, attribution, occurred_at)
     values
     (${aAuthEmailDeliveryEvent}, ${`svix-${aAuthEmailDeliveryEvent}`},
+      ${"a".repeat(64)},
       ${`resend-${aAuthEmailAttempt}`}, ${aAuthEmailAttempt},
       'email.delivered', 'delivered', 'attempt_tag', now())`;
+  await owner`insert into auth_email_attempts
+    (id, practice_id, user_id, source, provider, idempotency_key)
+    values
+    (${aTransitionAuthEmailAttempt}, ${aId}, ${aUser}, 'authenticated_resend',
+      'console', ${`rls-auth:${aTransitionAuthEmailAttempt}`})`;
   await owner`insert into sms_consent_events
     (id, practice_id, client_id, destination_e164, action, source, detail, actor_type, event_key)
     values
@@ -1243,6 +1250,59 @@ try {
     systemAuthEmailRows.length === 1,
   );
 
+  const transitionedAuthEmailAttempt = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`update auth_email_attempts
+      set outcome = 'accepted', resolved_at = now(),
+          provider_message_id = ${`console-${aTransitionAuthEmailAttempt}`}
+      where id = ${aTransitionAuthEmailAttempt} and outcome = 'reserved'
+      returning outcome`;
+  });
+  check(
+    "system bypass can resolve a reserved auth email attempt exactly once",
+    transitionedAuthEmailAttempt.length === 1 &&
+      transitionedAuthEmailAttempt[0]!.outcome === "accepted",
+  );
+
+  let appCannotReresolveAuthEmailAttempt = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`update auth_email_attempts
+        set resolved_at = now() where id = ${aTransitionAuthEmailAttempt}`;
+    });
+  } catch {
+    appCannotReresolveAuthEmailAttempt = true;
+  }
+  check(
+    "database trigger keeps resolved auth email attempts immutable",
+    appCannotReresolveAuthEmailAttempt,
+  );
+
+  let ownerCannotRewriteAuthEmailIdentity = false;
+  try {
+    await owner`update auth_email_attempts
+      set source = 'authenticated_resend' where id = ${aAuthEmailAttempt}`;
+  } catch {
+    ownerCannotRewriteAuthEmailIdentity = true;
+  }
+  check(
+    "database trigger freezes auth email attempt identity for the owner",
+    ownerCannotRewriteAuthEmailIdentity,
+  );
+
+  let ownerCannotDeleteAuthEmailAttempt = false;
+  try {
+    await owner`delete from auth_email_attempts
+      where id = ${aTransitionAuthEmailAttempt}`;
+  } catch {
+    ownerCannotDeleteAuthEmailAttempt = true;
+  }
+  check(
+    "owner cannot delete auth email attempts outside ledger maintenance",
+    ownerCannotDeleteAuthEmailAttempt,
+  );
+
   let appCannotRewriteAuthEmailDelivery = false;
   try {
     await appTransaction(async (tx) => {
@@ -1350,7 +1410,7 @@ try {
     const cleanup = tx as unknown as typeof owner;
     await cleanup`select set_config('app.ledger_maintenance', 'on', true)`;
     await cleanup`delete from auth_email_delivery_events where id = ${aAuthEmailDeliveryEvent}`;
-    await cleanup`delete from auth_email_attempts where id = ${aAuthEmailAttempt}`;
+    await cleanup`delete from auth_email_attempts where id in (${aAuthEmailAttempt}, ${aTransitionAuthEmailAttempt})`;
     await cleanup`delete from sms_delivery_event_history where id in (${aSmsDeliveryHistory}, ${bSmsDeliveryHistory}, ${bSmsDeliveryConflictHistory})`;
     await cleanup`delete from sms_delivery_events where id in (${aSmsDeliveryEvent}, ${bSmsDeliveryEvent}, ${unmatchedSmsDeliveryEvent})`;
     await cleanup`delete from lab_result_events where id in (${aLabResultEvent}, ${bLabResultEvent})`;

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -84,6 +84,8 @@ const aLabResultEvent = randomUUID();
 const bLabResultEvent = randomUUID();
 const aAppSmsSendAttempt = randomUUID();
 const aAppSmsSendAttemptEvent = randomUUID();
+const aAuthEmailAttempt = randomUUID();
+const aAuthEmailDeliveryEvent = randomUUID();
 const aSmsDeliveryEvent = randomUUID();
 const bSmsDeliveryEvent = randomUUID();
 const unmatchedSmsDeliveryEvent = randomUUID();
@@ -118,6 +120,20 @@ try {
   await owner`insert into users (id, email, password_hash, name, role, practice_id) values
     (${aUser}, ${`rls-${aUser}@example.com`}, 'not-a-real-hash', 'RLS Admin A', 'admin', ${aId}),
     (${bUser}, ${`rls-${bUser}@example.com`}, 'not-a-real-hash', 'RLS Admin B', 'admin', ${bId})`;
+  await owner`insert into auth_email_attempts
+    (id, resolved_at, practice_id, user_id, source, idempotency_key,
+     provider_message_id, outcome)
+    values
+    (${aAuthEmailAttempt}, now(), ${aId}, ${aUser}, 'registration',
+      ${`rls-auth:${aAuthEmailAttempt}`}, ${`resend-${aAuthEmailAttempt}`},
+      'accepted')`;
+  await owner`insert into auth_email_delivery_events
+    (id, webhook_id, provider_message_id, attempt_id, event_type,
+     classification, attribution, occurred_at)
+    values
+    (${aAuthEmailDeliveryEvent}, ${`svix-${aAuthEmailDeliveryEvent}`},
+      ${`resend-${aAuthEmailAttempt}`}, ${aAuthEmailAttempt},
+      'email.delivered', 'delivered', 'attempt_tag', now())`;
   await owner`insert into sms_consent_events
     (id, practice_id, client_id, destination_e164, action, source, detail, actor_type, event_key)
     values
@@ -284,6 +300,39 @@ try {
     "tenant A sees only A's SMS consent events",
     aSmsConsentEvents.length === 1 &&
       aSmsConsentEvents[0]!.id === aSmsConsentEvent,
+  );
+
+  const hiddenAuthEmailAttempts = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id from auth_email_attempts where id = ${aAuthEmailAttempt}`;
+  });
+  check(
+    "tenant context cannot read system-only auth email attempts",
+    hiddenAuthEmailAttempts.length === 0,
+  );
+  const hiddenAuthEmailDelivery = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id from auth_email_delivery_events where id = ${aAuthEmailDeliveryEvent}`;
+  });
+  check(
+    "tenant context cannot read system-only auth email delivery evidence",
+    hiddenAuthEmailDelivery.length === 0,
+  );
+
+  let tenantAuthEmailInsertBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into auth_email_attempts
+        (practice_id, user_id, source, idempotency_key)
+        values (${aId}, ${aUser}, 'authenticated_resend', ${`forged:${randomUUID()}`})`;
+    });
+  } catch {
+    tenantAuthEmailInsertBlocked = true;
+  }
+  check(
+    "tenant context cannot forge auth email attempts",
+    tenantAuthEmailInsertBlocked,
   );
 
   let smsConsentUpdateBlocked = false;
@@ -805,7 +854,10 @@ try {
   } catch {
     crossTenantLabActorBlocked = true;
   }
-  check("cross-tenant lab evidence actor is blocked", crossTenantLabActorBlocked);
+  check(
+    "cross-tenant lab evidence actor is blocked",
+    crossTenantLabActorBlocked,
+  );
 
   let crossTenantLabAssigneeBlocked = false;
   try {
@@ -1182,6 +1234,40 @@ try {
     "system bypass can read conversion milestones",
     systemConversionRows.length === 1,
   );
+  const systemAuthEmailRows = await appTransaction(async (tx) => {
+    await tx`select set_config('app.rls_bypass', 'on', true)`;
+    return tx`select id from auth_email_attempts where id = ${aAuthEmailAttempt}`;
+  });
+  check(
+    "system bypass can read auth email attempts",
+    systemAuthEmailRows.length === 1,
+  );
+
+  let appCannotRewriteAuthEmailDelivery = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`update auth_email_delivery_events
+        set occurred_at = occurred_at where id = ${aAuthEmailDeliveryEvent}`;
+    });
+  } catch {
+    appCannotRewriteAuthEmailDelivery = true;
+  }
+  check(
+    "application role cannot rewrite auth email delivery evidence",
+    appCannotRewriteAuthEmailDelivery,
+  );
+  let ownerCannotRewriteAuthEmailDelivery = false;
+  try {
+    await owner`update auth_email_delivery_events
+      set occurred_at = occurred_at where id = ${aAuthEmailDeliveryEvent}`;
+  } catch {
+    ownerCannotRewriteAuthEmailDelivery = true;
+  }
+  check(
+    "database trigger keeps auth email delivery evidence immutable for the owner",
+    ownerCannotRewriteAuthEmailDelivery,
+  );
 
   let bypassCannotDeletePrescriptionHistory = false;
   try {
@@ -1263,6 +1349,8 @@ try {
   await owner.begin(async (tx) => {
     const cleanup = tx as unknown as typeof owner;
     await cleanup`select set_config('app.ledger_maintenance', 'on', true)`;
+    await cleanup`delete from auth_email_delivery_events where id = ${aAuthEmailDeliveryEvent}`;
+    await cleanup`delete from auth_email_attempts where id = ${aAuthEmailAttempt}`;
     await cleanup`delete from sms_delivery_event_history where id in (${aSmsDeliveryHistory}, ${bSmsDeliveryHistory}, ${bSmsDeliveryConflictHistory})`;
     await cleanup`delete from sms_delivery_events where id in (${aSmsDeliveryEvent}, ${bSmsDeliveryEvent}, ${unmatchedSmsDeliveryEvent})`;
     await cleanup`delete from lab_result_events where id in (${aLabResultEvent}, ${bLabResultEvent})`;


### PR DESCRIPTION
## Summary
- add system-only, recipient-free verification-email attempt and signed delivery ledgers
- dispatch verification mail only after the account/token transaction commits
- make provider acceptance, unknown outcomes, callback repair, and duplicate/conflicting webhook evidence durable and idempotent
- expose a bounded platform-admin recovery queue for current failed, uncertain, missing, and identity-conflict cases
- report console preview delivery truthfully without treating it as a real sent email

## Safety
- no recipient, token, URL, subject, or body is persisted in the operational ledgers
- attempt identity/state and delivery/conflict evidence are protected by database checks, append-only triggers, RLS, and least-privilege grants
- accepted or possibly accepted provider calls are never replayed because of ledger persistence uncertainty
- changed signed webhook bodies are quarantined before acknowledgment and repeat conflicts do not create alert storms
- practice backup/restore excludes global auth operations evidence

## Verification
- `pnpm type-check`
- `pnpm test` — 318 files / 3,211 tests passed; one opt-in PostgreSQL integration test skipped locally
- `pnpm --filter @openpims/web build`
- focused auth suite — 233 tests before the final narrow fix; final targeted identity suite 166 tests
- `pnpm --filter @openpims/db exec drizzle-kit check`
- migration snapshot parse, identifier-length, and diff checks
- independent adversarial review: merge-ready

CI's PostgreSQL job remains the authoritative migration, schema-drift, trigger, and RLS execution gate.
