### PR TITLE
Preserve former staff attribution in clinic records

### DIFF
--- a/apps/web/server/__tests__/appointments-safety.test.ts
+++ b/apps/web/server/__tests__/appointments-safety.test.ts
@@ -1457,10 +1457,9 @@ describe("appointments display join scoping", () => {
     "utf8"
   );
 
-  it("keeps joined patient, client, staff, type, and room rows tenant scoped", () => {
+  it("keeps joined patient, client, type, and room rows tenant scoped and active", () => {
     for (const [table, foreignKey] of [
       ["clients", "appointments.clientId"],
-      ["users", "appointments.doctorId"],
       ["appointmentTypes", "appointments.typeId"],
       ["rooms", "appointments.roomId"],
     ]) {
@@ -1474,6 +1473,15 @@ describe("appointments display join scoping", () => {
         )
       );
     }
+  });
+
+  it("keeps historical doctor attribution tenant scoped after deactivation", () => {
+    expect(source).toMatch(
+      /leftJoin\(\s*users,\s*and\(\s*eq\(appointments\.doctorId, users\.id\),\s*eq\(users\.practiceId, ctx\.practiceId\)\s*\)\s*\)/s
+    );
+    expect(source).not.toMatch(
+      /eq\(appointments\.doctorId, users\.id\)[\s\S]{0,120}?isNull\(users\.deletedAt\)/s
+    );
   });
 
   it("keeps displayed patients tied to the appointment client", () => {

--- a/apps/web/server/__tests__/billing-query-scoping.test.ts
+++ b/apps/web/server/__tests__/billing-query-scoping.test.ts
@@ -50,12 +50,18 @@ describe("billing query scoping", () => {
     expect(createInvoiceBlock).toContain("throw practiceNotFound()");
   });
 
-  it("keeps billing staff display joins tenant scoped and active", () => {
+  it("keeps billing actor display joins tenant scoped after deactivation", () => {
     expect(source).toMatch(
-      /leftJoin\(\s*users,\s*and\(\s*eq\(payments\.receivedBy, users\.id\),\s*eq\(users\.practiceId, ctx\.practiceId\),\s*isNull\(users\.deletedAt\)\s*,?\s*\)\s*,?\s*\)/s
+      /leftJoin\(\s*users,\s*and\(\s*eq\(payments\.receivedBy, users\.id\),\s*eq\(users\.practiceId, ctx\.practiceId\)\s*,?\s*\)\s*,?\s*\)/s
     );
     expect(source).toMatch(
-      /leftJoin\(\s*users,\s*and\(\s*eq\(invoiceAdjustments\.createdBy, users\.id\),\s*eq\(users\.practiceId, ctx\.practiceId\),\s*isNull\(users\.deletedAt\)\s*,?\s*\)\s*,?\s*\)/s
+      /leftJoin\(\s*users,\s*and\(\s*eq\(invoiceAdjustments\.createdBy, users\.id\),\s*eq\(users\.practiceId, ctx\.practiceId\)\s*,?\s*\)\s*,?\s*\)/s
+    );
+    expect(source).not.toMatch(
+      /eq\(payments\.receivedBy, users\.id\)[\s\S]{0,120}?isNull\(users\.deletedAt\)/s
+    );
+    expect(source).not.toMatch(
+      /eq\(invoiceAdjustments\.createdBy, users\.id\)[\s\S]{0,120}?isNull\(users\.deletedAt\)/s
     );
   });
 

--- a/apps/web/server/__tests__/controlled-substances-safety.test.ts
+++ b/apps/web/server/__tests__/controlled-substances-safety.test.ts
@@ -656,15 +656,21 @@ describe("controlled substance list scoping", () => {
     "utf8"
   );
 
-  it("keeps displayed patient and staff joins tenant scoped and active", () => {
+  it("keeps patients active while preserving former-staff ledger attribution", () => {
     expect(source).toMatch(
       /leftJoin\(\s*patients,\s*and\(\s*eq\(controlledSubstanceLog\.patientId, patients\.id\),\s*eq\(patients\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\),\s*isNull\(patients\.deletedAt\)\s*\)\s*\)/s
     );
     expect(source).toMatch(
-      /leftJoin\(\s*performer,\s*and\(\s*eq\(controlledSubstanceLog\.performedBy, performer\.id\),\s*eq\(performer\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\),\s*isNull\(performer\.deletedAt\)\s*\)\s*\)/s
+      /leftJoin\(\s*performer,\s*and\(\s*eq\(controlledSubstanceLog\.performedBy, performer\.id\),\s*eq\(performer\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\)\s*,?\s*\)\s*\)/s
     );
     expect(source).toMatch(
-      /leftJoin\(\s*witness,\s*and\(\s*eq\(controlledSubstanceLog\.witnessedBy, witness\.id\),\s*eq\(witness\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\),\s*isNull\(witness\.deletedAt\)\s*\)\s*\)/s
+      /leftJoin\(\s*witness,\s*and\(\s*eq\(controlledSubstanceLog\.witnessedBy, witness\.id\),\s*eq\(witness\.practiceId, ctx\.practiceId\),\s*activePracticePredicate\(ctx\.practiceId\)\s*,?\s*\)\s*\)/s
+    );
+    expect(source).not.toMatch(
+      /eq\(controlledSubstanceLog\.performedBy, performer\.id\)[\s\S]{0,180}?isNull\(performer\.deletedAt\)/s
+    );
+    expect(source).not.toMatch(
+      /eq\(controlledSubstanceLog\.witnessedBy, witness\.id\)[\s\S]{0,180}?isNull\(witness\.deletedAt\)/s
     );
   });
 

--- a/apps/web/server/__tests__/dashboard.test.ts
+++ b/apps/web/server/__tests__/dashboard.test.ts
@@ -151,6 +151,9 @@ describe("dashboard router", () => {
     expect(source).toContain("eq(invoices.appointmentId, appointments.id)");
     expect(source).toContain("eq(appointments.practiceId, ctx.practiceId)");
     expect(source).toContain("eq(users.practiceId, ctx.practiceId)");
+    expect(source).not.toMatch(
+      /eq\(appointments\.doctorId, users\.id\)[\s\S]{0,180}?isNull\(users\.deletedAt\)/s
+    );
     expect(
       source.match(/activePracticePredicate\(ctx\.practiceId\)/g)?.length ?? 0
     ).toBeGreaterThanOrEqual(10);
@@ -164,7 +167,7 @@ describe("dashboard router", () => {
       /eq\(patients\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(patients\.deletedAt\)/
     );
     expect(source).toMatch(
-      /eq\(users\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\),\s+isNull\(users\.deletedAt\)/
+      /eq\(appointments\.doctorId, users\.id\),\s+eq\(users\.practiceId, ctx\.practiceId\),\s+activePracticePredicate\(ctx\.practiceId\)/
     );
     expect(source).not.toContain(
       "date_trunc('day', ${appointments.startTime})"

--- a/apps/web/server/__tests__/data-export.test.ts
+++ b/apps/web/server/__tests__/data-export.test.ts
@@ -331,17 +331,25 @@ describe("data CSV export safety", () => {
     );
   });
 
-  it("scopes appointment export display joins to active tenant rows", () => {
+  it("scopes appointment export entity joins to active tenant rows", () => {
     for (const [table, foreignKey] of [
       ["patients", "appointments.patientId"],
       ["clients", "appointments.clientId"],
-      ["users", "appointments.doctorId"],
       ["appointmentTypes", "appointments.typeId"],
     ]) {
       expect(source).toMatch(
         scopedJoinPattern("leftJoin", table, foreignKey)
       );
     }
+  });
+
+  it("preserves exported doctor attribution after staff deactivation", () => {
+    expect(source).toMatch(
+      /leftJoin\(\s*users,\s*and\(\s*eq\(appointments\.doctorId, users\.id\),[\s\S]*?eq\(users\.practiceId, ctx\.practiceId\),?[\s\S]*?\)\s*\)/s
+    );
+    expect(source).not.toMatch(
+      /eq\(appointments\.doctorId, users\.id\)[\s\S]{0,180}?isNull\(users\.deletedAt\)/s
+    );
   });
 
   it("keeps appointment export patient names scoped to the appointment client", () => {

--- a/apps/web/server/__tests__/encounters-closeout.test.ts
+++ b/apps/web/server/__tests__/encounters-closeout.test.ts
@@ -181,6 +181,20 @@ describe("encounter closeout database locking", () => {
 
     expect(source).toContain('.for("update", { of: appointments })');
   });
+
+  it("preserves visit-work resolver attribution after staff deactivation", () => {
+    const source = readFileSync(
+      new URL("../routers/encounters.ts", import.meta.url),
+      "utf8"
+    );
+
+    expect(source).toMatch(
+      /leftJoin\(\s*users,\s*and\(\s*eq\(visitWorkItems\.resolvedBy, users\.id\),\s*eq\(users\.practiceId, ctx\.practiceId\)\s*,?\s*\)\s*,?\s*\)/s
+    );
+    expect(source).not.toMatch(
+      /eq\(visitWorkItems\.resolvedBy, users\.id\)[\s\S]{0,120}?isNull\(users\.deletedAt\)/s
+    );
+  });
 });
 
 describe("encounter prescription lifecycle semantics", () => {

--- a/apps/web/server/__tests__/portal-scoping.test.ts
+++ b/apps/web/server/__tests__/portal-scoping.test.ts
@@ -228,9 +228,12 @@ describe("portal public read scoping", () => {
     expect(activePatientFilters?.length).toBeGreaterThanOrEqual(3);
   });
 
-  it("keeps portal appointment doctor display rows scoped to active practice users", () => {
+  it("keeps portal doctor history tenant scoped after staff deactivation", () => {
     expect(src).toMatch(
-      /leftJoin\(\s*users,\s*and\(\s*eq\(appointments\.doctorId, users\.id\),\s*eq\(users\.practiceId, client\.practiceId\),\s*isNull\(users\.deletedAt\)\s*\)\s*\)/s
+      /leftJoin\(\s*users,\s*and\(\s*eq\(appointments\.doctorId, users\.id\),\s*eq\(users\.practiceId, client\.practiceId\)\s*\)\s*\)/s
+    );
+    expect(src).not.toMatch(
+      /eq\(appointments\.doctorId, users\.id\)[\s\S]{0,120}?isNull\(users\.deletedAt\)/s
     );
   });
 

--- a/apps/web/server/__tests__/records-prescription-safety.test.ts
+++ b/apps/web/server/__tests__/records-prescription-safety.test.ts
@@ -678,7 +678,7 @@ describe("records list query scoping", () => {
     "utf8",
   );
 
-  it("keeps joined staff rows tenant scoped and active", () => {
+  it("keeps historical clinical actors tenant scoped after deactivation", () => {
     for (const foreignKey of [
       "vaccinationRecords.administeredBy",
       "prescriptions.prescribedBy",
@@ -689,7 +689,16 @@ describe("records list query scoping", () => {
           `leftJoin\\(\\s*users,\\s*and\\(\\s*eq\\(${foreignKey.replace(
             ".",
             "\\.",
-          )}, users\\.id\\),\\s*eq\\(users\\.practiceId, ctx\\.practiceId\\),\\s*isNull\\(users\\.deletedAt\\)\\s*,?\\s*\\)\\s*,?\\s*\\)`,
+          )}, users\\.id\\),\\s*eq\\(users\\.practiceId, ctx\\.practiceId\\)\\s*,?\\s*\\)\\s*,?\\s*\\)`,
+          "s",
+        ),
+      );
+      expect(source).not.toMatch(
+        new RegExp(
+          `eq\\(${foreignKey.replace(
+            ".",
+            "\\.",
+          )}, users\\.id\\)[\\s\\S]{0,120}?isNull\\(users\\.deletedAt\\)`,
           "s",
         ),
       );

--- a/apps/web/server/__tests__/reports.test.ts
+++ b/apps/web/server/__tests__/reports.test.ts
@@ -271,7 +271,9 @@ describe("reports", () => {
       source.match(/activePracticePredicate\(ctx\.practiceId\)/g)?.length ?? 0
     ).toBeGreaterThanOrEqual(6);
     expect(source).toContain("eq(users.practiceId, ctx.practiceId)");
-    expect(source).toContain("isNull(users.deletedAt)");
+    expect(source).not.toMatch(
+      /eq\(appointments\.doctorId, users\.id\)[\s\S]{0,180}?isNull\(users\.deletedAt\)/s
+    );
     expect(source).toContain("isNull(invoiceItems.deletedAt)");
     expect(source).toContain("name: invoiceItems.description");
     expect(source).toContain(".groupBy(invoiceItems.description)");

--- a/apps/web/server/routers/appointments.ts
+++ b/apps/web/server/routers/appointments.ts
@@ -531,8 +531,7 @@ export const appointmentsRouter = createRouter({
           users,
           and(
             eq(appointments.doctorId, users.id),
-            eq(users.practiceId, ctx.practiceId),
-            isNull(users.deletedAt)
+            eq(users.practiceId, ctx.practiceId)
           )
         )
         .leftJoin(
@@ -580,8 +579,7 @@ export const appointmentsRouter = createRouter({
           users,
           and(
             eq(appointments.doctorId, users.id),
-            eq(users.practiceId, ctx.practiceId),
-            isNull(users.deletedAt)
+            eq(users.practiceId, ctx.practiceId)
           )
         )
         .leftJoin(
@@ -650,8 +648,7 @@ export const appointmentsRouter = createRouter({
           users,
           and(
             eq(appointments.doctorId, users.id),
-            eq(users.practiceId, ctx.practiceId),
-            isNull(users.deletedAt)
+            eq(users.practiceId, ctx.practiceId)
           )
         )
         .leftJoin(

--- a/apps/web/server/routers/billing.ts
+++ b/apps/web/server/routers/billing.ts
@@ -3314,8 +3314,7 @@ export const billingRouter = createRouter({
           users,
           and(
             eq(payments.receivedBy, users.id),
-            eq(users.practiceId, ctx.practiceId),
-            isNull(users.deletedAt)
+            eq(users.practiceId, ctx.practiceId)
           )
         )
         .where(
@@ -3847,8 +3846,7 @@ export const billingRouter = createRouter({
           users,
           and(
             eq(invoiceAdjustments.createdBy, users.id),
-            eq(users.practiceId, ctx.practiceId),
-            isNull(users.deletedAt)
+            eq(users.practiceId, ctx.practiceId)
           )
         )
         .where(

--- a/apps/web/server/routers/controlled-substances.ts
+++ b/apps/web/server/routers/controlled-substances.ts
@@ -403,8 +403,7 @@ export const controlledSubstancesRouter = createRouter({
             and(
               eq(controlledSubstanceLog.performedBy, performer.id),
               eq(performer.practiceId, ctx.practiceId),
-              activePracticePredicate(ctx.practiceId),
-              isNull(performer.deletedAt)
+              activePracticePredicate(ctx.practiceId)
             )
           )
           .leftJoin(
@@ -412,8 +411,7 @@ export const controlledSubstancesRouter = createRouter({
             and(
               eq(controlledSubstanceLog.witnessedBy, witness.id),
               eq(witness.practiceId, ctx.practiceId),
-              activePracticePredicate(ctx.practiceId),
-              isNull(witness.deletedAt)
+              activePracticePredicate(ctx.practiceId)
             )
           )
           .where(and(...conditions))

--- a/apps/web/server/routers/dashboard.ts
+++ b/apps/web/server/routers/dashboard.ts
@@ -321,8 +321,7 @@ export const dashboardRouter = createRouter({
         and(
           eq(appointments.doctorId, users.id),
           eq(users.practiceId, ctx.practiceId),
-          activePracticePredicate(ctx.practiceId),
-          isNull(users.deletedAt)
+          activePracticePredicate(ctx.practiceId)
         )
       )
       .where(

--- a/apps/web/server/routers/data.ts
+++ b/apps/web/server/routers/data.ts
@@ -2156,7 +2156,6 @@ export const dataRouter = createRouter({
           eq(appointments.doctorId, users.id),
           eq(users.practiceId, ctx.practiceId),
           activePracticePredicate(ctx.practiceId),
-          isNull(users.deletedAt),
         ),
       )
       .leftJoin(

--- a/apps/web/server/routers/encounters.ts
+++ b/apps/web/server/routers/encounters.ts
@@ -969,8 +969,7 @@ export const encountersRouter = createRouter({
             users,
             and(
               eq(visitWorkItems.resolvedBy, users.id),
-              eq(users.practiceId, ctx.practiceId),
-              isNull(users.deletedAt)
+              eq(users.practiceId, ctx.practiceId)
             )
           )
           .where(

--- a/apps/web/server/routers/portal.ts
+++ b/apps/web/server/routers/portal.ts
@@ -646,8 +646,7 @@ export const portalRouter = createRouter({
           users,
           and(
             eq(appointments.doctorId, users.id),
-            eq(users.practiceId, client.practiceId),
-            isNull(users.deletedAt)
+            eq(users.practiceId, client.practiceId)
           )
         )
         .leftJoin(

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -1503,8 +1503,7 @@ export const recordsRouter = createRouter({
           users,
           and(
             eq(vaccinationRecords.administeredBy, users.id),
-            eq(users.practiceId, ctx.practiceId),
-            isNull(users.deletedAt)
+            eq(users.practiceId, ctx.practiceId)
           )
         )
         .leftJoin(
@@ -1781,8 +1780,7 @@ export const recordsRouter = createRouter({
           users,
           and(
             eq(prescriptions.prescribedBy, users.id),
-            eq(users.practiceId, ctx.practiceId),
-            isNull(users.deletedAt)
+            eq(users.practiceId, ctx.practiceId)
           )
         )
         .leftJoin(
@@ -3511,8 +3509,7 @@ export const recordsRouter = createRouter({
           users,
           and(
             eq(procedures.performedBy, users.id),
-            eq(users.practiceId, ctx.practiceId),
-            isNull(users.deletedAt)
+            eq(users.practiceId, ctx.practiceId)
           )
         )
         .where(

--- a/apps/web/server/routers/reports.ts
+++ b/apps/web/server/routers/reports.ts
@@ -232,8 +232,7 @@ export const reportsRouter = createRouter({
             and(
               eq(appointments.doctorId, users.id),
               eq(users.practiceId, ctx.practiceId),
-              activePracticePredicate(ctx.practiceId),
-              isNull(users.deletedAt)
+              activePracticePredicate(ctx.practiceId)
             )
           )
           .where(and(...baseConds))


### PR DESCRIPTION
Summary
- keep deactivated staff names visible in payments, adjustments, controlled-substance logs, visit reconciliation, and clinical records
- preserve historical doctor names in appointment views, client portal history, exports, reports, and production dashboards
- retain tenant predicates and all active staff/authentication filters

Verification
- 181 focused tests passed
- full web suite: 3,255 passed, 1 expected integration skip
- web typecheck passed
- production Next.js build passed
- diff, secret, participant-data, and local-path scans passed
- independent review found no merge blockers

Residual non-blocking debt
- legacy rows still reflect the user current name; immutable event-time name snapshots can follow as a schema hardening release