### PR TITLE
Make SOAP documentation clinic-safe

### DIFF
--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -383,16 +383,19 @@ export default function EncounterWorkspacePage() {
                   <div className="flex flex-wrap gap-2">
                     {canCreateSoap(role) &&
                     appointment.status === "in_exam" &&
+                    closeoutQuery.data?.linkedSoapCount === 0 &&
                     closeoutQuery.data?.closeout?.status !==
                       "clinical_finalized" &&
                     closeoutQuery.data?.closeout?.status !== "completed" ? (
                       <Button size="sm" asChild>
-                        <Link
+                        <a
                           href={`/records/new-soap/${appointment.patientId}?appointmentId=${appointmentId}`}
                         >
                           <FileText className="mr-2 h-4 w-4" />
-                          Write SOAP note
-                        </Link>
+                          {closeoutQuery.data?.soapDraft
+                            ? "Resume SOAP draft"
+                            : "Write SOAP note"}
+                        </a>
                       </Button>
                     ) : null}
                     {canCreateSoap(role) &&
@@ -528,6 +531,7 @@ function VisitCloseout({
 }: {
   appointment: {
     status: string;
+    patientId: string | null;
     patientName: string | null;
     patientSpecies: string | null;
     clientFirstName: string | null;
@@ -848,11 +852,13 @@ function VisitCloseout({
           <ReadinessTile
             label="Clinical note"
             value={
-              data.linkedSoapCount > 0
-                ? `${data.linkedSoapCount} linked SOAP note${data.linkedSoapCount === 1 ? "" : "s"}`
-                : closeout?.documentationExceptionReason
-                  ? "Documented exception"
-                  : "Missing"
+              data.soapDraft
+                ? `Draft in progress · revision ${data.soapDraft.revision}`
+                : data.linkedSoapCount > 0
+                  ? `${data.linkedSoapCount} linked SOAP note${data.linkedSoapCount === 1 ? "" : "s"}`
+                  : closeout?.documentationExceptionReason
+                    ? "Documented exception"
+                    : "Missing"
             }
           />
           <ReadinessTile
@@ -904,6 +910,8 @@ function VisitCloseout({
               documentationExceptionReason={documentationExceptionReason}
               setDocumentationExceptionReason={setDocumentationExceptionReason}
               linkedSoapCount={data.linkedSoapCount}
+              soapDraft={data.soapDraft}
+              soapDraftHref={`/records/new-soap/${appointment.patientId}?appointmentId=${appointmentId}`}
               linkedMedicationCount={data.activeMedications.length}
               followUpAppointments={data.followUpAppointments}
               followUpAssignees={data.followUpAssignees}
@@ -1287,6 +1295,12 @@ type ClinicalCloseoutFormProps = {
   documentationExceptionReason: string;
   setDocumentationExceptionReason: (value: string) => void;
   linkedSoapCount: number;
+  soapDraft: {
+    revision: number;
+    authorName: string;
+    updatedAt: Date | string;
+  } | null;
+  soapDraftHref: string;
   linkedMedicationCount: number;
   followUpAppointments: Array<{ id: string; startTime: Date | string }>;
   followUpAssignees: Array<{
@@ -1306,6 +1320,9 @@ type ClinicalCloseoutFormProps = {
 
 function ClinicalCloseoutForm(props: ClinicalCloseoutFormProps) {
   const finalizationIssues = [
+    props.soapDraft
+      ? "Finalize or discard the SOAP draft before signing clinical closeout."
+      : null,
     !props.dischargeInstructions.trim() && !props.noInstructionsReason.trim()
       ? "Enter home-care instructions or a clinical reason why none are needed."
       : null,
@@ -1558,7 +1575,22 @@ function ClinicalCloseoutForm(props: ClinicalCloseoutFormProps) {
           />
         </div>
       ) : null}
-      {props.linkedSoapCount === 0 ? (
+      {props.soapDraft ? (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
+          <p className="text-sm font-medium">SOAP draft in progress</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Revision {props.soapDraft.revision} is not part of the signed chart.
+            Finalize or discard it before clinical closeout; a documentation
+            exception cannot leave an unfinished draft behind.
+          </p>
+          <Button className="mt-3" size="sm" variant="outline" asChild>
+            <a href={props.soapDraftHref}>
+              <FileText className="mr-2 h-4 w-4" />
+              Resume SOAP draft
+            </a>
+          </Button>
+        </div>
+      ) : props.linkedSoapCount === 0 ? (
         <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
           <p className="text-sm font-medium">No SOAP note is linked</p>
           <p className="mt-1 text-xs text-muted-foreground">

--- a/apps/web/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/patients/[id]/page.tsx
@@ -51,6 +51,7 @@ import {
   formatClinicalDate,
   formatClinicalDateTime,
 } from "@/lib/records/clinical-dates";
+import { soapSectionText } from "@/lib/records/soap-content";
 import {
   patientFileKind,
   patientFileLabel,
@@ -552,17 +553,46 @@ export default function PatientDetailPage() {
             : undefined,
         })),
         recentNotes: soapNotes
-          .filter((note) => !note.correctionId)
+          .filter((note) => note.status === "finalized" && !note.correctionId)
           .slice(0, 5)
           .map((n) => ({
-          date: n.createdAt
-            ? formatClinicalDate(n.createdAt, recordsTimeZone, "Unknown")
-            : "Unknown",
-          subjective: n.subjective ?? undefined,
-          objective: n.objective ?? undefined,
-          assessment: n.assessment ?? undefined,
-          plan: n.plan ?? undefined,
-          imported: n.imported,
+            date: n.createdAt
+              ? formatClinicalDate(n.createdAt, recordsTimeZone, "Unknown")
+              : "Unknown",
+            subjective: n.subjective ?? undefined,
+            objective: n.objective ?? undefined,
+            assessment: n.assessment ?? undefined,
+            plan: n.plan ?? undefined,
+            imported: n.imported,
+            authorName: n.authorName,
+            finalizerName: n.finalizerName ?? undefined,
+            finalizedAt: n.finalizedAt
+              ? formatClinicalDateTime(n.finalizedAt, recordsTimeZone)
+              : undefined,
+            addenda: n.addenda.map((addendum) => ({
+              content: soapSectionText(addendum.content),
+              authorName: addendum.authorName,
+              createdAt: formatClinicalDateTime(
+                addendum.createdAt,
+                recordsTimeZone,
+              ),
+            })),
+          })),
+        recordCorrections: soapNotes
+          .filter(
+            (note) => note.status === "finalized" && Boolean(note.correctionId),
+          )
+          .map((note) => ({
+            recordLabel: `SOAP note dated ${formatClinicalDate(
+              note.createdAt,
+              recordsTimeZone,
+              "Unknown date",
+            )}`,
+            reason: note.correctionReason ?? "Reason unavailable",
+            correctedByName: note.correctedByName ?? "Unknown clinician",
+            correctedAt: note.correctedAt
+              ? formatClinicalDateTime(note.correctedAt, recordsTimeZone)
+              : "Unknown time",
           })),
         prescriptions: prescriptions.map((rx) => ({
           medication: rx.medicationName,
@@ -1582,6 +1612,16 @@ function MedicalRecordsTab({
                   Imported
                 </span>
               ) : null}
+              <span
+                className={cn(
+                  "rounded-full px-2 py-0.5 text-[11px] font-medium",
+                  note.status === "draft"
+                    ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+                    : "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
+                )}
+              >
+                {note.status === "draft" ? "Draft" : "Finalized"}
+              </span>
             </div>
             <p className="text-xs text-muted-foreground">
               {note.imported
@@ -1591,6 +1631,21 @@ function MedicalRecordsTab({
                 : (note.authorName ?? "Unknown author")}
             </p>
           </div>
+          {note.status === "finalized" ? (
+            <p className="mb-3 text-xs text-muted-foreground">
+              Finalized by {note.finalizerName ?? "Unknown clinician"}
+              {note.finalizedAt
+                ? ` on ${formatClinicalDateTime(note.finalizedAt, timeZone)}`
+                : ""}
+            </p>
+          ) : note.appointmentId && canCorrectClinicalRecords ? (
+            <a
+              href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
+              className="mb-3 inline-flex text-xs font-medium text-primary hover:underline"
+            >
+              Resume draft
+            </a>
+          ) : null}
           <dl className="grid gap-3 sm:grid-cols-2">
             {(
               [
@@ -1605,39 +1660,157 @@ function MedicalRecordsTab({
                   <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                     {label}
                   </dt>
-                  <dd className="mt-1 whitespace-pre-wrap text-sm">{value}</dd>
+                  <dd className="mt-1 whitespace-pre-wrap text-sm">
+                    {soapSectionText(value)}
+                  </dd>
                 </div>
               ) : null
             )}
           </dl>
-          <ClinicalCorrectionControl
-            correction={
-              note.correctionId &&
-              note.correctionReason &&
-              note.correctedAt
-                ? {
-                    id: note.correctionId,
-                    reason: note.correctionReason,
-                    correctedAt: note.correctedAt,
-                    correctedByName: note.correctedByName,
-                  }
-                : null
-            }
-            canCorrect={canCorrectClinicalRecords}
-            isPending={
-              correctSoap.isPending &&
-              correctSoap.variables?.recordId === note.id
-            }
-            onCorrect={(reason) =>
-              correctSoap.mutateAsync({
-                patientId,
-                recordId: note.id,
-                reason,
-              })
-            }
-          />
+          {note.addenda.length > 0 ? (
+            <div className="mt-4 space-y-2 border-t border-border pt-3">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Addenda
+              </p>
+              {note.addenda.map((addendum) => (
+                <div key={addendum.id} className="rounded-md bg-muted/40 p-3">
+                  <p className="text-xs font-medium">
+                    {addendum.authorName} -{" "}
+                    {formatClinicalDateTime(addendum.createdAt, timeZone)}
+                  </p>
+                  <p className="mt-1 whitespace-pre-wrap text-sm">
+                    {soapSectionText(addendum.content)}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : null}
+          {note.status === "finalized" && !note.correctionId ? (
+            <SoapAddendumControl
+              patientId={patientId}
+              noteId={note.id}
+              enabled={canCorrectClinicalRecords}
+            />
+          ) : null}
+          {note.status === "finalized" ? (
+            <ClinicalCorrectionControl
+              correction={
+                note.correctionId && note.correctionReason && note.correctedAt
+                  ? {
+                      id: note.correctionId,
+                      reason: note.correctionReason,
+                      correctedAt: note.correctedAt,
+                      correctedByName: note.correctedByName,
+                    }
+                  : null
+              }
+              canCorrect={canCorrectClinicalRecords}
+              isPending={
+                correctSoap.isPending &&
+                correctSoap.variables?.recordId === note.id
+              }
+              onCorrect={(reason) =>
+                correctSoap.mutateAsync({
+                  patientId,
+                  recordId: note.id,
+                  reason,
+                })
+              }
+            />
+          ) : null}
         </div>
       ))}
+    </div>
+  );
+}
+
+function SoapAddendumControl({
+  patientId,
+  noteId,
+  enabled,
+}: {
+  patientId: string;
+  noteId: string;
+  enabled: boolean;
+}) {
+  const utils = trpc.useUtils();
+  const [open, setOpen] = useState(false);
+  const [content, setContent] = useState("");
+  const [operationId, setOperationId] = useState(() => crypto.randomUUID());
+  const addendum = trpc.records.addSoapNoteAddendum.useMutation({
+    onSuccess: async () => {
+      setContent("");
+      setOpen(false);
+      setOperationId(crypto.randomUUID());
+      toast.success("Addendum added to the finalized record");
+      await utils.records.listSoapNotes.invalidate({ patientId });
+    },
+    onError: (error) => toast.error(error.message),
+  });
+  if (!enabled) return null;
+  if (!open) {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-4"
+        onClick={() => {
+          setOperationId(crypto.randomUUID());
+          setOpen(true);
+        }}
+      >
+        <Plus className="mr-2 h-4 w-4" />
+        Add addendum
+      </Button>
+    );
+  }
+  return (
+    <div className="mt-4 rounded-md border border-border p-3">
+      <label className="text-sm font-medium" htmlFor={`addendum-${noteId}`}>
+        Add attributed addendum
+      </label>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Addenda cannot be edited or deleted after saving.
+      </p>
+      <textarea
+        id={`addendum-${noteId}`}
+        value={content}
+        onChange={(event) => setContent(event.target.value)}
+        maxLength={10_000}
+        rows={3}
+        className="mt-2 w-full rounded-md border border-border bg-background p-2 text-sm"
+      />
+      <div className="mt-2 flex gap-2">
+        <Button
+          type="button"
+          size="sm"
+          disabled={!content.trim() || addendum.isPending}
+          onClick={() =>
+            addendum.mutate({
+              patientId,
+              noteId,
+              operationId,
+              content,
+            })
+          }
+        >
+          {addendum.isPending ? "Saving..." : "Save addendum"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={addendum.isPending}
+          onClick={() => {
+            setOpen(false);
+            setContent("");
+            setOperationId(crypto.randomUUID());
+          }}
+        >
+          Cancel
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/(dashboard)/records/new-soap/[patientId]/page.tsx
+++ b/apps/web/app/(dashboard)/records/new-soap/[patientId]/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import {
   AlertCircle,
+  CheckCircle2,
+  Copy,
   ArrowLeft,
   ClipboardList,
   Loader2,
@@ -22,6 +24,7 @@ import { toast } from "sonner";
 import {
   hasSoapContent,
   normalizeSoapSection,
+  soapSectionText,
 } from "@/lib/records/soap-content";
 import {
   SOAP_NOTE_TEMPLATES,
@@ -29,6 +32,11 @@ import {
   getSoapTemplateById,
   hasUnresolvedSoapTemplatePrompts,
 } from "@/lib/records/soap-templates";
+import {
+  guardedSoapNavigationDestination,
+  runSoapSafeLeave,
+  soapEditorNeedsLeaveGuard,
+} from "@/lib/records/soap-navigation";
 
 const SoapNoteEditor = dynamic(
   () =>
@@ -59,6 +67,54 @@ function draftTextToHtml(text: string): string {
     .filter(Boolean)
     .map((paragraph) => `<p>${paragraph.replace(/\n/g, "<br>")}</p>`);
   return paragraphs.join("");
+}
+
+type SoapEditorSections = {
+  subjective: string;
+  objective: string;
+  assessment: string;
+  plan: string;
+};
+
+function soapDraftFingerprint(sections: SoapEditorSections): string {
+  return JSON.stringify({
+    subjective: normalizeSoapSection(sections.subjective),
+    objective: normalizeSoapSection(sections.objective),
+    assessment: normalizeSoapSection(sections.assessment),
+    plan: normalizeSoapSection(sections.plan),
+  });
+}
+
+function localSoapTextForClipboard(sections: SoapEditorSections): string {
+  return [
+    ["Subjective", soapSectionText(sections.subjective)],
+    ["Objective", soapSectionText(sections.objective)],
+    ["Assessment", soapSectionText(sections.assessment)],
+    ["Plan", soapSectionText(sections.plan)],
+  ]
+    .filter((entry) => Boolean(entry[1]))
+    .map(([label, content]) => `${label}\n${content}`)
+    .join("\n\n");
+}
+
+async function copyTextToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return;
+  } catch {
+    // Clipboard API can be unavailable or denied in some managed browsers.
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand("copy");
+  textarea.remove();
+  if (!copied) throw new Error("Clipboard access was denied");
 }
 
 export default function NewSoapNotePage() {
@@ -102,15 +158,183 @@ export default function NewSoapNotePage() {
       { enabled: !!params.patientId && canCreateSoapNote && !!appointmentId }
     );
 
-  const createNote = trpc.records.createSoapNote.useMutation({
-    onSuccess: () => {
-      toast.success("SOAP note created");
-      router.push(returnPath);
+  const draftQuery = trpc.records.getSoapDraft.useQuery(
+    { patientId: params.patientId, appointmentId: appointmentId! },
+    {
+      enabled:
+        !!params.patientId && !!appointmentId && canCreateSoapNote && !!patient,
     },
-    onError: (err) => {
-      toast.error(err.message);
-    },
+  );
+  const saveDraftMutation = trpc.records.saveSoapDraft.useMutation();
+  const finalizeMutation = trpc.records.finalizeSoapNote.useMutation();
+  const discardMutation = trpc.records.discardSoapDraft.useMutation();
+  const [draftInitialized, setDraftInitialized] = useState(false);
+  const draftInitializedRef = useRef(false);
+  const [saveState, setSaveState] = useState<
+    "idle" | "unsaved" | "saving" | "saved" | "error" | "conflict"
+  >("idle");
+  const [finalizedElsewhere, setFinalizedElsewhere] = useState(false);
+  const [localTextCopied, setLocalTextCopied] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const [conflictDraft, setConflictDraft] = useState<NonNullable<
+    typeof draftQuery.data
+  > | null>(null);
+  const draftIdRef = useRef<string | null>(null);
+  const revisionRef = useRef(0);
+  const lastSavedFingerprintRef = useRef("");
+  const savePromiseRef = useRef<Promise<unknown> | null>(null);
+  const navigationAttemptRef = useRef<Promise<boolean> | null>(null);
+  const saveDraftRef = useRef(saveDraftMutation.mutateAsync);
+  saveDraftRef.current = saveDraftMutation.mutateAsync;
+  const conflictRef = useRef(false);
+  const finalizedElsewhereRef = useRef(false);
+  const localTextCopiedRef = useRef(false);
+  const sectionsRef = useRef<SoapEditorSections>({
+    subjective,
+    objective,
+    assessment,
+    plan,
   });
+  sectionsRef.current = { subjective, objective, assessment, plan };
+
+  const editorNeedsLeaveGuard = useCallback(
+    () =>
+      soapEditorNeedsLeaveGuard({
+        draftInitialized: draftInitializedRef.current,
+        finalizedElsewhere: finalizedElsewhereRef.current,
+        localTextCopied: localTextCopiedRef.current,
+        hasLocalText: Boolean(
+          localSoapTextForClipboard(sectionsRef.current),
+        ),
+        conflict: conflictRef.current,
+        savePending: savePromiseRef.current !== null,
+        dirty:
+          soapDraftFingerprint(sectionsRef.current) !==
+          lastSavedFingerprintRef.current,
+      }),
+    [],
+  );
+
+  useEffect(() => {
+    if (!draftQuery.isSuccess || draftInitialized) return;
+    const draft = draftQuery.data;
+    const sections = {
+      subjective: draft?.subjective ?? "",
+      objective: draft?.objective ?? "",
+      assessment: draft?.assessment ?? "",
+      plan: draft?.plan ?? "",
+    };
+    setSubjective(sections.subjective);
+    setObjective(sections.objective);
+    setAssessment(sections.assessment);
+    setPlan(sections.plan);
+    sectionsRef.current = sections;
+    draftIdRef.current = draft?.id ?? null;
+    revisionRef.current = draft?.revision ?? 0;
+    lastSavedFingerprintRef.current = soapDraftFingerprint(sections);
+    setLastSavedAt(draft?.updatedAt ?? null);
+    setSaveState(draft ? "saved" : "idle");
+    draftInitializedRef.current = true;
+    setDraftInitialized(true);
+  }, [draftInitialized, draftQuery.data, draftQuery.isSuccess]);
+
+  const persistDraft = useCallback(async () => {
+    if (
+      finalizedElsewhereRef.current ||
+      !appointmentId ||
+      !params.patientId ||
+      !draftInitialized
+    )
+      return null;
+
+    while (true) {
+      if (finalizedElsewhereRef.current) return null;
+      if (conflictRef.current) return null;
+      if (savePromiseRef.current) {
+        await savePromiseRef.current.catch(() => null);
+        continue;
+      }
+      const sections = { ...sectionsRef.current };
+      const fingerprint = soapDraftFingerprint(sections);
+      if (fingerprint === lastSavedFingerprintRef.current) {
+        return draftIdRef.current
+          ? { id: draftIdRef.current, revision: revisionRef.current }
+          : null;
+      }
+      setSaveState("saving");
+      const request = saveDraftRef.current({
+        patientId: params.patientId,
+        appointmentId,
+        noteId: draftIdRef.current ?? undefined,
+        expectedRevision: revisionRef.current,
+        ...sections,
+      });
+      savePromiseRef.current = request;
+      try {
+        const result = await request;
+        if (result.outcome === "already_finalized") {
+          finalizedElsewhereRef.current = true;
+          localTextCopiedRef.current = false;
+          setLocalTextCopied(false);
+          setFinalizedElsewhere(true);
+          return null;
+        }
+        if (result.outcome === "conflict") {
+          conflictRef.current = true;
+          setConflictDraft(result.draft);
+          setSaveState("conflict");
+          return null;
+        }
+        draftIdRef.current = result.draft.id;
+        revisionRef.current = result.draft.revision;
+        lastSavedFingerprintRef.current = fingerprint;
+        setLastSavedAt(result.draft.updatedAt);
+        setSaveState("saved");
+      } catch (error) {
+        setSaveState("error");
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "SOAP draft could not be saved",
+        );
+        return null;
+      } finally {
+        if (savePromiseRef.current === request) savePromiseRef.current = null;
+      }
+    }
+  }, [appointmentId, draftInitialized, params.patientId]);
+
+  useEffect(() => {
+    if (
+      finalizedElsewhere ||
+      !draftInitialized ||
+      conflictRef.current
+    )
+      return;
+    const fingerprint = soapDraftFingerprint(sectionsRef.current);
+    if (fingerprint === lastSavedFingerprintRef.current) return;
+    setSaveState("unsaved");
+    const timer = window.setTimeout(() => void persistDraft(), 1_200);
+    return () => window.clearTimeout(timer);
+  }, [
+    assessment,
+    draftInitialized,
+    finalizedElsewhere,
+    objective,
+    persistDraft,
+    plan,
+    subjective,
+  ]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!editorNeedsLeaveGuard()) return;
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [editorNeedsLeaveGuard]);
 
   // AI draft availability mirrors the OpenVPM Agent (same key + model config).
   const agentStatus = trpc.agent.status.useQuery(undefined, {
@@ -119,6 +343,7 @@ export default function NewSoapNotePage() {
   const aiConfigured = agentStatus.data?.configured ?? false;
   const draftWithAi = trpc.ai.draftSoapNote.useMutation({
     onSuccess: (draft) => {
+      if (finalizedElsewhereRef.current) return;
       setSubjective(draftTextToHtml(draft.subjective));
       setObjective(draftTextToHtml(draft.objective));
       setAssessment(draftTextToHtml(draft.assessment));
@@ -129,7 +354,12 @@ export default function NewSoapNotePage() {
   });
 
   function handleDraftWithAi() {
-    if (!params.patientId || draftWithAi.isPending) return;
+    if (
+      finalizedElsewhereRef.current ||
+      !params.patientId ||
+      draftWithAi.isPending
+    )
+      return;
     if (
       canSave &&
       !window.confirm("Replace what you typed with the AI draft?")
@@ -139,35 +369,154 @@ export default function NewSoapNotePage() {
     draftWithAi.mutate({ patientId: params.patientId });
   }
 
-  function handleSave() {
+  async function handleFinalize() {
+    if (finalizedElsewhereRef.current) return;
     if (!appointmentId) {
-      toast.error("Open an active visit before creating a SOAP note");
+      toast.error("Open an active visit before finalizing a SOAP note");
       return;
     }
     if (!params.patientId || !patient) {
-      toast.error("Load the patient before saving a SOAP note");
+      toast.error("Load the patient before finalizing a SOAP note");
       return;
     }
     if (!canSave) {
-      toast.error("Add at least one SOAP section before saving");
+      toast.error("Add at least one SOAP section before finalizing");
       return;
     }
     if (hasTemplatePrompts) {
-      toast.error("Replace or delete every draft prompt before saving");
+      toast.error("Replace or delete every draft prompt before finalizing");
       return;
     }
-    createNote.mutate({
-      patientId: params.patientId,
-      appointmentId,
-      subjective: normalizeSoapSection(subjective),
-      objective: normalizeSoapSection(objective),
-      assessment: normalizeSoapSection(assessment),
-      plan: normalizeSoapSection(plan),
+    const saved = await persistDraft();
+    if (!saved) return;
+    if (
+      !window.confirm(
+        "Finalize this SOAP note? The signed note cannot be edited; later clarification must be an attributed addendum.",
+      )
+    ) {
+      return;
+    }
+    try {
+      const result = await finalizeMutation.mutateAsync({
+        patientId: params.patientId,
+        appointmentId,
+        noteId: saved.id,
+        expectedRevision: saved.revision,
+      });
+      if (result.outcome === "conflict") {
+        if (result.note.status === "finalized") {
+          finalizedElsewhereRef.current = true;
+          localTextCopiedRef.current = false;
+          setLocalTextCopied(false);
+          setFinalizedElsewhere(true);
+          return;
+        }
+        conflictRef.current = true;
+        setConflictDraft(result.note);
+        setSaveState("conflict");
+        return;
+      }
+      toast.success("SOAP note finalized");
+      router.push(returnPath);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "SOAP note could not be finalized",
+      );
+    }
+  }
+
+  function useServerDraft() {
+    if (finalizedElsewhereRef.current || !conflictDraft) return;
+    const sections = {
+      subjective: conflictDraft.subjective ?? "",
+      objective: conflictDraft.objective ?? "",
+      assessment: conflictDraft.assessment ?? "",
+      plan: conflictDraft.plan ?? "",
+    };
+    setSubjective(sections.subjective);
+    setObjective(sections.objective);
+    setAssessment(sections.assessment);
+    setPlan(sections.plan);
+    sectionsRef.current = sections;
+    draftIdRef.current = conflictDraft.id;
+    revisionRef.current = conflictDraft.revision;
+    lastSavedFingerprintRef.current = soapDraftFingerprint(sections);
+    setLastSavedAt(conflictDraft.updatedAt);
+    conflictRef.current = false;
+    setConflictDraft(null);
+    setSaveState("saved");
+  }
+
+  async function overwriteServerDraft() {
+    if (finalizedElsewhereRef.current || !conflictDraft) return;
+    if (
+      !window.confirm(
+        "Replace the newer server draft with the version in this editor?",
+      )
+    )
+      return;
+    draftIdRef.current = conflictDraft.id;
+    revisionRef.current = conflictDraft.revision;
+    lastSavedFingerprintRef.current = soapDraftFingerprint({
+      subjective: conflictDraft.subjective ?? "",
+      objective: conflictDraft.objective ?? "",
+      assessment: conflictDraft.assessment ?? "",
+      plan: conflictDraft.plan ?? "",
     });
+    conflictRef.current = false;
+    setConflictDraft(null);
+    setSaveState("unsaved");
+    await persistDraft();
+  }
+
+  async function handleDiscardDraft() {
+    if (
+      finalizedElsewhereRef.current ||
+      !appointmentId ||
+      !draftIdRef.current
+    )
+      return;
+    if (
+      !window.confirm(
+        "Discard this unfinished SOAP draft? This cannot be undone.",
+      )
+    )
+      return;
+    try {
+      const result = await discardMutation.mutateAsync({
+        patientId: params.patientId,
+        appointmentId,
+        noteId: draftIdRef.current,
+        expectedRevision: revisionRef.current,
+      });
+      if (result.outcome === "already_finalized") {
+        finalizedElsewhereRef.current = true;
+        localTextCopiedRef.current = false;
+        setLocalTextCopied(false);
+        setFinalizedElsewhere(true);
+        return;
+      }
+      if (result.outcome === "conflict") {
+        conflictRef.current = true;
+        setConflictDraft(result.draft);
+        setSaveState("conflict");
+        return;
+      }
+      toast.success("SOAP draft discarded");
+      router.push(returnPath);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "SOAP draft could not be discarded",
+      );
+    }
   }
 
   function handleApplyTemplate() {
-    if (!selectedTemplate) return;
+    if (finalizedElsewhereRef.current || !selectedTemplate) return;
     const next = applySoapTemplateToSections(
       { subjective, objective, assessment, plan },
       selectedTemplate,
@@ -183,6 +532,100 @@ export default function NewSoapNotePage() {
         : `${selectedTemplate.name} draft prompts filled blank sections`
     );
   }
+
+  const leaveEditorSafely = useCallback(
+    (destination: string): Promise<boolean> => {
+      if (navigationAttemptRef.current) {
+        return navigationAttemptRef.current;
+      }
+
+      const attempt = runSoapSafeLeave({
+        readState: () => ({
+          finalizedElsewhere: finalizedElsewhereRef.current,
+          needsGuard: editorNeedsLeaveGuard(),
+          localTextCopied: localTextCopiedRef.current,
+          hasLocalText: Boolean(
+            localSoapTextForClipboard(sectionsRef.current),
+          ),
+        }),
+        persistDraft,
+        confirmFinalizedLocalTextLeave: () =>
+          window.confirm(
+            "Your local SOAP text was not included in the finalized note and has not been copied. Leave anyway?",
+          ),
+        confirmUnsavedLeave: () =>
+          window.confirm(
+            "The latest draft changes could not be saved. Leave the editor anyway?",
+          ),
+        navigate: () => router.push(destination),
+      });
+
+      navigationAttemptRef.current = attempt;
+      void attempt.finally(() => {
+        if (navigationAttemptRef.current === attempt) {
+          navigationAttemptRef.current = null;
+        }
+      });
+      return attempt;
+    },
+    [editorNeedsLeaveGuard, persistDraft, router],
+  );
+
+  const copyLocalSoapText = useCallback(async () => {
+    const text = localSoapTextForClipboard(sectionsRef.current);
+    if (!text) {
+      toast.error("There is no local SOAP text to copy");
+      return;
+    }
+    try {
+      await copyTextToClipboard(text);
+      localTextCopiedRef.current = true;
+      setLocalTextCopied(true);
+      toast.success("Local SOAP text copied");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Local SOAP text could not be copied",
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleDocumentClick = (event: MouseEvent) => {
+      if (
+        !editorNeedsLeaveGuard() &&
+        navigationAttemptRef.current === null
+      ) {
+        return;
+      }
+      if (!(event.target instanceof Element)) return;
+      const anchor = event.target.closest<HTMLAnchorElement>("a[href]");
+      if (!anchor) return;
+
+      const destination = guardedSoapNavigationDestination({
+        href: anchor.href,
+        currentHref: window.location.href,
+        button: event.button,
+        defaultPrevented: event.defaultPrevented,
+        metaKey: event.metaKey,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        target: anchor.getAttribute("target"),
+        download: anchor.hasAttribute("download"),
+      });
+      if (!destination) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      void leaveEditorSafely(destination);
+    };
+
+    document.addEventListener("click", handleDocumentClick, true);
+    return () =>
+      document.removeEventListener("click", handleDocumentClick, true);
+  }, [editorNeedsLeaveGuard, leaveEditorSafely]);
 
   if (accessDenied) {
     return (
@@ -254,12 +697,126 @@ export default function NewSoapNotePage() {
     );
   }
 
+  if (!draftQuery.error && (draftQuery.isLoading || !draftInitialized)) {
+    return (
+      <div className="flex items-center justify-center gap-2 rounded-lg border border-border bg-card p-8 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading saved SOAP draft...
+      </div>
+    );
+  }
+
+  if (draftQuery.error) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="Unable to load the saved draft"
+        description={`${draftQuery.error.message} Editing is paused to prevent a duplicate clinical record.`}
+        action={{
+          label: "Back to visit",
+          onClick: () => router.push(returnPath),
+          icon: ArrowLeft,
+        }}
+      />
+    );
+  }
+
+  if (finalizedElsewhere) {
+    const localSections = [
+      ["Subjective", soapSectionText(subjective)],
+      ["Objective", soapSectionText(objective)],
+      ["Assessment", soapSectionText(assessment)],
+      ["Plan", soapSectionText(plan)],
+    ].filter((entry) => Boolean(entry[1]));
+    return (
+      <div className="space-y-5">
+        <div
+          role="alert"
+          className="rounded-lg border-2 border-destructive bg-destructive/10 p-5"
+        >
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 h-6 w-6 shrink-0 text-destructive" />
+            <div>
+              <h2 className="font-heading text-xl font-semibold text-destructive">
+                SOAP note finalized in another session
+              </h2>
+              <p className="mt-2 font-medium">
+                Important: the local SOAP text below was NOT included in the
+                finalized note.
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Copy it before leaving, compare it with the signed chart, and
+                add any clinically relevant clarification as an attributed
+                addendum. Editing, autosave, AI drafting, templates,
+                finalization, and discard are now disabled.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-5">
+          <h3 className="font-semibold">Preserved local SOAP text</h3>
+          <div className="mt-4 space-y-4">
+            {localSections.length > 0 ? (
+              localSections.map(([label, content]) => (
+                <div key={label}>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {label}
+                  </p>
+                  <p className="mt-1 whitespace-pre-wrap text-sm">{content}</p>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No local SOAP text was present.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            onClick={() => void copyLocalSoapText()}
+            disabled={localSections.length === 0}
+          >
+            {localTextCopied ? (
+              <CheckCircle2 className="mr-2 h-4 w-4" />
+            ) : (
+              <Copy className="mr-2 h-4 w-4" />
+            )}
+            {localTextCopied ? "Local SOAP text copied" : "Copy local SOAP text"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void leaveEditorSafely(returnPath)}
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to visit
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() =>
+              void leaveEditorSafely(
+                `/patients/${encodeURIComponent(params.patientId)}`,
+              )
+            }
+          >
+            View signed patient chart
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div>
       <Button
         variant="ghost"
         size="sm"
-        onClick={() => router.push(returnPath)}
+        onClick={() => void leaveEditorSafely(returnPath)}
         className="mb-4"
       >
         <ArrowLeft className="mr-2 h-4 w-4" />
@@ -268,7 +825,9 @@ export default function NewSoapNotePage() {
 
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 className="font-heading text-xl font-semibold">New SOAP Note</h2>
+          <h2 className="font-heading text-xl font-semibold">
+            SOAP Documentation
+          </h2>
           {patient && (
             <p className="text-sm text-muted-foreground">
               Patient: {patient.name}
@@ -279,7 +838,8 @@ export default function NewSoapNotePage() {
             </p>
           )}
           <p className="text-xs text-muted-foreground">
-            This note will be linked to the current appointment.
+            Draft changes save automatically. Finalization creates the signed
+            clinical record.
           </p>
         </div>
         <div className="flex flex-col items-end gap-1">
@@ -308,6 +868,88 @@ export default function NewSoapNotePage() {
       </div>
 
       <div className="mt-6 space-y-6">
+        <div
+          className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-card px-4 py-3"
+          aria-live="polite"
+        >
+          <div className="flex items-center gap-2 text-sm">
+            {saveState === "saving" ? (
+              <Loader2 className="h-4 w-4 animate-spin text-primary" />
+            ) : saveState === "saved" ? (
+              <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+            ) : saveState === "error" || saveState === "conflict" ? (
+              <AlertCircle className="h-4 w-4 text-destructive" />
+            ) : (
+              <Save className="h-4 w-4 text-muted-foreground" />
+            )}
+            <span>
+              {saveState === "saving"
+                ? "Saving draft..."
+                : saveState === "saved"
+                  ? `Draft saved${lastSavedAt ? ` at ${lastSavedAt.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}` : ""}`
+                  : saveState === "error"
+                    ? "Draft could not be saved"
+                    : saveState === "conflict"
+                      ? "A newer draft exists in another session"
+                      : saveState === "unsaved"
+                        ? "Changes not saved yet"
+                        : "Draft will save after you begin typing"}
+            </span>
+          </div>
+          <div className="flex gap-2">
+            {(saveState === "error" || saveState === "unsaved") && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void persistDraft()}
+              >
+                Retry save
+              </Button>
+            )}
+            {draftIdRef.current ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="text-destructive hover:text-destructive"
+                disabled={discardMutation.isPending || saveState === "saving"}
+                onClick={() => void handleDiscardDraft()}
+              >
+                {discardMutation.isPending ? "Discarding..." : "Discard draft"}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+
+        {conflictDraft ? (
+          <div
+            role="alert"
+            className="rounded-lg border border-destructive/40 bg-destructive/5 p-4"
+          >
+            <h3 className="font-medium">
+              This draft changed in another session
+            </h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              The saved draft was updated in another session at{" "}
+              {conflictDraft.updatedAt.toLocaleString()}. Your editor content
+              has been kept unchanged.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button type="button" size="sm" onClick={useServerDraft}>
+                Use server version
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => void overwriteServerDraft()}
+              >
+                Overwrite with my version
+              </Button>
+            </div>
+          </div>
+        ) : null}
         <div className="rounded-lg border border-border bg-card p-4">
           <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
             <div className="w-full lg:max-w-sm">
@@ -349,7 +991,7 @@ export default function NewSoapNotePage() {
           </div>
           <p className="mt-2 text-xs text-muted-foreground">
             Templates add drafting prompts, not assumed findings. Replace or
-            delete every prompt before saving the clinical record.
+            delete every prompt before finalizing the clinical record.
           </p>
         </div>
 
@@ -429,29 +1071,35 @@ export default function NewSoapNotePage() {
         {/* Actions */}
         <div className="flex items-center gap-3">
           <Button
-            onClick={handleSave}
-            disabled={createNote.isPending || !canSubmit}
+            onClick={() => void handleFinalize()}
+            disabled={
+              finalizeMutation.isPending ||
+              saveState === "saving" ||
+              saveState === "error" ||
+              saveState === "conflict" ||
+              !canSubmit
+            }
           >
             <Save className="mr-2 h-4 w-4" />
-            {createNote.isPending ? "Saving..." : "Save Note"}
+            {finalizeMutation.isPending
+              ? "Finalizing..."
+              : "Finalize SOAP note"}
           </Button>
           {!canSave ? (
             <p className="text-sm text-muted-foreground">
-              Add at least one section to save this note.
+              Add at least one section before finalizing.
             </p>
           ) : hasTemplatePrompts ? (
             <p className="text-sm text-amber-700 dark:text-amber-300">
-              Replace or delete every draft prompt before saving.
+              Replace or delete every draft prompt before finalizing.
             </p>
           ) : null}
-          <Button variant="outline" onClick={() => router.push(returnPath)}>
+          <Button
+            variant="outline"
+            onClick={() => void leaveEditorSafely(returnPath)}
+          >
             Cancel
           </Button>
-          {createNote.isError && (
-            <p className="text-sm text-destructive">
-              Failed to save: {createNote.error.message}
-            </p>
-          )}
         </div>
       </div>
     </div>

--- a/apps/web/app/(dashboard)/records/page.tsx
+++ b/apps/web/app/(dashboard)/records/page.tsx
@@ -25,6 +25,7 @@ import {
 import { trpc } from "@/lib/trpc";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
 import { formatClinicalDateTime } from "@/lib/records/clinical-dates";
+import { soapSectionText } from "@/lib/records/soap-content";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -734,6 +735,21 @@ function RecordsPageContent() {
     },
     onError: (error) => toast.error(error.message),
   });
+  const [addendumNoteId, setAddendumNoteId] = useState<string | null>(null);
+  const [addendumContent, setAddendumContent] = useState("");
+  const [addendumOperationId, setAddendumOperationId] = useState<string | null>(
+    null,
+  );
+  const addSoapAddendum = trpc.records.addSoapNoteAddendum.useMutation({
+    onSuccess: async () => {
+      setAddendumNoteId(null);
+      setAddendumContent("");
+      setAddendumOperationId(null);
+      toast.success("Addendum added to the finalized record");
+      await utils.records.listSoapNotes.invalidate({ patientId });
+    },
+    onError: (error) => toast.error(error.message),
+  });
   const {
     data: vaccinations,
     isLoading: isLoadingVaccinations,
@@ -1345,132 +1361,272 @@ function RecordsPageContent() {
                   <RecordsLoadingPanel label="Loading SOAP notes..." />
                 ) : soapNotes && soapNotes.length > 0 ? (
                   <div className="space-y-3">
-                    {soapNotes.map((note) => {
-                      const isExpanded = expandedNoteId === note.id;
-                      return (
-                        <div
-                          key={note.id}
-                          className={cn(
-                            "rounded-lg border border-border bg-card",
-                            note.correctionId &&
-                              "border-destructive/40 bg-destructive/5"
-                          )}
-                        >
-                          <button
-                            onClick={() =>
-                              setExpandedNoteId(isExpanded ? null : note.id)
-                            }
-                            className="flex w-full items-center justify-between px-4 py-3 text-left"
-                          >
-                            <div className="flex items-center gap-4">
-                              <FileText className="h-4 w-4 text-muted-foreground" />
-                              <div>
-                                <div className="flex items-center gap-2">
-                                  <p className="text-sm font-medium">
-                                    {note.createdAt
-                                      ? formatClinicalDate(
-                                          note.createdAt,
-                                          recordsTimeZone
-                                        )
-                                      : "No date"}
+                        {soapNotes.map((note) => {
+                          const isExpanded = expandedNoteId === note.id;
+                          return (
+                            <div
+                              key={note.id}
+                              className={cn(
+                                "rounded-lg border border-border bg-card",
+                                note.correctionId &&
+                                  "border-destructive/40 bg-destructive/5",
+                              )}
+                            >
+                              <button
+                                onClick={() =>
+                                  setExpandedNoteId(isExpanded ? null : note.id)
+                                }
+                                className="flex w-full items-center justify-between px-4 py-3 text-left"
+                              >
+                                <div className="flex items-center gap-4">
+                                  <FileText className="h-4 w-4 text-muted-foreground" />
+                                  <div>
+                                    <div className="flex items-center gap-2">
+                                      <p className="text-sm font-medium">
+                                        {note.createdAt
+                                          ? formatClinicalDate(
+                                              note.createdAt,
+                                              recordsTimeZone,
+                                            )
+                                          : "No date"}
+                                      </p>
+                                      {note.imported ? (
+                                        <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                                          Imported
+                                        </span>
+                                      ) : null}
+                                      <span
+                                        className={cn(
+                                          "rounded-full px-2 py-0.5 text-[11px] font-medium",
+                                          note.status === "draft"
+                                            ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+                                            : "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
+                                        )}
+                                      >
+                                        {note.status === "draft"
+                                          ? "Draft"
+                                          : "Finalized"}
+                                      </span>
+                                      {note.correctionId ? (
+                                        <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[11px] font-medium text-destructive">
+                                          Entered in error
+                                        </span>
+                                      ) : null}
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                      {note.imported
+                                        ? note.authorName
+                                          ? `Imported by ${note.authorName}`
+                                          : "Imported record"
+                                        : (note.authorName ?? "Unknown author")}
+                                    </p>
+                                  </div>
+                                  <p className="text-sm text-muted-foreground line-clamp-1 max-w-md">
+                                    {soapSectionText(
+                                      note.assessment ||
+                                        note.subjective ||
+                                        note.objective ||
+                                        note.plan,
+                                    ) || "No note recorded"}
                                   </p>
-                                  {note.imported ? (
-                                    <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
-                                      Imported
-                                    </span>
+                                </div>
+                                {isExpanded ? (
+                                  <ChevronUp className="h-4 w-4 text-muted-foreground" />
+                                ) : (
+                                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                                )}
+                              </button>
+                              {isExpanded && (
+                                <div className="border-t border-border px-4 py-4 space-y-4">
+                                  {note.status === "finalized" ? (
+                                    <p className="text-xs text-muted-foreground">
+                                      Finalized by{" "}
+                                      {note.finalizerName ??
+                                        "Unknown clinician"}
+                                      {note.finalizedAt
+                                        ? ` on ${formatClinicalDateTime(note.finalizedAt, recordsTimeZone)}`
+                                        : ""}
+                                    </p>
+                                  ) : note.appointmentId &&
+                                    canCorrectClinicalRecords ? (
+                                    <a
+                                      href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
+                                      className="inline-flex text-sm font-medium text-primary hover:underline"
+                                    >
+                                      Resume draft
+                                    </a>
                                   ) : null}
-                                  {note.correctionId ? (
-                                    <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-[11px] font-medium text-destructive">
-                                      Entered in error
-                                    </span>
+                                  <div>
+                                    <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+                                      Subjective
+                                    </h4>
+                                    <p className="text-sm">
+                                      {soapSectionText(note.subjective) || "--"}
+                                    </p>
+                                  </div>
+                                  <div>
+                                    <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+                                      Objective
+                                    </h4>
+                                    <p className="text-sm">
+                                      {soapSectionText(note.objective) || "--"}
+                                    </p>
+                                  </div>
+                                  <div>
+                                    <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+                                      Assessment
+                                    </h4>
+                                    <p className="text-sm">
+                                      {soapSectionText(note.assessment) || "--"}
+                                    </p>
+                                  </div>
+                                  <div>
+                                    <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
+                                      Plan
+                                    </h4>
+                                    <p className="text-sm">
+                                      {soapSectionText(note.plan) || "--"}
+                                    </p>
+                                  </div>
+                                  {note.addenda.length > 0 ? (
+                                    <div className="space-y-2 border-t border-border pt-3">
+                                      <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                                        Addenda
+                                      </h4>
+                                      {note.addenda.map((addendum) => (
+                                        <div
+                                          key={addendum.id}
+                                          className="rounded-md bg-muted/40 p-3"
+                                        >
+                                          <p className="text-xs font-medium">
+                                            {addendum.authorName} -{" "}
+                                            {formatClinicalDateTime(
+                                              addendum.createdAt,
+                                              recordsTimeZone,
+                                            )}
+                                          </p>
+                                          <p className="mt-1 whitespace-pre-wrap text-sm">
+                                            {soapSectionText(addendum.content)}
+                                          </p>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  ) : null}
+                                  {note.status === "finalized" &&
+                                  !note.correctionId &&
+                                  canCorrectClinicalRecords ? (
+                                    addendumNoteId === note.id ? (
+                                      <div className="rounded-md border border-border p-3">
+                                        <label
+                                          className="text-sm font-medium"
+                                          htmlFor={`records-addendum-${note.id}`}
+                                        >
+                                          Add attributed addendum
+                                        </label>
+                                        <p className="mt-1 text-xs text-muted-foreground">
+                                          Addenda cannot be edited or deleted
+                                          after saving.
+                                        </p>
+                                        <textarea
+                                          id={`records-addendum-${note.id}`}
+                                          value={addendumContent}
+                                          onChange={(event) =>
+                                            setAddendumContent(
+                                              event.target.value,
+                                            )
+                                          }
+                                          maxLength={10_000}
+                                          rows={3}
+                                          className="mt-2 w-full rounded-md border border-border bg-background p-2 text-sm"
+                                        />
+                                        <div className="mt-2 flex gap-2">
+                                          <Button
+                                            size="sm"
+                                            disabled={
+                                              !addendumContent.trim() ||
+                                              addSoapAddendum.isPending
+                                            }
+                                            onClick={() =>
+                                              addSoapAddendum.mutate({
+                                                patientId,
+                                                noteId: note.id,
+                                                operationId:
+                                                  addendumOperationId!,
+                                                content: addendumContent,
+                                              })
+                                            }
+                                          >
+                                            {addSoapAddendum.isPending
+                                              ? "Saving..."
+                                              : "Save addendum"}
+                                          </Button>
+                                          <Button
+                                            size="sm"
+                                            variant="outline"
+                                            disabled={addSoapAddendum.isPending}
+                                            onClick={() => {
+                                              setAddendumNoteId(null);
+                                              setAddendumContent("");
+                                              setAddendumOperationId(null);
+                                            }}
+                                          >
+                                            Cancel
+                                          </Button>
+                                        </div>
+                                      </div>
+                                    ) : (
+                                      <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() => {
+                                          setAddendumNoteId(note.id);
+                                          setAddendumContent("");
+                                          setAddendumOperationId(
+                                            crypto.randomUUID(),
+                                          );
+                                        }}
+                                      >
+                                        <Plus className="mr-2 h-4 w-4" />
+                                        Add addendum
+                                      </Button>
+                                    )
+                                  ) : null}
+                                  {note.status === "finalized" ? (
+                                    <ClinicalCorrectionControl
+                                      timeZone={recordsTimeZone}
+                                      correction={
+                                        note.correctionId &&
+                                        note.correctionReason &&
+                                        note.correctedAt
+                                          ? {
+                                              id: note.correctionId,
+                                              reason: note.correctionReason,
+                                              correctedAt: note.correctedAt,
+                                              correctedByName:
+                                                note.correctedByName,
+                                            }
+                                          : null
+                                      }
+                                      canCorrect={canCorrectClinicalRecords}
+                                      isPending={
+                                        correctSoap.isPending &&
+                                        correctSoap.variables?.recordId ===
+                                          note.id
+                                      }
+                                      onCorrect={(reason) =>
+                                        correctSoap.mutateAsync({
+                                          patientId,
+                                          recordId: note.id,
+                                          reason,
+                                        })
+                                      }
+                                    />
                                   ) : null}
                                 </div>
-                                <p className="text-xs text-muted-foreground">
-                                  {note.imported
-                                    ? note.authorName
-                                      ? `Imported by ${note.authorName}`
-                                      : "Imported record"
-                                    : (note.authorName ?? "Unknown author")}
-                                </p>
-                              </div>
-                              <p className="text-sm text-muted-foreground line-clamp-1 max-w-md">
-                                {note.assessment ||
-                                  note.subjective ||
-                                  note.objective ||
-                                  note.plan ||
-                                  "No note recorded"}
-                              </p>
+                              )}
                             </div>
-                            {isExpanded ? (
-                              <ChevronUp className="h-4 w-4 text-muted-foreground" />
-                            ) : (
-                              <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                            )}
-                          </button>
-                          {isExpanded && (
-                            <div className="border-t border-border px-4 py-4 space-y-4">
-                              <div>
-                                <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
-                                  Subjective
-                                </h4>
-                                <p className="text-sm">
-                                  {note.subjective || "--"}
-                                </p>
-                              </div>
-                              <div>
-                                <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
-                                  Objective
-                                </h4>
-                                <p className="text-sm">
-                                  {note.objective || "--"}
-                                </p>
-                              </div>
-                              <div>
-                                <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
-                                  Assessment
-                                </h4>
-                                <p className="text-sm">
-                                  {note.assessment || "--"}
-                                </p>
-                              </div>
-                              <div>
-                                <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
-                                  Plan
-                                </h4>
-                                <p className="text-sm">{note.plan || "--"}</p>
-                              </div>
-                              <ClinicalCorrectionControl
-                                timeZone={recordsTimeZone}
-                                correction={
-                                  note.correctionId &&
-                                  note.correctionReason &&
-                                  note.correctedAt
-                                    ? {
-                                        id: note.correctionId,
-                                        reason: note.correctionReason,
-                                        correctedAt: note.correctedAt,
-                                        correctedByName: note.correctedByName,
-                                      }
-                                    : null
-                                }
-                                canCorrect={canCorrectClinicalRecords}
-                                isPending={
-                                  correctSoap.isPending &&
-                                  correctSoap.variables?.recordId === note.id
-                                }
-                                onCorrect={(reason) =>
-                                  correctSoap.mutateAsync({
-                                    patientId,
-                                    recordId: note.id,
-                                    reason,
-                                  })
-                                }
-                              />
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
+                          );
+                        })}
                   </div>
                 ) : (
                   <EmptyState
@@ -1656,90 +1812,90 @@ function RecordsPageContent() {
                         </tr>
                       </thead>
                       <tbody>
-                        {vaccinations.map((vax) => {
-                          const dueStatus = getVaccineDueStatus(
-                            vax.nextDueDate,
-                            recordsTimeZone
-                          );
-                          return (
-                            <tr
-                              key={vax.id}
-                              className={cn(
-                                "border-b border-border last:border-0",
-                                vax.correctionId &&
-                                  "bg-destructive/5 text-muted-foreground"
-                              )}
-                            >
-                              <td className="px-4 py-3 font-medium">
-                                {vax.vaccineName}
-                              </td>
-                              <td className="px-4 py-3">
-                                {vax.administeredAt
-                                  ? formatClinicalDate(
-                                      vax.administeredAt,
-                                      recordsTimeZone
-                                    )
-                                  : "--"}
-                              </td>
-                              <td className="px-4 py-3">
-                                {vax.nextDueDate
-                                  ? formatClinicalDate(
-                                      vax.nextDueDate,
-                                      recordsTimeZone
-                                    )
-                                  : "--"}
-                              </td>
-                              <td className="px-4 py-3 text-muted-foreground">
-                                {vax.administeredByName ?? "--"}
-                              </td>
-                              <td className="px-4 py-3">
-                                {vax.correctionId ? (
-                                  <span className="inline-flex items-center rounded-full bg-destructive/10 px-2.5 py-0.5 text-xs font-medium text-destructive">
-                                    Entered in error
-                                  </span>
-                                ) : (
-                                  <span
-                                    className={cn(
-                                      "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
-                                      dueStatus.className
-                                    )}
-                                  >
-                                    {dueStatus.label}
-                                  </span>
-                                )}
-                                <ClinicalCorrectionControl
-                                  timeZone={recordsTimeZone}
-                                  correction={
+                            {vaccinations.map((vax) => {
+                              const dueStatus = getVaccineDueStatus(
+                                vax.nextDueDate,
+                                recordsTimeZone,
+                              );
+                              return (
+                                <tr
+                                  key={vax.id}
+                                  className={cn(
+                                    "border-b border-border last:border-0",
                                     vax.correctionId &&
-                                    vax.correctionReason &&
-                                    vax.correctedAt
-                                      ? {
-                                          id: vax.correctionId,
-                                          reason: vax.correctionReason,
-                                          correctedAt: vax.correctedAt,
-                                          correctedByName:
-                                            vax.correctedByName,
-                                        }
-                                      : null
-                                  }
-                                  canCorrect={canCorrectClinicalRecords}
-                                  isPending={
-                                    correctVaccination.isPending &&
-                                    correctVaccination.variables?.recordId ===
-                                      vax.id
-                                  }
-                                  onCorrect={(reason) =>
-                                    correctVaccination.mutateAsync({
-                                      patientId,
-                                      recordId: vax.id,
-                                      reason,
-                                    })
-                                  }
-                                />
-                              </td>
-                            </tr>
-                          );
-                        })}
+                                      "bg-destructive/5 text-muted-foreground",
+                                  )}
+                                >
+                                  <td className="px-4 py-3 font-medium">
+                                    {vax.vaccineName}
+                                  </td>
+                                  <td className="px-4 py-3">
+                                    {vax.administeredAt
+                                      ? formatClinicalDate(
+                                          vax.administeredAt,
+                                          recordsTimeZone,
+                                        )
+                                      : "--"}
+                                  </td>
+                                  <td className="px-4 py-3">
+                                    {vax.nextDueDate
+                                      ? formatClinicalDate(
+                                          vax.nextDueDate,
+                                          recordsTimeZone,
+                                        )
+                                      : "--"}
+                                  </td>
+                                  <td className="px-4 py-3 text-muted-foreground">
+                                    {vax.administeredByName ?? "--"}
+                                  </td>
+                                  <td className="px-4 py-3">
+                                    {vax.correctionId ? (
+                                      <span className="inline-flex items-center rounded-full bg-destructive/10 px-2.5 py-0.5 text-xs font-medium text-destructive">
+                                        Entered in error
+                                      </span>
+                                    ) : (
+                                      <span
+                                        className={cn(
+                                          "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+                                          dueStatus.className,
+                                        )}
+                                      >
+                                        {dueStatus.label}
+                                      </span>
+                                    )}
+                                    <ClinicalCorrectionControl
+                                      timeZone={recordsTimeZone}
+                                      correction={
+                                        vax.correctionId &&
+                                        vax.correctionReason &&
+                                        vax.correctedAt
+                                          ? {
+                                              id: vax.correctionId,
+                                              reason: vax.correctionReason,
+                                              correctedAt: vax.correctedAt,
+                                              correctedByName:
+                                                vax.correctedByName,
+                                            }
+                                          : null
+                                      }
+                                      canCorrect={canCorrectClinicalRecords}
+                                      isPending={
+                                        correctVaccination.isPending &&
+                                        correctVaccination.variables
+                                          ?.recordId === vax.id
+                                      }
+                                      onCorrect={(reason) =>
+                                        correctVaccination.mutateAsync({
+                                          patientId,
+                                          recordId: vax.id,
+                                          reason,
+                                        })
+                                      }
+                                    />
+                                  </td>
+                                </tr>
+                              );
+                            })}
                       </tbody>
                     </table>
                   </div>

--- a/apps/web/app/api-docs/ai/page.tsx
+++ b/apps/web/app/api-docs/ai/page.tsx
@@ -66,12 +66,12 @@ export default function AIIntegrationDocs() {
         {/* SOAP Note Integration */}
         <Section id="soap-notes" title="SOAP Note Integration">
           <p className="mb-4 text-gray-700">
-            Connect an AI scribe &mdash; such as{" "}
-            <strong>Scribenote</strong>, <strong>VetRec</strong>, or{" "}
-            <strong>HappyDoc</strong> &mdash; to automatically populate SOAP
-            notes after each appointment. The AI listens to the consultation,
-            generates structured clinical notes, and posts them directly to
-            OpenVPM.
+            Connect an AI scribe &mdash; such as <strong>Scribenote</strong>,{" "}
+            <strong>VetRec</strong>, or <strong>HappyDoc</strong> &mdash; to
+            automatically populate SOAP notes during an active visit. This
+            endpoint creates an immediately finalized, immutable clinical
+            record; use it only after the clinician has reviewed the generated
+            content.
           </p>
 
           <h3 className="mb-2 mt-6 text-sm font-semibold uppercase tracking-wider text-gray-500">
@@ -101,8 +101,10 @@ Content-Type: application/json`}
           </CodeBlock>
           <p className="mt-3 text-sm text-gray-500">
             Create the key with the <strong>records:write</strong> scope.
-            OpenVPM validates the patient, optional appointment, and author
-            against the authenticated practice before inserting the note.
+            OpenVPM validates the patient, active in-exam appointment, and
+            author against the authenticated practice. A saved draft or
+            effective finalized SOAP note for the encounter returns a conflict
+            so an integration cannot silently replace clinical documentation.
           </p>
 
           <h3 className="mb-2 mt-6 text-sm font-semibold uppercase tracking-wider text-gray-500">

--- a/apps/web/app/api-docs/page.tsx
+++ b/apps/web/app/api-docs/page.tsx
@@ -344,7 +344,8 @@ const sections: Section[] = [
       {
         name: "records.createSoapNote",
         method: "POST",
-        description: "Create a SOAP note for an active in-exam appointment.",
+        description:
+          "Create an immediately finalized, immutable SOAP note for an active in-exam appointment. Conflicts with an existing draft or effective finalized note.",
         input: `{
   patientId: string,
   appointmentId: string,
@@ -898,7 +899,7 @@ const sections: Section[] = [
         name: "POST /api/v1/soap-notes",
         method: "POST",
         description:
-          "Create a SOAP note for an external AI scribe during an active in-exam appointment and emit the soap_note.created webhook.",
+          "Create an immediately finalized, immutable SOAP note for an external AI scribe during an active in-exam appointment and emit the soap_note.created webhook. Returns a conflict when the encounter already has a draft or effective finalized note.",
         input: `{
   patient_id: string,
   appointment_id: string,

--- a/apps/web/app/api/v1/soap-notes/route.test.ts
+++ b/apps/web/app/api/v1/soap-notes/route.test.ts
@@ -24,14 +24,20 @@ const mocks = vi.hoisted(() => {
   };
   const insertReturning = vi.fn(async () => [insertRow]);
   const insertValues = vi.fn(() => ({ returning: insertReturning }));
+  const tenantRollback = vi.fn();
   const db = {
+    execute: vi.fn(async () => []),
     select: vi.fn(() => {
       const result = selectResults.shift() ?? [];
       const builder = {
         from: vi.fn(() => builder),
         where: vi.fn(() => builder),
         for: vi.fn(async () => result),
-        limit: vi.fn(async () => result),
+        limit: vi.fn(() => builder),
+        then: (
+          resolve: (rows: unknown[]) => unknown,
+          reject?: (error: unknown) => unknown,
+        ) => Promise.resolve(result).then(resolve, reject),
       };
       selectBuilders.push(builder);
       return builder;
@@ -52,8 +58,15 @@ const mocks = vi.hoisted(() => {
       async (
         _db: unknown,
         _practiceId: string,
-        fn: (tx: unknown) => Promise<unknown>
-      ) => fn(db)
+        fn: (tx: unknown) => Promise<unknown>,
+      ) => {
+        try {
+          return await fn(db);
+        } catch (error) {
+          tenantRollback(error);
+          throw error;
+        }
+      },
     ),
     dispatchWebhookEvent: vi.fn(async () => undefined),
     db,
@@ -61,6 +74,7 @@ const mocks = vi.hoisted(() => {
     insertValues,
     selectBuilders,
     selectResults,
+    tenantRollback,
   };
 });
 
@@ -347,7 +361,11 @@ describe("POST /api/v1/soap-notes", () => {
       [{ id: PATIENT_ID }],
       [{ id: APPOINTMENT_ID, doctorId: AUTHOR_ID, status: "in_exam" }],
       [],
-      [{ id: AUTHOR_ID }]
+      [{ id: AUTHOR_ID, name: "Dr. Rivera" }],
+      [{ id: APPOINTMENT_ID, doctorId: AUTHOR_ID, status: "in_exam" }],
+      [],
+      [],
+      [],
     );
 
     const response = await POST(request(soapBody()));
@@ -382,5 +400,41 @@ describe("POST /api/v1/soap-notes", () => {
         source: "scribenote",
       })
     );
+  });
+
+  it("rolls back a deferred SOAP invariant failure before returning 409", async () => {
+    mocks.selectResults.push(
+      ACTIVE_PRACTICE,
+      [{ id: PATIENT_ID }],
+      [{ id: APPOINTMENT_ID, doctorId: AUTHOR_ID, status: "in_exam" }],
+      [],
+      [{ id: AUTHOR_ID, name: "Dr. Rivera" }],
+      [{ id: APPOINTMENT_ID, doctorId: AUTHOR_ID, status: "in_exam" }],
+      [],
+      [],
+      [],
+    );
+    mocks.db.execute.mockRejectedValueOnce({
+      code: "23514",
+      constraint_name: "soap_notes_appointment_invariant",
+    });
+
+    const response = await POST(request(soapBody()));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        message:
+          "Clinical documentation changed in another session. Refresh and retry.",
+      },
+    });
+    expect(mocks.tenantRollback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "23514",
+        constraint_name: "soap_notes_appointment_invariant",
+      }),
+    );
+    expect(mocks.db.insert).toHaveBeenCalledTimes(1);
+    expect(mocks.dispatchWebhookEvent).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/v1/soap-notes/route.ts
+++ b/apps/web/app/api/v1/soap-notes/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import { db } from "@openpims/db/client";
 import type { Database } from "@openpims/db/client";
-import { patients, soapNotes, users } from "@openpims/db";
+import { patients, users } from "@openpims/db";
 import { authenticateApiKey } from "@/lib/api-auth";
 import { withTenant } from "@/lib/tenant-db";
 import { dispatchWebhookEvent } from "@/lib/webhook-dispatcher";
@@ -24,6 +24,10 @@ import {
 import { assertActivePractice } from "@/lib/compat/shared/active-practice";
 import { lockOpenVisitForClinicalAppend } from "@/lib/records/visit-integrity";
 import { hasUnresolvedSoapTemplatePrompts } from "@/lib/records/soap-templates";
+import {
+  createFinalizedAppointmentSoapNote,
+  SoapLifecycleError,
+} from "@/lib/records/soap-lifecycle";
 
 export const dynamic = "force-dynamic";
 
@@ -31,7 +35,7 @@ const AUTHOR_REQUIRED_MESSAGE =
   "author_id is required when the appointment has no assigned doctor.";
 
 type TargetValidationResult =
-  | { ok: true; authorId: string }
+  | { ok: true; author: { id: string; name: string } }
   | { ok: false; response: NextResponse };
 
 async function validateSoapTargets(
@@ -79,7 +83,7 @@ async function validateSoapTargets(
   }
 
   const [author] = await tx
-    .select({ id: users.id })
+    .select({ id: users.id, name: users.name })
     .from(users)
     .where(
       and(
@@ -95,7 +99,7 @@ async function validateSoapTargets(
     return { ok: false, response: apiError("Author not found", 404) };
   }
 
-  return { ok: true, authorId };
+  return { ok: true, author };
 }
 
 // POST /api/v1/soap-notes - create a SOAP note for an external AI scribe.
@@ -130,34 +134,70 @@ export async function POST(req: Request) {
         400
       );
     }
-    const result = await withTenant(db, auth.ctx.practiceId, async (tx) => {
-      const activePractice = await assertActivePractice(tx, auth.ctx.practiceId);
-      if (!activePractice.ok) {
-        return { ok: false as const, response: activePractice.response };
+    let result;
+    try {
+      result = await withTenant(db, auth.ctx.practiceId, async (tx) => {
+        const activePractice = await assertActivePractice(
+          tx,
+          auth.ctx.practiceId,
+        );
+        if (!activePractice.ok) {
+          return { ok: false as const, response: activePractice.response };
+        }
+
+        const targets = await validateSoapTargets(
+          tx,
+          auth.ctx.practiceId,
+          parsed.data,
+        );
+        if (!targets.ok) {
+          return { ok: false as const, response: targets.response };
+        }
+
+        try {
+          const row = await createFinalizedAppointmentSoapNote(tx, {
+            patientId: parsed.data.patient_id,
+            appointmentId: parsed.data.appointment_id,
+            actor: targets.author,
+            sections: normalizedNote,
+            practiceId: auth.ctx.practiceId,
+          });
+          await tx.execute(sql`set constraints all immediate`);
+          return { ok: true as const, row };
+        } catch (error) {
+          if (error instanceof SoapLifecycleError) {
+            const status =
+              error.code === "NOT_FOUND"
+                ? 404
+                : error.code === "BAD_REQUEST"
+                  ? 400
+                  : 409;
+            return {
+              ok: false as const,
+              response: apiError(error.message, status),
+            };
+          }
+          // Database errors must leave the tenant callback so withTenant can
+          // roll the transaction back before this route translates them.
+          throw error;
+        }
+      });
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "23514" &&
+        "constraint_name" in error &&
+        error.constraint_name === "soap_notes_appointment_invariant"
+      ) {
+        return apiError(
+          "Clinical documentation changed in another session. Refresh and retry.",
+          409,
+        );
       }
-
-      const targets = await validateSoapTargets(
-        tx,
-        auth.ctx.practiceId,
-        parsed.data
-      );
-      if (!targets.ok) {
-        return { ok: false as const, response: targets.response };
-      }
-
-      const [row] = await tx
-        .insert(soapNotes)
-        .values({
-          patientId: parsed.data.patient_id,
-          appointmentId: parsed.data.appointment_id,
-          authorId: targets.authorId,
-          ...normalizedNote,
-          practiceId: auth.ctx.practiceId,
-        })
-        .returning();
-
-      return { ok: true as const, row: row! };
-    });
+      throw error;
+    }
     if (!result.ok) return result.response;
 
     const apiSoapNote = toApiSoapNote(result.row, parsed.data.source);

--- a/apps/web/lib/__tests__/api-docs.test.ts
+++ b/apps/web/lib/__tests__/api-docs.test.ts
@@ -81,8 +81,8 @@ describe("API reference docs", () => {
   it("keeps the standalone REST API README aligned with current v1 writes", () => {
     const source = readFileSync("../../docs/api/README.md", "utf8");
 
-    expect(source).toContain(
-      "| `appointments:read` | List/read appointments |",
+    expect(source).toMatch(
+      /\| `appointments:read`\s+\| List\/read appointments\s+\|/,
     );
     expect(source).toContain("### `GET /api/v1/appointments`");
     expect(source).toContain("Scope `appointments:read`");

--- a/apps/web/lib/__tests__/clinical-corrections-safety.test.ts
+++ b/apps/web/lib/__tests__/clinical-corrections-safety.test.ts
@@ -340,7 +340,9 @@ describe("clinical correction consumers", () => {
     expect(ai).toContain(
       "and ${clinicalRecordCorrections.soapNoteId} = ${soapNotes.id}",
     );
-    expect(patient).toContain(".filter((note) => !note.correctionId)");
+    expect(patient).toContain(
+      '(note) => note.status === "finalized" && !note.correctionId',
+    );
     expect(recordsPage).toContain("<ClinicalCorrectionControl");
     expect(recordsPage).toContain("Entered in error");
   });
@@ -409,8 +411,8 @@ describe("clinical correction consumers", () => {
     expect(records).toContain("isNull(visitWorkItems.invoiceId)");
     expect(records).toContain("isNull(visitWorkItems.invoiceItemId)");
     expect(recordsPage).toContain("correctVaccination.mutateAsync");
-    expect(patient).toContain(
-      "vaccinations.filter((v) => !v.correctionId).map",
+    expect(patient).toMatch(
+      /vaccinations\s*\.filter\(\(v\) => !v\.correctionId\)\s*\.map/,
     );
     for (const source of [portal, recalls, notifications, ai, agent]) {
       expect(source).toContain("vaccination_record_id");

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -1082,4 +1082,95 @@ describe("committed Drizzle migrations", () => {
       "REVOKE ALL ON auth_email_attempts, auth_email_delivery_events, auth_email_webhook_conflicts, auth_email_provider_identity_conflicts FROM openpims_app",
     );
   });
+
+  it("creates an immutable, tenant-safe SOAP draft/final/addendum ledger", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries?: Array<{ tag?: string }> };
+    expect(journal.entries?.map((entry) => entry.tag)).toContain(
+      "0063_modern_starbolt",
+    );
+
+    const sql = readRepoFile("packages/db/drizzle/0063_modern_starbolt.sql");
+    expect(sql).toContain('CREATE TYPE "public"."soap_note_status"');
+    expect(sql).toContain('CREATE TABLE "soap_note_addenda"');
+    expect(sql).toContain("soap_notes_active_appointment_draft_uq");
+    expect(sql).toContain("guard_soap_note_lifecycle");
+    expect(sql).toContain(
+      "Only a draft from an open, unsigned encounter may be discarded.",
+    );
+    expect(sql).toContain(
+      "CREATE CONSTRAINT TRIGGER soap_notes_appointment_invariant",
+    );
+    expect(sql).toContain("DEFERRABLE INITIALLY DEFERRED");
+    expect(sql).toContain("CONSTRAINT = 'soap_notes_appointment_invariant'");
+    expect(sql).toContain("source.status = 'finalized'");
+    expect(sql).toContain("SOAP addenda are immutable");
+    expect(sql).toContain("restore_soap_note_addendum");
+    const addendumGuard = sql.slice(
+      sql.indexOf("CREATE OR REPLACE FUNCTION guard_soap_note_addendum"),
+      sql.indexOf("CREATE TRIGGER soap_note_addenda_guard"),
+    );
+    expect(addendumGuard).toContain("NEW.created_at < source_finalized_at");
+    expect(addendumGuard).toContain("NEW.created_at > pg_catalog.now()");
+    expect(addendumGuard).toContain("pg_catalog.sha256");
+    expect(addendumGuard.indexOf("SOAP addendum payload hash is invalid.")).toBeLessThan(
+      addendumGuard.indexOf("app.ledger_maintenance"),
+    );
+    const restoreFunction = sql.slice(
+      sql.indexOf("CREATE OR REPLACE FUNCTION restore_soap_note_addendum"),
+      sql.indexOf("REVOKE ALL ON FUNCTION restore_soap_note_addendum"),
+    );
+    expect(restoreFunction).toContain(
+      "p_practice_id IS DISTINCT FROM nullif(current_setting('app.current_practice_id', true), '')::uuid",
+    );
+    expect(restoreFunction).not.toContain("app.rls_bypass");
+    expect(restoreFunction).toContain("p_created_at < source_finalized_at");
+    expect(restoreFunction).toContain("p_created_at > pg_catalog.now()");
+    expect(restoreFunction).toContain(
+      "p_created_at > correction_created_at",
+    );
+    expect(restoreFunction).toContain("pg_catalog.sha256");
+    expect(restoreFunction).toContain(
+      "SOAP addendum restore payload hash is invalid.",
+    );
+    expect(restoreFunction).toContain(
+      "RETURNS TABLE(result_id uuid, was_inserted boolean)",
+    );
+    expect(restoreFunction).toContain(
+      "existing_addendum.created_at IS DISTINCT FROM p_created_at",
+    );
+    expect(restoreFunction).toContain(
+      "existing_addendum.author_name IS DISTINCT FROM p_author_name",
+    );
+    expect(restoreFunction).toContain(
+      "existing_addendum.content IS DISTINCT FROM p_content",
+    );
+    expect(sql).toContain(
+      "GRANT SELECT, INSERT ON soap_note_addenda TO openpims_app",
+    );
+    expect(sql).toContain(
+      "Cannot enforce encounter SOAP lifecycle: historical appointments contain conflicting active documentation.",
+    );
+    expect(
+      sql.match(
+        /MESSAGE = 'Cannot enforce encounter SOAP lifecycle: historical appointments contain conflicting active documentation\.'/g,
+      ),
+    ).toHaveLength(1);
+    expect(sql).toContain("'{demoData,soapNoteIds}'");
+    expect(sql).toContain("'{demoData,appointmentIds}'");
+    expect(sql).toContain("'{demoData,patientIds}'");
+    expect(sql).toContain("note.patient_id::text IN");
+    expect(sql).toContain(
+      "WHEN pg_catalog.jsonb_typeof(practice.settings #> '{demoData,soapNoteIds}') = 'array'",
+    );
+    expect(
+      sql.match(
+        /CROSS JOIN LATERAL pg_catalog\.jsonb_array_elements_text\(/g,
+      ),
+    ).toHaveLength(1);
+    expect(sql).not.toContain(
+      "jsonb_array_elements_text(\n\t\tCROSS JOIN LATERAL",
+    );
+  });
 });

--- a/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
+++ b/apps/web/lib/__tests__/encounter-workspace-ui.test.ts
@@ -21,6 +21,10 @@ const patientChartSource = readFileSync(
   "app/(dashboard)/patients/[id]/page.tsx",
   "utf8",
 );
+const recordsSource = readFileSync(
+  "app/(dashboard)/records/page.tsx",
+  "utf8",
+);
 
 describe("clinic encounter workspace", () => {
   it("opens from an appointment and keeps visit and patient context together", () => {
@@ -45,8 +49,28 @@ describe("clinic encounter workspace", () => {
     expect(soapSource).toContain(
       "`/encounters/${encodeURIComponent(appointmentId)}`",
     );
-    expect(soapSource).toContain(
-      "This note will be linked to the current appointment.",
+    expect(soapSource).toContain("Draft will save after you begin typing");
+    expect(soapSource).toContain("Finalize SOAP note");
+  });
+
+  it("opens every SOAP editor entry as a separate document history entry", () => {
+    expect(workspaceSource).toMatch(
+      /<a\s+href=\{`\/records\/new-soap\/\$\{appointment\.patientId\}/,
+    );
+    expect(workspaceSource).toContain("<a href={props.soapDraftHref}>");
+    expect(recordsSource).toMatch(
+      /<a\s+href=\{`\/records\/new-soap\/\$\{encodeURIComponent\(patientId\)\}/,
+    );
+    expect(patientChartSource).toMatch(
+      /<a\s+href=\{`\/records\/new-soap\/\$\{encodeURIComponent\(patientId\)\}/,
+    );
+    for (const source of [workspaceSource, recordsSource, patientChartSource]) {
+      expect(source).not.toMatch(
+        /<Link\s+href=\{`\/records\/new-soap\//,
+      );
+    }
+    expect(workspaceSource).not.toContain(
+      "<Link href={props.soapDraftHref}>",
     );
   });
 

--- a/apps/web/lib/__tests__/patient-detail-ui.test.ts
+++ b/apps/web/lib/__tests__/patient-detail-ui.test.ts
@@ -42,7 +42,9 @@ describe("patient detail UI states", () => {
     expect(source).toContain("patient.mergeMetadata.performedByName");
     expect(source).toContain("patient.mergeMetadata.reason");
     expect(source).toContain("{ patientId: canonicalPatientId }");
-    expect(source).toContain("{ id: canonicalPatientId, photoUrl: data.url }");
+    expect(source).toMatch(
+      /\{\s*id: canonicalPatientId,\s*photoUrl: data\.url,?\s*\}/,
+    );
     expect(source).toContain(
       "Array.from(new Set([params.id, canonicalPatientId]))"
     );
@@ -144,7 +146,9 @@ describe("patient detail UI states", () => {
     expect(source).toContain("Unable to load clinical settings. Please retry.");
     expect(source).toContain('label: "Back to Patients"');
     expect(source).toContain("router.push(\"/patients\")");
-    expect(source).toContain("const { data: vitals, isLoading, error }");
+    expect(source).toMatch(
+      /const \{\s*data: vitals,\s*isLoading,\s*error,?\s*\}/,
+    );
     expect(source).toContain("const vitalsMissing =");
     expect(source).toContain("{error ? (");
     expect(source).toContain("Unable to load vitals. ${error.message}");
@@ -174,7 +178,7 @@ describe("patient detail UI states", () => {
     expect(source).toContain(
       "Unable to load complete medical summary data. Please retry."
     );
-    expect(source).toContain("err instanceof Error ? err.message");
+    expect(source).toMatch(/err instanceof Error\s*\?\s*err\.message/);
     expect(source).toContain("const problems = problemsResult.data;");
     expect(source).toContain("const vaccinations = vaccinationsResult.data;");
     expect(source).toContain("const soapNotes = soapNotesResult.data;");

--- a/apps/web/lib/__tests__/pdf-generation.test.ts
+++ b/apps/web/lib/__tests__/pdf-generation.test.ts
@@ -39,6 +39,51 @@ describe("medical summary header", () => {
     expect(doc.getNumberOfPages()).toBeGreaterThanOrEqual(1);
     expect(doc.output("arraybuffer").byteLength).toBeGreaterThan(1000);
   });
+
+  it("paginates long SOAP sections and addenda while retaining correction evidence", () => {
+    const longClinicalText = Array.from(
+      { length: 900 },
+      (_, index) => `observation-${index}`,
+    ).join(" ");
+    const doc = generateMedicalSummaryPdf({
+      practiceName: "OpenVPM Test Clinic",
+      patientName: "Biscuit",
+      species: "Canine",
+      clientName: "Jordan Avery",
+      allergies: [],
+      problems: [],
+      vaccinations: [],
+      recentNotes: [
+        {
+          date: "August 9, 2026",
+          subjective: longClinicalText,
+          authorName: "Dr. Rivera",
+          finalizerName: "Dr. Rivera",
+          finalizedAt: "August 9, 2026 at 10:30 AM",
+          addenda: [
+            {
+              content: longClinicalText,
+              authorName: "Dr. Rivera",
+              createdAt: "August 9, 2026 at 11:00 AM",
+            },
+          ],
+        },
+      ],
+      recordCorrections: [
+        {
+          recordLabel: "SOAP note dated August 8, 2026",
+          reason: "Documented on the wrong visit.",
+          correctedByName: "Dr. Rivera",
+          correctedAt: "August 9, 2026 at 11:30 AM",
+        },
+      ],
+      prescriptions: [],
+      generatedDate: "8/9/2026",
+    });
+
+    expect(doc.getNumberOfPages()).toBeGreaterThan(2);
+    expect(doc.output("arraybuffer").byteLength).toBeGreaterThan(10_000);
+  });
 });
 
 describe("pdf generation date labels", () => {

--- a/apps/web/lib/__tests__/schema-indexes.test.ts
+++ b/apps/web/lib/__tests__/schema-indexes.test.ts
@@ -37,6 +37,7 @@ import {
   rateLimitBuckets,
   rooms,
   services,
+  soapNoteAddenda,
   soapNotes,
   staffSchedules,
   smsSuppressions,
@@ -159,7 +160,16 @@ describe("hot table indexes", () => {
     [
       "soap_notes",
       soapNotes,
-      ["soap_notes_patient_idx", "soap_notes_practice_idx"],
+      [
+        "soap_notes_patient_idx",
+        "soap_notes_practice_idx",
+        "soap_notes_active_appointment_draft_uq",
+      ],
+    ],
+    [
+      "soap_note_addenda",
+      soapNoteAddenda,
+      ["soap_note_addenda_history_idx", "soap_note_addenda_operation_uq"],
     ],
     [
       "clinical_notes",

--- a/apps/web/lib/__tests__/soap-editor-ui.test.ts
+++ b/apps/web/lib/__tests__/soap-editor-ui.test.ts
@@ -72,7 +72,7 @@ describe("SOAP note editor UX", () => {
     expect(source).not.toContain("`<p>${placeholder}</p>`");
   });
 
-  it("disables SOAP note save until content exists and template prompts are resolved", () => {
+  it("autosaves drafts and disables finalization until content is ready", () => {
     const source = readFileSync(
       "app/(dashboard)/records/new-soap/[patientId]/page.tsx",
       "utf8"
@@ -82,12 +82,20 @@ describe("SOAP note editor UX", () => {
     expect(source).toContain(
       "const hasTemplatePrompts = hasUnresolvedSoapTemplatePrompts"
     );
-    expect(source).toContain("const canSubmit = canSave && !hasTemplatePrompts");
-    expect(source).toContain("disabled={createNote.isPending || !canSubmit}");
     expect(source).toContain(
-      "Replace or delete every draft prompt before saving"
+      "const saveDraftMutation = trpc.records.saveSoapDraft.useMutation()",
     );
-    expect(source).toContain("normalizeSoapSection(subjective)");
+    expect(source).toContain(
+      "const finalizeMutation = trpc.records.finalizeSoapNote.useMutation()",
+    );
+    expect(source).toContain(
+      "const timer = window.setTimeout(() => void persistDraft(), 1_200)",
+    );
+    expect(source).toContain("!canSubmit");
+    expect(source).toContain(
+      "Replace or delete every draft prompt before finalizing",
+    );
+    expect(source).toContain("normalizeSoapSection(sections.subjective)");
   });
 
   it("offers structured SOAP templates without clobbering drafts by default", () => {
@@ -163,10 +171,65 @@ describe("SOAP note editor UX", () => {
     expect(source).toContain('title="Unable to load patient"');
     expect(source).toContain('label: "Back to Records"');
     expect(source).toContain("!params.patientId || !patient");
-    expect(source).toContain("Load the patient before saving a SOAP note");
+    expect(source).toContain("Load the patient before finalizing a SOAP note");
     expect(source.indexOf("if (patientError || !patient)")).toBeLessThan(
       source.indexOf("<SoapNoteEditor")
     );
+  });
+
+  it("serializes dirty in-app link navigation through save-before-leave", () => {
+    const source = readFileSync(
+      "app/(dashboard)/records/new-soap/[patientId]/page.tsx",
+      "utf8",
+    );
+
+    expect(source).toContain("const navigationAttemptRef = useRef");
+    expect(source).toContain("guardedSoapNavigationDestination({");
+    expect(source).toContain('event.target.closest<HTMLAnchorElement>("a[href]")');
+    expect(source).toContain("event.preventDefault()");
+    expect(source).toContain("event.stopPropagation()");
+    expect(source).toContain(
+      'document.addEventListener("click", handleDocumentClick, true)',
+    );
+    expect(source).toContain("void leaveEditorSafely(destination)");
+    expect(source).toContain("void leaveEditorSafely(returnPath)");
+    const safeLeave = source.slice(
+      source.indexOf("const leaveEditorSafely"),
+      source.indexOf("const copyLocalSoapText"),
+    );
+    expect(safeLeave).toContain("runSoapSafeLeave({");
+    expect(safeLeave).toContain("persistDraft,");
+    expect(safeLeave).toContain(
+      "navigate: () => router.push(destination)",
+    );
+  });
+
+  it("preserves and exposes unsaved local text when another session finalizes", () => {
+    const source = readFileSync(
+      "app/(dashboard)/records/new-soap/[patientId]/page.tsx",
+      "utf8",
+    );
+
+    expect(source).toContain("localSoapTextForClipboard");
+    expect(source).toContain("copyTextToClipboard");
+    expect(source).toContain("SOAP note finalized in another session");
+    expect(source).toContain("was NOT included in the");
+    expect(source).toContain("Preserved local SOAP text");
+    expect(source).toContain("Copy local SOAP text");
+    expect(source).toContain("View signed patient chart");
+    expect(source).toContain("if (finalizedElsewhereRef.current) return;");
+    expect(source).toContain(
+      "finalizedElsewhere ||\n      !draftInitialized",
+    );
+    const alreadyFinalized = source.slice(
+      source.indexOf('if (result.outcome === "already_finalized")'),
+      source.indexOf('if (result.outcome === "conflict")'),
+    );
+    expect(alreadyFinalized).toContain("setFinalizedElsewhere(true)");
+    expect(alreadyFinalized).not.toContain("setSubjective");
+    expect(alreadyFinalized).not.toContain("setObjective");
+    expect(alreadyFinalized).not.toContain("setAssessment");
+    expect(alreadyFinalized).not.toContain("setPlan");
   });
 });
 
@@ -190,8 +253,8 @@ describe("records prescription form UX", () => {
     expect(isPrescriptionOptionalPositiveIntegerInputValid("")).toBe(true);
     expect(isPrescriptionNonnegativeIntegerInputValid("0")).toBe(true);
     expect(isPrescriptionNonnegativeIntegerInputValid("-1")).toBe(false);
-    expect(source).toContain(
-      "maxLength={PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH}"
+    expect(source).toMatch(
+      /maxLength=\{\s*PRESCRIPTION_MEDICATION_NAME_MAX_LENGTH\s*\}/,
     );
     expect(source).toContain("maxLength={PRESCRIPTION_DOSAGE_MAX_LENGTH}");
     expect(source).toContain("maxLength={PRESCRIPTION_FREQUENCY_MAX_LENGTH}");
@@ -261,7 +324,7 @@ describe("records lab result form UX", () => {
     expect(source).toMatch(
       /canReviewLabResults\s*&&\s*lab\.status === "completed"/,
     );
-    expect(source).toContain('lab.followUpStatus !== "not_required"');
+    expect(source).toMatch(/lab\.followUpStatus\s*!==\s*"not_required"/);
     expect(source).toContain("isLabOptionalReferenceInputValid");
     expect(source).toContain("isLabReferenceRangeOrdered");
     expect(source).toContain("labForm.resultValue.trim() || undefined");
@@ -273,7 +336,9 @@ describe("records lab result form UX", () => {
     const source = readFileSync("app/(dashboard)/records/page.tsx", "utf8");
 
     expect(source).toContain("Manual lab entry only");
-    expect(source).toContain("Reference lab ordering is disabled until IDEXX, Antech,");
+    expect(source).toMatch(
+      /Reference lab ordering is disabled until IDEXX,\s+Antech,/,
+    );
     expect(source).toContain("Add Manual Lab Result");
     expect(source).not.toContain("Order Lab");
   });
@@ -417,21 +482,23 @@ describe("records page state handling", () => {
     expect(source).toMatch(
       /formatClinicalDate\(\s+note\.createdAt,\s+recordsTimeZone/
     );
-    expect(source).toContain(
-      "getVaccineDueStatus(\n                            vax.nextDueDate,\n                            recordsTimeZone"
+    expect(source).toMatch(
+      /getVaccineDueStatus\(\s*vax\.nextDueDate,\s*recordsTimeZone/,
     );
-    expect(source).toContain(
-      "formatClinicalDate(\n                                      vax.administeredAt,\n                                      recordsTimeZone"
+    expect(source).toMatch(
+      /formatClinicalDate\(\s*vax\.administeredAt,\s*recordsTimeZone/,
     );
-    expect(source).toContain(
-      "formatClinicalDate(\n                                      vax.nextDueDate,\n                                      recordsTimeZone"
+    expect(source).toMatch(
+      /formatClinicalDate\(\s*vax\.nextDueDate,\s*recordsTimeZone/,
     );
-    expect(source).toContain(
-      "formatClinicalDate(\n                                problem.onsetDate,\n                                recordsTimeZone"
+    expect(source).toMatch(
+      /formatClinicalDate\(\s*problem\.onsetDate,\s*recordsTimeZone/,
     );
-    expect(source).toMatch(/formatClinicalDate\(\s+lab\.createdAt,\s+recordsTimeZone/);
-    expect(source).toContain(
-      "formatClinicalDate(\n                                    proc.createdAt,\n                                    recordsTimeZone"
+    expect(source).toMatch(
+      /formatClinicalDate\(\s+lab\.createdAt,\s+recordsTimeZone/,
+    );
+    expect(source).toMatch(
+      /formatClinicalDate\(\s*proc\.createdAt,\s*recordsTimeZone/,
     );
     expect(source).toContain("practiceName: recordsPracticeName");
     expect(source).toContain("recordsPracticePhone ?? undefined");
@@ -508,7 +575,10 @@ describe("records page state handling", () => {
     const source = readFileSync("app/(dashboard)/records/page.tsx", "utf8");
 
     expect(source).not.toContain("const canCreateSoapNotes =");
-    expect(source).not.toContain("/records/new-soap/");
+    expect(source).toMatch(
+      /note\.appointmentId\s*&&\s*canCorrectClinicalRecords/,
+    );
+    expect(source).toContain("Resume draft");
     expect(source).toContain(
       "SOAP notes are created from an active visit so documentation stays attached to the correct encounter."
     );

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import {
   backupKey,
   coerceRowDates,
@@ -19,6 +20,19 @@ import {
   isPracticeBackupJsonSizeValid,
   practiceBackupJsonByteLength,
 } from "../policy";
+
+function soapAddendumHash(noteId: string, authorId: string, content: string) {
+  return createHash("sha256")
+    .update(JSON.stringify({ noteId, authorId, content }))
+    .digest("hex");
+}
+
+const SOAP_BACKUP_USER_ID = "00000000-0000-4000-8000-000000000041";
+const SOAP_SOURCE_ID = "00000000-0000-4000-8000-000000000042";
+const SOAP_REPLACEMENT_ID = "00000000-0000-4000-8000-000000000043";
+const SOAP_RETIRED_ID = "00000000-0000-4000-8000-000000000044";
+const SOAP_ADDENDUM_SOURCE_ID = "00000000-0000-4000-8000-000000000045";
+const SOAP_ADDENDUM_RETIRED_ID = "00000000-0000-4000-8000-000000000046";
 
 describe("backup restore policy", () => {
   it("bounds direct backup JSON restore payloads by UTF-8 bytes", () => {
@@ -50,21 +64,42 @@ function emptyBackup(): Record<string, unknown[]> {
   );
 }
 
-function restoreDb() {
+function restoreDb(executeResults: unknown[][] = []) {
   const inserted: { rows: Record<string, unknown>[] }[] = [];
+  const executed: unknown[] = [];
+  const timeline: string[] = [];
+  const pendingExecuteResults = [...executeResults];
   const db = {
+    execute: vi.fn(async (query: unknown) => {
+      executed.push(query);
+      timeline.push("execute");
+      return (
+        pendingExecuteResults.shift() ?? [
+          {
+            result_id:
+              executed.length === 1
+                ? SOAP_ADDENDUM_SOURCE_ID
+                : SOAP_ADDENDUM_RETIRED_ID,
+            was_inserted: true,
+          },
+        ]
+      );
+    }),
     insert: vi.fn(() => ({
       values: vi.fn((values: Record<string, unknown>[]) => ({
         onConflictDoNothing: vi.fn(() => ({
           returning: vi.fn(async () => {
             inserted.push({ rows: values });
+            timeline.push(
+              ...values.map((row) => `insert:${String(row.id)}`),
+            );
             return values.map((row) => ({ id: row.id }));
           }),
         })),
       })),
     })),
   };
-  return { db, inserted };
+  return { db, inserted, executed, timeline };
 }
 
 const MERGE_OPERATION_ID = "00000000-0000-4000-8000-000000000011";
@@ -245,7 +280,7 @@ describe("summarizePracticeExport", () => {
 
   it("requires replacement lineage in current backups but accepts its legacy absence", () => {
     const currentMissing: Record<string, unknown> = {
-      formatVersion: 2,
+      formatVersion: 3,
       ...emptyBackup(),
     };
     delete currentMissing["labResultReplacements"];
@@ -828,6 +863,276 @@ describe("restorePracticeData", () => {
       valid: true,
       errors: [],
     });
+  });
+
+  it("restores corrected same-encounter SOAP history and soft-deleted addendum evidence", async () => {
+    const finalizedAt = "2026-08-09T15:00:00.000Z";
+    const sourceAddendumContent =
+      "Clarification recorded before the correction.";
+    const retiredAddendumContent =
+      "Evidence retained before the record was retired.";
+    const backup = {
+      formatVersion: 3,
+      practiceId: "source-practice",
+      ...emptyBackup(),
+      users: [
+        {
+          id: SOAP_BACKUP_USER_ID,
+          practiceId: "source-practice",
+          name: "Dr. Rivera",
+        },
+      ],
+      clients: [{ id: "client-1", practiceId: "source-practice" }],
+      patients: [
+        {
+          id: "patient-1",
+          practiceId: "source-practice",
+          clientId: "client-1",
+        },
+      ],
+      appointments: [
+        {
+          id: "appointment-1",
+          practiceId: "source-practice",
+          clientId: "client-1",
+          patientId: "patient-1",
+        },
+      ],
+      soapNotes: [
+        {
+          id: SOAP_SOURCE_ID,
+          practiceId: "source-practice",
+          patientId: "patient-1",
+          appointmentId: "appointment-1",
+          authorId: SOAP_BACKUP_USER_ID,
+          authorName: "Dr. Rivera",
+          status: "finalized",
+          revision: 1,
+          finalizedAt,
+          finalizedBy: SOAP_BACKUP_USER_ID,
+          finalizerName: "Dr. Rivera",
+          imported: false,
+          deletedAt: null,
+        },
+        {
+          id: SOAP_REPLACEMENT_ID,
+          practiceId: "source-practice",
+          patientId: "patient-1",
+          appointmentId: "appointment-1",
+          authorId: SOAP_BACKUP_USER_ID,
+          authorName: "Dr. Rivera",
+          status: "finalized",
+          revision: 1,
+          finalizedAt,
+          finalizedBy: SOAP_BACKUP_USER_ID,
+          finalizerName: "Dr. Rivera",
+          imported: false,
+          deletedAt: null,
+        },
+        {
+          id: SOAP_RETIRED_ID,
+          practiceId: "source-practice",
+          patientId: "patient-1",
+          appointmentId: null,
+          authorId: SOAP_BACKUP_USER_ID,
+          authorName: "Dr. Rivera",
+          status: "finalized",
+          revision: 1,
+          finalizedAt,
+          finalizedBy: SOAP_BACKUP_USER_ID,
+          finalizerName: "Dr. Rivera",
+          imported: false,
+          deletedAt: "2026-08-09T18:00:00.000Z",
+        },
+      ],
+      soapNoteAddenda: [
+        {
+          id: SOAP_ADDENDUM_SOURCE_ID,
+          createdAt: "2026-08-09T16:00:00.000Z",
+          practiceId: "source-practice",
+          soapNoteId: SOAP_SOURCE_ID,
+          authorId: SOAP_BACKUP_USER_ID,
+          authorName: "Dr. Rivera",
+          content: sourceAddendumContent,
+          operationId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1",
+          operationPayloadHash: soapAddendumHash(
+            SOAP_SOURCE_ID,
+            SOAP_BACKUP_USER_ID,
+            sourceAddendumContent,
+          ),
+        },
+        {
+          id: SOAP_ADDENDUM_RETIRED_ID,
+          createdAt: "2026-08-09T17:00:00.000Z",
+          practiceId: "source-practice",
+          soapNoteId: SOAP_RETIRED_ID,
+          authorId: SOAP_BACKUP_USER_ID,
+          authorName: "Dr. Rivera",
+          content: retiredAddendumContent,
+          operationId: "00000000-0000-4000-8000-000000000032",
+          operationPayloadHash: soapAddendumHash(
+            SOAP_RETIRED_ID,
+            SOAP_BACKUP_USER_ID,
+            retiredAddendumContent,
+          ),
+        },
+      ],
+      clinicalRecordCorrections: [
+        {
+          id: "correction-1",
+          practiceId: "source-practice",
+          recordType: "soap_note",
+          action: "entered_in_error",
+          soapNoteId: SOAP_SOURCE_ID,
+          vitalSignId: null,
+          vaccinationRecordId: null,
+          labResultId: null,
+          patientId: "patient-1",
+          appointmentId: "appointment-1",
+          correctedBy: SOAP_BACKUP_USER_ID,
+          correctedByName: "Dr. Rivera",
+          reason: "Documented on the wrong encounter.",
+          createdAt: "2026-08-09T16:30:00.000Z",
+          operationId: null,
+          operationPayloadHash: null,
+        },
+      ],
+    };
+    expect(validatePracticeExportRestore(backup)).toEqual({
+      valid: true,
+      errors: [],
+    });
+
+    const addendumError = (
+      replacement: Record<string, unknown>,
+      extra: Record<string, unknown>[] = [],
+    ) =>
+      validatePracticeExportRestore({
+        ...backup,
+        soapNoteAddenda: [
+          { ...backup.soapNoteAddenda[0], ...replacement },
+          backup.soapNoteAddenda[1],
+          ...extra,
+        ],
+      }).errors;
+    expect(
+      addendumError({ createdAt: "2026-08-09T14:59:59.000Z" }),
+    ).toContain(
+      `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].createdAt must be on or after finalization, not in the future, and no later than source deletion or correction.`,
+    );
+    expect(addendumError({ createdAt: "2099-08-09T16:00:00.000Z" })).toContain(
+      `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].createdAt must be on or after finalization, not in the future, and no later than source deletion or correction.`,
+    );
+    expect(
+      addendumError({ createdAt: "2026-08-09T16:31:00.000Z" }),
+    ).toContain(
+      `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].createdAt must be on or after finalization, not in the future, and no later than source deletion or correction.`,
+    );
+    expect(addendumError({ operationPayloadHash: "0".repeat(64) })).toContain(
+      `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].operationPayloadHash must match its exact note, author, and content payload.`,
+    );
+    expect(
+      addendumError({
+        soapNoteId: "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA",
+      }),
+    ).toContain(
+      `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].soapNoteId must be a canonical lowercase UUID.`,
+    );
+    expect(addendumError({ authorId: SOAP_BACKUP_USER_ID.replaceAll("-", "") })).toContain(
+      `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].authorId must be a canonical lowercase UUID.`,
+    );
+    expect(addendumError({ id: "not-a-uuid" })).toContain(
+      "soapNoteAddenda[not-a-uuid].id must be a canonical lowercase UUID.",
+    );
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        clinicalRecordCorrections: [
+          { ...backup.clinicalRecordCorrections[0], createdAt: undefined },
+        ],
+      }).errors,
+    ).toContain(
+      `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}] linked correction.createdAt must be a timestamp.`,
+    );
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        soapNotes: backup.soapNotes.map((note) =>
+          note.id === SOAP_RETIRED_ID
+            ? { ...note, deletedAt: "not-a-timestamp" }
+            : note,
+        ),
+      }).errors,
+    ).toContain(
+      `soapNoteAddenda[${SOAP_ADDENDUM_RETIRED_ID}] source deletedAt must be a valid timestamp.`,
+    );
+    const duplicateContent = "Second copy with a reused operation.";
+    const duplicateOperationErrors = addendumError({}, [
+        {
+          ...backup.soapNoteAddenda[0],
+          id: "00000000-0000-4000-8000-000000000047",
+          content: duplicateContent,
+          operationId: String(
+            backup.soapNoteAddenda[0].operationId,
+          ).toUpperCase(),
+          operationPayloadHash: soapAddendumHash(
+            SOAP_SOURCE_ID,
+            SOAP_BACKUP_USER_ID,
+            duplicateContent,
+          ),
+        },
+      ]);
+    expect(duplicateOperationErrors).toContain(
+      "soapNoteAddenda[00000000-0000-4000-8000-000000000047].operationId must be unique within its practice.",
+    );
+    expect(duplicateOperationErrors).toContain(
+      "soapNoteAddenda[00000000-0000-4000-8000-000000000047].operationId must be a canonical lowercase UUID.",
+    );
+
+    const { db, inserted, executed, timeline } = restoreDb();
+    await expect(
+      restorePracticeData(db as never, "target-practice", backup),
+    ).resolves.toMatchObject({
+      restored: {
+        soapNotes: 3,
+        soapNoteAddenda: 2,
+        clinicalRecordCorrections: 1,
+      },
+    });
+
+    const restoredRows = inserted.flatMap(({ rows }) => rows);
+    const correctionIndex = restoredRows.findIndex(
+      (row) => row.id === "correction-1",
+    );
+    expect(
+      restoredRows.findIndex((row) => row.id === SOAP_SOURCE_ID),
+    ).toBeLessThan(correctionIndex);
+    expect(
+      restoredRows.findIndex((row) => row.id === SOAP_REPLACEMENT_ID),
+    ).toBeLessThan(correctionIndex);
+    expect(timeline.indexOf("insert:correction-1")).toBeLessThan(
+      timeline.indexOf("execute"),
+    );
+    expect(executed).toHaveLength(2);
+
+    const retry = restoreDb([
+      [
+        {
+          result_id: SOAP_ADDENDUM_SOURCE_ID,
+          was_inserted: false,
+        },
+      ],
+      [
+        {
+          result_id: SOAP_ADDENDUM_RETIRED_ID,
+          was_inserted: false,
+        },
+      ],
+    ]);
+    await expect(
+      restorePracticeData(retry.db as never, "target-practice", backup),
+    ).resolves.toMatchObject({ restored: { soapNoteAddenda: 0 } });
+    expect(retry.executed).toHaveLength(2);
   });
 
   it("validates and restores immutable patient lineage after its parent rows", async () => {

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { Database } from "@openpims/db/client";
 import { redactSecrets } from "@/lib/audit";
 import { normalizeE164 } from "@/lib/messaging/phone";
+import { rowsFromExecute } from "@/lib/db/execute-rows";
 import {
   appointmentTypes,
   appointmentWaitlist,
@@ -49,6 +50,7 @@ import {
   smsSendAttemptEvents,
   smsSendAttempts,
   smsSuppressions,
+  soapNoteAddenda,
   soapNotes,
   staffSchedules,
   suppliers,
@@ -162,6 +164,7 @@ export const PRACTICE_EXPORT_SECTIONS = [
   "invoiceAdjustments",
   "insuranceClaims",
   "soapNotes",
+  "soapNoteAddenda",
   "vaccinationRecords",
   "labResults",
   "labResultEvents",
@@ -202,6 +205,8 @@ const PRACTICE_EXPORT_OPTIONAL_RESTORE_SECTIONS = [
   "smsSendAttemptEvents",
   "visitCloseouts",
   "clinicalRecordCorrections",
+  // Backward compatibility for pre-v3 backups.
+  "soapNoteAddenda",
   // Backward compatibility for backups created before the lab result safety
   // ledger and clinic-wide review inbox were introduced.
   "labResultEvents",
@@ -215,7 +220,7 @@ export type PracticeExport = {
   counts: Record<PracticeExportSection, number>;
 } & Record<PracticeExportSection, unknown[]>;
 
-export const PRACTICE_EXPORT_FORMAT_VERSION = 2;
+export const PRACTICE_EXPORT_FORMAT_VERSION = 3;
 
 type Row = Record<string, unknown>;
 
@@ -376,6 +381,9 @@ const RESTORE_REFERENCE_RULES: RestoreReferenceRule[] = [
   requiredRef("soapNotes", "patientId", "patients"),
   optionalRef("soapNotes", "appointmentId", "appointments"),
   requiredRef("soapNotes", "authorId", "users"),
+  optionalRef("soapNotes", "finalizedBy", "users"),
+  requiredRef("soapNoteAddenda", "soapNoteId", "soapNotes"),
+  requiredRef("soapNoteAddenda", "authorId", "users"),
   requiredRef("vaccinationRecords", "patientId", "patients"),
   optionalRef("vaccinationRecords", "appointmentId", "appointments"),
   optionalRef("vaccinationRecords", "administeredBy", "users"),
@@ -523,6 +531,8 @@ const PATIENT_IDENTITY_SEX = new Set([
   "male_neutered",
   "female_spayed",
 ]);
+const CANONICAL_LOWER_UUID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 function isNullableBoundedString(value: unknown, maxLength: number): boolean {
   return (
@@ -580,6 +590,12 @@ function isRestoredTimestamp(value: unknown): boolean {
     value instanceof Date ||
     (typeof value === "string" && !Number.isNaN(new Date(value).getTime()))
   );
+}
+
+function restoredTimestampMillis(value: unknown): number | null {
+  if (!(value instanceof Date) && typeof value !== "string") return null;
+  const milliseconds = new Date(value).getTime();
+  return Number.isNaN(milliseconds) ? null : milliseconds;
 }
 
 function validateRestoreRows(
@@ -1132,6 +1148,114 @@ export function validatePracticeExportRestore(data: unknown): {
     }
   });
 
+  const soapCorrectionByNoteId = new Map(
+    rowsFor(data, "clinicalRecordCorrections")
+      .filter(
+        (row) =>
+          row.recordType === "soap_note" && typeof row.soapNoteId === "string",
+      )
+      .map((row) => [row.soapNoteId as string, row]),
+  );
+  const addendumOperationIds = new Set<string>();
+  const restoreValidationNow = Date.now();
+  rowsFor(data, "soapNoteAddenda").forEach((row, index) => {
+    const label = `soapNoteAddenda[${rowLabel(row, index)}]`;
+    for (const field of [
+      "id",
+      "soapNoteId",
+      "authorId",
+      "operationId",
+    ] as const) {
+      if (
+        typeof row[field] !== "string" ||
+        !CANONICAL_LOWER_UUID.test(row[field])
+      ) {
+        pushError(`${label}.${field} must be a canonical lowercase UUID.`);
+      }
+    }
+    if (
+      typeof row.authorName !== "string" ||
+      row.authorName.trim() !== row.authorName ||
+      row.authorName.length < 1 ||
+      row.authorName.length > 255
+    ) {
+      pushError(`${label}.authorName must be trimmed and 1-255 characters.`);
+    }
+    if (
+      typeof row.content !== "string" ||
+      row.content.trim() !== row.content ||
+      row.content.length < 1 ||
+      row.content.length > 10_000
+    ) {
+      pushError(`${label}.content must be trimmed and 1-10000 characters.`);
+    }
+    if (
+      typeof row.operationPayloadHash !== "string" ||
+      !/^[0-9a-f]{64}$/.test(row.operationPayloadHash)
+    ) {
+      pushError(`${label}.operationPayloadHash must be a SHA-256 hex digest.`);
+    }
+    const source =
+      typeof row.soapNoteId === "string"
+        ? soapRows.get(row.soapNoteId)
+        : undefined;
+    if (!source) return;
+
+    const createdAt = restoredTimestampMillis(row.createdAt);
+    const finalizedAt = restoredTimestampMillis(source.finalizedAt);
+    const deletedAt = restoredTimestampMillis(source.deletedAt);
+    const correction = soapCorrectionByNoteId.get(String(row.soapNoteId));
+    const correctedAt = restoredTimestampMillis(correction?.createdAt);
+    if (source.deletedAt != null && deletedAt === null) {
+      pushError(`${label} source deletedAt must be a valid timestamp.`);
+    }
+    if (correction && correctedAt === null) {
+      pushError(`${label} linked correction.createdAt must be a timestamp.`);
+    }
+    if (source.status !== "finalized" || finalizedAt === null) {
+      pushError(`${label} must reference a finalized SOAP note.`);
+    } else if (
+      createdAt === null ||
+      createdAt < finalizedAt ||
+      createdAt > restoreValidationNow ||
+      (deletedAt !== null && createdAt > deletedAt) ||
+      (correctedAt !== null && createdAt > correctedAt)
+    ) {
+      pushError(
+        `${label}.createdAt must be on or after finalization, not in the future, and no later than source deletion or correction.`,
+      );
+    }
+
+    if (typeof row.operationId === "string") {
+      const normalizedOperationId = row.operationId.toLowerCase();
+      if (addendumOperationIds.has(normalizedOperationId)) {
+        pushError(`${label}.operationId must be unique within its practice.`);
+      }
+      addendumOperationIds.add(normalizedOperationId);
+    }
+
+    if (
+      typeof row.soapNoteId === "string" &&
+      typeof row.authorId === "string" &&
+      typeof row.content === "string"
+    ) {
+      const expectedHash = createHash("sha256")
+        .update(
+          JSON.stringify({
+            noteId: row.soapNoteId.toLowerCase(),
+            authorId: row.authorId.toLowerCase(),
+            content: row.content,
+          }),
+        )
+        .digest("hex");
+      if (row.operationPayloadHash !== expectedHash) {
+        pushError(
+          `${label}.operationPayloadHash must match its exact note, author, and content payload.`,
+        );
+      }
+    }
+  });
+
   const correctionRows = rowsById("clinicalRecordCorrections");
   const replacementSources = new Set<string>();
   const replacements = new Set<string>();
@@ -1530,6 +1654,7 @@ export async function exportPracticeData(
     wellnessPlanRows,
     wellnessEnrollmentRows,
     allSoapNoteRows,
+    soapNoteAddendumRows,
     allVaccinationRows,
     labRows,
     labResultEventRows,
@@ -1581,6 +1706,7 @@ export async function exportPracticeData(
     activeRows(db, wellnessPlans, practiceId),
     activeRows(db, wellnessEnrollments, practiceId),
     allPracticeRows(db, soapNotes, practiceId),
+    allPracticeRows(db, soapNoteAddenda, practiceId),
     allPracticeRows(db, vaccinationRecords, practiceId),
     allPracticeRows(db, labResults, practiceId),
     allPracticeRows(db, labResultEvents, practiceId),
@@ -1627,9 +1753,10 @@ export async function exportPracticeData(
       referencedPrescriptionIds.has(prescription.id),
   );
   const referencedSoapNoteIds = new Set(
-    clinicalCorrectionRows
-      .map((correction) => correction.soapNoteId)
-      .filter((id): id is string => typeof id === "string"),
+    [
+      ...clinicalCorrectionRows.map((correction) => correction.soapNoteId),
+      ...soapNoteAddendumRows.map((addendum) => addendum.soapNoteId),
+    ].filter((id): id is string => typeof id === "string"),
   );
   const soapNoteRows = allSoapNoteRows.filter(
     (note) => note.deletedAt == null || referencedSoapNoteIds.has(note.id),
@@ -1706,6 +1833,8 @@ export async function exportPracticeData(
       ...clinicalCorrectionRows.map((correction) => correction.correctedBy),
       ...labReplacementRows.map((replacement) => replacement.actorId),
       ...soapNoteRows.map((note) => note.authorId),
+      ...soapNoteRows.map((note) => note.finalizedBy),
+      ...soapNoteAddendumRows.map((addendum) => addendum.authorId),
       ...vitalRows.map((vital) => vital.recordedBy),
       ...vaccinationRows.map((vaccination) => vaccination.administeredBy),
       ...labRows.flatMap((result) => [
@@ -1933,6 +2062,7 @@ export async function exportPracticeData(
     invoiceAdjustments: adjustmentRows,
     insuranceClaims: insuranceClaimRows,
     soapNotes: soapNoteRows,
+    soapNoteAddenda: soapNoteAddendumRows,
     vaccinationRecords: vaccinationRows,
     labResults: labRows,
     labResultEvents: labResultEventRows,
@@ -1998,6 +2128,44 @@ async function restorePracticeDataRows(
   );
   const dispenseChargeRestoreRows = rowsFor(data, "dispenseChargeQueue");
   const smsConsentRestore = prepareLegacySmsConsentRestore(data);
+  const soapNoteRestoreRows = rowsFor(data, "soapNotes").map((row) => {
+    const authorName =
+      typeof row.authorName === "string" && row.authorName.trim()
+        ? row.authorName.trim()
+        : row.imported === true
+          ? "Imported record"
+          : "Restored legacy record";
+    const revision =
+      typeof row.revision === "number" &&
+      Number.isInteger(row.revision) &&
+      row.revision > 0
+        ? row.revision
+        : 1;
+    if (row.status === "draft") {
+      return {
+        ...row,
+        authorName,
+        status: "draft",
+        revision,
+        imported: false,
+        finalizedAt: null,
+        finalizedBy: null,
+        finalizerName: null,
+      };
+    }
+    return {
+      ...row,
+      authorName,
+      status: "finalized",
+      revision,
+      finalizedAt: row.finalizedAt ?? row.createdAt ?? row.updatedAt,
+      finalizedBy: row.finalizedBy ?? row.authorId,
+      finalizerName:
+        typeof row.finalizerName === "string" && row.finalizerName.trim()
+          ? row.finalizerName.trim()
+          : authorName,
+    };
+  });
   const labResultRestoreRows = rowsFor(data, "labResults").map((row) => {
     const fallbackTime = row.updatedAt ?? row.createdAt;
     const hasResult =
@@ -2164,7 +2332,13 @@ async function restorePracticeDataRows(
   await restoreChildRows("invoiceAdjustments", invoiceAdjustments);
   await restorePracticeRows("insuranceClaims", insuranceClaims);
   await restorePracticeRows("problemList", problemList);
-  await restorePracticeRows("soapNotes", soapNotes);
+  restored.soapNotes = await restoreRows(
+    db,
+    soapNotes,
+    "soapNotes",
+    soapNoteRestoreRows,
+    { practiceId },
+  );
   await restorePracticeRows("vaccinationRecords", vaccinationRecords);
   restored.labResults = await restoreRows(
     db,
@@ -2181,6 +2355,45 @@ async function restorePracticeDataRows(
     "clinicalRecordCorrections",
     clinicalRecordCorrections,
   );
+  restored.soapNoteAddenda = 0;
+  for (const row of coerceRowDates(
+    soapNoteAddenda,
+    rowsFor(data, "soapNoteAddenda"),
+  )) {
+    if (
+      typeof row.id !== "string" ||
+      !(row.createdAt instanceof Date) ||
+      typeof row.soapNoteId !== "string" ||
+      typeof row.authorId !== "string" ||
+      typeof row.authorName !== "string" ||
+      typeof row.content !== "string" ||
+      typeof row.operationId !== "string" ||
+      typeof row.operationPayloadHash !== "string"
+    ) {
+      throw new Error("Backup contains an invalid SOAP addendum row.");
+    }
+    const restoreResult = await db.execute(sql`
+      select result_id, was_inserted
+      from public.restore_soap_note_addendum(
+      ${row.id}::uuid,
+      ${row.createdAt},
+      ${practiceId}::uuid,
+      ${row.soapNoteId}::uuid,
+      ${row.authorId}::uuid,
+      ${row.authorName},
+      ${row.content},
+      ${row.operationId}::uuid,
+      ${row.operationPayloadHash}
+    )`);
+    const [outcome] = rowsFromExecute<{
+      result_id: string;
+      was_inserted: boolean;
+    }>(restoreResult);
+    if (!outcome || outcome.result_id !== row.id) {
+      throw new Error("SOAP addendum restore returned invalid evidence.");
+    }
+    if (outcome.was_inserted) restored.soapNoteAddenda += 1;
+  }
   await restorePracticeRows("labResultReplacements", labResultReplacements);
   await restorePracticeRows("cases", cases);
   await restoreChildRows("caseEntries", caseEntries);

--- a/apps/web/lib/onboarding/defaults.ts
+++ b/apps/web/lib/onboarding/defaults.ts
@@ -18,6 +18,7 @@ import {
 } from "@openpims/db";
 import { centsToMoney, moneyToCents } from "@/lib/billing/invoice-balance";
 import { calculateInvoiceTaxTotals } from "@/lib/billing/invoice-tax";
+import { finalizedSoapInsertValues } from "@/lib/records/soap-lifecycle";
 
 /**
  * Sensible defaults seeded for a brand-new practice so it's usable immediately
@@ -177,7 +178,7 @@ export async function seedDemoData(
     .where(eq(services.practiceId, opts.practiceId));
   // The owner is the admin user for this practice.
   const [owner] = await db
-    .select({ id: users.id })
+    .select({ id: users.id, name: users.name })
     .from(users)
     .where(
       and(
@@ -324,7 +325,7 @@ export async function seedDemoData(
   // Clinical records so the Records page tabs are not empty. authorId is required
   // on soap_notes, so only add them when we found the owner.
   let soapNoteIds: string[] = [];
-  if (doctorId) {
+  if (owner) {
     const insertedSoap = await db
       .insert(soapNotes)
       .values([
@@ -332,21 +333,32 @@ export async function seedDemoData(
           practiceId: opts.practiceId,
           patientId: insertedPatients[0]!.id,
           appointmentId: insertedAppts[0]?.id ?? null,
-          authorId: doctorId,
-          subjective: "Owner reports Biscuit is bright and eating well. Here for a yearly wellness check.",
-          objective: "Weight 31 kg. Temp normal. Heart and lungs sound clear. Coat looks healthy.",
-          assessment: "Healthy adult dog. No problems found today.",
-          plan: "Keep up the current diet. Give the Rabies booster. Recheck in one year.",
+          ...finalizedSoapInsertValues({
+            actor: owner,
+            sections: {
+              subjective:
+                "Owner reports Biscuit is bright and eating well. Here for a yearly wellness check.",
+              objective:
+                "Weight 31 kg. Temp normal. Heart and lungs sound clear. Coat looks healthy.",
+              assessment: "Healthy adult dog. No problems found today.",
+              plan: "Keep up the current diet. Give the Rabies booster. Recheck in one year.",
+            },
+          }),
         },
         {
           practiceId: opts.practiceId,
           patientId: insertedPatients[1]!.id,
           appointmentId: null,
-          authorId: doctorId,
-          subjective: "Luna is a bit less active this week per owner.",
-          objective: "Weight 4.2 kg. Mild tartar on back teeth. Rest of exam is normal.",
-          assessment: "Early dental tartar. Otherwise healthy cat.",
-          plan: "Start at-home dental care. Plan a dental cleaning in the next few months.",
+          ...finalizedSoapInsertValues({
+            actor: owner,
+            sections: {
+              subjective: "Luna is a bit less active this week per owner.",
+              objective:
+                "Weight 4.2 kg. Mild tartar on back teeth. Rest of exam is normal.",
+              assessment: "Early dental tartar. Otherwise healthy cat.",
+              plan: "Start at-home dental care. Plan a dental cleaning in the next few months.",
+            },
+          }),
         },
       ])
       .returning({ id: soapNotes.id });

--- a/apps/web/lib/pdf.ts
+++ b/apps/web/lib/pdf.ts
@@ -1,4 +1,5 @@
 import jsPDF from "jspdf";
+import { soapSectionText } from "@/lib/records/soap-content";
 
 // ---------------------------------------------------------------------------
 // Shared constants
@@ -436,6 +437,16 @@ export interface MedicalSummaryData {
     assessment?: string;
     plan?: string;
     imported?: boolean;
+    authorName?: string;
+    finalizerName?: string;
+    finalizedAt?: string;
+    addenda?: Array<{ content: string; authorName: string; createdAt: string }>;
+  }>;
+  recordCorrections?: Array<{
+    recordLabel: string;
+    reason: string;
+    correctedByName: string;
+    correctedAt: string;
   }>;
   prescriptions: Array<{
     medication: string;
@@ -449,6 +460,20 @@ export interface MedicalSummaryData {
 export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
   const doc = new jsPDF();
   let y = PAGE_MARGIN;
+
+  function writeWrappedText(
+    value: string,
+    x: number,
+    width: number,
+    lineHeight = 4,
+  ) {
+    const lines = doc.splitTextToSize(value, width) as string[];
+    for (const line of lines) {
+      y = ensureSpace(doc, y, lineHeight + 1);
+      doc.text(line, x, y);
+      y += lineHeight;
+    }
+  }
 
   // ---- Helper: section heading ---------------------------------------------
   function sectionHeading(title: string) {
@@ -660,18 +685,29 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
       doc.setFontSize(10);
       setColor(doc, COLOR_DARK);
       doc.text(
-        note.imported ? `${note.date}  (Imported record)` : note.date,
+        note.imported
+          ? `${note.date}  (Finalized imported record)`
+          : `${note.date}  (Finalized)`,
         PAGE_MARGIN,
         y
       );
       y += 6;
 
+      doc.setFont(FONT, "normal");
+      doc.setFontSize(8);
+      setColor(doc, COLOR_GRAY);
+      const attribution = note.imported
+        ? `Imported by ${note.authorName ?? "Unknown clinician"}`
+        : `Authored by ${note.authorName ?? "Unknown clinician"}; finalized by ${note.finalizerName ?? "Unknown clinician"}${note.finalizedAt ? ` on ${note.finalizedAt}` : ""}`;
+      writeWrappedText(attribution, PAGE_MARGIN, CONTENT_WIDTH);
+      y += 2;
+
       doc.setFontSize(9);
       const soapSections: [string, string | undefined][] = [
-        ["S: ", note.subjective],
-        ["O: ", note.objective],
-        ["A: ", note.assessment],
-        ["P: ", note.plan],
+        ["S: ", soapSectionText(note.subjective)],
+        ["O: ", soapSectionText(note.objective)],
+        ["A: ", soapSectionText(note.assessment)],
+        ["P: ", soapSectionText(note.plan)],
       ];
 
       for (const [prefix, content] of soapSections) {
@@ -682,14 +718,64 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
         doc.text(prefix, PAGE_MARGIN + 4, y);
         doc.setFont(FONT, "normal");
         setColor(doc, COLOR_DARK);
-        const lines = doc.splitTextToSize(content, CONTENT_WIDTH - 14);
-        doc.text(lines, PAGE_MARGIN + 14, y);
-        y += lines.length * 4 + 2;
+        writeWrappedText(content, PAGE_MARGIN + 14, CONTENT_WIDTH - 14);
+        y += 2;
+      }
+
+      for (const addendum of note.addenda ?? []) {
+        y = ensureSpace(doc, y, 14);
+        doc.setFont(FONT, "bold");
+        setColor(doc, COLOR_TEAL);
+        writeWrappedText(
+          `Addendum - ${addendum.authorName}, ${addendum.createdAt}`,
+          PAGE_MARGIN + 4,
+          CONTENT_WIDTH - 8,
+          5,
+        );
+        doc.setFont(FONT, "normal");
+        setColor(doc, COLOR_DARK);
+        writeWrappedText(
+          soapSectionText(addendum.content),
+          PAGE_MARGIN + 4,
+          CONTENT_WIDTH - 8,
+        );
+        y += 2;
       }
 
       y += 4;
       drawLine(doc, y);
       y += 4;
+    }
+  }
+
+  // Invalidated clinical content stays excluded, while its durable correction
+  // evidence remains visible to a downstream clinician reviewing the summary.
+  if ((data.recordCorrections?.length ?? 0) > 0) {
+    sectionHeading("Record Corrections");
+    for (const correction of data.recordCorrections ?? []) {
+      y = ensureSpace(doc, y, 18);
+      doc.setFont(FONT, "bold");
+      doc.setFontSize(9);
+      setColor(doc, COLOR_DARK);
+      writeWrappedText(
+        correction.recordLabel,
+        PAGE_MARGIN + 4,
+        CONTENT_WIDTH - 8,
+      );
+      doc.setFont(FONT, "normal");
+      setColor(doc, COLOR_GRAY);
+      writeWrappedText(
+        `Entered in error by ${correction.correctedByName} on ${correction.correctedAt}`,
+        PAGE_MARGIN + 4,
+        CONTENT_WIDTH - 8,
+      );
+      setColor(doc, COLOR_DARK);
+      writeWrappedText(
+        `Reason: ${soapSectionText(correction.reason)}`,
+        PAGE_MARGIN + 4,
+        CONTENT_WIDTH - 8,
+      );
+      y += 3;
     }
   }
 

--- a/apps/web/lib/records/__tests__/soap-lifecycle.test.ts
+++ b/apps/web/lib/records/__tests__/soap-lifecycle.test.ts
@@ -1,0 +1,541 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import type { Database } from "@openpims/db/client";
+import {
+  addFinalizedSoapAddendum,
+  createFinalizedAppointmentSoapNote,
+  discardAppointmentSoapDraft,
+  finalizeAppointmentSoapDraft,
+  saveAppointmentSoapDraft,
+} from "../soap-lifecycle";
+
+const PRACTICE_ID = "00000000-0000-4000-8000-000000000001";
+const PATIENT_ID = "00000000-0000-4000-8000-000000000002";
+const APPOINTMENT_ID = "00000000-0000-4000-8000-000000000003";
+const NOTE_ID = "00000000-0000-4000-8000-000000000004";
+const USER_ID = "00000000-0000-4000-8000-000000000005";
+const OPERATION_ID = "00000000-0000-4000-8000-000000000006";
+const actor = { id: USER_ID, name: "Dr. Rivera" };
+const openVisit = {
+  id: APPOINTMENT_ID,
+  doctorId: USER_ID,
+  status: "in_exam",
+};
+
+function note(overrides: Record<string, unknown> = {}) {
+  return {
+    id: NOTE_ID,
+    createdAt: new Date("2026-08-09T16:00:00.000Z"),
+    updatedAt: new Date("2026-08-09T16:05:00.000Z"),
+    deletedAt: null,
+    practiceId: PRACTICE_ID,
+    patientId: PATIENT_ID,
+    appointmentId: APPOINTMENT_ID,
+    authorId: USER_ID,
+    authorName: "Dr. Rivera",
+    status: "draft",
+    revision: 1,
+    finalizedAt: null,
+    finalizedBy: null,
+    finalizerName: null,
+    subjective: "Eating less",
+    objective: null,
+    assessment: null,
+    plan: null,
+    imported: false,
+    importFingerprint: null,
+    ...overrides,
+  };
+}
+
+function lifecycleDb(opts: {
+  selectResults: unknown[][];
+  insertResults?: unknown[][];
+  updateResults?: unknown[][];
+  deleteResults?: unknown[][];
+}) {
+  const selectResults = [...opts.selectResults];
+  const select = vi.fn(() => {
+    const rows = selectResults.shift() ?? [];
+    const builder: Record<string, any> = {};
+    builder.from = vi.fn(() => builder);
+    builder.where = vi.fn(() => builder);
+    builder.limit = vi.fn(() => builder);
+    builder.for = vi.fn(async () => rows);
+    builder.then = (
+      resolve: (value: unknown[]) => unknown,
+      reject?: (error: unknown) => unknown,
+    ) => Promise.resolve(rows).then(resolve, reject);
+    return builder;
+  });
+
+  const insertResults = [...(opts.insertResults ?? [])];
+  const insertValues = vi.fn((values: unknown) => ({
+    onConflictDoNothing: vi.fn(() => ({
+      returning: vi.fn(async () => insertResults.shift() ?? []),
+    })),
+    returning: vi.fn(async () => insertResults.shift() ?? []),
+    values,
+  }));
+  const updateResults = [...(opts.updateResults ?? [])];
+  const updateSet = vi.fn((values: unknown) => ({
+    where: vi.fn(() => ({
+      returning: vi.fn(async () => updateResults.shift() ?? []),
+    })),
+    values,
+  }));
+  const deleteResults = [...(opts.deleteResults ?? [])];
+  const deleteWhere = vi.fn(() => ({
+    returning: vi.fn(async () => deleteResults.shift() ?? []),
+  }));
+  const db = {
+    select,
+    insert: vi.fn(() => ({ values: insertValues })),
+    update: vi.fn(() => ({ set: updateSet })),
+    delete: vi.fn(() => ({ where: deleteWhere })),
+  };
+  return {
+    db: db as unknown as Database,
+    insertValues,
+    updateSet,
+    deleteWhere,
+  };
+}
+
+function visitPrefix() {
+  return [[openVisit], []] as unknown[][];
+}
+
+describe("SOAP lifecycle service", () => {
+  it("creates one persisted draft with server attribution and explicit null sections", async () => {
+    const created = note();
+    const { db, insertValues } = lifecycleDb({
+      selectResults: [...visitPrefix(), [], []],
+      insertResults: [[created]],
+    });
+
+    await expect(
+      saveAppointmentSoapDraft(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 0,
+        actor,
+        sections: { subjective: " Eating less ", objective: "<p><br></p>" },
+      }),
+    ).resolves.toEqual({ outcome: "saved", draft: created });
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorId: USER_ID,
+        authorName: "Dr. Rivera",
+        status: "draft",
+        revision: 1,
+        subjective: "Eating less",
+        objective: null,
+      }),
+    );
+  });
+
+  it("treats an exact save retry as success without rewriting the draft", async () => {
+    const existing = note({ revision: 2 });
+    const { db, updateSet } = lifecycleDb({
+      selectResults: [...visitPrefix(), [existing]],
+    });
+    await expect(
+      saveAppointmentSoapDraft(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 1,
+        actor,
+        sections: { subjective: "Eating less" },
+      }),
+    ).resolves.toEqual({ outcome: "saved", draft: existing });
+    expect(updateSet).not.toHaveBeenCalled();
+  });
+
+  it("updates existing draft content through CAS and advances its revision", async () => {
+    const existing = note({ revision: 2, subjective: "Eating less" });
+    const saved = note({
+      revision: 3,
+      subjective: "Eating normally",
+      assessment: "Appetite improved",
+    });
+    const { db, updateSet } = lifecycleDb({
+      selectResults: [...visitPrefix(), [existing]],
+      updateResults: [[saved]],
+    });
+
+    await expect(
+      saveAppointmentSoapDraft(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 2,
+        actor,
+        sections: {
+          subjective: " Eating normally ",
+          assessment: "Appetite improved",
+        },
+      }),
+    ).resolves.toEqual({ outcome: "saved", draft: saved });
+    expect(updateSet).toHaveBeenCalledWith({
+      subjective: "Eating normally",
+      objective: null,
+      assessment: "Appetite improved",
+      plan: null,
+      revision: 3,
+    });
+  });
+
+  it("returns the current draft on a stale CAS save", async () => {
+    const current = note({ revision: 3, subjective: "Server version" });
+    const { db } = lifecycleDb({
+      selectResults: [...visitPrefix(), [current]],
+    });
+    await expect(
+      saveAppointmentSoapDraft(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 1,
+        actor,
+        sections: { subjective: "Local version" },
+      }),
+    ).resolves.toEqual({ outcome: "conflict", draft: current });
+  });
+
+  it("is idempotent only for the exact finalized revision", async () => {
+    const finalized = note({
+      status: "finalized",
+      revision: 2,
+      finalizedAt: new Date(),
+      finalizedBy: USER_ID,
+      finalizerName: "Dr. Rivera",
+    });
+    const exact = lifecycleDb({
+      selectResults: [...visitPrefix(), [finalized]],
+    });
+    await expect(
+      finalizeAppointmentSoapDraft(exact.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 2,
+        actor,
+      }),
+    ).resolves.toEqual({
+      outcome: "finalized",
+      note: finalized,
+      transitioned: false,
+    });
+
+    const stale = lifecycleDb({
+      selectResults: [...visitPrefix(), [finalized]],
+    });
+    await expect(
+      finalizeAppointmentSoapDraft(stale.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 1,
+        actor,
+      }),
+    ).resolves.toEqual({ outcome: "conflict", note: finalized });
+  });
+
+  it("recovers exact finalize retries after the visit closes", async () => {
+    const finalized = note({
+      status: "finalized",
+      revision: 2,
+      finalizedAt: new Date(),
+      finalizedBy: USER_ID,
+      finalizerName: "Dr. Rivera",
+    });
+    const closedVisit = { ...openVisit, status: "checked_out" };
+    const exact = lifecycleDb({ selectResults: [[closedVisit], [finalized]] });
+
+    await expect(
+      finalizeAppointmentSoapDraft(exact.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 2,
+        actor,
+      }),
+    ).resolves.toEqual({
+      outcome: "finalized",
+      note: finalized,
+      transitioned: false,
+    });
+
+    const stale = lifecycleDb({ selectResults: [[closedVisit], [finalized]] });
+    await expect(
+      finalizeAppointmentSoapDraft(stale.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 1,
+        actor,
+      }),
+    ).resolves.toEqual({ outcome: "conflict", note: finalized });
+  });
+
+  it("reports remote finalization to save and discard after visit close", async () => {
+    const finalized = note({
+      status: "finalized",
+      revision: 2,
+      finalizedAt: new Date(),
+      finalizedBy: USER_ID,
+      finalizerName: "Dr. Rivera",
+    });
+    const closedVisit = { ...openVisit, status: "checked_out" };
+    const save = lifecycleDb({ selectResults: [[closedVisit], [finalized]] });
+    await expect(
+      saveAppointmentSoapDraft(save.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 1,
+        actor,
+        sections: { subjective: "Local version" },
+      }),
+    ).resolves.toEqual({ outcome: "already_finalized", note: finalized });
+
+    const discard = lifecycleDb({
+      selectResults: [[closedVisit], [finalized]],
+    });
+    await expect(
+      discardAppointmentSoapDraft(discard.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 1,
+      }),
+    ).resolves.toEqual({ outcome: "already_finalized", note: finalized });
+  });
+
+  it("preserves a first unsaved edit when another session finalizes", async () => {
+    const finalized = note({
+      status: "finalized",
+      revision: 1,
+      finalizedAt: new Date(),
+      finalizedBy: USER_ID,
+      finalizerName: "Dr. Rivera",
+    });
+    const closedVisit = { ...openVisit, status: "checked_out" };
+    const closed = lifecycleDb({
+      selectResults: [[closedVisit], [finalized]],
+    });
+    await expect(
+      saveAppointmentSoapDraft(closed.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 0,
+        actor,
+        sections: { subjective: "First local edit" },
+      }),
+    ).resolves.toEqual({ outcome: "already_finalized", note: finalized });
+
+    const stillOpen = lifecycleDb({
+      selectResults: [...visitPrefix(), [], [finalized]],
+    });
+    await expect(
+      saveAppointmentSoapDraft(stillOpen.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        expectedRevision: 0,
+        actor,
+        sections: { subjective: "First local edit" },
+      }),
+    ).resolves.toEqual({ outcome: "already_finalized", note: finalized });
+  });
+
+  it("finalizes the matching draft with signer attribution", async () => {
+    const draft = note({ revision: 4 });
+    const finalized = note({
+      status: "finalized",
+      revision: 4,
+      finalizedAt: new Date("2026-08-09T16:10:00.000Z"),
+      finalizedBy: USER_ID,
+      finalizerName: "Dr. Rivera",
+    });
+    const { db, updateSet } = lifecycleDb({
+      selectResults: [...visitPrefix(), [draft]],
+      updateResults: [[finalized]],
+    });
+
+    await expect(
+      finalizeAppointmentSoapDraft(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 4,
+        actor,
+      }),
+    ).resolves.toEqual({
+      outcome: "finalized",
+      note: finalized,
+      transitioned: true,
+    });
+    expect(updateSet).toHaveBeenCalledWith({
+      status: "finalized",
+      finalizedAt: expect.any(Date),
+      finalizedBy: USER_ID,
+      finalizerName: "Dr. Rivera",
+    });
+  });
+
+  it("enforces discard CAS and deletes only the matching open-visit draft", async () => {
+    const current = note({ revision: 2 });
+    const stale = lifecycleDb({
+      selectResults: [...visitPrefix(), [current]],
+    });
+    await expect(
+      discardAppointmentSoapDraft(stale.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 1,
+      }),
+    ).resolves.toEqual({ outcome: "conflict", draft: current });
+    expect(stale.deleteWhere).not.toHaveBeenCalled();
+
+    const exact = lifecycleDb({
+      selectResults: [...visitPrefix(), [current]],
+      deleteResults: [[{ id: NOTE_ID }]],
+    });
+    await expect(
+      discardAppointmentSoapDraft(exact.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 2,
+      }),
+    ).resolves.toEqual({ outcome: "discarded", noteId: NOTE_ID });
+  });
+
+  it("makes addendum retries idempotent and rejects operation reuse", async () => {
+    const content = "Owner clarified the dose was given at 8 AM.";
+    const payloadHash = createHash("sha256")
+      .update(JSON.stringify({ noteId: NOTE_ID, authorId: USER_ID, content }))
+      .digest("hex");
+    const existing = {
+      id: "addendum-1",
+      practiceId: PRACTICE_ID,
+      soapNoteId: NOTE_ID,
+      operationId: OPERATION_ID,
+      operationPayloadHash: payloadHash,
+    };
+    const exact = lifecycleDb({ selectResults: [[existing]] });
+    await expect(
+      addFinalizedSoapAddendum(exact.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        noteId: NOTE_ID,
+        operationId: OPERATION_ID,
+        content,
+        actor,
+      }),
+    ).resolves.toBe(existing);
+
+    const reused = lifecycleDb({
+      selectResults: [[{ ...existing, operationPayloadHash: "f".repeat(64) }]],
+    });
+    await expect(
+      addFinalizedSoapAddendum(reused.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        noteId: NOTE_ID,
+        operationId: OPERATION_ID,
+        content,
+        actor,
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+
+  it("creates an addendum with actor, content, operation, and payload binding", async () => {
+    const content = "Owner clarified the dose was given at 8 AM.";
+    const payloadHash = createHash("sha256")
+      .update(JSON.stringify({ noteId: NOTE_ID, authorId: USER_ID, content }))
+      .digest("hex");
+    const created = {
+      id: "addendum-1",
+      practiceId: PRACTICE_ID,
+      soapNoteId: NOTE_ID,
+      authorId: USER_ID,
+      authorName: "Dr. Rivera",
+      content,
+      operationId: OPERATION_ID,
+      operationPayloadHash: payloadHash,
+    };
+    const { db, insertValues } = lifecycleDb({
+      selectResults: [[], [{ id: NOTE_ID }]],
+      insertResults: [[created]],
+    });
+
+    await expect(
+      addFinalizedSoapAddendum(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        noteId: NOTE_ID,
+        operationId: OPERATION_ID,
+        content: `  ${content}  `,
+        actor,
+      }),
+    ).resolves.toEqual(created);
+    expect(insertValues).toHaveBeenCalledWith({
+      practiceId: PRACTICE_ID,
+      soapNoteId: NOTE_ID,
+      authorId: USER_ID,
+      authorName: "Dr. Rivera",
+      content,
+      operationId: OPERATION_ID,
+      operationPayloadHash: payloadHash,
+    });
+  });
+
+  it("rejects addenda when the finalized source is missing or entered in error", async () => {
+    const { db } = lifecycleDb({ selectResults: [[], []] });
+    await expect(
+      addFinalizedSoapAddendum(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        noteId: NOTE_ID,
+        operationId: OPERATION_ID,
+        content: "Clarification",
+        actor,
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
+  });
+
+  it("rejects a second effective finalized note for the encounter", async () => {
+    const { db, insertValues } = lifecycleDb({
+      selectResults: [...visitPrefix(), [], [{ id: "existing-final" }]],
+    });
+    await expect(
+      createFinalizedAppointmentSoapNote(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        actor,
+        sections: { subjective: "Reviewed" },
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/records/__tests__/soap-navigation.test.ts
+++ b/apps/web/lib/records/__tests__/soap-navigation.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  guardedSoapNavigationDestination,
+  runSoapSafeLeave,
+  soapEditorNeedsLeaveGuard,
+  type SoapNavigationClick,
+} from "../soap-navigation";
+
+const currentHref =
+  "https://app.openvpm.com/records/new-soap/patient-1?appointmentId=visit-1";
+
+function click(
+  overrides: Partial<SoapNavigationClick> = {},
+): SoapNavigationClick {
+  return {
+    href: "https://app.openvpm.com/records",
+    currentHref,
+    button: 0,
+    defaultPrevented: false,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    target: null,
+    download: false,
+    ...overrides,
+  };
+}
+
+describe("SOAP editor navigation classification", () => {
+  it("returns an ordinary same-origin application destination", () => {
+    expect(
+      guardedSoapNavigationDestination(
+        click({
+          href: "https://app.openvpm.com/patients/one?tab=records#latest",
+        }),
+      ),
+    ).toBe("/patients/one?tab=records#latest");
+  });
+
+  it.each([
+    { button: 1 },
+    { metaKey: true },
+    { ctrlKey: true },
+    { shiftKey: true },
+    { altKey: true },
+    { defaultPrevented: true },
+    { download: true },
+    { target: "_blank" },
+  ])("ignores modified or special clicks: %o", (overrides) => {
+    expect(guardedSoapNavigationDestination(click(overrides))).toBeNull();
+  });
+
+  it("ignores external destinations", () => {
+    expect(
+      guardedSoapNavigationDestination(
+        click({ href: "https://example.com/records" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores hash-only and current-page destinations", () => {
+    expect(
+      guardedSoapNavigationDestination(click({ href: `${currentHref}#plan` })),
+    ).toBeNull();
+    expect(
+      guardedSoapNavigationDestination(click({ href: currentHref })),
+    ).toBeNull();
+  });
+});
+
+describe("SOAP editor safe leave", () => {
+  it("does not warn before the draft has initialized", () => {
+    expect(
+      soapEditorNeedsLeaveGuard({
+        draftInitialized: false,
+        finalizedElsewhere: false,
+        localTextCopied: false,
+        hasLocalText: false,
+        conflict: false,
+        savePending: false,
+        dirty: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("retains finalized local-text protection regardless of initialization", () => {
+    expect(
+      soapEditorNeedsLeaveGuard({
+        draftInitialized: false,
+        finalizedElsewhere: true,
+        localTextCopied: false,
+        hasLocalText: true,
+        conflict: false,
+        savePending: false,
+        dirty: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not navigate when save discovers finalization until text is copied", async () => {
+    let finalizedElsewhere = false;
+    let localTextCopied = false;
+    const persistDraft = vi.fn(async () => {
+      finalizedElsewhere = true;
+      return { outcome: "already_finalized" };
+    });
+    const confirmFinalizedLocalTextLeave = vi.fn(() => false);
+    const navigate = vi.fn();
+    const run = () =>
+      runSoapSafeLeave({
+        readState: () => ({
+          finalizedElsewhere,
+          needsGuard: true,
+          localTextCopied,
+          hasLocalText: true,
+        }),
+        persistDraft,
+        confirmFinalizedLocalTextLeave,
+        confirmUnsavedLeave: () => false,
+        navigate,
+      });
+
+    await expect(run()).resolves.toBe(false);
+    expect(persistDraft).toHaveBeenCalledTimes(1);
+    expect(confirmFinalizedLocalTextLeave).toHaveBeenCalledTimes(1);
+    expect(navigate).not.toHaveBeenCalled();
+
+    localTextCopied = true;
+    await expect(run()).resolves.toBe(true);
+    expect(persistDraft).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/records/soap-lifecycle.ts
+++ b/apps/web/lib/records/soap-lifecycle.ts
@@ -1,0 +1,734 @@
+import { createHash } from "node:crypto";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import {
+  clinicalRecordCorrections,
+  soapNoteAddenda,
+  soapNotes,
+} from "@openpims/db";
+import type { Database } from "@openpims/db/client";
+import {
+  hasSoapContent,
+  normalizeSoapSection,
+} from "@/lib/records/soap-content";
+import { hasUnresolvedSoapTemplatePrompts } from "@/lib/records/soap-templates";
+import { lockOpenVisitForClinicalAppend } from "@/lib/records/visit-integrity";
+
+export interface SoapSections {
+  subjective?: string | null;
+  objective?: string | null;
+  assessment?: string | null;
+  plan?: string | null;
+}
+
+export interface SoapActor {
+  id: string;
+  name: string;
+}
+
+export type SoapDraft = typeof soapNotes.$inferSelect;
+
+export class SoapLifecycleError extends Error {
+  constructor(
+    readonly code:
+      | "BAD_REQUEST"
+      | "NOT_FOUND"
+      | "CONFLICT"
+      | "PRECONDITION_FAILED",
+    message: string,
+  ) {
+    super(message);
+    this.name = "SoapLifecycleError";
+  }
+}
+
+export function normalizeSoapSections(sections: SoapSections) {
+  return {
+    subjective: normalizeSoapSection(sections.subjective) ?? null,
+    objective: normalizeSoapSection(sections.objective) ?? null,
+    assessment: normalizeSoapSection(sections.assessment) ?? null,
+    plan: normalizeSoapSection(sections.plan) ?? null,
+  };
+}
+
+function sectionsMatch(left: SoapSections, right: SoapSections): boolean {
+  const a = normalizeSoapSections(left);
+  const b = normalizeSoapSections(right);
+  return (
+    a.subjective === b.subjective &&
+    a.objective === b.objective &&
+    a.assessment === b.assessment &&
+    a.plan === b.plan
+  );
+}
+
+async function assertOpenSoapVisit(
+  db: Database,
+  input: { practiceId: string; patientId: string; appointmentId: string },
+) {
+  const visit = await lockOpenVisitForClinicalAppend(db, input);
+  if (!visit.ok && visit.reason === "appointment_not_found") {
+    throw new SoapLifecycleError("NOT_FOUND", "Appointment not found");
+  }
+  if (!visit.ok) {
+    throw new SoapLifecycleError(
+      "PRECONDITION_FAILED",
+      "SOAP documentation can only be changed while the visit is in exam.",
+    );
+  }
+  return visit.appointment;
+}
+
+async function getScopedFinalizedSoapNote(
+  db: Database,
+  input: {
+    practiceId: string;
+    patientId: string;
+    appointmentId: string;
+    noteId?: string;
+  },
+) {
+  const predicates = [
+    eq(soapNotes.practiceId, input.practiceId),
+    eq(soapNotes.patientId, input.patientId),
+    eq(soapNotes.appointmentId, input.appointmentId),
+    eq(soapNotes.status, "finalized"),
+    isNull(soapNotes.deletedAt),
+  ];
+  if (input.noteId) {
+    predicates.push(eq(soapNotes.id, input.noteId));
+  } else {
+    predicates.push(sql`not exists (
+      select 1 from ${clinicalRecordCorrections}
+      where ${clinicalRecordCorrections.practiceId} = ${input.practiceId}
+        and ${clinicalRecordCorrections.soapNoteId} = ${soapNotes.id}
+    )`);
+  }
+  const [note] = await db
+    .select()
+    .from(soapNotes)
+    .where(and(...predicates))
+    .limit(1);
+  return note ?? null;
+}
+
+async function assertOpenSoapVisitWithFinalizedRecovery(
+  db: Database,
+  input: {
+    practiceId: string;
+    patientId: string;
+    appointmentId: string;
+    noteId?: string;
+  },
+) {
+  try {
+    await assertOpenSoapVisit(db, input);
+    return null;
+  } catch (error) {
+    if (
+      error instanceof SoapLifecycleError &&
+      error.code === "PRECONDITION_FAILED"
+    ) {
+      const finalized = await getScopedFinalizedSoapNote(db, input);
+      if (finalized) return finalized;
+    }
+    throw error;
+  }
+}
+
+export function finalizedSoapInsertValues(input: {
+  actor: SoapActor;
+  sections: SoapSections;
+  finalizedAt?: Date;
+  imported?: boolean;
+}) {
+  const finalizedAt = input.finalizedAt ?? new Date();
+  return {
+    ...normalizeSoapSections(input.sections),
+    authorId: input.actor.id,
+    authorName: input.actor.name,
+    status: "finalized" as const,
+    revision: 1,
+    finalizedAt,
+    finalizedBy: input.actor.id,
+    finalizerName: input.actor.name,
+    imported: input.imported ?? false,
+  };
+}
+
+export async function getAppointmentSoapDraft(
+  db: Database,
+  input: { practiceId: string; patientId: string; appointmentId: string },
+) {
+  const [draft] = await db
+    .select()
+    .from(soapNotes)
+    .where(
+      and(
+        eq(soapNotes.practiceId, input.practiceId),
+        eq(soapNotes.patientId, input.patientId),
+        eq(soapNotes.appointmentId, input.appointmentId),
+        eq(soapNotes.status, "draft"),
+        isNull(soapNotes.deletedAt),
+      ),
+    )
+    .limit(1);
+  return draft ?? null;
+}
+
+export type SaveSoapDraftResult =
+  | { outcome: "saved"; draft: SoapDraft }
+  | { outcome: "conflict"; draft: SoapDraft }
+  | { outcome: "already_finalized"; note: SoapDraft };
+
+export async function saveAppointmentSoapDraft(
+  db: Database,
+  input: {
+    practiceId: string;
+    patientId: string;
+    appointmentId: string;
+    noteId?: string;
+    expectedRevision: number;
+    actor: SoapActor;
+    sections: SoapSections;
+  },
+): Promise<SaveSoapDraftResult> {
+  const finalizedAfterClose =
+    await assertOpenSoapVisitWithFinalizedRecovery(db, input);
+  if (finalizedAfterClose) {
+    if (!input.noteId || finalizedAfterClose.id === input.noteId) {
+      return { outcome: "already_finalized", note: finalizedAfterClose };
+    }
+    throw new SoapLifecycleError(
+      "CONFLICT",
+      "This encounter already has finalized SOAP documentation.",
+    );
+  }
+  const sections = normalizeSoapSections(input.sections);
+  const [existing] = await db
+    .select()
+    .from(soapNotes)
+    .where(
+      and(
+        eq(soapNotes.practiceId, input.practiceId),
+        eq(soapNotes.patientId, input.patientId),
+        eq(soapNotes.appointmentId, input.appointmentId),
+        eq(soapNotes.status, "draft"),
+        isNull(soapNotes.deletedAt),
+      ),
+    )
+    .limit(1)
+    .for("update");
+
+  if (!existing) {
+    if (input.expectedRevision !== 0 || input.noteId) {
+      if (input.noteId) {
+        const [finalizedNote] = await db
+          .select()
+          .from(soapNotes)
+          .where(
+            and(
+              eq(soapNotes.id, input.noteId),
+              eq(soapNotes.practiceId, input.practiceId),
+              eq(soapNotes.patientId, input.patientId),
+              eq(soapNotes.appointmentId, input.appointmentId),
+              eq(soapNotes.status, "finalized"),
+              isNull(soapNotes.deletedAt),
+            ),
+          )
+          .limit(1);
+        if (finalizedNote) {
+          return { outcome: "already_finalized", note: finalizedNote };
+        }
+      }
+      throw new SoapLifecycleError("NOT_FOUND", "SOAP draft not found");
+    }
+    const [finalized] = await db
+      .select()
+      .from(soapNotes)
+      .where(
+        and(
+          eq(soapNotes.practiceId, input.practiceId),
+          eq(soapNotes.patientId, input.patientId),
+          eq(soapNotes.appointmentId, input.appointmentId),
+          eq(soapNotes.status, "finalized"),
+          isNull(soapNotes.deletedAt),
+          sql`not exists (
+            select 1 from ${clinicalRecordCorrections}
+            where ${clinicalRecordCorrections.practiceId} = ${input.practiceId}
+              and ${clinicalRecordCorrections.soapNoteId} = ${soapNotes.id}
+          )`,
+        ),
+      )
+      .limit(1);
+    if (finalized) {
+      return { outcome: "already_finalized", note: finalized };
+    }
+    const [created] = await db
+      .insert(soapNotes)
+      .values({
+        practiceId: input.practiceId,
+        patientId: input.patientId,
+        appointmentId: input.appointmentId,
+        authorId: input.actor.id,
+        authorName: input.actor.name,
+        status: "draft",
+        revision: 1,
+        finalizedAt: null,
+        finalizedBy: null,
+        finalizerName: null,
+        imported: false,
+        ...sections,
+      })
+      .onConflictDoNothing()
+      .returning();
+    if (created) return { outcome: "saved", draft: created };
+    const concurrent = await getAppointmentSoapDraft(db, input);
+    if (!concurrent) {
+      throw new SoapLifecycleError(
+        "CONFLICT",
+        "SOAP draft changed while saving.",
+      );
+    }
+    return sectionsMatch(concurrent, sections)
+      ? { outcome: "saved", draft: concurrent }
+      : { outcome: "conflict", draft: concurrent };
+  }
+
+  if (input.noteId && existing.id !== input.noteId) {
+    return { outcome: "conflict", draft: existing };
+  }
+  if (
+    existing.revision === input.expectedRevision + 1 &&
+    sectionsMatch(existing, sections)
+  ) {
+    return { outcome: "saved", draft: existing };
+  }
+  if (existing.revision !== input.expectedRevision) {
+    return { outcome: "conflict", draft: existing };
+  }
+  if (sectionsMatch(existing, sections)) {
+    return { outcome: "saved", draft: existing };
+  }
+
+  const [saved] = await db
+    .update(soapNotes)
+    .set({ ...sections, revision: existing.revision + 1 })
+    .where(
+      and(
+        eq(soapNotes.id, existing.id),
+        eq(soapNotes.practiceId, input.practiceId),
+        eq(soapNotes.status, "draft"),
+        eq(soapNotes.revision, existing.revision),
+        isNull(soapNotes.deletedAt),
+      ),
+    )
+    .returning();
+  if (!saved) {
+    const latest = await getAppointmentSoapDraft(db, input);
+    if (!latest) {
+      const [finalizedNote] = await db
+        .select()
+        .from(soapNotes)
+        .where(
+          and(
+            eq(soapNotes.id, existing.id),
+            eq(soapNotes.practiceId, input.practiceId),
+            eq(soapNotes.status, "finalized"),
+            isNull(soapNotes.deletedAt),
+          ),
+        )
+        .limit(1);
+      if (finalizedNote) {
+        return { outcome: "already_finalized", note: finalizedNote };
+      }
+      throw new SoapLifecycleError(
+        "CONFLICT",
+        "SOAP draft changed while saving.",
+      );
+    }
+    return { outcome: "conflict", draft: latest };
+  }
+  return { outcome: "saved", draft: saved };
+}
+
+export type FinalizeSoapResult =
+  | { outcome: "finalized"; note: SoapDraft; transitioned: boolean }
+  | { outcome: "conflict"; note: SoapDraft };
+
+export async function finalizeAppointmentSoapDraft(
+  db: Database,
+  input: {
+    practiceId: string;
+    patientId: string;
+    appointmentId: string;
+    noteId: string;
+    expectedRevision: number;
+    actor: SoapActor;
+  },
+): Promise<FinalizeSoapResult> {
+  const finalizedAfterClose =
+    await assertOpenSoapVisitWithFinalizedRecovery(db, input);
+  if (finalizedAfterClose) {
+    return finalizedAfterClose.revision === input.expectedRevision
+      ? {
+          outcome: "finalized",
+          note: finalizedAfterClose,
+          transitioned: false,
+        }
+      : { outcome: "conflict", note: finalizedAfterClose };
+  }
+  const [note] = await db
+    .select()
+    .from(soapNotes)
+    .where(
+      and(
+        eq(soapNotes.id, input.noteId),
+        eq(soapNotes.practiceId, input.practiceId),
+        eq(soapNotes.patientId, input.patientId),
+        eq(soapNotes.appointmentId, input.appointmentId),
+        isNull(soapNotes.deletedAt),
+      ),
+    )
+    .limit(1)
+    .for("update");
+  if (!note) {
+    throw new SoapLifecycleError("NOT_FOUND", "SOAP draft not found");
+  }
+  if (note.status === "finalized") {
+    return note.revision === input.expectedRevision
+      ? { outcome: "finalized", note, transitioned: false }
+      : { outcome: "conflict", note };
+  }
+  if (note.revision !== input.expectedRevision) {
+    return { outcome: "conflict", note };
+  }
+  const storedSections = normalizeSoapSections(note);
+  if (!hasSoapContent(storedSections)) {
+    throw new SoapLifecycleError(
+      "BAD_REQUEST",
+      "SOAP note must include at least one section before finalization.",
+    );
+  }
+  if (hasUnresolvedSoapTemplatePrompts(storedSections)) {
+    throw new SoapLifecycleError(
+      "BAD_REQUEST",
+      "Replace or delete every SOAP template prompt before finalization.",
+    );
+  }
+
+  const [finalized] = await db
+    .update(soapNotes)
+    .set({
+      status: "finalized",
+      finalizedAt: new Date(),
+      finalizedBy: input.actor.id,
+      finalizerName: input.actor.name,
+    })
+    .where(
+      and(
+        eq(soapNotes.id, note.id),
+        eq(soapNotes.practiceId, input.practiceId),
+        eq(soapNotes.status, "draft"),
+        eq(soapNotes.revision, note.revision),
+        isNull(soapNotes.deletedAt),
+      ),
+    )
+    .returning();
+  if (!finalized) {
+    const [latest] = await db
+      .select()
+      .from(soapNotes)
+      .where(
+        and(
+          eq(soapNotes.id, note.id),
+          eq(soapNotes.practiceId, input.practiceId),
+          isNull(soapNotes.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (!latest) {
+      throw new SoapLifecycleError(
+        "CONFLICT",
+        "SOAP draft changed while finalizing.",
+      );
+    }
+    if (latest.status === "finalized") {
+      return latest.revision === input.expectedRevision
+        ? { outcome: "finalized", note: latest, transitioned: false }
+        : { outcome: "conflict", note: latest };
+    }
+    return { outcome: "conflict", note: latest };
+  }
+  return { outcome: "finalized", note: finalized, transitioned: true };
+}
+
+export type DiscardSoapDraftResult =
+  | { outcome: "discarded"; noteId: string }
+  | { outcome: "conflict"; draft: SoapDraft }
+  | { outcome: "already_finalized"; note: SoapDraft };
+
+export async function discardAppointmentSoapDraft(
+  db: Database,
+  input: {
+    practiceId: string;
+    patientId: string;
+    appointmentId: string;
+    noteId: string;
+    expectedRevision: number;
+  },
+): Promise<DiscardSoapDraftResult> {
+  const finalizedAfterClose =
+    await assertOpenSoapVisitWithFinalizedRecovery(db, input);
+  if (finalizedAfterClose) {
+    return { outcome: "already_finalized", note: finalizedAfterClose };
+  }
+  const [draft] = await db
+    .select()
+    .from(soapNotes)
+    .where(
+      and(
+        eq(soapNotes.id, input.noteId),
+        eq(soapNotes.practiceId, input.practiceId),
+        eq(soapNotes.patientId, input.patientId),
+        eq(soapNotes.appointmentId, input.appointmentId),
+        eq(soapNotes.status, "draft"),
+        isNull(soapNotes.deletedAt),
+      ),
+    )
+    .limit(1)
+    .for("update");
+  if (!draft) {
+    const [finalizedNote] = await db
+      .select()
+      .from(soapNotes)
+      .where(
+        and(
+          eq(soapNotes.id, input.noteId),
+          eq(soapNotes.practiceId, input.practiceId),
+          eq(soapNotes.patientId, input.patientId),
+          eq(soapNotes.appointmentId, input.appointmentId),
+          eq(soapNotes.status, "finalized"),
+          isNull(soapNotes.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (finalizedNote) {
+      return { outcome: "already_finalized", note: finalizedNote };
+    }
+    throw new SoapLifecycleError("NOT_FOUND", "SOAP draft not found");
+  }
+  if (draft.revision !== input.expectedRevision) {
+    return { outcome: "conflict", draft };
+  }
+  const [deleted] = await db
+    .delete(soapNotes)
+    .where(
+      and(
+        eq(soapNotes.id, draft.id),
+        eq(soapNotes.practiceId, input.practiceId),
+        eq(soapNotes.status, "draft"),
+        eq(soapNotes.revision, draft.revision),
+      ),
+    )
+    .returning({ id: soapNotes.id });
+  if (!deleted) {
+    const latest = await getAppointmentSoapDraft(db, input);
+    if (latest) return { outcome: "conflict", draft: latest };
+    const [finalizedNote] = await db
+      .select()
+      .from(soapNotes)
+      .where(
+        and(
+          eq(soapNotes.id, draft.id),
+          eq(soapNotes.practiceId, input.practiceId),
+          eq(soapNotes.status, "finalized"),
+          isNull(soapNotes.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (finalizedNote) {
+      return { outcome: "already_finalized", note: finalizedNote };
+    }
+    throw new SoapLifecycleError(
+      "CONFLICT",
+      "SOAP draft changed while discarding.",
+    );
+  }
+  return { outcome: "discarded", noteId: deleted.id };
+}
+
+export async function createFinalizedAppointmentSoapNote(
+  db: Database,
+  input: {
+    practiceId: string;
+    patientId: string;
+    appointmentId: string;
+    actor: SoapActor;
+    sections: SoapSections;
+  },
+) {
+  const sections = normalizeSoapSections(input.sections);
+  if (!hasSoapContent(sections)) {
+    throw new SoapLifecycleError(
+      "BAD_REQUEST",
+      "SOAP note must include at least one section.",
+    );
+  }
+  if (hasUnresolvedSoapTemplatePrompts(sections)) {
+    throw new SoapLifecycleError(
+      "BAD_REQUEST",
+      "Replace or delete every SOAP template prompt before finalization.",
+    );
+  }
+  await assertOpenSoapVisit(db, input);
+  const draft = await getAppointmentSoapDraft(db, input);
+  if (draft) {
+    throw new SoapLifecycleError(
+      "CONFLICT",
+      "A SOAP draft already exists. Resume and finalize it instead.",
+    );
+  }
+  const [existingFinalized] = await db
+    .select({ id: soapNotes.id })
+    .from(soapNotes)
+    .where(
+      and(
+        eq(soapNotes.practiceId, input.practiceId),
+        eq(soapNotes.patientId, input.patientId),
+        eq(soapNotes.appointmentId, input.appointmentId),
+        eq(soapNotes.status, "finalized"),
+        isNull(soapNotes.deletedAt),
+        sql`not exists (
+          select 1 from ${clinicalRecordCorrections}
+          where ${clinicalRecordCorrections.practiceId} = ${input.practiceId}
+            and ${clinicalRecordCorrections.soapNoteId} = ${soapNotes.id}
+        )`,
+      ),
+    )
+    .limit(1);
+  if (existingFinalized) {
+    throw new SoapLifecycleError(
+      "CONFLICT",
+      "This encounter already has finalized SOAP documentation.",
+    );
+  }
+  const [note] = await db
+    .insert(soapNotes)
+    .values({
+      practiceId: input.practiceId,
+      patientId: input.patientId,
+      appointmentId: input.appointmentId,
+      ...finalizedSoapInsertValues({ actor: input.actor, sections }),
+    })
+    .returning();
+  return note!;
+}
+
+export async function addFinalizedSoapAddendum(
+  db: Database,
+  input: {
+    practiceId: string;
+    patientId: string;
+    noteId: string;
+    operationId: string;
+    content: string;
+    actor: SoapActor;
+  },
+) {
+  const content = input.content.trim();
+  if (!content) {
+    throw new SoapLifecycleError(
+      "BAD_REQUEST",
+      "Addendum content is required.",
+    );
+  }
+  if (content.length > 10_000) {
+    throw new SoapLifecycleError(
+      "BAD_REQUEST",
+      "Addendum content must be 10,000 characters or fewer.",
+    );
+  }
+  const payloadHash = createHash("sha256")
+    .update(
+      JSON.stringify({
+        noteId: input.noteId,
+        authorId: input.actor.id,
+        content,
+      }),
+    )
+    .digest("hex");
+
+  const [existing] = await db
+    .select()
+    .from(soapNoteAddenda)
+    .where(
+      and(
+        eq(soapNoteAddenda.practiceId, input.practiceId),
+        eq(soapNoteAddenda.operationId, input.operationId),
+      ),
+    )
+    .limit(1);
+  if (existing) {
+    if (existing.operationPayloadHash === payloadHash) return existing;
+    throw new SoapLifecycleError(
+      "CONFLICT",
+      "This addendum operation was already used for different content.",
+    );
+  }
+
+  const [note] = await db
+    .select({ id: soapNotes.id })
+    .from(soapNotes)
+    .where(
+      and(
+        eq(soapNotes.id, input.noteId),
+        eq(soapNotes.practiceId, input.practiceId),
+        eq(soapNotes.patientId, input.patientId),
+        eq(soapNotes.status, "finalized"),
+        isNull(soapNotes.deletedAt),
+        sql`not exists (
+          select 1 from ${clinicalRecordCorrections}
+          where ${clinicalRecordCorrections.practiceId} = ${input.practiceId}
+            and ${clinicalRecordCorrections.soapNoteId} = ${soapNotes.id}
+        )`,
+      ),
+    )
+    .limit(1)
+    .for("update");
+  if (!note) {
+    throw new SoapLifecycleError(
+      "PRECONDITION_FAILED",
+      "Addenda require an active finalized SOAP note.",
+    );
+  }
+
+  const [created] = await db
+    .insert(soapNoteAddenda)
+    .values({
+      practiceId: input.practiceId,
+      soapNoteId: note.id,
+      authorId: input.actor.id,
+      authorName: input.actor.name,
+      content,
+      operationId: input.operationId,
+      operationPayloadHash: payloadHash,
+    })
+    .onConflictDoNothing()
+    .returning();
+  if (created) return created;
+  const [concurrent] = await db
+    .select()
+    .from(soapNoteAddenda)
+    .where(
+      and(
+        eq(soapNoteAddenda.practiceId, input.practiceId),
+        eq(soapNoteAddenda.operationId, input.operationId),
+      ),
+    )
+    .limit(1);
+  if (concurrent?.operationPayloadHash === payloadHash) return concurrent;
+  throw new SoapLifecycleError(
+    "CONFLICT",
+    "This addendum operation was already used for different content.",
+  );
+}

--- a/apps/web/lib/records/soap-navigation.ts
+++ b/apps/web/lib/records/soap-navigation.ts
@@ -1,0 +1,115 @@
+export interface SoapNavigationClick {
+  href: string;
+  currentHref: string;
+  button: number;
+  defaultPrevented: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  target: string | null;
+  download: boolean;
+}
+
+export interface SoapLeaveState {
+  finalizedElsewhere: boolean;
+  needsGuard: boolean;
+  localTextCopied: boolean;
+  hasLocalText: boolean;
+}
+
+export function soapEditorNeedsLeaveGuard(input: {
+  draftInitialized: boolean;
+  finalizedElsewhere: boolean;
+  localTextCopied: boolean;
+  hasLocalText: boolean;
+  conflict: boolean;
+  savePending: boolean;
+  dirty: boolean;
+}): boolean {
+  if (input.finalizedElsewhere) {
+    return input.hasLocalText && !input.localTextCopied;
+  }
+  if (!input.draftInitialized) return false;
+  return input.conflict || input.savePending || input.dirty;
+}
+
+export async function runSoapSafeLeave(input: {
+  readState: () => SoapLeaveState;
+  persistDraft: () => Promise<unknown>;
+  confirmFinalizedLocalTextLeave: () => boolean;
+  confirmUnsavedLeave: () => boolean;
+  navigate: () => void;
+}): Promise<boolean> {
+  let state = input.readState();
+  if (!state.finalizedElsewhere && state.needsGuard) {
+    await input.persistDraft();
+    // Persist can discover that another session finalized the note. Re-read
+    // before navigation so preserved local text cannot be stranded by a race.
+    state = input.readState();
+  }
+
+  if (
+    state.finalizedElsewhere &&
+    state.hasLocalText &&
+    !state.localTextCopied &&
+    !input.confirmFinalizedLocalTextLeave()
+  ) {
+    return false;
+  }
+  if (
+    !state.finalizedElsewhere &&
+    state.needsGuard &&
+    !input.confirmUnsavedLeave()
+  ) {
+    return false;
+  }
+
+  input.navigate();
+  return true;
+}
+
+/**
+ * Returns an in-app destination only when an ordinary primary anchor click
+ * should be routed through the SOAP editor's save-before-leave guard.
+ */
+export function guardedSoapNavigationDestination(
+  click: SoapNavigationClick,
+): string | null {
+  if (
+    click.defaultPrevented ||
+    click.button !== 0 ||
+    click.metaKey ||
+    click.ctrlKey ||
+    click.shiftKey ||
+    click.altKey ||
+    click.download
+  ) {
+    return null;
+  }
+
+  const target = click.target?.trim().toLowerCase();
+  if (target && target !== "_self") return null;
+
+  let current: URL;
+  let destination: URL;
+  try {
+    current = new URL(click.currentHref);
+    destination = new URL(click.href, current);
+  } catch {
+    return null;
+  }
+
+  if (destination.origin !== current.origin) return null;
+
+  // Let the browser handle hash-only links and no-op links locally. There is
+  // no page teardown for the draft guard to protect in either case.
+  if (
+    destination.pathname === current.pathname &&
+    destination.search === current.search
+  ) {
+    return null;
+  }
+
+  return `${destination.pathname}${destination.search}${destination.hash}`;
+}

--- a/apps/web/lib/records/soap-templates.ts
+++ b/apps/web/lib/records/soap-templates.ts
@@ -167,9 +167,9 @@ export function applySoapTemplateToSections(
   };
 }
 
-export function hasUnresolvedSoapTemplatePrompts(
-  sections: Partial<SoapSections>
-): boolean {
+export function hasUnresolvedSoapTemplatePrompts(sections: {
+  [K in keyof SoapSections]?: string | null;
+}): boolean {
   return Object.values(sections).some((section) => {
     const text = soapSectionText(section ?? "");
     return (

--- a/apps/web/server/__tests__/admin-analytics-exclusion.test.ts
+++ b/apps/web/server/__tests__/admin-analytics-exclusion.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => {
   const where = vi.fn(() => ({ returning }));
   const updateSet = vi.fn(() => ({ where }));
   const update = vi.fn(() => ({ set: updateSet }));
-  const db = { update };
+  const db = { update, execute: vi.fn(async () => undefined) };
   return {
     db,
     update,

--- a/apps/web/server/__tests__/admin-extend-trial.test.ts
+++ b/apps/web/server/__tests__/admin-extend-trial.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => {
       return { where: vi.fn(async () => undefined) };
     }),
   }));
-  const db = { select, update };
+  const db = { select, update, execute: vi.fn(async () => undefined) };
 
   return {
     db,
@@ -48,6 +48,9 @@ vi.mock("@openpims/db/client", () => ({
 vi.mock("@/lib/tenant-db", () => ({
   withTenant: mocks.withTenant,
   withSystem: mocks.withSystem,
+}));
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(async () => undefined),
 }));
 
 const { adminRouter } = await import("../routers/admin");

--- a/apps/web/server/__tests__/admin-messaging-operations.test.ts
+++ b/apps/web/server/__tests__/admin-messaging-operations.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => {
   const updateWhere = vi.fn(() => ({ returning: updateReturning }));
   const updateSet = vi.fn(() => ({ where: updateWhere }));
   const update = vi.fn(() => ({ set: updateSet }));
-  const db = { select, update };
+  const db = { select, update, execute: vi.fn(async () => undefined) };
   return {
     db,
     selectResults,
@@ -59,6 +59,9 @@ vi.mock("@openpims/db/client", () => ({ db: mocks.db }));
 vi.mock("@/lib/tenant-db", () => ({
   withTenant: mocks.withTenant,
   withSystem: mocks.withSystem,
+}));
+vi.mock("@/lib/audit", () => ({
+  recordAuditLog: vi.fn(async () => undefined),
 }));
 vi.mock("@/lib/messaging/telnyx-provisioning", () => ({
   createA2pBrand: mocks.createA2pBrand,

--- a/apps/web/server/__tests__/ai-safety.test.ts
+++ b/apps/web/server/__tests__/ai-safety.test.ts
@@ -137,6 +137,10 @@ describe("AI SOAP note safety", () => {
         [{ id: PATIENT_ID }],
         [{ id: APPOINTMENT_ID, doctorId: USER_ID, status: "in_exam" }],
         [],
+        [{ id: APPOINTMENT_ID, doctorId: USER_ID, status: "in_exam" }],
+        [],
+        [],
+        [],
       ],
       insertedRows: [{ id: NOTE_ID, patientId: PATIENT_ID }],
     });
@@ -293,9 +297,9 @@ describe("AI recommendation query safety", () => {
     return new RegExp(
       `${joinMethod}\\(\\s*${table},\\s*and\\(\\s*eq\\(${foreignKey.replace(
         ".",
-        "\\."
-      )}, ${table}\\.id\\),\\s*eq\\(${table}\\.practiceId, ctx\\.practiceId\\),\\s*activePracticePredicate\\(ctx\\.practiceId\\),\\s*isNull\\(${table}\\.deletedAt\\)\\s*\\)\\s*\\)`,
-      "gs"
+        "\\.",
+      )}, ${table}\\.id\\),\\s*eq\\(${table}\\.practiceId, ctx\\.practiceId\\),\\s*activePracticePredicate\\(ctx\\.practiceId\\),\\s*isNull\\(${table}\\.deletedAt\\),?\\s*\\),?\\s*\\)`,
+      "gs",
     );
   }
 
@@ -389,8 +393,8 @@ describe("AI recommendation query safety", () => {
     expect(summaryBlock).toContain("const today = await practiceDayRange(ctx)");
     expect(summaryBlock).toContain("gte(appointments.startTime, today.start)");
     expect(summaryBlock).toContain("lt(appointments.startTime, today.end)");
-    expect(summaryBlock).toContain("gte(soapNotes.createdAt, today.start)");
-    expect(summaryBlock).toContain("lt(soapNotes.createdAt, today.end)");
+    expect(summaryBlock).toContain("gte(soapNotes.finalizedAt, today.start)");
+    expect(summaryBlock).toContain("lt(soapNotes.finalizedAt, today.end)");
     expect(summaryBlock).toContain("gte(invoices.updatedAt, today.start)");
     expect(summaryBlock).toContain("lt(invoices.updatedAt, today.end)");
     expect(summaryBlock).toContain("date: today.date");
@@ -459,7 +463,7 @@ describe("AI recommendation query safety", () => {
     );
 
     expect(followUpBlock).toMatch(
-      /innerJoin\(\s*patients,\s*and\(\s*eq\(appointments\.patientId, patients\.id\),\s*eq\(patients\.clientId, appointments\.clientId\),\s*eq\(patients\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\),\s*isNull\(patients\.deletedAt\)\s*\)\s*\)/s
+      /innerJoin\(\s*patients,\s*and\(\s*eq\(appointments\.patientId, patients\.id\),\s*eq\(patients\.clientId, appointments\.clientId\),\s*eq\(patients\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\),\s*isNull\(patients\.deletedAt\),?\s*\),?\s*\)/s,
     );
   });
 

--- a/apps/web/server/__tests__/clinical-corrections.test.ts
+++ b/apps/web/server/__tests__/clinical-corrections.test.ts
@@ -180,6 +180,14 @@ describe("append-only clinical corrections", () => {
             appointmentId: APPOINTMENT_ID,
           },
         ],
+        [{ id: APPOINTMENT_ID }],
+        [
+          {
+            id: RECORD_ID,
+            patientId: PATIENT_ID,
+            appointmentId: APPOINTMENT_ID,
+          },
+        ],
       ],
       insertResults: [[correction]],
     });
@@ -246,6 +254,7 @@ describe("append-only clinical corrections", () => {
     const { db, select } = createDb({
       selectResults: [
         [{ id: RECORD_ID, patientId: PATIENT_ID, appointmentId: null }],
+        [{ id: RECORD_ID, patientId: PATIENT_ID, appointmentId: null }],
         [existing],
       ],
       insertResults: [[]],
@@ -258,7 +267,7 @@ describe("append-only clinical corrections", () => {
         reason: "Duplicate request after a network retry.",
       }),
     ).resolves.toEqual(existing);
-    expect(select).toHaveBeenCalledTimes(2);
+    expect(select).toHaveBeenCalledTimes(3);
   });
 
   it("restricts vaccination correction to an administrator or veterinarian", async () => {

--- a/apps/web/server/__tests__/data-import-dedup.test.ts
+++ b/apps/web/server/__tests__/data-import-dedup.test.ts
@@ -362,9 +362,9 @@ describe("data import duplicate handling", () => {
       db,
       expect.objectContaining({ importedCount: 0, reconciledCount: 0 }),
     );
-    // Tenant scoping plus SERIALIZABLE isolation both execute inside the same
-    // transaction before the ledger is completed.
-    expect(execute).toHaveBeenCalledTimes(2);
+    // Tenant scoping, SERIALIZABLE isolation, and the deferred-constraint
+    // flush all execute inside the same transaction before commit.
+    expect(execute).toHaveBeenCalledTimes(3);
     expect(insertValues).not.toHaveBeenCalled();
   });
 
@@ -1181,7 +1181,7 @@ describe("data import duplicate handling", () => {
       db,
       expect.objectContaining({ importedCount: 0, reconciledCount: 0 }),
     );
-    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute).toHaveBeenCalledTimes(3);
     expect(insertValues).not.toHaveBeenCalled();
   });
 

--- a/apps/web/server/__tests__/encounters-closeout.test.ts
+++ b/apps/web/server/__tests__/encounters-closeout.test.ts
@@ -487,7 +487,28 @@ describe("encounter closeout safety", () => {
       })
     ).rejects.toMatchObject({
       code: "PRECONDITION_FAILED",
-      message: "Link a SOAP note or document why one is not required.",
+      message: "Finalize the SOAP draft or document why SOAP is not required.",
+    });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("does not let an exception strand an unfinished SOAP draft", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [],
+        [],
+        [{ id: "soap-draft" }],
+      ],
+    });
+
+    await expect(
+      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message:
+        "Finalize the SOAP draft before signing clinical closeout. A documentation exception cannot strand an unfinished draft.",
     });
     expect(insertValues).not.toHaveBeenCalled();
   });
@@ -539,6 +560,7 @@ describe("encounter closeout safety", () => {
         [{ id: PATIENT_ID }],
         [],
         [{ id: "soap" }],
+        [],
         [medication],
       ],
       insertResults: [[finalized]],
@@ -562,6 +584,7 @@ describe("encounter closeout safety", () => {
         [{ id: PATIENT_ID }],
         [],
         [{ id: "soap" }],
+        [],
         [
           {
             prescriptionId: "00000000-0000-0000-0000-000000000077",
@@ -830,6 +853,7 @@ describe("encounter closeout safety", () => {
         [completedWithDraft],
         [],
         [],
+        [],
         [{ name: "Alex Coordinator", email: "alex@example.com" }],
       ],
       updateResults: [[finalized]],
@@ -877,6 +901,7 @@ describe("encounter closeout safety", () => {
       selectResults: [
         [openAppointment],
         [{ id: PATIENT_ID }],
+        [],
         [],
         [],
         [],

--- a/apps/web/server/__tests__/records-prescription-safety.test.ts
+++ b/apps/web/server/__tests__/records-prescription-safety.test.ts
@@ -680,7 +680,6 @@ describe("records list query scoping", () => {
 
   it("keeps joined staff rows tenant scoped and active", () => {
     for (const foreignKey of [
-      "soapNotes.authorId",
       "vaccinationRecords.administeredBy",
       "prescriptions.prescribedBy",
       "procedures.performedBy",
@@ -695,6 +694,10 @@ describe("records list query scoping", () => {
         ),
       );
     }
+    expect(source).toContain("authorName: soapNotes.authorName");
+    expect(source).not.toMatch(
+      /leftJoin\(\s*users,\s*and\(\s*eq\(soapNotes\.authorId, users\.id\)/s,
+    );
     expect(source).toMatch(
       /leftJoin\(\s*orderedBy,\s*and\(\s*eq\(labResults\.orderedBy, orderedBy\.id\),\s*eq\(orderedBy\.practiceId, ctx\.practiceId\)\s*,?\s*\)\s*,?\s*\)/s,
     );
@@ -731,8 +734,8 @@ describe("records prescription retry UX", () => {
   );
 
   it("keeps one operation ID until prescription creation succeeds or is cancelled", () => {
-    expect(source).toContain(
-      "prescriptionOperationId.current ??= crypto.randomUUID()",
+    expect(source).toMatch(
+      /prescriptionOperationId\.current\s*\?\?=\s*crypto\.randomUUID\(\)/,
     );
     expect(source).toContain("operationId: prescriptionOperationId.current");
     expect(source).toContain("prescriptionOperationId.current = null");

--- a/apps/web/server/__tests__/records-target-safety.test.ts
+++ b/apps/web/server/__tests__/records-target-safety.test.ts
@@ -430,9 +430,9 @@ describe("records target safety", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
-  it("creates a SOAP note after validating patient and appointment ownership", async () => {
+  it("creates a finalized SOAP note after locking the owned open appointment", async () => {
     const { db, insertValues } = createDb({
-      selectResults: [patientRow, appointmentRow, []],
+      selectResults: [appointmentRow, [], []],
       insertedRows: [
         {
           id: RECORD_ID,
@@ -457,7 +457,11 @@ describe("records target safety", () => {
         appointmentId: APPOINTMENT_ID,
         practiceId: PRACTICE_ID,
         authorId: USER_ID,
-      })
+        authorName: "Doctor",
+        status: "finalized",
+        finalizedBy: USER_ID,
+        finalizerName: "Doctor",
+      }),
     );
     expect(mocks.dispatchWebhookEvent).toHaveBeenCalledWith(
       PRACTICE_ID,
@@ -501,7 +505,8 @@ describe("records target safety", () => {
       })
     ).rejects.toMatchObject({
       code: "BAD_REQUEST",
-      message: "Replace or delete every SOAP template prompt before saving.",
+      message:
+        "Replace or delete every SOAP template prompt before finalization.",
     });
 
     expect(select).not.toHaveBeenCalled();

--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -687,6 +687,27 @@ describe("settings demo data cleanup scoping", () => {
       "${invoices.practiceId} = ${ctx.practiceId}"
     );
   });
+
+  it("derives and records legacy demo SOAP ids before immutable cleanup", () => {
+    const clearDemoBlock = SETTINGS_SOURCE.match(
+      /clearDemoData:[\s\S]+?reseedDemoData:/,
+    )?.[0];
+
+    expect(clearDemoBlock).toContain("let demoSoapNoteIds");
+    expect(clearDemoBlock).toContain(
+      "inArray(soapNotes.appointmentId, demo.appointmentIds)",
+    );
+    expect(clearDemoBlock).toContain(
+      "inArray(soapNotes.patientId, demo.patientIds)",
+    );
+    expect(clearDemoBlock).toContain(
+      "demoData: { ...demo, soapNoteIds: demoSoapNoteIds }",
+    );
+    expect(clearDemoBlock?.indexOf("settingsMergePatch({")).toBeLessThan(
+      clearDemoBlock?.indexOf(".update(soapNotes)") ?? -1,
+    );
+    expect(clearDemoBlock).toContain("inArray(soapNotes.id, demoSoapNoteIds)");
+  });
 });
 
 describe("settings scheduling metadata delete safety", () => {

--- a/apps/web/server/__tests__/trpc-post-commit.test.ts
+++ b/apps/web/server/__tests__/trpc-post-commit.test.ts
@@ -4,8 +4,10 @@ const mocks = vi.hoisted(() => {
   let systemDepth = 0;
   let tenantDepth = 0;
   const events: string[] = [];
+  const executeErrors: unknown[] = [];
   return {
     events,
+    executeErrors,
     get systemDepth() {
       return systemDepth;
     },
@@ -33,7 +35,16 @@ const mocks = vi.hoisted(() => {
         tenantDepth += 1;
         events.push("tenant:begin");
         try {
-          return await fn({ scope: "tenant", root: database });
+          return await fn({
+            scope: "tenant",
+            root: database,
+            execute: vi.fn(async () => {
+              events.push("tenant:constraints");
+              const error = executeErrors.shift();
+              if (error) throw error;
+              return [];
+            }),
+          });
         } finally {
           events.push("tenant:commit");
           tenantDepth -= 1;
@@ -91,6 +102,7 @@ const router = createRouter({
 
 afterEach(() => {
   mocks.events.length = 0;
+  mocks.executeErrors.length = 0;
   vi.clearAllMocks();
 });
 
@@ -130,5 +142,67 @@ describe("tRPC post-commit effects", () => {
     const effectIndex = mocks.events.indexOf("protected:effect");
     expect(commitIndex).toBeGreaterThan(-1);
     expect(effectIndex).toBeGreaterThan(commitIndex);
+    expect(mocks.events.indexOf("tenant:constraints")).toBeLessThan(
+      commitIndex,
+    );
+  });
+
+  it("maps only the named deferred SOAP invariant and runs no audit or effect", async () => {
+    mocks.executeErrors.push({
+      code: "23514",
+      constraint_name: "soap_notes_appointment_invariant",
+    });
+    const caller = router.createCaller({
+      db: { kind: "root-tenant" },
+      session: {
+        user: {
+          id: "user-1",
+          email: "owner@example.com",
+          name: "Owner",
+          role: "admin",
+          practiceId: "practice-1",
+        },
+      },
+    } as never);
+
+    await expect(caller.protectedEffect()).rejects.toMatchObject({
+      code: "CONFLICT",
+      message:
+        "Clinical documentation changed in another session. Refresh and retry.",
+    });
+    expect(mocks.events).not.toContain("protected:effect");
+    expect(mocks.recordAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("does not mislabel unrelated check violations", async () => {
+    const unrelated = {
+      code: "23514",
+      constraint_name: "some_other_check",
+    };
+    mocks.executeErrors.push(unrelated);
+    const caller = router.createCaller({
+      db: { kind: "root-tenant" },
+      session: {
+        user: {
+          id: "user-1",
+          email: "owner@example.com",
+          name: "Owner",
+          role: "admin",
+          practiceId: "practice-1",
+        },
+      },
+    } as never);
+
+    const attempt = caller.protectedEffect();
+    await expect(attempt).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+    });
+    await expect(attempt).rejects.not.toMatchObject({
+      code: "CONFLICT",
+      message:
+        "Clinical documentation changed in another session. Refresh and retry.",
+    });
+    expect(mocks.events).not.toContain("protected:effect");
+    expect(mocks.recordAuditLog).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/routers/ai.ts
+++ b/apps/web/server/routers/ai.ts
@@ -42,6 +42,10 @@ import { optionalClinicalTextInput } from "@/lib/records/clinical-inputs";
 import { lockOpenVisitForClinicalAppend } from "@/lib/records/visit-integrity";
 import { hasUnresolvedSoapTemplatePrompts } from "@/lib/records/soap-templates";
 import { AI_SOURCE_MAX_LENGTH } from "@/lib/ai/soap";
+import {
+  createFinalizedAppointmentSoapNote,
+  SoapLifecycleError,
+} from "@/lib/records/soap-lifecycle";
 
 export { AI_SOURCE_MAX_LENGTH };
 
@@ -224,7 +228,7 @@ export const aiRouter = createRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      const { source, ...noteData } = input;
+      const { source } = input;
       const normalizedNote = {
         subjective: normalizeSoapSection(input.subjective),
         objective: normalizeSoapSection(input.objective),
@@ -250,24 +254,30 @@ export const aiRouter = createRouter({
         input.appointmentId,
         input.patientId
       );
-      const [note] = await ctx.db
-        .insert(soapNotes)
-        .values({
-          patientId: noteData.patientId,
-          appointmentId: noteData.appointmentId,
-          ...normalizedNote,
-          authorId: ctx.user.id,
-          practiceId: ctx.practiceId,
-        })
-        .returning();
-      return { ...note!, source };
+      try {
+        const note = await ctx.db.transaction((tx) =>
+          createFinalizedAppointmentSoapNote(tx as unknown as Database, {
+            practiceId: ctx.practiceId,
+            patientId: input.patientId,
+            appointmentId: input.appointmentId,
+            actor: { id: ctx.user.id, name: ctx.user.name },
+            sections: normalizedNote,
+          }),
+        );
+        return { ...note, source };
+      } catch (error) {
+        if (error instanceof SoapLifecycleError) {
+          throw new TRPCError({ code: error.code, message: error.message });
+        }
+        throw error;
+      }
     }),
 
   /**
    * AI SOAP draft for the in-app editor ("Draft with AI").
    * Unlike createSoapFromAI above (external scribes POST finished notes),
-   * this generates a draft from chart context and returns it WITHOUT saving;
-   * the clinician reviews, edits, and saves through records.createSoapNote.
+   * this generates a draft from chart context and returns it to the persisted
+   * editor draft; the clinician reviews, edits, and explicitly finalizes it.
    * Gated like the agent: SOAP-writing roles + the hosted "agent" feature.
    */
   draftSoapNote: protectedProcedure
@@ -609,43 +619,44 @@ export const aiRouter = createRouter({
             lt(appointments.startTime, today.end)
           )
         )
-        .groupBy(appointments.status),
+          .groupBy(appointments.status),
 
-      // SOAP notes created today
-      ctx.db
-        .select({ count: sql<number>`count(*)` })
-        .from(soapNotes)
-        .where(
-          and(
-            eq(soapNotes.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(soapNotes.deletedAt),
-            sql`not exists (
+        // SOAP notes created today
+        ctx.db
+          .select({ count: sql<number>`count(*)` })
+          .from(soapNotes)
+          .where(
+            and(
+              eq(soapNotes.practiceId, ctx.practiceId),
+              eq(soapNotes.status, "finalized"),
+              activePracticePredicate(ctx.practiceId),
+              isNull(soapNotes.deletedAt),
+              sql`not exists (
               select 1
               from ${clinicalRecordCorrections}
               where ${clinicalRecordCorrections.practiceId} = ${ctx.practiceId}
                 and ${clinicalRecordCorrections.soapNoteId} = ${soapNotes.id}
             )`,
-            gte(soapNotes.createdAt, today.start),
-            lt(soapNotes.createdAt, today.end)
-          )
-        ),
+              gte(soapNotes.finalizedAt, today.start),
+              lt(soapNotes.finalizedAt, today.end),
+            ),
+          ),
 
-      // Invoices paid today
-      ctx.db
-        .select({ count: sql<number>`count(*)` })
-        .from(invoices)
-        .where(
-          and(
-            eq(invoices.practiceId, ctx.practiceId),
-            activePracticePredicate(ctx.practiceId),
-            isNull(invoices.deletedAt),
-            eq(invoices.status, "paid"),
-            gte(invoices.updatedAt, today.start),
-            lt(invoices.updatedAt, today.end)
-          )
-        ),
-    ]);
+        // Invoices paid today
+        ctx.db
+          .select({ count: sql<number>`count(*)` })
+          .from(invoices)
+          .where(
+            and(
+              eq(invoices.practiceId, ctx.practiceId),
+              activePracticePredicate(ctx.practiceId),
+              isNull(invoices.deletedAt),
+              eq(invoices.status, "paid"),
+              gte(invoices.updatedAt, today.start),
+              lt(invoices.updatedAt, today.end),
+            ),
+          ),
+      ]);
 
     const statusMap = Object.fromEntries(
       appointmentsByStatus.map((r) => [r.status, Number(r.count)])

--- a/apps/web/server/routers/data.ts
+++ b/apps/web/server/routers/data.ts
@@ -29,6 +29,7 @@ import {
   SOAP_SECTION_MAX_LENGTH,
   hasSoapContent,
 } from "@/lib/records/soap-content";
+import { finalizedSoapInsertValues } from "@/lib/records/soap-lifecycle";
 import {
   exportPracticeData,
   restorePracticeData,
@@ -76,10 +77,16 @@ type VaccinationImportRow = Omit<
 >;
 // authorId is stamped in the mutation (the importing admin); historical
 // imports have no OpenVPM author of their own.
-type SoapNoteImportRow = Omit<
-  typeof soapNotes.$inferInsert,
-  "practiceId" | "authorId"
->;
+type SoapNoteImportRow = {
+  patientId: string;
+  appointmentId: null;
+  subjective: string | null;
+  objective: string | null;
+  assessment: string | null;
+  plan: string | null;
+  createdAt: Date;
+  importFingerprint: string;
+};
 type DataContext = {
   db: Database;
   practiceId: string;
@@ -1966,6 +1973,7 @@ async function loadSoapNoteCsvPlan(
     .where(
       and(
         eq(soapNotes.practiceId, practiceId),
+        eq(soapNotes.status, "finalized"),
         activePracticePredicate(practiceId),
         isNull(soapNotes.deletedAt),
       ),
@@ -3181,10 +3189,12 @@ export const dataRouter = createRouter({
             plan.rows.map((n) => ({
               ...n,
               practiceId: ctx.practiceId,
-              authorId: ctx.user.id,
-              // Mark as migrated so the record shows "Imported" rather than
-              // implying the importing admin authored this historical note.
-              imported: true,
+              ...finalizedSoapInsertValues({
+                actor: { id: ctx.user.id, name: ctx.user.name },
+                sections: n,
+                finalizedAt: n.createdAt,
+                imported: true,
+              }),
             })),
           );
         }

--- a/apps/web/server/routers/encounters.ts
+++ b/apps/web/server/routers/encounters.ts
@@ -655,79 +655,98 @@ export const encountersRouter = createRouter({
       const [
         closeout,
         linkedSoapRows,
+        soapDraftRows,
         medications,
         followUpAppointments,
         followUpAssignees,
       ] = await Promise.all([
-          getCloseoutRow(ctx, input.appointmentId),
-          ctx.db
-            .select({ id: soapNotes.id })
-            .from(soapNotes)
-            .where(
-              and(
-                eq(soapNotes.appointmentId, input.appointmentId),
-                eq(soapNotes.practiceId, ctx.practiceId),
-                isNull(soapNotes.deletedAt),
-                sql`not exists (
+        getCloseoutRow(ctx, input.appointmentId),
+        ctx.db
+          .select({ id: soapNotes.id })
+          .from(soapNotes)
+          .where(
+            and(
+              eq(soapNotes.appointmentId, input.appointmentId),
+              eq(soapNotes.practiceId, ctx.practiceId),
+              eq(soapNotes.status, "finalized"),
+              isNull(soapNotes.deletedAt),
+              sql`not exists (
                   select 1
                   from ${clinicalRecordCorrections}
                   where ${clinicalRecordCorrections.practiceId} = ${ctx.practiceId}
                     and ${clinicalRecordCorrections.soapNoteId} = ${soapNotes.id}
-                )`
-              )
+                )`,
             ),
-          ctx.db
-            .select({
-              id: prescriptions.id,
-              medicationName: prescriptions.medicationName,
-              dosage: prescriptions.dosage,
-              frequency: prescriptions.frequency,
-              instructions: prescriptions.instructions,
-              quantity: prescriptions.quantity,
-              productId: prescriptions.productId,
-              productName: products.name,
-              productTaxable: products.taxable,
-              productUnitPrice: dispenseChargeQueue.unitPriceSnapshot,
-              dispenseChargeId: dispenseChargeQueue.id,
-              dispenseChargeStatus: dispenseChargeQueue.status,
-              dispenseChargeDescription: dispenseChargeQueue.descriptionSnapshot,
-              status: prescriptions.status,
-              endDate: prescriptions.endDate,
-            })
-            .from(prescriptions)
-            .leftJoin(
-              products,
-              and(
-                eq(prescriptions.productId, products.id),
-                eq(products.practiceId, ctx.practiceId)
-              )
-            )
-            .leftJoin(
-              prescriptionEvents,
-              and(
-                eq(prescriptionEvents.prescriptionId, prescriptions.id),
-                eq(prescriptionEvents.practiceId, ctx.practiceId),
-                eq(prescriptionEvents.eventType, "created")
-              )
-            )
-            .leftJoin(
-              dispenseChargeQueue,
-              and(
-                eq(
-                  dispenseChargeQueue.prescriptionEventId,
-                  prescriptionEvents.id
-                ),
-                eq(dispenseChargeQueue.practiceId, ctx.practiceId)
-              )
-            )
-            .where(
-              and(
-                eq(prescriptions.appointmentId, input.appointmentId),
-                eq(prescriptions.practiceId, ctx.practiceId),
-                isNull(prescriptions.deletedAt)
-              )
-            )
-            .orderBy(desc(prescriptions.createdAt)),
+          ),
+        ctx.db
+          .select({
+            id: soapNotes.id,
+            revision: soapNotes.revision,
+            authorName: soapNotes.authorName,
+            updatedAt: soapNotes.updatedAt,
+          })
+          .from(soapNotes)
+          .where(
+            and(
+              eq(soapNotes.appointmentId, input.appointmentId),
+              eq(soapNotes.practiceId, ctx.practiceId),
+              eq(soapNotes.status, "draft"),
+              isNull(soapNotes.deletedAt),
+            ),
+          )
+          .limit(1),
+        ctx.db
+          .select({
+            id: prescriptions.id,
+            medicationName: prescriptions.medicationName,
+            dosage: prescriptions.dosage,
+            frequency: prescriptions.frequency,
+            instructions: prescriptions.instructions,
+            quantity: prescriptions.quantity,
+            productId: prescriptions.productId,
+            productName: products.name,
+            productTaxable: products.taxable,
+            productUnitPrice: dispenseChargeQueue.unitPriceSnapshot,
+            dispenseChargeId: dispenseChargeQueue.id,
+            dispenseChargeStatus: dispenseChargeQueue.status,
+            dispenseChargeDescription: dispenseChargeQueue.descriptionSnapshot,
+            status: prescriptions.status,
+            endDate: prescriptions.endDate,
+          })
+          .from(prescriptions)
+          .leftJoin(
+            products,
+            and(
+              eq(prescriptions.productId, products.id),
+              eq(products.practiceId, ctx.practiceId),
+            ),
+          )
+          .leftJoin(
+            prescriptionEvents,
+            and(
+              eq(prescriptionEvents.prescriptionId, prescriptions.id),
+              eq(prescriptionEvents.practiceId, ctx.practiceId),
+              eq(prescriptionEvents.eventType, "created"),
+            ),
+          )
+          .leftJoin(
+            dispenseChargeQueue,
+            and(
+              eq(
+                dispenseChargeQueue.prescriptionEventId,
+                prescriptionEvents.id,
+              ),
+              eq(dispenseChargeQueue.practiceId, ctx.practiceId),
+            ),
+          )
+          .where(
+            and(
+              eq(prescriptions.appointmentId, input.appointmentId),
+              eq(prescriptions.practiceId, ctx.practiceId),
+              isNull(prescriptions.deletedAt),
+            ),
+          )
+          .orderBy(desc(prescriptions.createdAt)),
           appointment.patientId && appointment.clientId
             ? ctx.db
                 .select({
@@ -807,6 +826,7 @@ export const encountersRouter = createRouter({
           timezone: appointment.practiceTimezone,
         },
         linkedSoapCount: linkedSoapRows.length,
+        soapDraft: soapDraftRows[0] ?? null,
         medications: medicationHistory,
         activeMedications: medicationHistory.filter(
           (medication) => medication.effectiveStatus === "active",
@@ -1637,6 +1657,7 @@ export const encountersRouter = createRouter({
             and(
               eq(soapNotes.appointmentId, input.appointmentId),
               eq(soapNotes.practiceId, ctx.practiceId),
+              eq(soapNotes.status, "finalized"),
               isNull(soapNotes.deletedAt),
               sql`not exists (
                 select 1
@@ -1647,10 +1668,30 @@ export const encountersRouter = createRouter({
             )
           )
           .limit(1);
+        const [soapDraft] = await tx
+          .select({ id: soapNotes.id })
+          .from(soapNotes)
+          .where(
+            and(
+              eq(soapNotes.appointmentId, input.appointmentId),
+              eq(soapNotes.practiceId, ctx.practiceId),
+              eq(soapNotes.status, "draft"),
+              isNull(soapNotes.deletedAt),
+            ),
+          )
+          .limit(1);
+        if (soapDraft) {
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message:
+              "Finalize the SOAP draft before signing clinical closeout. A documentation exception cannot strand an unfinished draft.",
+          });
+        }
         if (!soap && !input.documentationExceptionReason) {
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
-            message: "Link a SOAP note or document why one is not required.",
+            message:
+              "Finalize the SOAP draft or document why SOAP is not required.",
           });
         }
 

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -41,6 +41,7 @@ import {
   files,
   visitWorkItems,
   clinicalRecordCorrections,
+  soapNoteAddenda,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
@@ -108,6 +109,15 @@ import {
   CLINICAL_CORRECTION_REASON_MAX_LENGTH,
   CLINICAL_CORRECTION_REASON_MIN_LENGTH,
 } from "@/lib/records/clinical-correction-policy";
+import {
+  addFinalizedSoapAddendum,
+  createFinalizedAppointmentSoapNote,
+  discardAppointmentSoapDraft,
+  finalizeAppointmentSoapDraft,
+  getAppointmentSoapDraft,
+  saveAppointmentSoapDraft,
+  SoapLifecycleError,
+} from "@/lib/records/soap-lifecycle";
 import {
   effectivePrescriptionStatus,
   PRESCRIPTION_LIFECYCLE_REASON_MAX_LENGTH,
@@ -1081,6 +1091,29 @@ function assertLabStatusTransition(current: LabStatus, next: LabStatus) {
   });
 }
 
+const soapSectionsInput = {
+  subjective: optionalClinicalTextInput(
+    "SOAP subjective",
+    SOAP_SECTION_MAX_LENGTH,
+  ),
+  objective: optionalClinicalTextInput(
+    "SOAP objective",
+    SOAP_SECTION_MAX_LENGTH,
+  ),
+  assessment: optionalClinicalTextInput(
+    "SOAP assessment",
+    SOAP_SECTION_MAX_LENGTH,
+  ),
+  plan: optionalClinicalTextInput("SOAP plan", SOAP_SECTION_MAX_LENGTH),
+};
+
+function rethrowSoapLifecycleError(error: unknown): never {
+  if (error instanceof SoapLifecycleError) {
+    throw new TRPCError({ code: error.code, message: error.message });
+  }
+  throw error;
+}
+
 export const recordsRouter = createRouter({
   settings: protectedProcedure.query(async ({ ctx }) => practiceSettings(ctx)),
 
@@ -1088,7 +1121,7 @@ export const recordsRouter = createRouter({
   listSoapNotes: protectedProcedure
     .input(z.object({ patientId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
-      return ctx.db
+      const notes = await ctx.db
         .select({
           id: soapNotes.id,
           patientId: soapNotes.patientId,
@@ -1097,7 +1130,13 @@ export const recordsRouter = createRouter({
           objective: soapNotes.objective,
           assessment: soapNotes.assessment,
           plan: soapNotes.plan,
-          authorName: users.name,
+          authorId: soapNotes.authorId,
+          authorName: soapNotes.authorName,
+          status: soapNotes.status,
+          revision: soapNotes.revision,
+          finalizedAt: soapNotes.finalizedAt,
+          finalizedBy: soapNotes.finalizedBy,
+          finalizerName: soapNotes.finalizerName,
           imported: soapNotes.imported,
           createdAt: soapNotes.createdAt,
           correctionId: clinicalRecordCorrections.id,
@@ -1108,14 +1147,6 @@ export const recordsRouter = createRouter({
           correctedByName: clinicalRecordCorrections.correctedByName,
         })
         .from(soapNotes)
-        .leftJoin(
-          users,
-          and(
-            eq(soapNotes.authorId, users.id),
-            eq(users.practiceId, ctx.practiceId),
-            isNull(users.deletedAt)
-          )
-        )
         .leftJoin(
           clinicalRecordCorrections,
           and(
@@ -1132,6 +1163,38 @@ export const recordsRouter = createRouter({
           )
         )
         .orderBy(desc(soapNotes.createdAt));
+
+      if (notes.length === 0) return [];
+      const addenda = await ctx.db
+        .select({
+          id: soapNoteAddenda.id,
+          soapNoteId: soapNoteAddenda.soapNoteId,
+          authorId: soapNoteAddenda.authorId,
+          authorName: soapNoteAddenda.authorName,
+          content: soapNoteAddenda.content,
+          createdAt: soapNoteAddenda.createdAt,
+        })
+        .from(soapNoteAddenda)
+        .where(
+          and(
+            eq(soapNoteAddenda.practiceId, ctx.practiceId),
+            inArray(
+              soapNoteAddenda.soapNoteId,
+              notes.map((note) => note.id),
+            ),
+          ),
+        )
+        .orderBy(asc(soapNoteAddenda.createdAt), asc(soapNoteAddenda.id));
+      const addendaByNote = new Map<string, typeof addenda>();
+      for (const addendum of addenda) {
+        const list = addendaByNote.get(addendum.soapNoteId) ?? [];
+        list.push(addendum);
+        addendaByNote.set(addendum.soapNoteId, list);
+      }
+      return notes.map((note) => ({
+        ...note,
+        addenda: addendaByNote.get(note.id) ?? [],
+      }));
     }),
 
   markSoapNoteEnteredInError: protectedProcedure
@@ -1149,6 +1212,48 @@ export const recordsRouter = createRouter({
     )
     .mutation(async ({ ctx, input }) =>
       ctx.db.transaction(async (tx) => {
+        const sourcePredicate = and(
+          eq(soapNotes.id, input.recordId),
+          eq(soapNotes.patientId, input.patientId),
+          eq(soapNotes.practiceId, ctx.practiceId),
+          eq(soapNotes.status, "finalized"),
+          activePracticePredicate(ctx.practiceId),
+          isNull(soapNotes.deletedAt),
+        );
+        const [sourceIdentity] = await tx
+          .select({
+            id: soapNotes.id,
+            patientId: soapNotes.patientId,
+            appointmentId: soapNotes.appointmentId,
+          })
+          .from(soapNotes)
+          .where(sourcePredicate)
+          .limit(1);
+
+        if (!sourceIdentity) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Clinical record not found",
+          });
+        }
+
+        // The closeout path locks the appointment before reading SOAP state.
+        // Use the same order so correction and closeout cannot sign through
+        // one another based on different views of the chart.
+        if (sourceIdentity.appointmentId) {
+          await tx
+            .select({ id: appointments.id })
+            .from(appointments)
+            .where(
+              and(
+                eq(appointments.id, sourceIdentity.appointmentId),
+                eq(appointments.practiceId, ctx.practiceId),
+              ),
+            )
+            .limit(1)
+            .for("update");
+        }
+
         const [source] = await tx
           .select({
             id: soapNotes.id,
@@ -1156,21 +1261,14 @@ export const recordsRouter = createRouter({
             appointmentId: soapNotes.appointmentId,
           })
           .from(soapNotes)
-          .where(
-            and(
-              eq(soapNotes.id, input.recordId),
-              eq(soapNotes.patientId, input.patientId),
-              eq(soapNotes.practiceId, ctx.practiceId),
-              activePracticePredicate(ctx.practiceId),
-              isNull(soapNotes.deletedAt)
-            )
-          )
-          .limit(1);
-
+          .where(sourcePredicate)
+          .limit(1)
+          .for("update");
         if (!source) {
           throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Clinical record not found",
+            code: "CONFLICT",
+            message:
+              "SOAP note changed while the correction was being recorded. Refresh and retry.",
           });
         }
 
@@ -1216,65 +1314,168 @@ export const recordsRouter = createRouter({
       z.object({
         patientId: z.string().uuid(),
         appointmentId: z.string().uuid(),
-        subjective: optionalClinicalTextInput(
-          "SOAP subjective",
-          SOAP_SECTION_MAX_LENGTH
-        ),
-        objective: optionalClinicalTextInput(
-          "SOAP objective",
-          SOAP_SECTION_MAX_LENGTH
-        ),
-        assessment: optionalClinicalTextInput(
-          "SOAP assessment",
-          SOAP_SECTION_MAX_LENGTH
-        ),
-        plan: optionalClinicalTextInput("SOAP plan", SOAP_SECTION_MAX_LENGTH),
-      })
+        ...soapSectionsInput,
+      }),
     )
     .mutation(async ({ ctx, input }) => {
-      const normalizedNote = {
-        subjective: normalizeSoapSection(input.subjective),
-        objective: normalizeSoapSection(input.objective),
-        assessment: normalizeSoapSection(input.assessment),
-        plan: normalizeSoapSection(input.plan),
-      };
-      if (!hasSoapContent(normalizedNote)) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "SOAP note must include at least one section.",
-        });
+      let note;
+      try {
+        note = await ctx.db.transaction((tx) =>
+          createFinalizedAppointmentSoapNote(tx as unknown as Database, {
+            practiceId: ctx.practiceId,
+            patientId: input.patientId,
+            appointmentId: input.appointmentId,
+            actor: { id: ctx.user.id, name: ctx.user.name },
+            sections: input,
+          }),
+        );
+      } catch (error) {
+        rethrowSoapLifecycleError(error);
       }
-      if (hasUnresolvedSoapTemplatePrompts(normalizedNote)) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Replace or delete every SOAP template prompt before saving.",
+      const dispatch = () =>
+        dispatchWebhookEvent(ctx.practiceId, "soap_note.created", {
+          id: note.id,
+          patientId: note.patientId,
+          appointmentId: note.appointmentId,
+          authorId: note.authorId,
+          source: "dashboard",
         });
+      if (ctx.postCommitEffect) {
+        ctx.postCommitEffect(async () => dispatch());
+      } else {
+        await dispatch();
       }
-      await assertPatientBelongsToPractice(ctx, input.patientId);
-      await lockOpenAppointmentForClinicalWork(
-        ctx,
-        input.appointmentId,
-        input.patientId,
-        "SOAP documentation"
-      );
-      const [note] = await ctx.db
-        .insert(soapNotes)
-        .values({
-          patientId: input.patientId,
-          appointmentId: input.appointmentId,
-          ...normalizedNote,
-          authorId: ctx.user.id,
-          practiceId: ctx.practiceId,
-        })
-        .returning();
-      await dispatchWebhookEvent(ctx.practiceId, "soap_note.created", {
-        id: note!.id,
-        patientId: note!.patientId,
-        appointmentId: note!.appointmentId,
-        authorId: note!.authorId,
-        source: "dashboard",
-      });
-      return note!;
+      return note;
+    }),
+
+  getSoapDraft: protectedProcedure
+    .use(requireRole("admin", "veterinarian"))
+    .input(
+      z.object({
+        patientId: z.string().uuid(),
+        appointmentId: z.string().uuid(),
+      }),
+    )
+    .query(async ({ ctx, input }) =>
+      getAppointmentSoapDraft(ctx.db, {
+        practiceId: ctx.practiceId,
+        ...input,
+      }),
+    ),
+
+  saveSoapDraft: protectedProcedure
+    .use(requireRole("admin", "veterinarian"))
+    .input(
+      z.object({
+        patientId: z.string().uuid(),
+        appointmentId: z.string().uuid(),
+        noteId: z.string().uuid().optional(),
+        expectedRevision: z.number().int().min(0),
+        ...soapSectionsInput,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await ctx.db.transaction((tx) =>
+          saveAppointmentSoapDraft(tx as unknown as Database, {
+            practiceId: ctx.practiceId,
+            ...input,
+            actor: { id: ctx.user.id, name: ctx.user.name },
+            sections: input,
+          }),
+        );
+      } catch (error) {
+        rethrowSoapLifecycleError(error);
+      }
+    }),
+
+  finalizeSoapNote: protectedProcedure
+    .use(requireRole("admin", "veterinarian"))
+    .input(
+      z.object({
+        patientId: z.string().uuid(),
+        appointmentId: z.string().uuid(),
+        noteId: z.string().uuid(),
+        expectedRevision: z.number().int().min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      let result;
+      try {
+        result = await ctx.db.transaction((tx) =>
+          finalizeAppointmentSoapDraft(tx as unknown as Database, {
+            practiceId: ctx.practiceId,
+            ...input,
+            actor: { id: ctx.user.id, name: ctx.user.name },
+          }),
+        );
+      } catch (error) {
+        rethrowSoapLifecycleError(error);
+      }
+      if (result.outcome === "finalized" && result.transitioned) {
+        const note = result.note;
+        const dispatch = () =>
+          dispatchWebhookEvent(ctx.practiceId, "soap_note.created", {
+            id: note.id,
+            patientId: note.patientId,
+            appointmentId: note.appointmentId,
+            authorId: note.authorId,
+            source: "dashboard",
+          });
+        if (ctx.postCommitEffect) {
+          ctx.postCommitEffect(async () => dispatch());
+        } else {
+          await dispatch();
+        }
+      }
+      return result;
+    }),
+
+  discardSoapDraft: protectedProcedure
+    .use(requireRole("admin", "veterinarian"))
+    .input(
+      z.object({
+        patientId: z.string().uuid(),
+        appointmentId: z.string().uuid(),
+        noteId: z.string().uuid(),
+        expectedRevision: z.number().int().min(1),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await ctx.db.transaction((tx) =>
+          discardAppointmentSoapDraft(tx as unknown as Database, {
+            practiceId: ctx.practiceId,
+            ...input,
+          }),
+        );
+      } catch (error) {
+        rethrowSoapLifecycleError(error);
+      }
+    }),
+
+  addSoapNoteAddendum: protectedProcedure
+    .use(requireRole("admin", "veterinarian"))
+    .input(
+      z.object({
+        patientId: z.string().uuid(),
+        noteId: z.string().uuid(),
+        operationId: z.string().uuid(),
+        content: z.string().trim().min(1).max(SOAP_SECTION_MAX_LENGTH),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await ctx.db.transaction((tx) =>
+          addFinalizedSoapAddendum(tx as unknown as Database, {
+            practiceId: ctx.practiceId,
+            ...input,
+            actor: { id: ctx.user.id, name: ctx.user.name },
+          }),
+        );
+      } catch (error) {
+        rethrowSoapLifecycleError(error);
+      }
     }),
 
   // Vaccinations

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -5,6 +5,7 @@ import {
   desc,
   eq,
   and,
+  or,
   isNull,
   inArray,
   ne,
@@ -1309,6 +1310,35 @@ export const settingsRouter = createRouter({
     const demo = settings.demoData;
     if (demo) {
       const now = new Date();
+      let demoSoapNoteIds = demo.soapNoteIds ?? [];
+      if (
+        demoSoapNoteIds.length === 0 &&
+        (demo.appointmentIds.length > 0 || demo.patientIds.length > 0)
+      ) {
+        const legacyDemoSoapNotes = await ctx.db
+          .select({ id: soapNotes.id })
+          .from(soapNotes)
+          .where(
+            and(
+              eq(soapNotes.practiceId, ctx.practiceId),
+              or(
+                inArray(soapNotes.appointmentId, demo.appointmentIds),
+                inArray(soapNotes.patientId, demo.patientIds),
+              ),
+            ),
+          );
+        demoSoapNoteIds = legacyDemoSoapNotes.map((note) => note.id);
+        if (demoSoapNoteIds.length > 0) {
+          await ctx.db
+            .update(practices)
+            .set({
+              settings: settingsMergePatch({
+                demoData: { ...demo, soapNoteIds: demoSoapNoteIds },
+              }),
+            })
+            .where(activePracticeWhere(ctx.practiceId));
+        }
+      }
       // Soft-delete the clinical and billing records first, then the
       // appointments/patients/clients they hang off of.
       if (demo.productIds?.length) {
@@ -1382,14 +1412,14 @@ export const settingsRouter = createRouter({
             ),
           );
       }
-      if (demo.soapNoteIds?.length) {
+      if (demoSoapNoteIds.length) {
         await ctx.db
           .update(soapNotes)
           .set({ deletedAt: now })
           .where(
             and(
               eq(soapNotes.practiceId, ctx.practiceId),
-              inArray(soapNotes.id, demo.soapNoteIds),
+              inArray(soapNotes.id, demoSoapNoteIds),
             ),
           );
       }

--- a/apps/web/server/trpc.ts
+++ b/apps/web/server/trpc.ts
@@ -3,7 +3,7 @@ import type { Session } from "next-auth";
 import { getServerSession } from "next-auth";
 import superjson from "superjson";
 import { ZodError } from "zod";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { authOptions } from "@/lib/auth";
 import { hasBlankConfiguredNextAuthSecret } from "@/lib/auth-secret";
 import { recordAuditLog } from "@/lib/audit";
@@ -261,25 +261,47 @@ export const protectedProcedure = t.procedure.use(
         },
       });
 
-      // Audit every successful mutation: who changed what, when, from where.
-      // Runs in its own system-context tx so it's independent of this request's
-      // transaction lifecycle and never blocks or fails the request.
       if (type === "mutation" && result.ok) {
-        const rawInput = await getRawInput().catch(() => undefined);
-        void withSystem(db, (sysTx) =>
-          recordAuditLog(sysTx, {
-            practiceId: user.practiceId,
-            userId: user.id,
-            ip: ctx.ip,
-            path,
-            rawInput,
-            resultData: (result as { data?: unknown }).data,
-          }),
-        ).catch(() => {});
+        // Surface deferred clinical invariants while this transaction can
+        // still return a truthful procedure error. The audit is scheduled
+        // only after withTenant confirms the commit succeeded.
+        await tx.execute(sql`set constraints all immediate`);
       }
 
       return result;
+    }).catch((error: unknown) => {
+      if (
+        type === "mutation" &&
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "23514" &&
+        "constraint_name" in error &&
+        error.constraint_name === "soap_notes_appointment_invariant"
+      ) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message:
+            "Clinical documentation changed in another session. Refresh and retry.",
+        });
+      }
+      throw error;
     });
+    // Audit every successful mutation after the tenant transaction committed.
+    // Runs in its own system-context tx and never blocks or fails the request.
+    if (type === "mutation" && result.ok) {
+      const rawInput = await getRawInput().catch(() => undefined);
+      void withSystem(db, (sysTx) =>
+        recordAuditLog(sysTx, {
+          practiceId: user.practiceId,
+          userId: user.id,
+          ip: ctx.ip,
+          path,
+          rawInput,
+          resultData: (result as { data?: unknown }).data,
+        }),
+      ).catch(() => {});
+    }
     if (result.ok) {
       await runPostCommitEffects(ctx.db, effects, path);
     }

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -172,7 +172,10 @@ subscribed endpoints with camelCase appointment fields (see the
 [Webhooks](../../README.md#webhooks) section).
 
 ### `POST /api/v1/soap-notes`
-Scope `records:write`. Create a SOAP note from an external AI scribe. Body:
+
+Scope `records:write`. Create an immediately finalized, immutable SOAP note
+from an external AI scribe. The clinician should review the content before the
+integration submits it. Body:
 
 ```json
 {
@@ -193,7 +196,9 @@ clinical closeout has not been finalized. `author_id` is optional when the
 appointment has an assigned doctor; otherwise it must identify an active admin
 or veterinarian in the authenticated practice. At least one SOAP section must
 contain clinical text. Returns `201` with `{ data: <soap_note> }` and fires the
-`soap_note.created` webhook.
+`soap_note.created` webhook. Returns `409` if the encounter already has a saved
+SOAP draft or an effective finalized SOAP note; integrations must not treat
+this endpoint as an editable draft workflow.
 
 ### `POST /api/v1/agent`
 Scope `agent:run`. Run the OpenVPM Agent over the API, scoped to the key's

--- a/docs/backup-restore-runbook.md
+++ b/docs/backup-restore-runbook.md
@@ -10,7 +10,8 @@ proves the whole path works.
 - **Where:** object storage, one file per practice per day:
   `backups/{practiceId}/{YYYY-MM-DD}.json` (date in the practice's timezone).
 - **What:** every practice-owned table, active rows only. That includes the
-  full clinical record (SOAP notes, clinical notes, vitals, vaccinations,
+  full clinical record (persisted SOAP drafts, immutable finalized SOAP notes
+  with attribution, SOAP corrections and addenda, clinical notes, vitals, vaccinations,
   labs plus their immutable completion/review/follow-up history, procedures,
   prescriptions, problem lists, cases, treatment plans,
   controlled-substance log), clients and patients, scheduling, billing

--- a/docs/help/your-data.md
+++ b/docs/help/your-data.md
@@ -9,8 +9,9 @@ Everything on this page lives in one place: **Settings → Data**.
 - **CSV exports.** Download your clients, patients, appointments, or
   invoices as simple spreadsheet files.
 - **Full backup.** Download your whole practice as one file: every client,
-  pet, note, shot, lab, bill, and payment. Click **Export Full Backup** and
-  keep the file somewhere safe.
+  pet, saved SOAP draft, signed note with its attribution, correction,
+  addendum, shot, lab, bill, and payment. Click **Export Full Backup** and keep
+  the file somewhere safe.
 
 On OpenVPM Cloud we also take a full backup of your practice every night and
 store it encrypted, separate from the live database.

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,7 +18,7 @@ The hosted application connects as `openpims_app`, a role with only `SELECT`, `I
 
 ## Backups and restore validation
 
-A scheduled job (`apps/web/app/api/cron/backup`, daily at 03:00 UTC) exports each practice's full data set to a private S3-compatible object storage bucket, one restorable snapshot per practice per day. The export includes the complete medical record: SOAP notes, clinical notes, problem lists, lab results, prescriptions, vaccination records, vital signs, and the controlled substance log, alongside scheduling, client, inventory, and billing data (`apps/web/lib/backup/export.ts`).
+A scheduled job (`apps/web/app/api/cron/backup`, daily at 03:00 UTC) exports each practice's full data set to a private S3-compatible object storage bucket, one restorable snapshot per practice per day. The export includes the complete medical record: persisted SOAP drafts, immutable finalized SOAP attribution, correction and addendum evidence, clinical notes, problem lists, lab results, prescriptions, vaccination records, vital signs, and the controlled substance log, alongside scheduling, client, inventory, and billing data (`apps/web/lib/backup/export.ts`).
 
 Restores are validated before anything is written: the backup file is checked against the expected sections and row shapes, and invalid or oversized files (over 50 MB) are rejected (`validatePracticeExportRestore`, `apps/web/lib/backup/policy.ts`). Backup failures page the operators through the ops alert webhook, and a dead-man heartbeat monitors that the job actually ran.
 

--- a/packages/db/drizzle/0063_modern_starbolt.sql
+++ b/packages/db/drizzle/0063_modern_starbolt.sql
@@ -1,0 +1,672 @@
+CREATE TYPE "public"."soap_note_status" AS ENUM('draft', 'finalized');--> statement-breakpoint
+CREATE TABLE "soap_note_addenda" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"practice_id" uuid NOT NULL,
+	"soap_note_id" uuid NOT NULL,
+	"author_id" uuid NOT NULL,
+	"author_name" varchar(255) NOT NULL,
+	"content" text NOT NULL,
+	"operation_id" uuid NOT NULL,
+	"operation_payload_hash" varchar(64) NOT NULL,
+	CONSTRAINT "soap_note_addenda_content_check" CHECK (length(btrim("soap_note_addenda"."content")) between 1 and 10000),
+	CONSTRAINT "soap_note_addenda_author_name_check" CHECK (length(btrim("soap_note_addenda"."author_name")) between 1 and 255),
+	CONSTRAINT "soap_note_addenda_payload_hash_check" CHECK ("soap_note_addenda"."operation_payload_hash" ~ '^[0-9a-f]{64}$')
+);
+--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD COLUMN "author_name" varchar(255);--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD COLUMN "status" "soap_note_status" DEFAULT 'finalized' NOT NULL;--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD COLUMN "revision" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD COLUMN "finalized_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD COLUMN "finalized_by" uuid;--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD COLUMN "finalizer_name" varchar(255);--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM soap_notes AS note
+		JOIN users AS author_user ON author_user.id = note.author_id
+		WHERE author_user.practice_id <> note.practice_id
+	) THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			MESSAGE = 'Cannot add tenant-safe SOAP attribution: a legacy SOAP author belongs to another practice.',
+			HINT = 'Before retrying migration 0063, inspect: SELECT note.id, note.practice_id, note.author_id, author_user.practice_id AS author_practice_id FROM soap_notes note JOIN users author_user ON author_user.id = note.author_id WHERE author_user.practice_id <> note.practice_id; Correct the source attribution under an approved clinical data repair.';
+	END IF;
+END
+$$;--> statement-breakpoint
+UPDATE "soap_notes" AS note
+SET
+	"author_name" = COALESCE(NULLIF(btrim(author_user."name"), ''), CASE WHEN note."imported" THEN 'Imported record' ELSE 'Unknown clinician' END),
+	"status" = 'finalized',
+	"revision" = 1,
+	"finalized_at" = note."created_at",
+	"finalized_by" = note."author_id",
+	"finalizer_name" = COALESCE(NULLIF(btrim(author_user."name"), ''), CASE WHEN note."imported" THEN 'Imported record' ELSE 'Unknown clinician' END)
+FROM "users" AS author_user
+WHERE author_user."id" = note."author_id"
+	AND author_user."practice_id" = note."practice_id";--> statement-breakpoint
+UPDATE "soap_notes"
+SET
+	"author_name" = CASE WHEN "imported" THEN 'Imported record' ELSE 'Unknown clinician' END,
+	"status" = 'finalized',
+	"revision" = 1,
+	"finalized_at" = "created_at",
+	"finalized_by" = "author_id",
+	"finalizer_name" = CASE WHEN "imported" THEN 'Imported record' ELSE 'Unknown clinician' END
+WHERE "author_name" IS NULL;--> statement-breakpoint
+UPDATE public.practices AS practice
+SET settings = pg_catalog.jsonb_set(
+	practice.settings,
+	'{demoData,soapNoteIds}',
+	(
+		SELECT COALESCE(pg_catalog.jsonb_agg(ids.id), '[]'::jsonb)
+		FROM (
+			SELECT existing_id.id
+			FROM pg_catalog.jsonb_array_elements_text(
+				CASE
+					WHEN pg_catalog.jsonb_typeof(practice.settings #> '{demoData,soapNoteIds}') = 'array'
+						THEN practice.settings #> '{demoData,soapNoteIds}'
+					ELSE '[]'::jsonb
+				END
+			) AS existing_id(id)
+			UNION
+			SELECT note.id::text
+			FROM public.soap_notes AS note
+			WHERE note.practice_id = practice.id
+				AND (
+					note.appointment_id::text IN (
+						SELECT demo_appointment.id
+						FROM pg_catalog.jsonb_array_elements_text(
+							CASE
+								WHEN pg_catalog.jsonb_typeof(practice.settings #> '{demoData,appointmentIds}') = 'array'
+									THEN practice.settings #> '{demoData,appointmentIds}'
+								ELSE '[]'::jsonb
+							END
+						) AS demo_appointment(id)
+					)
+					OR note.patient_id::text IN (
+						SELECT demo_patient.id
+						FROM pg_catalog.jsonb_array_elements_text(
+							CASE
+								WHEN pg_catalog.jsonb_typeof(practice.settings #> '{demoData,patientIds}') = 'array'
+									THEN practice.settings #> '{demoData,patientIds}'
+								ELSE '[]'::jsonb
+							END
+						) AS demo_patient(id)
+					)
+				)
+		) AS ids
+	),
+	true
+)
+WHERE pg_catalog.jsonb_typeof(practice.settings -> 'demoData') = 'object'
+	AND (
+		pg_catalog.jsonb_typeof(practice.settings #> '{demoData,appointmentIds}') = 'array'
+		OR pg_catalog.jsonb_typeof(practice.settings #> '{demoData,patientIds}') = 'array'
+	);--> statement-breakpoint
+ALTER TABLE "soap_notes" ALTER COLUMN "author_name" SET NOT NULL;--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (
+		SELECT 1
+		FROM public.soap_notes AS note
+		WHERE note.appointment_id IS NOT NULL
+			AND note.deleted_at IS NULL
+		GROUP BY note.practice_id, note.appointment_id
+		HAVING count(*) FILTER (WHERE note.status = 'draft') > 1
+			OR count(*) FILTER (
+				WHERE note.status = 'finalized'
+					AND NOT EXISTS (
+						SELECT 1
+						FROM public.clinical_record_corrections AS correction
+						WHERE correction.practice_id = note.practice_id
+							AND correction.soap_note_id = note.id
+					)
+			) > 1
+			OR (
+				count(*) FILTER (WHERE note.status = 'draft') > 0
+				AND count(*) FILTER (
+					WHERE note.status = 'finalized'
+						AND NOT EXISTS (
+							SELECT 1
+							FROM public.clinical_record_corrections AS correction
+							WHERE correction.practice_id = note.practice_id
+								AND correction.soap_note_id = note.id
+						)
+				) > 0
+			)
+	) THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			MESSAGE = 'Cannot enforce encounter SOAP lifecycle: historical appointments contain conflicting active documentation.',
+			HINT = 'Inspect active SOAP counts grouped by practice_id and appointment_id, excluding finalized notes referenced by clinical_record_corrections. Correct duplicate attribution under an approved clinical data repair, then retry migration 0063.';
+	END IF;
+END
+$$;--> statement-breakpoint
+ALTER TABLE "soap_note_addenda" ADD CONSTRAINT "soap_note_addenda_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_note_addenda" ADD CONSTRAINT "soap_note_addenda_practice_source_fk" FOREIGN KEY ("practice_id","soap_note_id") REFERENCES "public"."soap_notes"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_note_addenda" ADD CONSTRAINT "soap_note_addenda_practice_author_fk" FOREIGN KEY ("practice_id","author_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "soap_note_addenda_history_idx" ON "soap_note_addenda" USING btree ("practice_id","soap_note_id","created_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "soap_note_addenda_operation_uq" ON "soap_note_addenda" USING btree ("practice_id","operation_id");--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD CONSTRAINT "soap_notes_practice_author_fk" FOREIGN KEY ("practice_id","author_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD CONSTRAINT "soap_notes_practice_finalizer_fk" FOREIGN KEY ("practice_id","finalized_by") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "soap_notes_active_appointment_draft_uq" ON "soap_notes" USING btree ("practice_id","appointment_id") WHERE "soap_notes"."status" = 'draft' and "soap_notes"."appointment_id" is not null and "soap_notes"."deleted_at" is null;--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD CONSTRAINT "soap_notes_revision_check" CHECK ("soap_notes"."revision" >= 1);--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD CONSTRAINT "soap_notes_author_name_check" CHECK (length(btrim("soap_notes"."author_name")) between 1 and 255);--> statement-breakpoint
+ALTER TABLE "soap_notes" ADD CONSTRAINT "soap_notes_lifecycle_check" CHECK ((
+        "soap_notes"."status" = 'draft'
+        and "soap_notes"."finalized_at" is null
+        and "soap_notes"."finalized_by" is null
+        and "soap_notes"."finalizer_name" is null
+        and "soap_notes"."imported" = false
+      ) or (
+        "soap_notes"."status" = 'finalized'
+        and "soap_notes"."finalized_at" is not null
+        and "soap_notes"."finalized_by" is not null
+        and length(btrim("soap_notes"."finalizer_name")) between 1 and 255
+      ));--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION guard_soap_note_lifecycle()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+	is_owner boolean;
+	actor_name text;
+	is_seeded_demo_note boolean;
+BEGIN
+	is_owner := current_user = (
+		SELECT pg_catalog.pg_get_userbyid(class.relowner)
+		FROM pg_catalog.pg_class class
+		JOIN pg_catalog.pg_namespace namespace ON namespace.oid = class.relnamespace
+		WHERE namespace.nspname = TG_TABLE_SCHEMA
+			AND class.relname = TG_TABLE_NAME
+	);
+
+	IF is_owner
+		AND coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+	THEN
+		IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+		RETURN NEW;
+	END IF;
+
+	IF TG_OP = 'INSERT' THEN
+		SELECT NULLIF(btrim(actor."name"), '')
+		INTO actor_name
+		FROM public.users AS actor
+		WHERE actor.id = NEW.author_id
+			AND actor.practice_id = NEW.practice_id;
+		IF NEW.appointment_id IS NOT NULL THEN
+			PERFORM 1
+			FROM public.appointments AS appointment
+			WHERE appointment.id = NEW.appointment_id
+				AND appointment.practice_id = NEW.practice_id
+			FOR UPDATE;
+		END IF;
+
+		NEW.author_name := COALESCE(NULLIF(btrim(NEW.author_name), ''), actor_name,
+			CASE WHEN NEW.imported THEN 'Imported record' ELSE 'Unknown clinician' END);
+		NEW.revision := COALESCE(NEW.revision, 1);
+
+		IF NEW.status = 'finalized' THEN
+			NEW.finalized_at := COALESCE(
+				NEW.finalized_at,
+				CASE WHEN NEW.imported THEN NEW.created_at ELSE pg_catalog.now() END
+			);
+			NEW.finalized_by := COALESCE(NEW.finalized_by, NEW.author_id);
+			NEW.finalizer_name := COALESCE(NULLIF(btrim(NEW.finalizer_name), ''), NEW.author_name);
+		END IF;
+		RETURN NEW;
+	END IF;
+
+	IF TG_OP = 'DELETE' THEN
+		IF OLD.status = 'draft' THEN
+			IF OLD.appointment_id IS NULL THEN
+				RAISE EXCEPTION USING
+					ERRCODE = '55000',
+					MESSAGE = 'Only an open encounter SOAP draft may be discarded.';
+			END IF;
+			PERFORM 1
+			FROM public.appointments AS appointment
+			WHERE appointment.id = OLD.appointment_id
+				AND appointment.practice_id = OLD.practice_id
+				AND appointment.status = 'in_exam'
+				AND appointment.deleted_at IS NULL
+			FOR UPDATE;
+			IF NOT FOUND OR EXISTS (
+				SELECT 1
+				FROM public.visit_closeouts AS closeout
+				WHERE closeout.practice_id = OLD.practice_id
+					AND closeout.appointment_id = OLD.appointment_id
+					AND closeout.status IN ('clinical_finalized', 'completed')
+					AND closeout.deleted_at IS NULL
+			) THEN
+				RAISE EXCEPTION USING
+					ERRCODE = '55000',
+					MESSAGE = 'Only a draft from an open, unsigned encounter may be discarded.';
+			END IF;
+			RETURN OLD;
+		END IF;
+		RAISE EXCEPTION USING
+			ERRCODE = '55000',
+			MESSAGE = 'SOAP notes may only be deleted during owner maintenance.';
+	END IF;
+
+	SELECT EXISTS (
+		SELECT 1
+		FROM public.practices AS practice
+		CROSS JOIN LATERAL pg_catalog.jsonb_array_elements_text(
+			CASE
+				WHEN pg_catalog.jsonb_typeof(practice.settings #> '{demoData,soapNoteIds}') = 'array'
+					THEN practice.settings #> '{demoData,soapNoteIds}'
+				ELSE '[]'::jsonb
+			END
+		) AS demo_note(id)
+		WHERE practice.id = OLD.practice_id
+			AND demo_note.id = OLD.id::text
+	) INTO is_seeded_demo_note;
+
+	IF is_seeded_demo_note
+		AND OLD.deleted_at IS NULL
+		AND NEW.deleted_at IS NOT NULL
+		AND NEW.id IS NOT DISTINCT FROM OLD.id
+		AND NEW.created_at IS NOT DISTINCT FROM OLD.created_at
+		AND NEW.practice_id IS NOT DISTINCT FROM OLD.practice_id
+		AND NEW.patient_id IS NOT DISTINCT FROM OLD.patient_id
+		AND NEW.appointment_id IS NOT DISTINCT FROM OLD.appointment_id
+		AND NEW.author_id IS NOT DISTINCT FROM OLD.author_id
+		AND NEW.author_name IS NOT DISTINCT FROM OLD.author_name
+		AND NEW.status IS NOT DISTINCT FROM OLD.status
+		AND NEW.revision IS NOT DISTINCT FROM OLD.revision
+		AND NEW.finalized_at IS NOT DISTINCT FROM OLD.finalized_at
+		AND NEW.finalized_by IS NOT DISTINCT FROM OLD.finalized_by
+		AND NEW.finalizer_name IS NOT DISTINCT FROM OLD.finalizer_name
+		AND NEW.subjective IS NOT DISTINCT FROM OLD.subjective
+		AND NEW.objective IS NOT DISTINCT FROM OLD.objective
+		AND NEW.assessment IS NOT DISTINCT FROM OLD.assessment
+		AND NEW.plan IS NOT DISTINCT FROM OLD.plan
+		AND NEW.imported IS NOT DISTINCT FROM OLD.imported
+		AND NEW.import_fingerprint IS NOT DISTINCT FROM OLD.import_fingerprint
+	THEN
+		RETURN NEW;
+	END IF;
+
+	IF OLD.status = 'draft' AND NEW.status = 'draft' THEN
+		IF NEW.id IS DISTINCT FROM OLD.id
+			OR NEW.created_at IS DISTINCT FROM OLD.created_at
+			OR NEW.deleted_at IS DISTINCT FROM OLD.deleted_at
+			OR NEW.practice_id IS DISTINCT FROM OLD.practice_id
+			OR NEW.patient_id IS DISTINCT FROM OLD.patient_id
+			OR NEW.appointment_id IS DISTINCT FROM OLD.appointment_id
+			OR NEW.author_id IS DISTINCT FROM OLD.author_id
+			OR NEW.author_name IS DISTINCT FROM OLD.author_name
+			OR NEW.imported IS DISTINCT FROM OLD.imported
+			OR NEW.import_fingerprint IS DISTINCT FROM OLD.import_fingerprint
+			OR NEW.finalized_at IS DISTINCT FROM OLD.finalized_at
+			OR NEW.finalized_by IS DISTINCT FROM OLD.finalized_by
+			OR NEW.finalizer_name IS DISTINCT FROM OLD.finalizer_name
+			OR NEW.revision <> OLD.revision + 1
+		THEN
+			RAISE EXCEPTION USING
+				ERRCODE = '40001',
+				MESSAGE = 'SOAP draft update must preserve identity and advance exactly one revision.';
+		END IF;
+		RETURN NEW;
+	END IF;
+
+	IF OLD.status = 'draft' AND NEW.status = 'finalized' THEN
+		IF OLD.appointment_id IS NOT NULL THEN
+			PERFORM 1
+			FROM public.appointments AS appointment
+			WHERE appointment.id = OLD.appointment_id
+				AND appointment.practice_id = OLD.practice_id
+			FOR UPDATE;
+		END IF;
+		IF NEW.id IS DISTINCT FROM OLD.id
+			OR NEW.created_at IS DISTINCT FROM OLD.created_at
+			OR NEW.deleted_at IS DISTINCT FROM OLD.deleted_at
+			OR NEW.practice_id IS DISTINCT FROM OLD.practice_id
+			OR NEW.patient_id IS DISTINCT FROM OLD.patient_id
+			OR NEW.appointment_id IS DISTINCT FROM OLD.appointment_id
+			OR NEW.author_id IS DISTINCT FROM OLD.author_id
+			OR NEW.author_name IS DISTINCT FROM OLD.author_name
+			OR NEW.subjective IS DISTINCT FROM OLD.subjective
+			OR NEW.objective IS DISTINCT FROM OLD.objective
+			OR NEW.assessment IS DISTINCT FROM OLD.assessment
+			OR NEW.plan IS DISTINCT FROM OLD.plan
+			OR NEW.imported IS DISTINCT FROM OLD.imported
+			OR NEW.import_fingerprint IS DISTINCT FROM OLD.import_fingerprint
+			OR NEW.revision IS DISTINCT FROM OLD.revision
+			OR NEW.finalized_at IS NULL
+			OR NEW.finalized_by IS NULL
+			OR NULLIF(btrim(NEW.finalizer_name), '') IS NULL
+		THEN
+			RAISE EXCEPTION USING
+				ERRCODE = '55000',
+				MESSAGE = 'SOAP finalization must preserve the saved draft and add attribution.';
+		END IF;
+		RETURN NEW;
+	END IF;
+
+	RAISE EXCEPTION USING
+		ERRCODE = '55000',
+		MESSAGE = 'Finalized SOAP notes and SOAP identity are immutable.';
+END;
+$$;--> statement-breakpoint
+
+CREATE TRIGGER soap_notes_lifecycle_guard
+	BEFORE INSERT OR UPDATE OR DELETE ON soap_notes
+	FOR EACH ROW EXECUTE FUNCTION guard_soap_note_lifecycle();--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION enforce_soap_appointment_invariant()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+	target_practice_id uuid;
+	target_appointment_id uuid;
+	draft_count integer;
+	effective_final_count integer;
+BEGIN
+	IF TG_OP = 'DELETE' THEN
+		target_practice_id := OLD.practice_id;
+		target_appointment_id := OLD.appointment_id;
+	ELSE
+		target_practice_id := NEW.practice_id;
+		target_appointment_id := NEW.appointment_id;
+	END IF;
+	IF target_appointment_id IS NULL THEN RETURN NULL; END IF;
+
+	SELECT
+		count(*) FILTER (WHERE note.status = 'draft'),
+		count(*) FILTER (
+			WHERE note.status = 'finalized'
+				AND NOT EXISTS (
+					SELECT 1
+					FROM public.clinical_record_corrections AS correction
+					WHERE correction.practice_id = note.practice_id
+						AND correction.soap_note_id = note.id
+				)
+		)
+	INTO draft_count, effective_final_count
+	FROM public.soap_notes AS note
+	WHERE note.practice_id = target_practice_id
+		AND note.appointment_id = target_appointment_id
+		AND note.deleted_at IS NULL;
+
+	IF draft_count > 1
+		OR effective_final_count > 1
+		OR (draft_count > 0 AND effective_final_count > 0)
+	THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			CONSTRAINT = 'soap_notes_appointment_invariant',
+			MESSAGE = 'An encounter may have one active SOAP draft or one effective finalized SOAP note, but not both.';
+	END IF;
+	RETURN NULL;
+END;
+$$;--> statement-breakpoint
+
+CREATE CONSTRAINT TRIGGER soap_notes_appointment_invariant
+	AFTER INSERT OR UPDATE OR DELETE ON soap_notes
+	DEFERRABLE INITIALLY DEFERRED
+	FOR EACH ROW EXECUTE FUNCTION enforce_soap_appointment_invariant();--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION validate_clinical_record_correction_source()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+	source_matches boolean := false;
+BEGIN
+	IF NEW.record_type = 'soap_note' THEN
+		SELECT EXISTS (
+			SELECT 1 FROM public.soap_notes source
+			WHERE source.practice_id = NEW.practice_id
+				AND source.id = NEW.soap_note_id
+				AND source.patient_id = NEW.patient_id
+				AND source.appointment_id IS NOT DISTINCT FROM NEW.appointment_id
+				AND source.status = 'finalized'
+		) INTO source_matches;
+	ELSIF NEW.record_type = 'vital_sign' THEN
+		SELECT EXISTS (SELECT 1 FROM public.vital_signs source WHERE source.practice_id = NEW.practice_id AND source.id = NEW.vital_sign_id AND source.patient_id = NEW.patient_id AND source.appointment_id IS NOT DISTINCT FROM NEW.appointment_id) INTO source_matches;
+	ELSIF NEW.record_type = 'vaccination_record' THEN
+		SELECT EXISTS (SELECT 1 FROM public.vaccination_records source WHERE source.practice_id = NEW.practice_id AND source.id = NEW.vaccination_record_id AND source.patient_id = NEW.patient_id AND source.appointment_id IS NOT DISTINCT FROM NEW.appointment_id) INTO source_matches;
+	ELSIF NEW.record_type = 'lab_result' THEN
+		SELECT EXISTS (SELECT 1 FROM public.lab_results source WHERE source.practice_id = NEW.practice_id AND source.id = NEW.lab_result_id AND source.patient_id = NEW.patient_id AND source.appointment_id IS NOT DISTINCT FROM NEW.appointment_id) INTO source_matches;
+	END IF;
+	IF NOT source_matches THEN
+		RAISE EXCEPTION USING ERRCODE = '23503', MESSAGE = 'Clinical correction source does not match its patient and appointment, or is not final.';
+	END IF;
+	RETURN NEW;
+END;
+$$;--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION guard_soap_note_addendum()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+	is_owner boolean;
+	expected_hash text;
+	source_finalized_at timestamptz;
+BEGIN
+	is_owner := current_user = (
+		SELECT pg_catalog.pg_get_userbyid(class.relowner)
+		FROM pg_catalog.pg_class class
+		JOIN pg_catalog.pg_namespace namespace ON namespace.oid = class.relnamespace
+		WHERE namespace.nspname = TG_TABLE_SCHEMA
+			AND class.relname = TG_TABLE_NAME
+	);
+
+	IF TG_OP = 'INSERT' THEN
+		SELECT note.finalized_at
+		INTO source_finalized_at
+		FROM public.soap_notes AS note
+		WHERE note.id = NEW.soap_note_id
+			AND note.practice_id = NEW.practice_id
+			AND note.status = 'finalized';
+		IF source_finalized_at IS NULL
+			OR NEW.created_at < source_finalized_at
+			OR NEW.created_at > pg_catalog.now()
+		THEN
+			RAISE EXCEPTION USING
+				ERRCODE = '23514',
+				MESSAGE = 'SOAP addendum chronology is invalid.';
+		END IF;
+		expected_hash := pg_catalog.encode(
+			pg_catalog.sha256(
+				pg_catalog.convert_to(
+					'{"noteId":' || pg_catalog.to_json(NEW.soap_note_id::text)::text ||
+					',"authorId":' || pg_catalog.to_json(NEW.author_id::text)::text ||
+					',"content":' || pg_catalog.to_json(NEW.content)::text || '}',
+					'UTF8'
+				)
+			),
+			'hex'
+		);
+		IF NEW.operation_payload_hash IS DISTINCT FROM expected_hash THEN
+			RAISE EXCEPTION USING
+				ERRCODE = '23514',
+				MESSAGE = 'SOAP addendum payload hash is invalid.';
+		END IF;
+	END IF;
+
+	IF is_owner
+		AND coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+	THEN
+		IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+		RETURN NEW;
+	END IF;
+
+	IF TG_OP = 'INSERT' THEN
+		IF NOT EXISTS (
+			SELECT 1
+			FROM public.soap_notes AS note
+			WHERE note.id = NEW.soap_note_id
+				AND note.practice_id = NEW.practice_id
+				AND note.status = 'finalized'
+				AND note.deleted_at IS NULL
+				AND NOT EXISTS (
+					SELECT 1
+					FROM public.clinical_record_corrections AS correction
+					WHERE correction.practice_id = NEW.practice_id
+						AND correction.soap_note_id = note.id
+				)
+		) THEN
+			RAISE EXCEPTION USING
+				ERRCODE = '55000',
+				MESSAGE = 'Addenda require an active finalized SOAP note.';
+		END IF;
+		RETURN NEW;
+	END IF;
+
+	RAISE EXCEPTION USING
+		ERRCODE = '55000',
+		MESSAGE = 'SOAP addenda are immutable.';
+END;
+$$;--> statement-breakpoint
+
+CREATE TRIGGER soap_note_addenda_guard
+	BEFORE INSERT OR UPDATE OR DELETE ON soap_note_addenda
+	FOR EACH ROW EXECUTE FUNCTION guard_soap_note_addendum();--> statement-breakpoint
+
+CREATE OR REPLACE FUNCTION restore_soap_note_addendum(
+	p_id uuid,
+	p_created_at timestamptz,
+	p_practice_id uuid,
+	p_soap_note_id uuid,
+	p_author_id uuid,
+	p_author_name text,
+	p_content text,
+	p_operation_id uuid,
+	p_operation_payload_hash text
+)
+RETURNS TABLE(result_id uuid, was_inserted boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+	restored_id uuid;
+	existing_addendum public.soap_note_addenda%ROWTYPE;
+	expected_hash text;
+	source_finalized_at timestamptz;
+	source_deleted_at timestamptz;
+	correction_created_at timestamptz;
+BEGIN
+	IF p_practice_id IS DISTINCT FROM nullif(current_setting('app.current_practice_id', true), '')::uuid THEN
+		RAISE EXCEPTION USING ERRCODE = '42501', MESSAGE = 'SOAP addendum restore tenant mismatch.';
+	END IF;
+
+	SELECT note.finalized_at, note.deleted_at
+	INTO source_finalized_at, source_deleted_at
+		FROM public.soap_notes AS note
+		WHERE note.id = p_soap_note_id
+			AND note.practice_id = p_practice_id
+			AND note.status = 'finalized';
+
+	SELECT correction.created_at
+	INTO correction_created_at
+	FROM public.clinical_record_corrections AS correction
+	WHERE correction.practice_id = p_practice_id
+		AND correction.soap_note_id = p_soap_note_id
+	LIMIT 1;
+
+	IF source_finalized_at IS NULL OR NOT EXISTS (
+		SELECT 1 FROM public.users AS actor
+		WHERE actor.id = p_author_id AND actor.practice_id = p_practice_id
+	) THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '55000',
+			MESSAGE = 'SOAP addendum restore source or attribution is invalid.';
+	END IF;
+
+	IF p_created_at IS NULL
+		OR p_created_at < source_finalized_at
+		OR p_created_at > pg_catalog.now()
+		OR (source_deleted_at IS NOT NULL AND p_created_at > source_deleted_at)
+		OR (correction_created_at IS NOT NULL AND p_created_at > correction_created_at)
+	THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			MESSAGE = 'SOAP addendum restore chronology is invalid.';
+	END IF;
+
+	expected_hash := pg_catalog.encode(
+		pg_catalog.sha256(
+			pg_catalog.convert_to(
+				'{"noteId":' || pg_catalog.to_json(p_soap_note_id::text)::text ||
+				',"authorId":' || pg_catalog.to_json(p_author_id::text)::text ||
+				',"content":' || pg_catalog.to_json(p_content)::text || '}',
+				'UTF8'
+			)
+		),
+		'hex'
+	);
+	IF p_operation_payload_hash IS DISTINCT FROM expected_hash THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			MESSAGE = 'SOAP addendum restore payload hash is invalid.';
+	END IF;
+
+	PERFORM pg_catalog.set_config('app.ledger_maintenance', 'on', true);
+	INSERT INTO public.soap_note_addenda (
+		id, created_at, practice_id, soap_note_id, author_id, author_name,
+		content, operation_id, operation_payload_hash
+	) VALUES (
+		p_id, p_created_at, p_practice_id, p_soap_note_id, p_author_id,
+		p_author_name, p_content, p_operation_id, p_operation_payload_hash
+	)
+	ON CONFLICT (practice_id, operation_id) DO NOTHING
+	RETURNING id INTO restored_id;
+
+	IF restored_id IS NOT NULL THEN
+		RETURN QUERY SELECT restored_id, true;
+		RETURN;
+	END IF;
+	SELECT * INTO existing_addendum
+	FROM public.soap_note_addenda
+	WHERE practice_id = p_practice_id AND operation_id = p_operation_id;
+	IF existing_addendum.id IS NULL
+		OR existing_addendum.id IS DISTINCT FROM p_id
+		OR existing_addendum.created_at IS DISTINCT FROM p_created_at
+		OR existing_addendum.soap_note_id IS DISTINCT FROM p_soap_note_id
+		OR existing_addendum.author_id IS DISTINCT FROM p_author_id
+		OR existing_addendum.author_name IS DISTINCT FROM p_author_name
+		OR existing_addendum.content IS DISTINCT FROM p_content
+		OR existing_addendum.operation_payload_hash IS DISTINCT FROM p_operation_payload_hash
+	THEN
+		RAISE EXCEPTION USING ERRCODE = '23505', MESSAGE = 'SOAP addendum restore operation conflicts with existing evidence.';
+	END IF;
+	RETURN QUERY SELECT existing_addendum.id, false;
+END;
+$$;--> statement-breakpoint
+
+REVOKE ALL ON FUNCTION restore_soap_note_addendum(uuid,timestamptz,uuid,uuid,uuid,text,text,uuid,text) FROM PUBLIC;--> statement-breakpoint
+
+ALTER TABLE soap_note_addenda ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY practice_isolation ON soap_note_addenda
+	USING (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	)
+	WITH CHECK (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	);--> statement-breakpoint
+
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'openpims_app') THEN
+		REVOKE ALL ON soap_note_addenda FROM openpims_app;
+		GRANT SELECT, INSERT ON soap_note_addenda TO openpims_app;
+		GRANT EXECUTE ON FUNCTION restore_soap_note_addendum(uuid,timestamptz,uuid,uuid,uuid,text,text,uuid,text) TO openpims_app;
+	END IF;
+END
+$$;

--- a/packages/db/drizzle/meta/0063_snapshot.json
+++ b/packages/db/drizzle/meta/0063_snapshot.json
@@ -1,0 +1,19735 @@
+{
+  "id": "0c25647c-e2a9-4c58-94b0-7e0dacfd7d44",
+  "prevId": "6e681576-4a9e-47eb-8a36-3074f9ecc813",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "performed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_operation_id": {
+          "name": "creation_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_payload_hash": {
+          "name": "creation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_note": {
+          "name": "follow_up_note",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_by": {
+          "name": "follow_up_completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_at": {
+          "name": "follow_up_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_outcome": {
+          "name": "follow_up_outcome",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_review_inbox_idx": {
+          "name": "lab_results_review_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_follow_up_inbox_idx": {
+          "name": "lab_results_follow_up_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_record_uq": {
+          "name": "lab_results_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_creation_operation_uq": {
+          "name": "lab_results_creation_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_results_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_completed_by_users_id_fk": {
+          "name": "lab_results_follow_up_completed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_patient_fk": {
+          "name": "lab_results_practice_patient_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_ordered_by_fk": {
+          "name": "lab_results_practice_ordered_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_reviewed_by_fk": {
+          "name": "lab_results_practice_reviewed_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_assigned_fk": {
+          "name": "lab_results_practice_follow_up_assigned_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_completed_fk": {
+          "name": "lab_results_practice_follow_up_completed_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_results_lifecycle_shape_check": {
+          "name": "lab_results_lifecycle_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"completed_at\" is null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'completed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is not null\n          and \"lab_results\".\"reviewed_by\" is not null\n        )"
+        },
+        "lab_results_creation_operation_shape_check": {
+          "name": "lab_results_creation_operation_shape_check",
+          "value": "(\"lab_results\".\"creation_operation_id\" is null and \"lab_results\".\"creation_payload_hash\" is null)\n        or (\"lab_results\".\"creation_operation_id\" is not null and \"lab_results\".\"creation_payload_hash\" ~ '^[0-9a-f]{64}$')"
+        },
+        "lab_results_result_shape_check": {
+          "name": "lab_results_result_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"result_value\" is null\n          and \"lab_results\".\"unit\" is null\n          and \"lab_results\".\"reference_range_low\" is null\n          and \"lab_results\".\"reference_range_high\" is null\n          and \"lab_results\".\"result_flag\" = 'unknown'\n        ) or (\n          \"lab_results\".\"status\" in ('completed', 'reviewed')\n          and length(btrim(coalesce(\"lab_results\".\"result_value\", ''))) > 0\n        )"
+        },
+        "lab_results_follow_up_shape_check": {
+          "name": "lab_results_follow_up_shape_check",
+          "value": "(\"lab_results\".\"status\" <> 'pending' or \"lab_results\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_results\".\"follow_up_due_at\" is null\n        )\n        and ((\n          \"lab_results\".\"follow_up_status\" = 'not_required'\n          and \"lab_results\".\"follow_up_assigned_to\" is null\n          and \"lab_results\".\"follow_up_due_at\" is null\n          and \"lab_results\".\"follow_up_note\" is null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'open'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'completed'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is not null\n          and \"lab_results\".\"follow_up_completed_at\" is not null\n          and length(btrim(coalesce(\"lab_results\".\"follow_up_outcome\", ''))) between 3 and 1000\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_note_addenda": {
+      "name": "soap_note_addenda",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_addenda_history_idx": {
+          "name": "soap_note_addenda_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_addenda_operation_uq": {
+          "name": "soap_note_addenda_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_addenda_practice_id_practices_id_fk": {
+          "name": "soap_note_addenda_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_source_fk": {
+          "name": "soap_note_addenda_practice_source_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_author_fk": {
+          "name": "soap_note_addenda_practice_author_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_addenda_content_check": {
+          "name": "soap_note_addenda_content_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"content\")) between 1 and 10000"
+        },
+        "soap_note_addenda_author_name_check": {
+          "name": "soap_note_addenda_author_name_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"author_name\")) between 1 and 255"
+        },
+        "soap_note_addenda_payload_hash_check": {
+          "name": "soap_note_addenda_payload_hash_check",
+          "value": "\"soap_note_addenda\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "soap_note_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finalized'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizer_name": {
+          "name": "finalizer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_active_appointment_draft_uq": {
+          "name": "soap_notes_active_appointment_draft_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"status\" = 'draft' and \"soap_notes\".\"appointment_id\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_author_fk": {
+          "name": "soap_notes_practice_author_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_finalizer_fk": {
+          "name": "soap_notes_practice_finalizer_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "finalized_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "soap_notes_revision_check": {
+          "name": "soap_notes_revision_check",
+          "value": "\"soap_notes\".\"revision\" >= 1"
+        },
+        "soap_notes_author_name_check": {
+          "name": "soap_notes_author_name_check",
+          "value": "length(btrim(\"soap_notes\".\"author_name\")) between 1 and 255"
+        },
+        "soap_notes_lifecycle_check": {
+          "name": "soap_notes_lifecycle_check",
+          "value": "(\n        \"soap_notes\".\"status\" = 'draft'\n        and \"soap_notes\".\"finalized_at\" is null\n        and \"soap_notes\".\"finalized_by\" is null\n        and \"soap_notes\".\"finalizer_name\" is null\n        and \"soap_notes\".\"imported\" = false\n      ) or (\n        \"soap_notes\".\"status\" = 'finalized'\n        and \"soap_notes\".\"finalized_at\" is not null\n        and \"soap_notes\".\"finalized_by\" is not null\n        and length(btrim(\"soap_notes\".\"finalizer_name\")) between 1 and 255\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_result_events": {
+      "name": "lab_result_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "lab_result_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_events_result_history_idx": {
+          "name": "lab_result_events_result_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_time_idx": {
+          "name": "lab_result_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_operation_uq": {
+          "name": "lab_result_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_created_uq": {
+          "name": "lab_result_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"lab_result_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_events_practice_id_practices_id_fk": {
+          "name": "lab_result_events_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_events_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_id_patients_id_fk": {
+          "name": "lab_result_events_patient_id_patients_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_id_appointments_id_fk": {
+          "name": "lab_result_events_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_result_events_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_id_users_id_fk": {
+          "name": "lab_result_events_actor_id_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_result_tenant_fk": {
+          "name": "lab_result_events_result_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_tenant_fk": {
+          "name": "lab_result_events_patient_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_tenant_fk": {
+          "name": "lab_result_events_appointment_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_tenant_fk": {
+          "name": "lab_result_events_actor_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_assignee_tenant_fk": {
+          "name": "lab_result_events_assignee_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_events_shape_check": {
+          "name": "lab_result_events_shape_check",
+          "value": "length(btrim(\"lab_result_events\".\"actor_name\")) between 1 and 255\n        and \"lab_result_events\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        and (\"lab_result_events\".\"note\" is null or length(\"lab_result_events\".\"note\") <= 1000)\n        and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_result_events\".\"status_after\" = 'reviewed'\n          and \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_result_events\".\"follow_up_due_at\" is null\n        )\n        and (\n          (\"lab_result_events\".\"status_after\" = 'pending'\n            and \"lab_result_events\".\"result_value\" is null\n            and \"lab_result_events\".\"unit\" is null\n            and \"lab_result_events\".\"reference_range_low\" is null\n            and \"lab_result_events\".\"reference_range_high\" is null\n            and \"lab_result_events\".\"result_flag\" = 'unknown')\n          or (\"lab_result_events\".\"status_after\" in ('completed', 'reviewed')\n            and length(btrim(coalesce(\"lab_result_events\".\"result_value\", ''))) between 1 and 128)\n        )\n        and (\n          (\"lab_result_events\".\"follow_up_status\" = 'not_required'\n            and \"lab_result_events\".\"follow_up_assigned_to\" is null\n            and \"lab_result_events\".\"follow_up_due_at\" is null)\n          or (\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n            and \"lab_result_events\".\"follow_up_assigned_to\" is not null)\n        )\n        and (\n          \"lab_result_events\".\"event_type\" = 'created'\n          and \"lab_result_events\".\"status_before\" is null\n          and \"lab_result_events\".\"status_after\" in ('pending', 'completed')\n          and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"result_flag\" = 'unknown')\n        or \"lab_result_events\".\"event_type\" = 'completed'\n          and \"lab_result_events\".\"status_before\" = 'pending'\n          and \"lab_result_events\".\"status_after\" = 'completed'\n        or \"lab_result_events\".\"event_type\" = 'reviewed'\n          and \"lab_result_events\".\"status_before\" = 'completed'\n          and \"lab_result_events\".\"status_after\" = 'reviewed'\n        or \"lab_result_events\".\"event_type\" in ('follow_up_assigned', 'follow_up_reassigned')\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'open'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n        or \"lab_result_events\".\"event_type\" = 'follow_up_completed'\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'completed'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n          and length(btrim(coalesce(\"lab_result_events\".\"note\", ''))) between 3 and 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_lab_result_uq": {
+          "name": "clinical_record_corrections_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"lab_result_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_operation_uq": {
+          "name": "clinical_record_corrections_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_lab_source_uq": {
+          "name": "clinical_record_corrections_practice_record_lab_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_id_lab_results_id_fk": {
+          "name": "clinical_record_corrections_lab_result_id_lab_results_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "practice_id",
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_source_fk": {
+          "name": "clinical_record_corrections_lab_result_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n        and \"clinical_record_corrections\".\"lab_result_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      )"
+        },
+        "clinical_record_corrections_operation_shape_check": {
+          "name": "clinical_record_corrections_operation_shape_check",
+          "value": "(\n          \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is not null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        ) or (\n          \"clinical_record_corrections\".\"record_type\" <> 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" is null\n        )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lab_result_replacements": {
+      "name": "lab_result_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lab_result_id": {
+          "name": "source_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_lab_result_id": {
+          "name": "replacement_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_replacements_source_history_idx": {
+          "name": "lab_result_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_source_uq": {
+          "name": "lab_result_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_replacement_uq": {
+          "name": "lab_result_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_operation_uq": {
+          "name": "lab_result_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_replacements_practice_id_practices_id_fk": {
+          "name": "lab_result_replacements_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "lab_result_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_source_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_id_users_id_fk": {
+          "name": "lab_result_replacements_actor_id_users_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_tenant_fk": {
+          "name": "lab_result_replacements_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_tenant_fk": {
+          "name": "lab_result_replacements_replacement_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_source_tenant_fk": {
+          "name": "lab_result_replacements_correction_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "lab_result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_tenant_fk": {
+          "name": "lab_result_replacements_actor_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_replacements_shape_check": {
+          "name": "lab_result_replacements_shape_check",
+          "value": "\"lab_result_replacements\".\"source_lab_result_id\" <> \"lab_result_replacements\".\"replacement_lab_result_id\"\n        and length(btrim(\"lab_result_replacements\".\"actor_name\")) between 1 and 255\n        and \"lab_result_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_email_attempts": {
+      "name": "auth_email_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "auth_email_attempt_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_email_attempts_idempotency_uq": {
+          "name": "auth_email_attempts_idempotency_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_provider_message_uq": {
+          "name": "auth_email_attempts_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_email_attempts\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_recovery_idx": {
+          "name": "auth_email_attempts_recovery_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_practice_created_idx": {
+          "name": "auth_email_attempts_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_attempts_practice_id_practices_id_fk": {
+          "name": "auth_email_attempts_practice_id_practices_id_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_email_attempts_user_tenant_fk": {
+          "name": "auth_email_attempts_user_tenant_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_attempts_provider_check": {
+          "name": "auth_email_attempts_provider_check",
+          "value": "\"auth_email_attempts\".\"provider\" in ('resend', 'console')"
+        },
+        "auth_email_attempts_outcome_shape_check": {
+          "name": "auth_email_attempts_outcome_shape_check",
+          "value": "(\n        \"auth_email_attempts\".\"outcome\" = 'reserved'\n        and \"auth_email_attempts\".\"resolved_at\" is null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" = 'accepted'\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"provider_message_id\", ''))) > 0\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"failure_code\", ''))) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_delivery_events": {
+      "name": "auth_email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint": {
+          "name": "raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "auth_email_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "auth_email_delivery_attribution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_delivery_events_webhook_uq": {
+          "name": "auth_email_delivery_events_webhook_uq",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attempt_timeline_idx": {
+          "name": "auth_email_delivery_events_attempt_timeline_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_provider_timeline_idx": {
+          "name": "auth_email_delivery_events_provider_timeline_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attribution_queue_idx": {
+          "name": "auth_email_delivery_events_attribution_queue_idx",
+          "columns": [
+            {
+              "expression": "attribution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk": {
+          "name": "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk",
+          "tableFrom": "auth_email_delivery_events",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_delivery_events_provider_check": {
+          "name": "auth_email_delivery_events_provider_check",
+          "value": "\"auth_email_delivery_events\".\"provider\" = 'resend'"
+        },
+        "auth_email_delivery_events_event_type_check": {
+          "name": "auth_email_delivery_events_event_type_check",
+          "value": "\"auth_email_delivery_events\".\"event_type\" ~ '^email\\.'"
+        },
+        "auth_email_delivery_events_raw_body_fingerprint_check": {
+          "name": "auth_email_delivery_events_raw_body_fingerprint_check",
+          "value": "\"auth_email_delivery_events\".\"raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "auth_email_delivery_events_attribution_shape_check": {
+          "name": "auth_email_delivery_events_attribution_shape_check",
+          "value": "(\n        \"auth_email_delivery_events\".\"attribution\" in ('attempt_tag', 'provider_message_id')\n        and \"auth_email_delivery_events\".\"attempt_id\" is not null\n      ) or (\n        \"auth_email_delivery_events\".\"attribution\" in ('unmatched', 'identity_conflict')\n        and \"auth_email_delivery_events\".\"attempt_id\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_provider_identity_conflicts": {
+      "name": "auth_email_provider_identity_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_provider_message_id": {
+          "name": "durable_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflicting_provider_message_id": {
+          "name": "conflicting_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_provider_identity_conflicts_identity_uq": {
+          "name": "auth_email_provider_identity_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "durable_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conflicting_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_provider_identity_conflicts_recovery_idx": {
+          "name": "auth_email_provider_identity_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_provider_identity_conflicts_attempt_fk": {
+          "name": "auth_email_provider_identity_conflicts_attempt_fk",
+          "tableFrom": "auth_email_provider_identity_conflicts",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_provider_identity_conflicts_provider_check": {
+          "name": "auth_email_provider_identity_conflicts_provider_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_provider_identity_conflicts_distinct_id_check": {
+          "name": "auth_email_provider_identity_conflicts_distinct_id_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\" <> \"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\""
+        },
+        "auth_email_provider_identity_conflicts_id_shape_check": {
+          "name": "auth_email_provider_identity_conflicts_id_shape_check",
+          "value": "length(btrim(\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\")) > 0\n        and length(btrim(\"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_webhook_conflicts": {
+      "name": "auth_email_webhook_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "original_webhook_id": {
+          "name": "original_webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint": {
+          "name": "incoming_raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_event_type": {
+          "name": "incoming_event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_webhook_conflicts_identity_uq": {
+          "name": "auth_email_webhook_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_webhook_conflicts_recovery_idx": {
+          "name": "auth_email_webhook_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_webhook_conflicts_webhook_fk": {
+          "name": "auth_email_webhook_conflicts_webhook_fk",
+          "tableFrom": "auth_email_webhook_conflicts",
+          "tableTo": "auth_email_delivery_events",
+          "columnsFrom": [
+            "original_webhook_id"
+          ],
+          "columnsTo": [
+            "webhook_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_webhook_conflicts_provider_check": {
+          "name": "auth_email_webhook_conflicts_provider_check",
+          "value": "\"auth_email_webhook_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_webhook_conflicts_event_type_check": {
+          "name": "auth_email_webhook_conflicts_event_type_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_event_type\" ~ '^email\\.'"
+        },
+        "auth_email_webhook_conflicts_raw_body_fingerprint_check": {
+          "name": "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ready": {
+          "name": "provider_profile_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_profile_synced_at": {
+          "name": "provider_profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_event_history": {
+      "name": "sms_delivery_event_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivery_event_id": {
+          "name": "delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_history_id": {
+          "name": "reviewed_history_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_delivery_history_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "sms_delivery_history_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_reason_code": {
+          "name": "operator_reason_code",
+          "type": "sms_delivery_reconciliation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_event_history_event_key_uq": {
+          "name": "sms_delivery_event_history_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_idx": {
+          "name": "sms_delivery_event_history_event_idx",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_id_uq": {
+          "name": "sms_delivery_event_history_event_id_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attribution_uq": {
+          "name": "sms_delivery_event_history_attribution_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"result\" = 'attributed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_reviewed_history_uq": {
+          "name": "sms_delivery_event_history_reviewed_history_uq",
+          "columns": [
+            {
+              "expression": "reviewed_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"reviewed_history_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_practice_queue_idx": {
+          "name": "sms_delivery_event_history_practice_queue_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attempt_idx": {
+          "name": "sms_delivery_event_history_attempt_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": [
+            "delivery_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_practice_id_practices_id_fk": {
+          "name": "sms_delivery_event_history_practice_id_practices_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_id_communications_id_fk": {
+          "name": "sms_delivery_event_history_communication_id_communications_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_user_id_users_id_fk": {
+          "name": "sms_delivery_event_history_actor_user_id_users_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_attempt_tenant_fk": {
+          "name": "sms_delivery_event_history_attempt_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_tenant_fk": {
+          "name": "sms_delivery_event_history_communication_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_tenant_fk": {
+          "name": "sms_delivery_event_history_actor_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_reviewed_history_fk": {
+          "name": "sms_delivery_event_history_reviewed_history_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_event_history",
+          "columnsFrom": [
+            "delivery_event_id",
+            "reviewed_history_id"
+          ],
+          "columnsTo": [
+            "delivery_event_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_event_history_event_key_check": {
+          "name": "sms_delivery_event_history_event_key_check",
+          "value": "length(btrim(\"sms_delivery_event_history\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_event_history_detail_check": {
+          "name": "sms_delivery_event_history_detail_check",
+          "value": "\"sms_delivery_event_history\".\"detail\" is null or length(\"sms_delivery_event_history\".\"detail\") <= 2000"
+        },
+        "sms_delivery_event_history_target_shape_check": {
+          "name": "sms_delivery_event_history_target_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous', 'operator_reviewed')\n          and \"sms_delivery_event_history\".\"practice_id\" is null\n          and \"sms_delivery_event_history\".\"attempt_id\" is null\n          and \"sms_delivery_event_history\".\"communication_id\" is null\n          and (\n            (\"sms_delivery_event_history\".\"result\" = 'operator_reviewed' and \"sms_delivery_event_history\".\"reviewed_history_id\" is not null)\n            or (\"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous') and \"sms_delivery_event_history\".\"reviewed_history_id\" is null)\n          )\n        ) or (\n          \"sms_delivery_event_history\".\"result\" in ('attributed', 'projection_miss', 'reconciled')\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"result\" = 'projected'\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"communication_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        )"
+        },
+        "sms_delivery_event_history_actor_shape_check": {
+          "name": "sms_delivery_event_history_actor_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"kind\" = 'automatic'\n          and \"sms_delivery_event_history\".\"result\" in (\n            'unmatched',\n            'ambiguous',\n            'attributed',\n            'projected',\n            'projection_miss'\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" is null\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and \"sms_delivery_event_history\".\"actor_identity\" is null\n          and \"sms_delivery_event_history\".\"actor_name\" is null\n          and \"sms_delivery_event_history\".\"operator_reason_code\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"kind\" = 'operator_reconciliation'\n          and (\n            (\n              \"sms_delivery_event_history\".\"result\" = 'reconciled'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'exact_attribution_retry',\n                'provider_portal_status_review',\n                'projection_repair'\n              )\n            )\n            or (\n              \"sms_delivery_event_history\".\"result\" = 'operator_reviewed'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'identity_conflict_review',\n                'unmatched_evidence_review'\n              )\n            )\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" = 'platform_operator'\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_name\", ''))) between 1 and 255\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_events": {
+      "name": "sms_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint_sha256": {
+          "name": "payload_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_events_provider_event_key_uq": {
+          "name": "sms_delivery_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_provider_message_idx": {
+          "name": "sms_delivery_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_classification_queue_idx": {
+          "name": "sms_delivery_events_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_events_provider_check": {
+          "name": "sms_delivery_events_provider_check",
+          "value": "\"sms_delivery_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_delivery_events_event_type_check": {
+          "name": "sms_delivery_events_event_type_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"provider_event_type\")) between 1 and 80"
+        },
+        "sms_delivery_events_event_key_check": {
+          "name": "sms_delivery_events_event_key_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_events_fingerprint_check": {
+          "name": "sms_delivery_events_fingerprint_check",
+          "value": "\"sms_delivery_events\".\"payload_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_delivery_events_provider_event_id_check": {
+          "name": "sms_delivery_events_provider_event_id_check",
+          "value": "\"sms_delivery_events\".\"provider_event_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_event_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_message_id_check": {
+          "name": "sms_delivery_events_provider_message_id_check",
+          "value": "\"sms_delivery_events\".\"provider_message_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_message_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_status_check": {
+          "name": "sms_delivery_events_provider_status_check",
+          "value": "\"sms_delivery_events\".\"provider_status\" is null or length(btrim(\"sms_delivery_events\".\"provider_status\")) between 1 and 80"
+        },
+        "sms_delivery_events_provider_error_code_check": {
+          "name": "sms_delivery_events_provider_error_code_check",
+          "value": "\"sms_delivery_events\".\"provider_error_code\" is null or length(btrim(\"sms_delivery_events\".\"provider_error_code\")) between 1 and 80"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "resend_of_attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": [
+            "practice_id",
+            "milestone"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_follow_up_status": {
+      "name": "lab_follow_up_status",
+      "schema": "public",
+      "values": [
+        "not_required",
+        "open",
+        "completed"
+      ]
+    },
+    "public.lab_result_flag": {
+      "name": "lab_result_flag",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "normal",
+        "abnormal",
+        "critical"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.soap_note_status": {
+      "name": "soap_note_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "finalized"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.lab_result_event_type": {
+      "name": "lab_result_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "completed",
+        "reviewed",
+        "follow_up_assigned",
+        "follow_up_reassigned",
+        "follow_up_completed"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": [
+        "entered_in_error"
+      ]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign",
+        "vaccination_record",
+        "lab_result"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invoiced",
+        "waived"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.auth_email_attempt_outcome": {
+      "name": "auth_email_attempt_outcome",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.auth_email_delivery_attribution": {
+      "name": "auth_email_delivery_attribution",
+      "schema": "public",
+      "values": [
+        "attempt_tag",
+        "provider_message_id",
+        "unmatched",
+        "identity_conflict"
+      ]
+    },
+    "public.auth_email_delivery_classification": {
+      "name": "auth_email_delivery_classification",
+      "schema": "public",
+      "values": [
+        "sent",
+        "delivered",
+        "delayed",
+        "failed",
+        "complained",
+        "opened",
+        "clicked",
+        "unknown"
+      ]
+    },
+    "public.auth_email_source": {
+      "name": "auth_email_source",
+      "schema": "public",
+      "values": [
+        "registration",
+        "authenticated_resend"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": [
+        "staff",
+        "client",
+        "system"
+      ]
+    },
+    "public.sms_delivery_classification": {
+      "name": "sms_delivery_classification",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "sent",
+        "failed",
+        "delivered"
+      ]
+    },
+    "public.sms_delivery_history_kind": {
+      "name": "sms_delivery_history_kind",
+      "schema": "public",
+      "values": [
+        "automatic",
+        "operator_reconciliation"
+      ]
+    },
+    "public.sms_delivery_history_result": {
+      "name": "sms_delivery_history_result",
+      "schema": "public",
+      "values": [
+        "unmatched",
+        "ambiguous",
+        "attributed",
+        "projected",
+        "projection_miss",
+        "reconciled",
+        "operator_reviewed"
+      ]
+    },
+    "public.sms_delivery_reconciliation_reason": {
+      "name": "sms_delivery_reconciliation_reason",
+      "schema": "public",
+      "values": [
+        "exact_attribution_retry",
+        "provider_portal_status_review",
+        "projection_repair",
+        "identity_conflict_review",
+        "unmatched_evidence_review"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator"
+      ]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": [
+        "provider_result",
+        "reconciliation"
+      ]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": [
+        "practice_created",
+        "product_records",
+        "stripe_webhook"
+      ]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": [
+        "unresolved",
+        "charged",
+        "no_charge",
+        "voided"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1786289519527,
       "tag": "0062_ambitious_moon_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1786296785895,
+      "tag": "0063_modern_starbolt",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -55,7 +55,7 @@ DECLARE
     'capture_sessions','cases','clients','clinical_notes','clinical_record_corrections','communications','consent_forms','consent_requests','controlled_substance_log','dispense_charge_queue','email_suppressions',
     'files','insurance_claims','insurance_policies','invoices','lab_result_events','lab_result_replacements','lab_results','location_messaging','messaging_registrations','migration_runs',
     'locations','patient_merge_events','patients','practice_payment_accounts','prescription_events','prescriptions','problem_list','procedures','products','purchase_orders',
-    'recurring_series','rooms','services','sms_consent_events','sms_send_attempt_events','sms_send_attempts','sms_suppressions','soap_notes','staff_schedules','suppliers',
+    'recurring_series','rooms','services','sms_consent_events','sms_send_attempt_events','sms_send_attempts','sms_suppressions','soap_note_addenda','soap_notes','staff_schedules','suppliers',
     'treatment_plans','treatment_templates','usage_records','users','vaccination_records',
     'visit_closeouts','visit_work_items','vital_signs','webhooks','wellness_enrollments','wellness_plans'
   ];
@@ -76,6 +76,12 @@ END$$;
 -- append and read them, but even a future generic repository path must not
 -- gain UPDATE or DELETE through the broad table grant above.
 REVOKE UPDATE, DELETE ON clinical_record_corrections FROM openpims_app;
+
+-- SOAP addenda are immutable, attributed extensions to a finalized note.
+REVOKE ALL ON soap_note_addenda FROM openpims_app;
+GRANT SELECT, INSERT ON soap_note_addenda TO openpims_app;
+REVOKE ALL ON FUNCTION restore_soap_note_addendum(uuid,timestamptz,uuid,uuid,uuid,text,text,uuid,text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION restore_soap_note_addendum(uuid,timestamptz,uuid,uuid,uuid,text,text,uuid,text) TO openpims_app;
 
 -- Prescription lifecycle events are an append-only clinical ledger. Tenant
 -- users may read and append attributed events through the transactional app

--- a/packages/db/schema/clinical.ts
+++ b/packages/db/schema/clinical.ts
@@ -65,6 +65,11 @@ export const treatmentPlanItemStatusEnum = pgEnum(
   ["pending", "in_progress", "done", "skipped"],
 );
 
+export const soapNoteStatusEnum = pgEnum("soap_note_status", [
+  "draft",
+  "finalized",
+]);
+
 export const soapNotes = pgTable(
   "soap_notes",
   {
@@ -79,6 +84,12 @@ export const soapNotes = pgTable(
     authorId: uuid("author_id")
       .notNull()
       .references(() => users.id),
+    authorName: varchar("author_name", { length: 255 }).notNull(),
+    status: soapNoteStatusEnum("status").notNull().default("finalized"),
+    revision: integer("revision").notNull().default(1),
+    finalizedAt: timestamp("finalized_at", { withTimezone: true }),
+    finalizedBy: uuid("finalized_by"),
+    finalizerName: varchar("finalizer_name", { length: 255 }),
     subjective: text("subjective"),
     objective: text("objective"),
     assessment: text("assessment"),
@@ -115,6 +126,13 @@ export const soapNotes = pgTable(
       table.appointmentId,
       table.deletedAt,
     ),
+    activeAppointmentDraftUq: uniqueIndex(
+      "soap_notes_active_appointment_draft_uq",
+    )
+      .on(table.practiceId, table.appointmentId)
+      .where(
+        sql`${table.status} = 'draft' and ${table.appointmentId} is not null and ${table.deletedAt} is null`,
+      ),
     patientPracticeFk: foreignKey({
       columns: [table.practiceId, table.patientId],
       foreignColumns: [patients.practiceId, patients.id],
@@ -129,6 +147,95 @@ export const soapNotes = pgTable(
       ],
       name: "soap_notes_practice_appointment_fk",
     }),
+    authorPracticeFk: foreignKey({
+      columns: [table.practiceId, table.authorId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "soap_notes_practice_author_fk",
+    }),
+    finalizerPracticeFk: foreignKey({
+      columns: [table.practiceId, table.finalizedBy],
+      foreignColumns: [users.practiceId, users.id],
+      name: "soap_notes_practice_finalizer_fk",
+    }),
+    revisionCheck: check(
+      "soap_notes_revision_check",
+      sql`${table.revision} >= 1`,
+    ),
+    authorNameCheck: check(
+      "soap_notes_author_name_check",
+      sql`length(btrim(${table.authorName})) between 1 and 255`,
+    ),
+    lifecycleCheck: check(
+      "soap_notes_lifecycle_check",
+      sql`(
+        ${table.status} = 'draft'
+        and ${table.finalizedAt} is null
+        and ${table.finalizedBy} is null
+        and ${table.finalizerName} is null
+        and ${table.imported} = false
+      ) or (
+        ${table.status} = 'finalized'
+        and ${table.finalizedAt} is not null
+        and ${table.finalizedBy} is not null
+        and length(btrim(${table.finalizerName})) between 1 and 255
+      )`,
+    ),
+  }),
+);
+
+/** Append-only clarifications to an immutable finalized SOAP note. */
+export const soapNoteAddenda = pgTable(
+  "soap_note_addenda",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    soapNoteId: uuid("soap_note_id").notNull(),
+    authorId: uuid("author_id").notNull(),
+    authorName: varchar("author_name", { length: 255 }).notNull(),
+    content: text("content").notNull(),
+    operationId: uuid("operation_id").notNull(),
+    operationPayloadHash: varchar("operation_payload_hash", {
+      length: 64,
+    }).notNull(),
+  },
+  (table) => ({
+    historyIdx: index("soap_note_addenda_history_idx").on(
+      table.practiceId,
+      table.soapNoteId,
+      table.createdAt,
+      table.id,
+    ),
+    operationUq: uniqueIndex("soap_note_addenda_operation_uq").on(
+      table.practiceId,
+      table.operationId,
+    ),
+    sourcePracticeFk: foreignKey({
+      columns: [table.practiceId, table.soapNoteId],
+      foreignColumns: [soapNotes.practiceId, soapNotes.id],
+      name: "soap_note_addenda_practice_source_fk",
+    }),
+    authorPracticeFk: foreignKey({
+      columns: [table.practiceId, table.authorId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "soap_note_addenda_practice_author_fk",
+    }),
+    contentCheck: check(
+      "soap_note_addenda_content_check",
+      sql`length(btrim(${table.content})) between 1 and 10000`,
+    ),
+    authorNameCheck: check(
+      "soap_note_addenda_author_name_check",
+      sql`length(btrim(${table.authorName})) between 1 and 255`,
+    ),
+    payloadHashCheck: check(
+      "soap_note_addenda_payload_hash_check",
+      sql`${table.operationPayloadHash} ~ '^[0-9a-f]{64}$'`,
+    ),
   }),
 );
 
@@ -675,7 +782,29 @@ export const soapNotesRelations = relations(soapNotes, ({ one }) => ({
     fields: [soapNotes.authorId],
     references: [users.id],
   }),
+  finalizer: one(users, {
+    fields: [soapNotes.finalizedBy],
+    references: [users.id],
+  }),
 }));
+
+export const soapNoteAddendaRelations = relations(
+  soapNoteAddenda,
+  ({ one }) => ({
+    practice: one(practices, {
+      fields: [soapNoteAddenda.practiceId],
+      references: [practices.id],
+    }),
+    soapNote: one(soapNotes, {
+      fields: [soapNoteAddenda.soapNoteId],
+      references: [soapNotes.id],
+    }),
+    author: one(users, {
+      fields: [soapNoteAddenda.authorId],
+      references: [users.id],
+    }),
+  }),
+);
 
 export const vaccinationRecordsRelations = relations(
   vaccinationRecords,

--- a/packages/db/seed.ts
+++ b/packages/db/seed.ts
@@ -533,11 +533,19 @@ async function seed() {
   await db.insert(soapNotes).values(
     soapNotesToCreate.map((appt) => {
       const template = pickRandom(soapTemplates);
+      const author = insertedUsers.find((user) => user.id === appt.doctorId)!;
+      const finalizedAt = new Date();
       return {
         practiceId,
         patientId: appt.patientId!,
         appointmentId: appt.id,
-        authorId: appt.doctorId!,
+        authorId: author.id,
+        authorName: author.name,
+        status: "finalized" as const,
+        revision: 1,
+        finalizedAt,
+        finalizedBy: author.id,
+        finalizerName: author.name,
         subjective: template.subjective,
         objective: template.objective,
         assessment: template.assessment,

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -8,7 +8,17 @@ import { config } from "dotenv";
 config({ path: "../../.env" });
 
 import postgres from "postgres";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
+
+function soapAddendumPayloadHash(
+  noteId: string,
+  authorId: string,
+  content: string,
+) {
+  return createHash("sha256")
+    .update(JSON.stringify({ noteId, authorId, content }))
+    .digest("hex");
+}
 
 function nonBlankEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
@@ -49,6 +59,18 @@ const aAppointment = randomUUID();
 const bAppointment = randomUUID();
 const aCloseout = randomUUID();
 const bCloseout = randomUUID();
+const aSoapLegalAppointment = randomUUID();
+const aSoapDraftFinalAppointment = randomUUID();
+const aSoapDoubleFinalAppointment = randomUUID();
+const aSoapDiscardAppointment = randomUUID();
+const aSoapSource = randomUUID();
+const aSoapReplacement = randomUUID();
+const aSoapDeletedSource = randomUUID();
+const aSoapCorrection = randomUUID();
+const aSoapAddendum = randomUUID();
+const aSoapRestoreAddendum = randomUUID();
+const aSoapDeletedRestoreAddendum = randomUUID();
+const aSoapDraft = randomUUID();
 const aPatient = randomUUID();
 const bPatient = randomUUID();
 const aMergeTargetPatient = randomUUID();
@@ -313,6 +335,391 @@ try {
     from clients where practice_id = ${bId}`;
   await owner`insert into visit_closeouts (id, practice_id, appointment_id)
     values (${aCloseout}, ${aId}, ${aAppointment}), (${bCloseout}, ${bId}, ${bAppointment})`;
+  await owner`insert into appointments
+    (id, practice_id, client_id, patient_id, start_time, end_time, status)
+    values
+    (${aSoapLegalAppointment}, ${aId}, ${aClient}, ${aPatient}, now(), now() + interval '30 minutes', 'in_exam'),
+    (${aSoapDraftFinalAppointment}, ${aId}, ${aClient}, ${aPatient}, now(), now() + interval '30 minutes', 'in_exam'),
+    (${aSoapDoubleFinalAppointment}, ${aId}, ${aClient}, ${aPatient}, now(), now() + interval '30 minutes', 'in_exam'),
+    (${aSoapDiscardAppointment}, ${aId}, ${aClient}, ${aPatient}, now(), now() + interval '30 minutes', 'in_exam')`;
+
+  let correctedReplacementTransactionAllowed = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into soap_notes
+        (id, practice_id, patient_id, appointment_id, author_id, author_name,
+         status, revision, finalized_at, finalized_by, finalizer_name,
+         subjective, imported)
+        values
+        (${aSoapSource}, ${aId}, ${aPatient}, ${aSoapLegalAppointment},
+          ${aUser}, 'RLS Admin A', 'finalized', 1, now() - interval '2 hours', ${aUser},
+          'RLS Admin A', 'Original SOAP', false),
+        (${aSoapReplacement}, ${aId}, ${aPatient}, ${aSoapLegalAppointment},
+          ${aUser}, 'RLS Admin A', 'finalized', 1, now() - interval '2 hours', ${aUser},
+          'RLS Admin A', 'Replacement SOAP', false)`;
+      await tx`insert into clinical_record_corrections
+        (id, created_at, practice_id, record_type, action, soap_note_id, patient_id,
+         appointment_id, reason, corrected_by, corrected_by_name)
+        values (${aSoapCorrection}, now() - interval '1 hour', ${aId}, 'soap_note', 'entered_in_error',
+          ${aSoapSource}, ${aPatient}, ${aSoapLegalAppointment},
+          'Original note was documented on the wrong encounter.', ${aUser},
+          'RLS Admin A')`;
+    });
+    correctedReplacementTransactionAllowed = true;
+  } catch {
+    correctedReplacementTransactionAllowed = false;
+  }
+  check(
+    "corrected source and replacement SOAP can commit atomically",
+    correctedReplacementTransactionAllowed,
+  );
+
+  await owner`insert into soap_notes
+    (id, created_at, updated_at, deleted_at, practice_id, patient_id,
+     appointment_id, author_id, author_name, status, revision, finalized_at,
+     finalized_by, finalizer_name, subjective, imported)
+    values (${aSoapDeletedSource}, now() - interval '2 hours',
+      now() - interval '1 hour', now() - interval '1 hour', ${aId},
+      ${aPatient}, null, ${aUser}, 'RLS Admin A', 'finalized', 1,
+      now() - interval '2 hours', ${aUser}, 'RLS Admin A',
+      'Retired finalized SOAP', false)`;
+
+  let draftAndFinalBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into soap_notes
+        (practice_id, patient_id, appointment_id, author_id, author_name,
+         status, revision, subjective, imported)
+        values (${aId}, ${aPatient}, ${aSoapDraftFinalAppointment}, ${aUser},
+          'RLS Admin A', 'draft', 1, 'Draft SOAP', false)`;
+      await tx`insert into soap_notes
+        (practice_id, patient_id, appointment_id, author_id, author_name,
+         status, revision, finalized_at, finalized_by, finalizer_name,
+         subjective, imported)
+        values (${aId}, ${aPatient}, ${aSoapDraftFinalAppointment}, ${aUser},
+          'RLS Admin A', 'finalized', 1, now(), ${aUser}, 'RLS Admin A',
+          'Final SOAP', false)`;
+    });
+  } catch {
+    draftAndFinalBlocked = true;
+  }
+  check(
+    "deferred SOAP invariant rejects a draft plus effective final",
+    draftAndFinalBlocked,
+  );
+
+  let twoEffectiveFinalsBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into soap_notes
+        (practice_id, patient_id, appointment_id, author_id, author_name,
+         status, revision, finalized_at, finalized_by, finalizer_name,
+         subjective, imported)
+        values
+        (${aId}, ${aPatient}, ${aSoapDoubleFinalAppointment}, ${aUser},
+          'RLS Admin A', 'finalized', 1, now(), ${aUser}, 'RLS Admin A',
+          'First final', false),
+        (${aId}, ${aPatient}, ${aSoapDoubleFinalAppointment}, ${aUser},
+          'RLS Admin A', 'finalized', 1, now(), ${aUser}, 'RLS Admin A',
+          'Second final', false)`;
+    });
+  } catch {
+    twoEffectiveFinalsBlocked = true;
+  }
+  check(
+    "deferred SOAP invariant rejects two effective finals",
+    twoEffectiveFinalsBlocked,
+  );
+
+  let openDraftDiscardAllowed = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into soap_notes
+        (id, practice_id, patient_id, appointment_id, author_id, author_name,
+         status, revision, subjective, imported)
+        values (${aSoapDraft}, ${aId}, ${aPatient}, ${aSoapDiscardAppointment},
+          ${aUser}, 'RLS Admin A', 'draft', 1, 'Discard me', false)`;
+      await tx`delete from soap_notes where id = ${aSoapDraft}`;
+    });
+    openDraftDiscardAllowed = true;
+  } catch {
+    openDraftDiscardAllowed = false;
+  }
+  check(
+    "open unsigned encounter draft can be discarded",
+    openDraftDiscardAllowed,
+  );
+
+  await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    await tx`insert into soap_notes
+      (id, practice_id, patient_id, appointment_id, author_id, author_name,
+       status, revision, subjective, imported)
+      values (${aSoapDraft}, ${aId}, ${aPatient}, ${aSoapDiscardAppointment},
+        ${aUser}, 'RLS Admin A', 'draft', 1, 'Cannot discard later', false)`;
+  });
+  await owner`update appointments set status = 'checked_out' where id = ${aSoapDiscardAppointment}`;
+  let closedDraftDiscardBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`delete from soap_notes where id = ${aSoapDraft}`;
+    });
+  } catch {
+    closedDraftDiscardBlocked = true;
+  }
+  check(
+    "closed encounter draft cannot be discarded by the app role",
+    closedDraftDiscardBlocked,
+  );
+
+  const addendumContent = 'Owner said "8 AM".\nDose unchanged — café 🐾';
+  const addendumHash = soapAddendumPayloadHash(
+    aSoapReplacement,
+    aUser,
+    addendumContent,
+  );
+  await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    await tx`insert into soap_note_addenda
+      (id, practice_id, soap_note_id, author_id, author_name, content,
+       operation_id, operation_payload_hash)
+      values (${aSoapAddendum}, ${aId}, ${aSoapReplacement}, ${aUser},
+        'RLS Admin A', ${addendumContent}, ${randomUUID()}, ${addendumHash})`;
+  });
+  let crossTenantAddendumBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into soap_note_addenda
+        (practice_id, soap_note_id, author_id, author_name, content,
+         operation_id, operation_payload_hash)
+        values (${bId}, ${aSoapReplacement}, ${bUser}, 'RLS Admin B',
+          'Cross tenant', ${randomUUID()}, ${"b".repeat(64)})`;
+    });
+  } catch {
+    crossTenantAddendumBlocked = true;
+  }
+  check(
+    "cross-tenant SOAP addendum insert is blocked",
+    crossTenantAddendumBlocked,
+  );
+
+  let invalidAddendumHashBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into soap_note_addenda
+        (practice_id, soap_note_id, author_id, author_name, content,
+         operation_id, operation_payload_hash)
+        values (${aId}, ${aSoapReplacement}, ${aUser}, 'RLS Admin A',
+          'Hash tampering attempt', ${randomUUID()}, ${"0".repeat(64)})`;
+    });
+  } catch {
+    invalidAddendumHashBlocked = true;
+  }
+  check(
+    "ordinary SOAP addendum insert rejects a mismatched payload hash",
+    invalidAddendumHashBlocked,
+  );
+
+  let addendumUpdateBlocked = false;
+  let addendumDeleteBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`select set_config('app.ledger_maintenance', 'on', true)`;
+      await tx`update soap_note_addenda set content = 'Tampered' where id = ${aSoapAddendum}`;
+    });
+  } catch {
+    addendumUpdateBlocked = true;
+  }
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`select set_config('app.ledger_maintenance', 'on', true)`;
+      await tx`delete from soap_note_addenda where id = ${aSoapAddendum}`;
+    });
+  } catch {
+    addendumDeleteBlocked = true;
+  }
+  check(
+    "SOAP addenda cannot be updated or deleted by the app role",
+    addendumUpdateBlocked && addendumDeleteBlocked,
+  );
+
+  let attributedRestoreAllowed = false;
+  const restoredContent =
+    'Restored owner quote: "yes".\nDose remains ½ tablet 🐾';
+  const restoredHash = soapAddendumPayloadHash(
+    aSoapSource,
+    aUser,
+    restoredContent,
+  );
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_addendum(
+        ${aSoapRestoreAddendum}, now() - interval '90 minutes', ${aId}, ${aSoapSource}, ${aUser},
+        'RLS Admin A', ${restoredContent}, ${randomUUID()}, ${restoredHash})`;
+    });
+    attributedRestoreAllowed = true;
+  } catch {
+    attributedRestoreAllowed = false;
+  }
+  check(
+    "same-tenant restore retains addendum evidence for a corrected final SOAP",
+    attributedRestoreAllowed,
+  );
+
+  const deletedBoundaryContent = "Clarification before record retirement";
+  let preDeletionRestoreAllowed = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_addendum(
+        ${aSoapDeletedRestoreAddendum}, now() - interval '90 minutes', ${aId},
+        ${aSoapDeletedSource}, ${aUser}, 'RLS Admin A', ${deletedBoundaryContent},
+        ${randomUUID()},
+        ${soapAddendumPayloadHash(aSoapDeletedSource, aUser, deletedBoundaryContent)})`;
+    });
+    preDeletionRestoreAllowed = true;
+  } catch {
+    preDeletionRestoreAllowed = false;
+  }
+  check(
+    "SOAP addendum restore accepts evidence before source deletion",
+    preDeletionRestoreAllowed,
+  );
+
+  const postDeletionContent = "Clarification after record retirement";
+  let postDeletionRestoreBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_addendum(
+        ${randomUUID()}, now() - interval '30 minutes', ${aId},
+        ${aSoapDeletedSource}, ${aUser}, 'RLS Admin A', ${postDeletionContent},
+        ${randomUUID()},
+        ${soapAddendumPayloadHash(aSoapDeletedSource, aUser, postDeletionContent)})`;
+    });
+  } catch {
+    postDeletionRestoreBlocked = true;
+  }
+  check(
+    "SOAP addendum restore rejects nonfuture evidence after source deletion",
+    postDeletionRestoreBlocked,
+  );
+
+  const preFinalContent = "Predates finalization";
+  let preFinalRestoreBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_addendum(
+        ${randomUUID()}, now() - interval '3 hours', ${aId}, ${aSoapSource}, ${aUser},
+        'RLS Admin A', ${preFinalContent}, ${randomUUID()},
+        ${soapAddendumPayloadHash(aSoapSource, aUser, preFinalContent)})`;
+    });
+  } catch {
+    preFinalRestoreBlocked = true;
+  }
+  check(
+    "SOAP addendum restore rejects evidence before finalization",
+    preFinalRestoreBlocked,
+  );
+
+  const futureContent = "Future-dated evidence";
+  let futureRestoreBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_addendum(
+        ${randomUUID()}, now() + interval '1 hour', ${aId}, ${aSoapSource}, ${aUser},
+        'RLS Admin A', ${futureContent}, ${randomUUID()},
+        ${soapAddendumPayloadHash(aSoapSource, aUser, futureContent)})`;
+    });
+  } catch {
+    futureRestoreBlocked = true;
+  }
+  check(
+    "SOAP addendum restore rejects future-dated evidence",
+    futureRestoreBlocked,
+  );
+
+  const postCorrectionContent = "Recorded after correction";
+  let postCorrectionRestoreBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_addendum(
+        ${randomUUID()}, now() - interval '30 minutes', ${aId}, ${aSoapSource}, ${aUser},
+        'RLS Admin A', ${postCorrectionContent}, ${randomUUID()},
+        ${soapAddendumPayloadHash(aSoapSource, aUser, postCorrectionContent)})`;
+    });
+  } catch {
+    postCorrectionRestoreBlocked = true;
+  }
+  check(
+    "SOAP addendum restore rejects evidence after correction",
+    postCorrectionRestoreBlocked,
+  );
+
+  let mismatchedRestoreHashBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_addendum(
+        ${randomUUID()}, now() - interval '90 minutes', ${aId}, ${aSoapSource}, ${aUser},
+        'RLS Admin A', 'Mismatched restore hash', ${randomUUID()}, ${"0".repeat(64)})`;
+    });
+  } catch {
+    mismatchedRestoreHashBlocked = true;
+  }
+  check(
+    "SOAP addendum restore rejects a mismatched payload hash",
+    mismatchedRestoreHashBlocked,
+  );
+
+  let crossTenantRestoreBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_addendum(
+        ${randomUUID()}, now(), ${bId}, ${aSoapSource}, ${bUser},
+        'RLS Admin B', 'Cross-tenant restore', ${randomUUID()}, ${"d".repeat(64)})`;
+    });
+  } catch {
+    crossTenantRestoreBlocked = true;
+  }
+  check(
+    "cross-tenant SOAP addendum restore is blocked",
+    crossTenantRestoreBlocked,
+  );
+
+  let spoofedRestoreBypassBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${bId}, true)`;
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`select set_config('app.ledger_maintenance', 'on', true)`;
+      await tx`select public.restore_soap_note_addendum(
+        ${randomUUID()}, now(), ${aId}, ${aSoapSource}, ${aUser},
+        'RLS Admin A', 'Spoofed bypass restore', ${randomUUID()}, ${"e".repeat(64)})`;
+    });
+  } catch {
+    spoofedRestoreBypassBlocked = true;
+  }
+  check(
+    "SOAP addendum restore cannot spoof tenant bypass GUCs",
+    spoofedRestoreBypassBlocked,
+  );
 
   // Tenant A context sees only A's rows.
   const aRows = await appTransaction(async (tx) => {
@@ -1583,7 +1990,9 @@ try {
     await cleanup`delete from sms_delivery_events where id in (${aSmsDeliveryEvent}, ${bSmsDeliveryEvent}, ${unmatchedSmsDeliveryEvent})`;
     await cleanup`delete from lab_result_events where id in (${aLabResultEvent}, ${bLabResultEvent})`;
     await cleanup`delete from lab_result_replacements where id in (${aLabReplacement}, ${bLabReplacement})`;
-    await cleanup`delete from clinical_record_corrections where id in (${aLabCorrection}, ${bLabCorrection})`;
+    await cleanup`delete from soap_note_addenda where id in (${aSoapAddendum}, ${aSoapRestoreAddendum}, ${aSoapDeletedRestoreAddendum})`;
+    await cleanup`delete from clinical_record_corrections where id in (${aLabCorrection}, ${bLabCorrection}, ${aSoapCorrection})`;
+    await cleanup`delete from soap_notes where id in (${aSoapSource}, ${aSoapReplacement}, ${aSoapDeletedSource}, ${aSoapDraft})`;
     await cleanup`delete from lab_results where id in (${aLabResult}, ${bLabResult}, ${aReplacementLabResult}, ${bReplacementLabResult})`;
     await cleanup`delete from sms_send_attempt_events where id in (${aSmsSendAttemptEvent}, ${bSmsSendAttemptEvent}, ${aAppSmsSendAttemptEvent})`;
     await cleanup`delete from sms_send_attempts where id in (${aSmsSendAttempt}, ${bSmsSendAttempt}, ${aAppSmsSendAttempt})`;
@@ -1598,7 +2007,7 @@ try {
     await cleanup`delete from practice_conversion_milestones where practice_id = ${aId}`;
     await cleanup`delete from invoices where id in (${aInvoice}, ${bInvoice})`;
     await cleanup`delete from migration_runs where id in (${aMigrationRun}, ${bMigrationRun})`;
-    await cleanup`delete from appointments where id in (${aAppointment}, ${bAppointment})`;
+    await cleanup`delete from appointments where id in (${aAppointment}, ${bAppointment}, ${aSoapLegalAppointment}, ${aSoapDraftFinalAppointment}, ${aSoapDoubleFinalAppointment}, ${aSoapDiscardAppointment})`;
     await cleanup`delete from prescriptions where id in (${aPrescription}, ${bPrescription})`;
     await cleanup`delete from products where id in (${aProduct}, ${bProduct})`;
     await cleanup`delete from patients where id in (${aPatient}, ${bPatient}, ${aMergeTargetPatient}, ${bMergeTargetPatient}, ${aLineageCandidatePatient})`;


### PR DESCRIPTION
## Summary

- persist encounter SOAP drafts with autosave, optimistic concurrency, explicit finalization, discard, and safe navigation
- preserve signed-note attribution and immutable addenda across charts, closeout, PDFs, API paths, imports, and backups
- enforce one effective encounter SOAP record with database constraints, tenant-safe restore validation, and demo-data cleanup
- keep webhook/audit side effects post-commit and return truthful concurrency errors

## Safety

- finalized SOAP notes and addenda are immutable outside owner maintenance
- restore validates tenant, canonical UUIDs, payload hash, chronology, deletion, and correction cutoffs
- backups restore correction history before addenda and remain idempotent
- drafts are excluded from signed charts, PDFs, closeout, exports intended as finalized evidence, and analytics

## Validation

- DB and web typechecks passed
- focused safety matrix: 19 files / 461 tests passed
- full suite: 320 files / 3,251 tests passed; 1 configured integration skip
- production Next build passed, including lint/type phase
- drizzle generation reports no schema drift
- diff, conflict-marker, public-path, and secret scans passed

## Required merge gate

The real PostgreSQL CI job must pass migration apply, schema drift, RLS apply/tests, and migration-ledger tests before merge.