### PR TITLE
Fix appointment check-in row locking

### DIFF
--- a/apps/web/server/__tests__/appointments-safety.test.ts
+++ b/apps/web/server/__tests__/appointments-safety.test.ts
@@ -1484,6 +1484,12 @@ describe("appointments display join scoping", () => {
     expect(joins?.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("locks only the appointment row during joined status transitions", () => {
+    expect(source).toMatch(
+      /updateStatus:[\s\S]*?leftJoin\([\s\S]*?appointmentTypes[\s\S]*?\.for\("update", \{ of: appointments \}\)/,
+    );
+  });
+
   it("uses the practice timezone when calculating available slots", () => {
     expect(source).toContain("const timezone = await practiceTimeZone(ctx)");
     expect(source).toContain("return practice.timezone ?? null");

--- a/apps/web/server/routers/appointments.ts
+++ b/apps/web/server/routers/appointments.ts
@@ -790,7 +790,10 @@ export const appointmentsRouter = createRouter({
               isNull(appointments.deletedAt)
             )
           )
-          .for("update");
+          // PostgreSQL cannot lock the nullable side of the appointment type
+          // LEFT JOIN. Lock only the appointment row that owns the status
+          // transition; the type row is read solely for policy metadata.
+          .for("update", { of: appointments });
 
         if (!current) {
           throw new TRPCError({


### PR DESCRIPTION
## Production finding

Live clinic smoke found that appointment check-in failed before status validation because PostgreSQL was asked to lock every relation in a query containing a nullable appointment type left join.

## Fix

- target the `FOR UPDATE` lock to the owning appointment row only
- retain the joined appointment type as read-only policy metadata
- add a regression assertion so this joined transition cannot return to an untargeted lock

## Validation

- appointment safety suite: 51 tests passed
- web typecheck passed
- independent P0 review approved the minimal lock target and found no sibling joined-lock blocker

Production smoke will resume after CI, merge, and deployment.