### PR TITLE
Add immutable finalized SOAP replacement workflow

### DIFF
--- a/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
+++ b/apps/web/app/(dashboard)/encounters/[appointmentId]/page.tsx
@@ -382,8 +382,22 @@ export default function EncounterWorkspacePage() {
 
                   <div className="flex flex-wrap gap-2">
                     {canCreateSoap(role) &&
+                    closeoutQuery.data?.linkedSoapCount === 0 &&
+                    !closeoutQuery.data?.soapDraft &&
+                    closeoutQuery.data?.missingSoapReplacement ? (
+                      <Button size="sm" asChild>
+                        <Link
+                          href={`/records/replace-soap/${appointment.patientId}?sourceNoteId=${closeoutQuery.data.missingSoapReplacement.sourceNoteId}&return=patient`}
+                        >
+                          <FileText className="mr-2 h-4 w-4" />
+                          Create missing SOAP replacement
+                        </Link>
+                      </Button>
+                    ) : null}
+                    {canCreateSoap(role) &&
                     appointment.status === "in_exam" &&
                     closeoutQuery.data?.linkedSoapCount === 0 &&
+                    !closeoutQuery.data?.missingSoapReplacement &&
                     closeoutQuery.data?.closeout?.status !==
                       "clinical_finalized" &&
                     closeoutQuery.data?.closeout?.status !== "completed" ? (
@@ -858,7 +872,9 @@ function VisitCloseout({
                   ? `${data.linkedSoapCount} linked SOAP note${data.linkedSoapCount === 1 ? "" : "s"}`
                   : closeout?.documentationExceptionReason
                     ? "Documented exception"
-                    : "Missing"
+                    : data.missingSoapReplacement
+                      ? "Replacement or exception needed"
+                      : "Missing"
             }
           />
           <ReadinessTile
@@ -910,6 +926,12 @@ function VisitCloseout({
               documentationExceptionReason={documentationExceptionReason}
               setDocumentationExceptionReason={setDocumentationExceptionReason}
               linkedSoapCount={data.linkedSoapCount}
+              missingSoapReplacement={data.missingSoapReplacement}
+              soapReplacementHref={
+                data.missingSoapReplacement
+                  ? `/records/replace-soap/${appointment.patientId}?sourceNoteId=${data.missingSoapReplacement.sourceNoteId}&return=patient`
+                  : null
+              }
               soapDraft={data.soapDraft}
               soapDraftHref={`/records/new-soap/${appointment.patientId}?appointmentId=${appointmentId}`}
               linkedMedicationCount={data.activeMedications.length}
@@ -1295,6 +1317,8 @@ type ClinicalCloseoutFormProps = {
   documentationExceptionReason: string;
   setDocumentationExceptionReason: (value: string) => void;
   linkedSoapCount: number;
+  missingSoapReplacement: { sourceNoteId: string } | null;
+  soapReplacementHref: string | null;
   soapDraft: {
     revision: number;
     authorName: string;
@@ -1589,6 +1613,31 @@ function ClinicalCloseoutForm(props: ClinicalCloseoutFormProps) {
               Resume SOAP draft
             </a>
           </Button>
+        </div>
+      ) : props.missingSoapReplacement ? (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
+          <p className="text-sm font-medium">The signed SOAP was voided</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Create an attributed replacement to keep current clinical
+            documentation linked to this visit. If a replacement is not
+            clinically appropriate—for example, the note belonged to another
+            encounter—document the reason below.
+          </p>
+          <Button className="mt-3" size="sm" asChild>
+            <Link href={props.soapReplacementHref ?? props.soapDraftHref}>
+              <FileText className="mr-2 h-4 w-4" />
+              Create signed replacement
+            </Link>
+          </Button>
+          <Input
+            aria-label="SOAP documentation exception"
+            value={props.documentationExceptionReason}
+            onChange={(event) =>
+              props.setDocumentationExceptionReason(event.target.value)
+            }
+            className="mt-3"
+            placeholder="Why a replacement SOAP is not required"
+          />
         </div>
       ) : props.linkedSoapCount === 0 ? (
         <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
@@ -2828,7 +2877,8 @@ function ChargeCapture({
                         {item.description}
                       </p>
                       <p className="text-xs capitalize text-muted-foreground">
-                        {item.itemType} · {item.taxable ? "Taxable" : "Not taxable"}
+                        {item.itemType} ·{" "}
+                        {item.taxable ? "Taxable" : "Not taxable"}
                       </p>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/patients/[id]/page.tsx
@@ -1805,11 +1805,11 @@ function MedicalRecordsTab({
               ) : hasAppointmentSoapDraft && note.appointmentId ? (
                 <div className="mt-3 flex justify-end">
                   <Button asChild size="sm" variant="outline">
-                    <Link
+                    <a
                       href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
                     >
                       Review encounter SOAP draft
-                    </Link>
+                    </a>
                   </Button>
                 </div>
               ) : note.correctionId && hasOtherCurrentAppointmentSoap ? (

--- a/apps/web/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/patients/[id]/page.tsx
@@ -569,6 +569,14 @@ export default function PatientDetailPage() {
             finalizedAt: n.finalizedAt
               ? formatClinicalDateTime(n.finalizedAt, recordsTimeZone)
               : undefined,
+            replacementForLabel: n.replacesSoapNoteId
+              ? `SOAP note dated ${formatClinicalDate(
+                  soapNotes.find((source) => source.id === n.replacesSoapNoteId)
+                    ?.createdAt,
+                  recordsTimeZone,
+                  "unknown date",
+                )}`
+              : undefined,
             addenda: n.addenda.map((addendum) => ({
               content: soapSectionText(addendum.content),
               authorName: addendum.authorName,
@@ -593,6 +601,20 @@ export default function PatientDetailPage() {
             correctedAt: note.correctedAt
               ? formatClinicalDateTime(note.correctedAt, recordsTimeZone)
               : "Unknown time",
+            replacementLabel: note.replacementSoapNoteId
+              ? (() => {
+                  const replacement = soapNotes.find(
+                    (candidate) => candidate.id === note.replacementSoapNoteId,
+                  );
+                  return replacement
+                    ? `SOAP note dated ${formatClinicalDate(
+                        replacement.createdAt,
+                        recordsTimeZone,
+                        "unknown date",
+                      )}, finalized by ${replacement.finalizerName ?? "Unknown clinician"}`
+                    : "Replacement SOAP retained in chart";
+                })()
+              : undefined,
           })),
         prescriptions: prescriptions.map((rx) => ({
           medication: rx.medicationName,
@@ -1592,134 +1614,214 @@ function MedicalRecordsTab({
 
   return (
     <div className="space-y-4">
-      {notes.map((note) => (
-        <div
-          key={note.id}
-          className={cn(
-            "rounded-lg border border-border bg-card p-4",
-            note.correctionId && "border-destructive/40 bg-destructive/5"
-          )}
-        >
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <p className="text-sm font-medium">
-                {note.createdAt
-                  ? formatClinicalDate(note.createdAt, timeZone, "Unknown")
-                  : "Unknown"}
-              </p>
-              {note.imported ? (
-                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
-                  Imported
-                </span>
-              ) : null}
-              <span
-                className={cn(
-                  "rounded-full px-2 py-0.5 text-[11px] font-medium",
-                  note.status === "draft"
-                    ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
-                    : "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
-                )}
-              >
-                {note.status === "draft" ? "Draft" : "Finalized"}
-              </span>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {note.imported
-                ? note.authorName
-                  ? `Imported by ${note.authorName}`
-                  : "Imported record"
-                : (note.authorName ?? "Unknown author")}
-            </p>
-          </div>
-          {note.status === "finalized" ? (
-            <p className="mb-3 text-xs text-muted-foreground">
-              Finalized by {note.finalizerName ?? "Unknown clinician"}
-              {note.finalizedAt
-                ? ` on ${formatClinicalDateTime(note.finalizedAt, timeZone)}`
-                : ""}
-            </p>
-          ) : note.appointmentId && canCorrectClinicalRecords ? (
-            <a
-              href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
-              className="mb-3 inline-flex text-xs font-medium text-primary hover:underline"
-            >
-              Resume draft
-            </a>
-          ) : null}
-          <dl className="grid gap-3 sm:grid-cols-2">
-            {(
-              [
-                ["Subjective", note.subjective],
-                ["Objective", note.objective],
-                ["Assessment", note.assessment],
-                ["Plan", note.plan],
-              ] as const
-            ).map(([label, value]) =>
-              value ? (
-                <div key={label}>
-                  <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    {label}
-                  </dt>
-                  <dd className="mt-1 whitespace-pre-wrap text-sm">
-                    {soapSectionText(value)}
-                  </dd>
-                </div>
-              ) : null
+      {notes.map((note) => {
+        const hasOtherCurrentAppointmentSoap = Boolean(
+          note.appointmentId &&
+          notes.some(
+            (candidate) =>
+              candidate.id !== note.id &&
+              candidate.appointmentId === note.appointmentId &&
+              candidate.status === "finalized" &&
+              !candidate.correctionId,
+          ),
+        );
+        const hasAppointmentSoapDraft = Boolean(
+          note.appointmentId &&
+            notes.some(
+              (candidate) =>
+                candidate.id !== note.id &&
+                candidate.appointmentId === note.appointmentId &&
+                candidate.status === "draft",
+            ),
+        );
+        return (
+          <div
+            key={note.id}
+            id={`soap-note-${note.id}`}
+            className={cn(
+              "rounded-lg border border-border bg-card p-4",
+              note.correctionId && "border-destructive/40 bg-destructive/5",
             )}
-          </dl>
-          {note.addenda.length > 0 ? (
-            <div className="mt-4 space-y-2 border-t border-border pt-3">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Addenda
+          >
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-medium">
+                  {note.createdAt
+                    ? formatClinicalDate(note.createdAt, timeZone, "Unknown")
+                    : "Unknown"}
+                </p>
+                {note.imported ? (
+                  <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                    Imported
+                  </span>
+                ) : null}
+                <span
+                  className={cn(
+                    "rounded-full px-2 py-0.5 text-[11px] font-medium",
+                    note.status === "draft"
+                      ? "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+                      : "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
+                  )}
+                >
+                  {note.status === "draft" ? "Draft" : "Finalized"}
+                </span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {note.imported
+                  ? note.authorName
+                    ? `Imported by ${note.authorName}`
+                    : "Imported record"
+                  : (note.authorName ?? "Unknown author")}
               </p>
-              {note.addenda.map((addendum) => (
-                <div key={addendum.id} className="rounded-md bg-muted/40 p-3">
-                  <p className="text-xs font-medium">
-                    {addendum.authorName} -{" "}
-                    {formatClinicalDateTime(addendum.createdAt, timeZone)}
-                  </p>
-                  <p className="mt-1 whitespace-pre-wrap text-sm">
-                    {soapSectionText(addendum.content)}
-                  </p>
-                </div>
-              ))}
             </div>
-          ) : null}
-          {note.status === "finalized" && !note.correctionId ? (
-            <SoapAddendumControl
-              patientId={patientId}
-              noteId={note.id}
-              enabled={canCorrectClinicalRecords}
-            />
-          ) : null}
-          {note.status === "finalized" ? (
-            <ClinicalCorrectionControl
-              correction={
-                note.correctionId && note.correctionReason && note.correctedAt
-                  ? {
-                      id: note.correctionId,
-                      reason: note.correctionReason,
-                      correctedAt: note.correctedAt,
-                      correctedByName: note.correctedByName,
-                    }
-                  : null
-              }
-              canCorrect={canCorrectClinicalRecords}
-              isPending={
-                correctSoap.isPending &&
-                correctSoap.variables?.recordId === note.id
-              }
-              onCorrect={(reason) =>
-                correctSoap.mutateAsync({
-                  patientId,
-                  recordId: note.id,
-                  reason,
-                })
-              }
-            />
-          ) : null}
-        </div>
-      ))}
+            {note.status === "finalized" ? (
+              <p className="mb-3 text-xs text-muted-foreground">
+                Finalized by {note.finalizerName ?? "Unknown clinician"}
+                {note.finalizedAt
+                  ? ` on ${formatClinicalDateTime(note.finalizedAt, timeZone)}`
+                  : ""}
+              </p>
+            ) : note.appointmentId && canCorrectClinicalRecords ? (
+              <a
+                href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
+                className="mb-3 inline-flex text-xs font-medium text-primary hover:underline"
+              >
+                Resume draft
+              </a>
+            ) : null}
+            {note.replacesSoapNoteId ? (
+              <div className="mb-3 rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
+                <p className="font-medium text-primary">
+                  Current replacement SOAP
+                </p>
+                <a
+                  href={`#soap-note-${note.replacesSoapNoteId}`}
+                  className="mt-1 inline-flex text-xs font-medium text-primary hover:underline"
+                >
+                  View retained original
+                </a>
+              </div>
+            ) : null}
+            <dl className="grid gap-3 sm:grid-cols-2">
+              {(
+                [
+                  ["Subjective", note.subjective],
+                  ["Objective", note.objective],
+                  ["Assessment", note.assessment],
+                  ["Plan", note.plan],
+                ] as const
+              ).map(([label, value]) =>
+                value ? (
+                  <div key={label}>
+                    <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {label}
+                    </dt>
+                    <dd className="mt-1 whitespace-pre-wrap text-sm">
+                      {soapSectionText(value)}
+                    </dd>
+                  </div>
+                ) : null,
+              )}
+            </dl>
+            {note.addenda.length > 0 ? (
+              <div className="mt-4 space-y-2 border-t border-border pt-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Addenda
+                </p>
+                {note.addenda.map((addendum) => (
+                  <div key={addendum.id} className="rounded-md bg-muted/40 p-3">
+                    <p className="text-xs font-medium">
+                      {addendum.authorName} -{" "}
+                      {formatClinicalDateTime(addendum.createdAt, timeZone)}
+                    </p>
+                    <p className="mt-1 whitespace-pre-wrap text-sm">
+                      {soapSectionText(addendum.content)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            {note.status === "finalized" && !note.correctionId ? (
+              <SoapAddendumControl
+                patientId={patientId}
+                noteId={note.id}
+                enabled={canCorrectClinicalRecords}
+              />
+            ) : null}
+            {note.status === "finalized" ? (
+              <>
+                <ClinicalCorrectionControl
+                  correction={
+                    note.correctionId &&
+                    note.correctionReason &&
+                    note.correctedAt
+                      ? {
+                          id: note.correctionId,
+                          reason: note.correctionReason,
+                          correctedAt: note.correctedAt,
+                          correctedByName: note.correctedByName,
+                        }
+                      : null
+                  }
+                  triggerLabel="Void without replacement"
+                  description="The original stays in permanent chart history but leaves current clinical summaries immediately. If its content needs correction, cancel and use Replace finalized SOAP. Use void alone only when no replacement belongs on this encounter; closeout will require a documented reason."
+                  canCorrect={canCorrectClinicalRecords}
+                  isPending={
+                    correctSoap.isPending &&
+                    correctSoap.variables?.recordId === note.id
+                  }
+                  onCorrect={(reason) =>
+                    correctSoap.mutateAsync({
+                      patientId,
+                      recordId: note.id,
+                      reason,
+                    })
+                  }
+                />
+                {note.replacementSoapNoteId ? (
+                  <div className="mt-3 flex justify-end">
+                    <a
+                      href={`#soap-note-${note.replacementSoapNoteId}`}
+                      className="text-sm font-medium text-primary hover:underline"
+                    >
+                      View signed replacement
+                    </a>
+                  </div>
+              ) : canCorrectClinicalRecords &&
+                (!note.correctionId ||
+                  (!hasOtherCurrentAppointmentSoap &&
+                    !hasAppointmentSoapDraft)) ? (
+                  <div className="mt-3 flex justify-end">
+                    <Button asChild size="sm">
+                      <Link
+                        href={`/records/replace-soap/${encodeURIComponent(patientId)}?sourceNoteId=${encodeURIComponent(note.id)}&return=patient`}
+                      >
+                        {note.correctionId
+                          ? "Create missing replacement"
+                          : "Replace finalized SOAP"}
+                      </Link>
+                    </Button>
+                  </div>
+              ) : hasAppointmentSoapDraft && note.appointmentId ? (
+                <div className="mt-3 flex justify-end">
+                  <Button asChild size="sm" variant="outline">
+                    <Link
+                      href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
+                    >
+                      Review encounter SOAP draft
+                    </Link>
+                  </Button>
+                </div>
+              ) : note.correctionId && hasOtherCurrentAppointmentSoap ? (
+                  <p className="mt-3 text-right text-xs text-muted-foreground">
+                    This encounter already has a current finalized SOAP.
+                  </p>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/app/(dashboard)/records/page.tsx
+++ b/apps/web/app/(dashboard)/records/page.tsx
@@ -1708,11 +1708,11 @@ function RecordsPageContent() {
                                         note.appointmentId ? (
                                         <div className="mt-3 flex justify-end">
                                           <Button asChild size="sm" variant="outline">
-                                            <Link
+                                            <a
                                               href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
                                             >
                                               Review encounter SOAP draft
-                                            </Link>
+                                            </a>
                                           </Button>
                                         </div>
                                       ) : note.correctionId &&

--- a/apps/web/app/(dashboard)/records/page.tsx
+++ b/apps/web/app/(dashboard)/records/page.tsx
@@ -602,6 +602,7 @@ function RecordsPageContent() {
     searchParams.get("new") === "1";
   const requestedAmendLabResultId = searchParams.get("amendLabResultId");
   const appliedVisitLink = useRef(false);
+  const appliedSoapHash = useRef<string | null>(null);
   const appliedLabAmendLink = useRef<string | null>(null);
   const prescriptionOperationId = useRef<string | null>(null);
   const labResultCreationOperationId = useRef<string | null>(null);
@@ -728,6 +729,26 @@ function RecordsPageContent() {
   );
   const soapNotesMissing =
     Boolean(patientId) && !isLoadingSoapNotes && !soapNotesError && !soapNotes;
+  useEffect(() => {
+    if (!soapNotes || typeof window === "undefined") return;
+    const match = window.location.hash.match(/^#soap-note-(.+)$/);
+    const noteId = match?.[1];
+    if (
+      !noteId ||
+      appliedSoapHash.current === noteId ||
+      !soapNotes.some((note) => note.id === noteId)
+    ) {
+      return;
+    }
+    appliedSoapHash.current = noteId;
+    setActiveTab("soap");
+    setExpandedNoteId(noteId);
+    window.requestAnimationFrame(() =>
+      document
+        .getElementById(`soap-note-${noteId}`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" }),
+    );
+  }, [soapNotes]);
   const correctSoap = trpc.records.markSoapNoteEnteredInError.useMutation({
     onSuccess: async () => {
       toast.success("SOAP note retained and marked entered in error");
@@ -1363,9 +1384,31 @@ function RecordsPageContent() {
                   <div className="space-y-3">
                         {soapNotes.map((note) => {
                           const isExpanded = expandedNoteId === note.id;
+                          const hasOtherCurrentAppointmentSoap = Boolean(
+                            note.appointmentId &&
+                            soapNotes.some(
+                              (candidate) =>
+                                candidate.id !== note.id &&
+                                candidate.appointmentId ===
+                                  note.appointmentId &&
+                                candidate.status === "finalized" &&
+                                !candidate.correctionId,
+                            ),
+                          );
+                          const hasAppointmentSoapDraft = Boolean(
+                            note.appointmentId &&
+                              soapNotes.some(
+                                (candidate) =>
+                                  candidate.id !== note.id &&
+                                  candidate.appointmentId ===
+                                    note.appointmentId &&
+                                  candidate.status === "draft",
+                              ),
+                          );
                           return (
                             <div
                               key={note.id}
+                              id={`soap-note-${note.id}`}
                               className={cn(
                                 "rounded-lg border border-border bg-card",
                                 note.correctionId &&
@@ -1455,6 +1498,19 @@ function RecordsPageContent() {
                                     >
                                       Resume draft
                                     </a>
+                                  ) : null}
+                                  {note.replacesSoapNoteId ? (
+                                    <div className="rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
+                                      <p className="font-medium text-primary">
+                                        Current replacement SOAP
+                                      </p>
+                                      <a
+                                        href={`#soap-note-${note.replacesSoapNoteId}`}
+                                        className="mt-1 inline-flex text-xs font-medium text-primary hover:underline"
+                                      >
+                                        View retained original
+                                      </a>
+                                    </div>
                                   ) : null}
                                   <div>
                                     <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1">
@@ -1592,35 +1648,81 @@ function RecordsPageContent() {
                                     )
                                   ) : null}
                                   {note.status === "finalized" ? (
-                                    <ClinicalCorrectionControl
-                                      timeZone={recordsTimeZone}
-                                      correction={
-                                        note.correctionId &&
-                                        note.correctionReason &&
-                                        note.correctedAt
-                                          ? {
-                                              id: note.correctionId,
-                                              reason: note.correctionReason,
-                                              correctedAt: note.correctedAt,
-                                              correctedByName:
-                                                note.correctedByName,
-                                            }
-                                          : null
-                                      }
-                                      canCorrect={canCorrectClinicalRecords}
-                                      isPending={
-                                        correctSoap.isPending &&
-                                        correctSoap.variables?.recordId ===
-                                          note.id
-                                      }
-                                      onCorrect={(reason) =>
-                                        correctSoap.mutateAsync({
-                                          patientId,
-                                          recordId: note.id,
-                                          reason,
-                                        })
-                                      }
-                                    />
+                                    <>
+                                      <ClinicalCorrectionControl
+                                        timeZone={recordsTimeZone}
+                                        correction={
+                                          note.correctionId &&
+                                          note.correctionReason &&
+                                          note.correctedAt
+                                            ? {
+                                                id: note.correctionId,
+                                                reason: note.correctionReason,
+                                                correctedAt: note.correctedAt,
+                                                correctedByName:
+                                                  note.correctedByName,
+                                              }
+                                            : null
+                                        }
+                                        triggerLabel="Void without replacement"
+                                        description="The original stays in permanent chart history but leaves current clinical summaries immediately. If its content needs correction, cancel and use Replace finalized SOAP. Use void alone only when no replacement belongs on this encounter; closeout will require a documented reason."
+                                        canCorrect={canCorrectClinicalRecords}
+                                        isPending={
+                                          correctSoap.isPending &&
+                                          correctSoap.variables?.recordId ===
+                                            note.id
+                                        }
+                                        onCorrect={(reason) =>
+                                          correctSoap.mutateAsync({
+                                            patientId,
+                                            recordId: note.id,
+                                            reason,
+                                          })
+                                        }
+                                      />
+                                      {note.replacementSoapNoteId ? (
+                                        <div className="mt-3 flex justify-end">
+                                          <a
+                                            href={`#soap-note-${note.replacementSoapNoteId}`}
+                                            className="text-sm font-medium text-primary hover:underline"
+                                          >
+                                            View signed replacement
+                                          </a>
+                                        </div>
+                                      ) : canCorrectClinicalRecords &&
+                                        (!note.correctionId ||
+                                          (!hasOtherCurrentAppointmentSoap &&
+                                            !hasAppointmentSoapDraft)) ? (
+                                        <div className="mt-3 flex justify-end">
+                                          <Button asChild size="sm">
+                                            <Link
+                                              href={`/records/replace-soap/${encodeURIComponent(patientId)}?sourceNoteId=${encodeURIComponent(note.id)}&return=records`}
+                                            >
+                                              {note.correctionId
+                                                ? "Create missing replacement"
+                                                : "Replace finalized SOAP"}
+                                            </Link>
+                                          </Button>
+                                        </div>
+                                      ) : hasAppointmentSoapDraft &&
+                                        note.appointmentId ? (
+                                        <div className="mt-3 flex justify-end">
+                                          <Button asChild size="sm" variant="outline">
+                                            <Link
+                                              href={`/records/new-soap/${encodeURIComponent(patientId)}?appointmentId=${encodeURIComponent(note.appointmentId)}`}
+                                            >
+                                              Review encounter SOAP draft
+                                            </Link>
+                                          </Button>
+                                        </div>
+                                      ) : note.correctionId &&
+                                        hasOtherCurrentAppointmentSoap ? (
+                                        <p className="mt-3 text-right text-xs text-muted-foreground">
+                                          This encounter already has a current
+                                          finalized SOAP.
+                                        </p>
+                                      ) : null}
+                                    </>
                                   ) : null}
                                 </div>
                               )}

--- a/apps/web/app/(dashboard)/records/replace-soap/[patientId]/page.tsx
+++ b/apps/web/app/(dashboard)/records/replace-soap/[patientId]/page.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useSession } from "next-auth/react";
+import {
+  AlertCircle,
+  ArrowLeft,
+  FilePenLine,
+  Loader2,
+  ShieldAlert,
+} from "lucide-react";
+import { toast } from "sonner";
+import { EmptyState } from "@/components/common/empty-state";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  CLINICAL_CORRECTION_REASON_MAX_LENGTH,
+  isClinicalCorrectionReasonValid,
+} from "@/lib/records/clinical-correction-policy";
+import {
+  hasSoapContent,
+  SOAP_SECTION_MAX_LENGTH,
+} from "@/lib/records/soap-content";
+import { hasUnresolvedSoapTemplatePrompts } from "@/lib/records/soap-templates";
+import { trpc } from "@/lib/trpc";
+
+const SoapNoteEditor = dynamic(
+  () =>
+    import("@/components/SoapNoteEditor").then((mod) => mod.SoapNoteEditor),
+  { ssr: false },
+);
+
+type Sections = {
+  subjective: string;
+  objective: string;
+  assessment: string;
+  plan: string;
+};
+
+function canReplaceSoap(role?: string | null): boolean {
+  return role === "admin" || role === "veterinarian";
+}
+
+function fingerprint(reason: string, sections: Sections): string {
+  return JSON.stringify({ reason, ...sections });
+}
+
+export default function ReplaceSoapNotePage() {
+  const params = useParams<{ patientId: string }>();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { data: session, status } = useSession();
+  const allowed = canReplaceSoap(session?.user?.role);
+  const sourceNoteId = searchParams.get("sourceNoteId") ?? "";
+  const returnTarget = searchParams.get("return");
+  const returnPath =
+    returnTarget === "records"
+      ? `/records?patientId=${encodeURIComponent(params.patientId)}&tab=soap`
+      : `/patients/${encodeURIComponent(params.patientId)}`;
+
+  const patient = trpc.patients.getById.useQuery(
+    { id: params.patientId },
+    { enabled: allowed && Boolean(params.patientId) },
+  );
+  const notes = trpc.records.listSoapNotes.useQuery(
+    { patientId: params.patientId },
+    { enabled: allowed && Boolean(params.patientId) && Boolean(sourceNoteId) },
+  );
+  const source = notes.data?.find((note) => note.id === sourceNoteId) ?? null;
+
+  const [sections, setSections] = useState<Sections>({
+    subjective: "",
+    objective: "",
+    assessment: "",
+    plan: "",
+  });
+  const [reason, setReason] = useState("");
+  const [initialized, setInitialized] = useState(false);
+  const initialFingerprint = useRef("");
+  const operationId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!source || initialized) return;
+    const nextSections = {
+      subjective: source.subjective ?? "",
+      objective: source.objective ?? "",
+      assessment: source.assessment ?? "",
+      plan: source.plan ?? "",
+    };
+    const nextReason = source.correctionReason ?? "";
+    setSections(nextSections);
+    setReason(nextReason);
+    initialFingerprint.current = fingerprint(nextReason, nextSections);
+    setInitialized(true);
+  }, [initialized, source]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (
+        !initialized ||
+        fingerprint(reason, sections) === initialFingerprint.current
+      ) {
+        return;
+      }
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [initialized, reason, sections]);
+
+  useEffect(() => {
+    const guardLinkNavigation = (event: MouseEvent) => {
+      if (
+        !initialized ||
+        fingerprint(reason, sections) === initialFingerprint.current ||
+        !(event.target instanceof Element) ||
+        !event.target.closest("a[href]")
+      ) {
+        return;
+      }
+      if (!window.confirm("Discard the replacement SOAP changes on this page?")) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    };
+    document.addEventListener("click", guardLinkNavigation, true);
+    return () => document.removeEventListener("click", guardLinkNavigation, true);
+  }, [initialized, reason, sections]);
+
+  const replace = trpc.records.replaceSoapNote.useMutation({
+    onSuccess: async (replacement) => {
+      initialFingerprint.current = fingerprint(reason, sections);
+      toast.success("Replacement SOAP finalized; original retained in history", {
+        description:
+          "Review the signed discharge separately if owner-facing instructions changed.",
+      });
+      router.push(`${returnPath}#soap-note-${replacement.id}`);
+    },
+    onError: (error) => toast.error(error.message),
+  });
+
+  const hasContent = hasSoapContent(sections);
+  const unresolvedPrompts = hasUnresolvedSoapTemplatePrompts(sections);
+  const valid =
+    hasContent &&
+    !unresolvedPrompts &&
+    isClinicalCorrectionReasonValid(reason) &&
+    Object.values(sections).every(
+      (value) => value.length <= SOAP_SECTION_MAX_LENGTH,
+    );
+  const leaveEditor = () => {
+    if (
+      initialized &&
+      fingerprint(reason, sections) !== initialFingerprint.current &&
+      !window.confirm("Discard the replacement SOAP changes on this page?")
+    ) {
+      return;
+    }
+    router.push(returnPath);
+  };
+
+  if (status === "loading") {
+    return (
+      <div className="flex items-center justify-center gap-2 p-8 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Checking access...
+      </div>
+    );
+  }
+  if (!allowed) {
+    return (
+      <EmptyState
+        icon={ShieldAlert}
+        title="Access denied"
+        description="Only veterinarians and administrators can replace finalized SOAP documentation."
+        action={{ label: "Back to chart", onClick: () => router.push(returnPath) }}
+      />
+    );
+  }
+  if (!sourceNoteId) {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="Choose a SOAP note"
+        description="Open the finalized note from the patient chart and choose Replace finalized SOAP."
+        action={{ label: "Back to chart", onClick: () => router.push(returnPath) }}
+      />
+    );
+  }
+  if (patient.isLoading || notes.isLoading || !initialized) {
+    if (patient.error || notes.error || (!notes.isLoading && !source)) {
+      return (
+        <EmptyState
+          icon={AlertCircle}
+          title="Unable to load the source SOAP"
+          description={patient.error?.message ?? notes.error?.message ?? "The finalized source note is unavailable in this patient chart."}
+          action={{ label: "Back to chart", onClick: () => router.push(returnPath) }}
+        />
+      );
+    }
+    return (
+      <div className="flex items-center justify-center gap-2 p-8 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading signed SOAP...
+      </div>
+    );
+  }
+  if (!source || source.status !== "finalized") {
+    return (
+      <EmptyState
+        icon={AlertCircle}
+        title="Finalized source required"
+        description="Only finalized SOAP notes can be replaced."
+        action={{ label: "Back to chart", onClick: () => router.push(returnPath) }}
+      />
+    );
+  }
+  if (source.replacementSoapNoteId) {
+    return (
+      <EmptyState
+        icon={FilePenLine}
+        title="Replacement already finalized"
+        description="This source already has a signed replacement. Open the current note from the chart."
+        action={{ label: "View chart", onClick: () => router.push(returnPath) }}
+      />
+    );
+  }
+
+  const updateSection = (key: keyof Sections, value: string) =>
+    setSections((current) => ({ ...current, [key]: value }));
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-5">
+      <Button variant="ghost" size="sm" onClick={leaveEditor}>
+        <ArrowLeft className="mr-2 h-4 w-4" /> Back to chart
+      </Button>
+
+      <div>
+        <h1 className="font-heading text-2xl font-semibold">
+          Replace finalized SOAP
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Patient: {patient.data?.name ?? "Unknown patient"}
+        </p>
+      </div>
+
+      <div role="alert" className="rounded-lg border border-amber-400/60 bg-amber-50 p-4 text-sm text-amber-950 dark:bg-amber-950/30 dark:text-amber-100">
+        <p className="font-semibold">This creates a new signed clinical record.</p>
+        <p className="mt-1">
+          The original remains permanently visible as entered in error. The
+          replacement becomes the current SOAP immediately. A completed visit,
+          invoice, payment, discharge, and signed handoffs are not reopened or
+          rewritten.
+        </p>
+        <p className="mt-2 font-medium">
+          This page is not an autosaved draft. Finish or copy your work before leaving.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card p-5">
+        <label htmlFor="soap-correction-reason" className="text-sm font-semibold">
+          Permanent correction reason
+        </label>
+        <Textarea
+          id="soap-correction-reason"
+          className="mt-2 bg-background"
+          rows={4}
+          maxLength={CLINICAL_CORRECTION_REASON_MAX_LENGTH}
+          value={reason}
+          disabled={Boolean(source.correctionId)}
+          placeholder="Required. Explain why the original signed note is incorrect."
+          onChange={(event) => setReason(event.currentTarget.value)}
+        />
+        {source.correctionId ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            This reason is already permanent chart history and cannot be changed.
+          </p>
+        ) : null}
+      </div>
+
+      {(
+        [
+          ["Subjective", "subjective"],
+          ["Objective", "objective"],
+          ["Assessment", "assessment"],
+          ["Plan", "plan"],
+        ] as const
+      ).map(([label, key]) => (
+        <section key={key}>
+          <h2 className="mb-2 text-sm font-semibold">{label}</h2>
+          <SoapNoteEditor
+            value={sections[key]}
+            onChange={(value) => updateSection(key, value)}
+            placeholder={`Enter corrected ${label.toLowerCase()} documentation...`}
+          />
+        </section>
+      ))}
+
+      {unresolvedPrompts ? (
+        <p role="alert" className="text-sm font-medium text-destructive">
+          Replace or delete every bracketed template prompt before finalizing.
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap justify-end gap-2 border-t border-border pt-5">
+        <Button variant="outline" disabled={replace.isPending} onClick={leaveEditor}>
+          Cancel
+        </Button>
+        <Button
+          disabled={!valid || replace.isPending}
+          onClick={() => {
+            if (
+              !window.confirm(
+                "Finalize this replacement SOAP now? It cannot be edited after signing; later clarification requires an attributed addendum.",
+              )
+            ) {
+              return;
+            }
+            operationId.current ??= crypto.randomUUID();
+            replace.mutate({
+              patientId: params.patientId,
+              sourceNoteId: source.id,
+              operationId: operationId.current,
+              reason: reason.trim(),
+              ...sections,
+            });
+          }}
+        >
+          {replace.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <FilePenLine className="mr-2 h-4 w-4" />
+          )}
+          {replace.isPending ? "Finalizing..." : "Finalize replacement"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/records/clinical-correction-control.tsx
+++ b/apps/web/components/records/clinical-correction-control.tsx
@@ -24,6 +24,7 @@ export function ClinicalCorrectionControl({
   isPending,
   onCorrect,
   description,
+  triggerLabel,
   timeZone,
 }: {
   correction?: ExistingCorrection | null;
@@ -31,6 +32,7 @@ export function ClinicalCorrectionControl({
   isPending: boolean;
   onCorrect: (reason: string) => Promise<unknown>;
   description?: string;
+  triggerLabel?: string;
   timeZone?: string | null;
 }) {
   const [editing, setEditing] = useState(false);
@@ -82,7 +84,7 @@ export function ClinicalCorrectionControl({
             variant="outline"
             className="text-destructive"
           >
-            Mark entered in error
+            {triggerLabel ?? "Mark entered in error"}
           </Button>
         </DialogPrimitive.Trigger>
       </div>

--- a/apps/web/lib/__tests__/clinical-corrections-safety.test.ts
+++ b/apps/web/lib/__tests__/clinical-corrections-safety.test.ts
@@ -6,6 +6,7 @@ import {
   clinicalRecordCorrections,
   labResultReplacements,
   patients,
+  soapNoteReplacements,
   soapNotes,
   users,
   vaccinationRecords,
@@ -315,6 +316,75 @@ describe("clinical correction schema and migration", () => {
     });
     expect(replacementConfig.checks.map((check) => check.name)).toContain(
       "lab_result_replacements_shape_check",
+    );
+  });
+
+  it("models SOAP replacement lineage as a separate exact append-only ledger", () => {
+    const correctionConfig = getTableConfig(clinicalRecordCorrections);
+    const replacementConfig = getTableConfig(soapNoteReplacements);
+    const correctionIndexes = correctionConfig.indexes.map(
+      (index) => index.config.name,
+    );
+    const replacementColumns = replacementConfig.columns.map(
+      (column) => column.name,
+    );
+    const replacementIndexes = replacementConfig.indexes.map(
+      (index) => index.config.name,
+    );
+    const replacementForeignKeys = replacementConfig.foreignKeys.map(
+      (foreignKey) => foreignKey.reference().name,
+    );
+
+    expect(correctionIndexes).toContain(
+      "clinical_record_corrections_practice_record_soap_source_uq",
+    );
+    expect(replacementColumns).toEqual(
+      expect.arrayContaining([
+        "practice_id",
+        "correction_id",
+        "source_soap_note_id",
+        "replacement_soap_note_id",
+        "actor_id",
+        "actor_name",
+        "operation_id",
+        "operation_payload_hash",
+      ]),
+    );
+    expect(replacementColumns).not.toContain("updated_at");
+    expect(replacementColumns).not.toContain("deleted_at");
+    expect(replacementIndexes).toEqual(
+      expect.arrayContaining([
+        "soap_note_replacements_source_uq",
+        "soap_note_replacements_replacement_uq",
+        "soap_note_replacements_operation_uq",
+      ]),
+    );
+    expect(replacementForeignKeys).toEqual(
+      expect.arrayContaining([
+        "soap_note_replacements_source_tenant_fk",
+        "soap_note_replacements_replacement_tenant_fk",
+        "soap_note_replacements_correction_source_tenant_fk",
+        "soap_note_replacements_actor_tenant_fk",
+      ]),
+    );
+    const exactCorrectionReference = replacementConfig.foreignKeys
+      .find(
+        (foreignKey) =>
+          foreignKey.reference().name ===
+          "soap_note_replacements_correction_source_tenant_fk",
+      )
+      ?.reference();
+    expect({
+      columns: exactCorrectionReference?.columns.map((column) => column.name),
+      foreignColumns: exactCorrectionReference?.foreignColumns.map(
+        (column) => column.name,
+      ),
+    }).toEqual({
+      columns: ["practice_id", "correction_id", "source_soap_note_id"],
+      foreignColumns: ["practice_id", "id", "soap_note_id"],
+    });
+    expect(replacementConfig.checks.map((check) => check.name)).toContain(
+      "soap_note_replacements_shape_check",
     );
   });
 });

--- a/apps/web/lib/__tests__/db-migrations.test.ts
+++ b/apps/web/lib/__tests__/db-migrations.test.ts
@@ -1114,9 +1114,9 @@ describe("committed Drizzle migrations", () => {
     expect(addendumGuard).toContain("NEW.created_at < source_finalized_at");
     expect(addendumGuard).toContain("NEW.created_at > pg_catalog.now()");
     expect(addendumGuard).toContain("pg_catalog.sha256");
-    expect(addendumGuard.indexOf("SOAP addendum payload hash is invalid.")).toBeLessThan(
-      addendumGuard.indexOf("app.ledger_maintenance"),
-    );
+    expect(
+      addendumGuard.indexOf("SOAP addendum payload hash is invalid."),
+    ).toBeLessThan(addendumGuard.indexOf("app.ledger_maintenance"));
     const restoreFunction = sql.slice(
       sql.indexOf("CREATE OR REPLACE FUNCTION restore_soap_note_addendum"),
       sql.indexOf("REVOKE ALL ON FUNCTION restore_soap_note_addendum"),
@@ -1127,9 +1127,7 @@ describe("committed Drizzle migrations", () => {
     expect(restoreFunction).not.toContain("app.rls_bypass");
     expect(restoreFunction).toContain("p_created_at < source_finalized_at");
     expect(restoreFunction).toContain("p_created_at > pg_catalog.now()");
-    expect(restoreFunction).toContain(
-      "p_created_at > correction_created_at",
-    );
+    expect(restoreFunction).toContain("p_created_at > correction_created_at");
     expect(restoreFunction).toContain("pg_catalog.sha256");
     expect(restoreFunction).toContain(
       "SOAP addendum restore payload hash is invalid.",
@@ -1165,12 +1163,152 @@ describe("committed Drizzle migrations", () => {
       "WHEN pg_catalog.jsonb_typeof(practice.settings #> '{demoData,soapNoteIds}') = 'array'",
     );
     expect(
-      sql.match(
-        /CROSS JOIN LATERAL pg_catalog\.jsonb_array_elements_text\(/g,
-      ),
+      sql.match(/CROSS JOIN LATERAL pg_catalog\.jsonb_array_elements_text\(/g),
     ).toHaveLength(1);
     expect(sql).not.toContain(
       "jsonb_array_elements_text(\n\t\tCROSS JOIN LATERAL",
+    );
+  });
+
+  it("creates exact, immutable SOAP replacement lineage", () => {
+    const journal = JSON.parse(
+      readRepoFile("packages/db/drizzle/meta/_journal.json"),
+    ) as { entries?: Array<{ tag?: string }> };
+    expect(journal.entries?.map((entry) => entry.tag)).toContain(
+      "0064_rainy_spacker_dave",
+    );
+
+    const sql = readRepoFile("packages/db/drizzle/0064_rainy_spacker_dave.sql");
+    const correctionSourceUniqueAt = sql.indexOf(
+      'CREATE UNIQUE INDEX "clinical_record_corrections_practice_record_soap_source_uq"',
+    );
+    const exactCorrectionFkAt = sql.indexOf(
+      'ADD CONSTRAINT "soap_note_replacements_correction_source_tenant_fk"',
+    );
+    expect(correctionSourceUniqueAt).toBeGreaterThan(0);
+    expect(exactCorrectionFkAt).toBeGreaterThan(0);
+    expect(exactCorrectionFkAt).toBeGreaterThan(correctionSourceUniqueAt);
+    expect(sql).toContain('CREATE TABLE "soap_note_replacements"');
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX "soap_note_replacements_source_uq"',
+    );
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX "soap_note_replacements_replacement_uq"',
+    );
+    expect(sql).toContain(
+      'CREATE UNIQUE INDEX "soap_note_replacements_operation_uq"',
+    );
+    expect(sql).toContain(
+      '"soap_note_replacements"."actor_name" = btrim("soap_note_replacements"."actor_name")',
+    );
+    expect(sql).toContain(
+      "pg_catalog.hashtextextended('soap-note-replacement-graph:' || NEW.practice_id::text, 0)",
+    );
+    expect(sql).toContain("WITH RECURSIVE descendants(id) AS");
+    expect(sql).toContain(
+      "SOAP note replacement lineage cannot contain a cycle.",
+    );
+    expect(sql).toContain("source.status = 'finalized'");
+    expect(sql).toContain("replacement.status = 'finalized'");
+    expect(sql).toContain(
+      "replacement.appointment_id IS NOT DISTINCT FROM source.appointment_id",
+    );
+    expect(sql).toContain("replacement.patient_id = source.patient_id");
+    expect(sql).toContain("replacement.finalized_by = NEW.actor_id");
+    expect(sql).toContain("source.finalized_at <= correction.created_at");
+    expect(sql).toContain("correction.created_at <= replacement.finalized_at");
+    expect(sql).toContain("replacement_correction.created_at < NEW.created_at");
+    const validationTrigger = sql.slice(
+      sql.indexOf(
+        "CREATE OR REPLACE FUNCTION validate_soap_note_replacement_insert",
+      ),
+      sql.indexOf("CREATE TRIGGER soap_note_replacements_validate"),
+    );
+    expect(validationTrigger).toContain("pg_catalog.sha256");
+    expect(validationTrigger).toContain("'{\"patientId\":'");
+    expect(validationTrigger).toContain("',\"sourceNoteId\":'");
+    expect(validationTrigger).toContain("',\"actorId\":'");
+    expect(validationTrigger).toContain("',\"reason\":'");
+    expect(validationTrigger).toContain("',\"subjective\":'");
+    expect(validationTrigger).toContain("',\"objective\":'");
+    expect(validationTrigger).toContain("',\"assessment\":'");
+    expect(validationTrigger).toContain("',\"plan\":'");
+    expect(validationTrigger).toContain(
+      "SOAP replacement payload hash is invalid.",
+    );
+    expect(validationTrigger).toContain(
+      "coalesce(current_setting('app.soap_replacement_restore', true), '') = 'on'",
+    );
+    expect(validationTrigger).toContain("current_user = (");
+    expect(validationTrigger).toContain("NEW.created_at <= source.deleted_at");
+    expect(validationTrigger).toContain(
+      "NEW.created_at <= replacement.deleted_at",
+    );
+    const restoreFunction = sql.slice(
+      sql.indexOf("CREATE OR REPLACE FUNCTION restore_soap_note_replacement"),
+      sql.indexOf("REVOKE ALL ON FUNCTION restore_soap_note_replacement"),
+    );
+    expect(restoreFunction).toContain("SECURITY DEFINER");
+    expect(restoreFunction).toContain("SET search_path = ''");
+    expect(restoreFunction).toContain(
+      "p_practice_id IS DISTINCT FROM nullif(current_setting('app.current_practice_id', true), '')::uuid",
+    );
+    expect(restoreFunction).not.toContain("app.rls_bypass");
+    expect(restoreFunction).toContain(
+      "pg_catalog.set_config('app.soap_replacement_restore', 'on', true)",
+    );
+    expect(restoreFunction).toContain(
+      "ON CONFLICT (practice_id, operation_id) DO NOTHING",
+    );
+    for (const replayField of [
+      "id",
+      "created_at",
+      "correction_id",
+      "source_soap_note_id",
+      "replacement_soap_note_id",
+      "actor_id",
+      "actor_name",
+      "operation_payload_hash",
+    ]) {
+      expect(restoreFunction).toContain(
+        `existing_replacement.${replayField} IS DISTINCT FROM`,
+      );
+    }
+    expect(sql).toContain(
+      "REVOKE ALL ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) FROM PUBLIC",
+    );
+    expect(sql).toContain(
+      "GRANT EXECUTE ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) TO openpims_app",
+    );
+    expect(sql).toContain("SOAP note replacement evidence is append-only");
+    expect(sql).toContain("current_setting('app.ledger_maintenance', true)");
+    expect(sql).toContain("current_user = (");
+    expect(sql).toContain(
+      "ALTER TABLE soap_note_replacements ENABLE ROW LEVEL SECURITY",
+    );
+    expect(sql).toContain(
+      "GRANT SELECT, INSERT ON soap_note_replacements TO openpims_app",
+    );
+    expect(sql).toContain(
+      "REVOKE ALL ON soap_note_replacements FROM authenticated",
+    );
+
+    const reset = readRepoFile("packages/db/reset.ts");
+    expect(reset).toContain('"soap_note_replacements"');
+    expect(reset.indexOf('"soap_note_replacements"')).toBeLessThan(
+      reset.indexOf('"clinical_record_corrections"'),
+    );
+
+    const rls = readRepoFile("packages/db/rls/enable-rls.sql");
+    expect(rls).toContain("'soap_note_replacements'");
+    expect(rls).toContain(
+      "GRANT SELECT, INSERT ON soap_note_replacements TO openpims_app",
+    );
+    expect(rls).toContain(
+      "REVOKE ALL ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) FROM PUBLIC",
+    );
+    expect(rls).toContain(
+      "GRANT EXECUTE ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) TO openpims_app",
     );
   });
 });

--- a/apps/web/lib/__tests__/soap-replacement-ui.test.ts
+++ b/apps/web/lib/__tests__/soap-replacement-ui.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const replacementPage = readFileSync(
+  "app/(dashboard)/records/replace-soap/[patientId]/page.tsx",
+  "utf8",
+);
+const patientPage = readFileSync(
+  "app/(dashboard)/patients/[id]/page.tsx",
+  "utf8",
+);
+const recordsPage = readFileSync("app/(dashboard)/records/page.tsx", "utf8");
+const encounterPage = readFileSync(
+  "app/(dashboard)/encounters/[appointmentId]/page.tsx",
+  "utf8",
+);
+
+describe("SOAP replacement workflow UI", () => {
+  it("limits access, prefills the retained source, and uses an idempotent finalization", () => {
+    expect(replacementPage).toContain(
+      'role === "admin" || role === "veterinarian"',
+    );
+    expect(replacementPage).toContain(
+      "const source = notes.data?.find((note) => note.id === sourceNoteId)",
+    );
+    expect(replacementPage).toContain('subjective: source.subjective ?? ""');
+    expect(replacementPage).toContain('source.correctionReason ?? ""');
+    expect(replacementPage).toContain(
+      "operationId.current ??= crypto.randomUUID()",
+    );
+    expect(replacementPage).toContain(
+      "trpc.records.replaceSoapNote.useMutation",
+    );
+    expect(replacementPage).toContain("disabled={!valid || replace.isPending}");
+  });
+
+  it("states the permanent clinical and operational consequences", () => {
+    expect(replacementPage).toContain(
+      "The original remains permanently visible as entered in error",
+    );
+    expect(replacementPage).toContain(
+      "invoice, payment, discharge, and signed handoffs are not reopened",
+    );
+    expect(replacementPage).toContain("This page is not an autosaved draft");
+    expect(replacementPage).toContain(
+      "later clarification requires an attributed addendum",
+    );
+    expect(replacementPage).toContain(
+      "Review the signed discharge separately if owner-facing instructions changed.",
+    );
+  });
+
+  it("shows reciprocal lineage on both chart surfaces", () => {
+    for (const source of [patientPage, recordsPage]) {
+      expect(source).toContain("Current replacement SOAP");
+      expect(source).toContain("View retained original");
+      expect(source).toContain("View signed replacement");
+      expect(source).toContain("Replace finalized SOAP");
+      expect(source).toContain("Create missing replacement");
+      expect(source).toContain("Void without replacement");
+    }
+  });
+
+  it("exposes checked-out recovery and permits only a documented exception", () => {
+    expect(encounterPage).toContain("Create missing SOAP replacement");
+    expect(encounterPage).toContain("!closeoutQuery.data?.soapDraft");
+    expect(encounterPage).toContain("The signed SOAP was voided");
+    expect(encounterPage).toContain("Why a replacement SOAP is not required");
+    expect(encounterPage).toMatch(
+      /props\.linkedSoapCount === 0 && !props\.documentationExceptionReason\.trim\(\)/,
+    );
+    for (const source of [patientPage, recordsPage]) {
+      expect(source).toContain("hasAppointmentSoapDraft");
+      expect(source).toContain("Review encounter SOAP draft");
+    }
+  });
+});

--- a/apps/web/lib/backup/__tests__/export.test.ts
+++ b/apps/web/lib/backup/__tests__/export.test.ts
@@ -33,6 +33,111 @@ const SOAP_REPLACEMENT_ID = "00000000-0000-4000-8000-000000000043";
 const SOAP_RETIRED_ID = "00000000-0000-4000-8000-000000000044";
 const SOAP_ADDENDUM_SOURCE_ID = "00000000-0000-4000-8000-000000000045";
 const SOAP_ADDENDUM_RETIRED_ID = "00000000-0000-4000-8000-000000000046";
+const SOAP_REPLACEMENT_LINK_ID = "00000000-0000-4000-8000-000000000047";
+const SOAP_CORRECTION_ID = "00000000-0000-4000-8000-000000000048";
+const SOAP_REPLACEMENT_OPERATION_ID = "00000000-0000-4000-8000-000000000049";
+
+function validSoapReplacementBackup() {
+  const practiceId = "00000000-0000-4000-8000-000000000040";
+  const clientId = "00000000-0000-4000-8000-000000000051";
+  const patientId = "00000000-0000-4000-8000-000000000050";
+  const reason = "Assessment was signed on the wrong encounter.";
+  const replacementSections = {
+    subjective: "Corrected history",
+    objective: null,
+    assessment: "Corrected assessment",
+    plan: null,
+  };
+  const operationPayloadHash = createHash("sha256")
+    .update(
+      JSON.stringify({
+        patientId,
+        sourceNoteId: SOAP_SOURCE_ID,
+        actorId: SOAP_BACKUP_USER_ID,
+        reason,
+        ...replacementSections,
+      }),
+    )
+    .digest("hex");
+  return {
+    practiceId,
+    ...emptyBackup(),
+    users: [
+      {
+        id: SOAP_BACKUP_USER_ID,
+        practiceId,
+        name: "Dr. Rivera",
+      },
+    ],
+    clients: [{ id: clientId, practiceId }],
+    patients: [{ id: patientId, practiceId, clientId }],
+    soapNotes: [
+      {
+        id: SOAP_SOURCE_ID,
+        practiceId,
+        patientId,
+        appointmentId: null,
+        authorId: SOAP_BACKUP_USER_ID,
+        authorName: "Dr. Rivera",
+        status: "finalized",
+        deletedAt: null,
+        finalizedAt: "2026-08-09T16:00:00.000Z",
+        finalizedBy: SOAP_BACKUP_USER_ID,
+        finalizerName: "Dr. Rivera",
+        subjective: "Wrong history",
+        objective: null,
+        assessment: "Wrong assessment",
+        plan: null,
+      },
+      {
+        id: SOAP_REPLACEMENT_ID,
+        practiceId,
+        patientId,
+        appointmentId: null,
+        authorId: SOAP_BACKUP_USER_ID,
+        authorName: "Dr. Rivera",
+        status: "finalized",
+        deletedAt: null,
+        finalizedAt: "2026-08-09T16:10:00.000Z",
+        finalizedBy: SOAP_BACKUP_USER_ID,
+        finalizerName: "Dr. Rivera",
+        ...replacementSections,
+      },
+    ],
+    clinicalRecordCorrections: [
+      {
+        id: SOAP_CORRECTION_ID,
+        createdAt: "2026-08-09T16:05:00.000Z",
+        practiceId,
+        recordType: "soap_note",
+        soapNoteId: SOAP_SOURCE_ID,
+        vitalSignId: null,
+        vaccinationRecordId: null,
+        labResultId: null,
+        patientId,
+        appointmentId: null,
+        reason,
+        correctedBy: SOAP_BACKUP_USER_ID,
+        operationId: null,
+        operationPayloadHash: null,
+      },
+    ],
+    soapNoteReplacements: [
+      {
+        id: SOAP_REPLACEMENT_LINK_ID,
+        createdAt: "2026-08-09T16:15:00.000Z",
+        practiceId,
+        correctionId: SOAP_CORRECTION_ID,
+        sourceSoapNoteId: SOAP_SOURCE_ID,
+        replacementSoapNoteId: SOAP_REPLACEMENT_ID,
+        actorId: SOAP_BACKUP_USER_ID,
+        actorName: "Dr. Rivera",
+        operationId: SOAP_REPLACEMENT_OPERATION_ID,
+        operationPayloadHash,
+      },
+    ],
+  };
+}
 
 describe("backup restore policy", () => {
   it("bounds direct backup JSON restore payloads by UTF-8 bytes", () => {
@@ -90,9 +195,7 @@ function restoreDb(executeResults: unknown[][] = []) {
         onConflictDoNothing: vi.fn(() => ({
           returning: vi.fn(async () => {
             inserted.push({ rows: values });
-            timeline.push(
-              ...values.map((row) => `insert:${String(row.id)}`),
-            );
+            timeline.push(...values.map((row) => `insert:${String(row.id)}`));
             return values.map((row) => ({ id: row.id }));
           }),
         })),
@@ -280,19 +383,31 @@ describe("summarizePracticeExport", () => {
 
   it("requires replacement lineage in current backups but accepts its legacy absence", () => {
     const currentMissing: Record<string, unknown> = {
-      formatVersion: 3,
+      formatVersion: 4,
       ...emptyBackup(),
     };
     delete currentMissing["labResultReplacements"];
     expect(summarizePracticeExport(currentMissing).missingSections).toContain(
       "labResultReplacements",
     );
+    const currentSoapMissing: Record<string, unknown> = {
+      formatVersion: 4,
+      ...emptyBackup(),
+    };
+    delete currentSoapMissing["soapNoteReplacements"];
+    expect(
+      summarizePracticeExport(currentSoapMissing).missingSections,
+    ).toContain("soapNoteReplacements");
 
     const legacyMissing: Record<string, unknown> = { ...emptyBackup() };
     delete legacyMissing["labResultReplacements"];
+    delete legacyMissing["soapNoteReplacements"];
     expect(
       summarizePracticeExport(legacyMissing).missingSections,
     ).not.toContain("labResultReplacements");
+    expect(
+      summarizePracticeExport(legacyMissing).missingSections,
+    ).not.toContain("soapNoteReplacements");
   });
 
   it("exports SMS provider ledgers for audit but marks them owner-restore only", () => {
@@ -532,6 +647,15 @@ describe("summarizePracticeExport", () => {
 describe("exportPracticeData query scoping", () => {
   const source = readFileSync(new URL("../export.ts", import.meta.url), "utf8");
 
+  it("retains both endpoints of immutable SOAP replacement history", () => {
+    expect(source).toContain(
+      "...soapNoteReplacementRows.flatMap((replacement) => [",
+    );
+    expect(source).toContain("replacement.sourceSoapNoteId");
+    expect(source).toContain("replacement.replacementSoapNoteId");
+    expect(source).toContain("public.restore_soap_note_replacement(");
+  });
+
   it("exports parent-scoped children through active tenant parents", () => {
     const helper = source.match(
       /async function tenantParentChildRows[\s\S]+?async function restoreRows/,
@@ -754,6 +878,41 @@ describe("practice backup secret handling", () => {
 });
 
 describe("restorePracticeData", () => {
+  it("restores immutable SOAP replacement history after later soft deletion", async () => {
+    const activeBackup = validSoapReplacementBackup();
+    const backup = {
+      ...activeBackup,
+      soapNotes: activeBackup.soapNotes.map((note, index) => ({
+        ...note,
+        deletedAt:
+          index === 0 ? "2026-08-09T16:20:00.000Z" : "2026-08-09T16:21:00.000Z",
+      })),
+    };
+    expect(validatePracticeExportRestore(backup)).toEqual({
+      valid: true,
+      errors: [],
+    });
+
+    const { db, executed } = restoreDb([
+      [
+        {
+          result_id: SOAP_REPLACEMENT_LINK_ID,
+          was_inserted: true,
+        },
+      ],
+    ]);
+    await expect(
+      restorePracticeData(db as never, backup.practiceId, backup),
+    ).resolves.toMatchObject({
+      restored: {
+        soapNotes: 2,
+        clinicalRecordCorrections: 1,
+        soapNoteReplacements: 1,
+      },
+    });
+    expect(executed).toHaveLength(1);
+  });
+
   it("does not restore any provider-authority SMS ledger through clinic restore", async () => {
     const backup = {
       ...emptyBackup(),
@@ -1015,17 +1174,13 @@ describe("restorePracticeData", () => {
           ...extra,
         ],
       }).errors;
-    expect(
-      addendumError({ createdAt: "2026-08-09T14:59:59.000Z" }),
-    ).toContain(
+    expect(addendumError({ createdAt: "2026-08-09T14:59:59.000Z" })).toContain(
       `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].createdAt must be on or after finalization, not in the future, and no later than source deletion or correction.`,
     );
     expect(addendumError({ createdAt: "2099-08-09T16:00:00.000Z" })).toContain(
       `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].createdAt must be on or after finalization, not in the future, and no later than source deletion or correction.`,
     );
-    expect(
-      addendumError({ createdAt: "2026-08-09T16:31:00.000Z" }),
-    ).toContain(
+    expect(addendumError({ createdAt: "2026-08-09T16:31:00.000Z" })).toContain(
       `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].createdAt must be on or after finalization, not in the future, and no later than source deletion or correction.`,
     );
     expect(addendumError({ operationPayloadHash: "0".repeat(64) })).toContain(
@@ -1038,7 +1193,9 @@ describe("restorePracticeData", () => {
     ).toContain(
       `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].soapNoteId must be a canonical lowercase UUID.`,
     );
-    expect(addendumError({ authorId: SOAP_BACKUP_USER_ID.replaceAll("-", "") })).toContain(
+    expect(
+      addendumError({ authorId: SOAP_BACKUP_USER_ID.replaceAll("-", "") }),
+    ).toContain(
       `soapNoteAddenda[${SOAP_ADDENDUM_SOURCE_ID}].authorId must be a canonical lowercase UUID.`,
     );
     expect(addendumError({ id: "not-a-uuid" })).toContain(
@@ -1068,20 +1225,20 @@ describe("restorePracticeData", () => {
     );
     const duplicateContent = "Second copy with a reused operation.";
     const duplicateOperationErrors = addendumError({}, [
-        {
-          ...backup.soapNoteAddenda[0],
-          id: "00000000-0000-4000-8000-000000000047",
-          content: duplicateContent,
-          operationId: String(
-            backup.soapNoteAddenda[0].operationId,
-          ).toUpperCase(),
-          operationPayloadHash: soapAddendumHash(
-            SOAP_SOURCE_ID,
-            SOAP_BACKUP_USER_ID,
-            duplicateContent,
-          ),
-        },
-      ]);
+      {
+        ...backup.soapNoteAddenda[0],
+        id: "00000000-0000-4000-8000-000000000047",
+        content: duplicateContent,
+        operationId: String(
+          backup.soapNoteAddenda[0].operationId,
+        ).toUpperCase(),
+        operationPayloadHash: soapAddendumHash(
+          SOAP_SOURCE_ID,
+          SOAP_BACKUP_USER_ID,
+          duplicateContent,
+        ),
+      },
+    ]);
     expect(duplicateOperationErrors).toContain(
       "soapNoteAddenda[00000000-0000-4000-8000-000000000047].operationId must be unique within its practice.",
     );
@@ -1490,6 +1647,79 @@ describe("restorePracticeData", () => {
       }).errors,
     ).toContain(
       "labResultReplacements[replacement-link-2].practiceId must match all linked evidence.",
+    );
+  });
+
+  it("validates exact immutable SOAP replacement evidence", () => {
+    const backup = validSoapReplacementBackup();
+    expect(validatePracticeExportRestore(backup)).toEqual({
+      valid: true,
+      errors: [],
+    });
+
+    const missingCorrectionErrors = validatePracticeExportRestore({
+      ...backup,
+      soapNoteReplacements: [
+        {
+          ...backup.soapNoteReplacements[0],
+          correctionId: "00000000-0000-4000-8000-000000000099",
+        },
+      ],
+    }).errors;
+    expect(missingCorrectionErrors.length).toBeGreaterThan(0);
+
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        soapNoteReplacements: [
+          {
+            ...backup.soapNoteReplacements[0],
+            operationPayloadHash: "b".repeat(64),
+          },
+        ],
+      }).errors,
+    ).toContain(
+      `soapNoteReplacements[${SOAP_REPLACEMENT_LINK_ID}].operationPayloadHash must match its exact correction and replacement payload.`,
+    );
+
+    const deletedHistory = {
+      ...backup,
+      soapNotes: backup.soapNotes.map((note, index) => ({
+        ...note,
+        deletedAt:
+          index === 0 ? "2026-08-09T16:20:00.000Z" : "2026-08-09T16:21:00.000Z",
+      })),
+    };
+    expect(validatePracticeExportRestore(deletedHistory)).toEqual({
+      valid: true,
+      errors: [],
+    });
+
+    expect(
+      validatePracticeExportRestore({
+        ...deletedHistory,
+        soapNotes: deletedHistory.soapNotes.map((note, index) =>
+          index === 1
+            ? { ...note, deletedAt: "2026-08-09T16:14:59.000Z" }
+            : note,
+        ),
+      }).errors,
+    ).toContain(
+      `soapNoteReplacements[${SOAP_REPLACEMENT_LINK_ID}] chronology must run from source finalization through correction, replacement finalization, link creation, and any later replacement correction.`,
+    );
+
+    expect(
+      validatePracticeExportRestore({
+        ...backup,
+        clinicalRecordCorrections: backup.clinicalRecordCorrections.map(
+          (correction) => ({
+            ...correction,
+            createdAt: "2026-08-09T16:11:00.000Z",
+          }),
+        ),
+      }).errors,
+    ).toContain(
+      `soapNoteReplacements[${SOAP_REPLACEMENT_LINK_ID}] chronology must run from source finalization through correction, replacement finalization, link creation, and any later replacement correction.`,
     );
   });
 

--- a/apps/web/lib/backup/export.ts
+++ b/apps/web/lib/backup/export.ts
@@ -51,6 +51,7 @@ import {
   smsSendAttempts,
   smsSuppressions,
   soapNoteAddenda,
+  soapNoteReplacements,
   soapNotes,
   staffSchedules,
   suppliers,
@@ -165,6 +166,7 @@ export const PRACTICE_EXPORT_SECTIONS = [
   "insuranceClaims",
   "soapNotes",
   "soapNoteAddenda",
+  "soapNoteReplacements",
   "vaccinationRecords",
   "labResults",
   "labResultEvents",
@@ -205,8 +207,10 @@ const PRACTICE_EXPORT_OPTIONAL_RESTORE_SECTIONS = [
   "smsSendAttemptEvents",
   "visitCloseouts",
   "clinicalRecordCorrections",
-  // Backward compatibility for pre-v3 backups.
+  // Backward compatibility: addenda were introduced in v3 and SOAP
+  // replacement lineage in v4.
   "soapNoteAddenda",
+  "soapNoteReplacements",
   // Backward compatibility for backups created before the lab result safety
   // ledger and clinic-wide review inbox were introduced.
   "labResultEvents",
@@ -220,7 +224,7 @@ export type PracticeExport = {
   counts: Record<PracticeExportSection, number>;
 } & Record<PracticeExportSection, unknown[]>;
 
-export const PRACTICE_EXPORT_FORMAT_VERSION = 3;
+export const PRACTICE_EXPORT_FORMAT_VERSION = 4;
 
 type Row = Record<string, unknown>;
 
@@ -384,6 +388,14 @@ const RESTORE_REFERENCE_RULES: RestoreReferenceRule[] = [
   optionalRef("soapNotes", "finalizedBy", "users"),
   requiredRef("soapNoteAddenda", "soapNoteId", "soapNotes"),
   requiredRef("soapNoteAddenda", "authorId", "users"),
+  requiredRef(
+    "soapNoteReplacements",
+    "correctionId",
+    "clinicalRecordCorrections",
+  ),
+  requiredRef("soapNoteReplacements", "sourceSoapNoteId", "soapNotes"),
+  requiredRef("soapNoteReplacements", "replacementSoapNoteId", "soapNotes"),
+  requiredRef("soapNoteReplacements", "actorId", "users"),
   requiredRef("vaccinationRecords", "patientId", "patients"),
   optionalRef("vaccinationRecords", "appointmentId", "appointments"),
   optionalRef("vaccinationRecords", "administeredBy", "users"),
@@ -1257,6 +1269,195 @@ export function validatePracticeExportRestore(data: unknown): {
   });
 
   const correctionRows = rowsById("clinicalRecordCorrections");
+  const soapReplacementSources = new Set<string>();
+  const soapReplacements = new Set<string>();
+  const soapReplacementOperations = new Set<string>();
+  const soapReplacementEdges = new Map<string, string>();
+  rowsFor(data, "soapNoteReplacements").forEach((row, index) => {
+    const label = `soapNoteReplacements[${rowLabel(row, index)}]`;
+    for (const field of [
+      "id",
+      "correctionId",
+      "sourceSoapNoteId",
+      "replacementSoapNoteId",
+      "actorId",
+      "operationId",
+    ] as const) {
+      if (
+        typeof row[field] !== "string" ||
+        !CANONICAL_LOWER_UUID.test(row[field])
+      ) {
+        pushError(`${label}.${field} must be a canonical lowercase UUID.`);
+      }
+    }
+    const correction =
+      typeof row.correctionId === "string"
+        ? correctionRows.get(row.correctionId)
+        : undefined;
+    const source =
+      typeof row.sourceSoapNoteId === "string"
+        ? soapRows.get(row.sourceSoapNoteId)
+        : undefined;
+    const replacement =
+      typeof row.replacementSoapNoteId === "string"
+        ? soapRows.get(row.replacementSoapNoteId)
+        : undefined;
+    if (!correction || !source || !replacement) return;
+
+    if (
+      correction.recordType !== "soap_note" ||
+      correction.soapNoteId !== row.sourceSoapNoteId
+    ) {
+      pushError(
+        `${label}.correctionId must identify the exact SOAP correction for its source.`,
+      );
+    }
+    if (row.sourceSoapNoteId === row.replacementSoapNoteId) {
+      pushError(`${label} cannot replace a SOAP note with itself.`);
+    }
+    if (
+      row.practiceId !== source.practiceId ||
+      row.practiceId !== replacement.practiceId ||
+      row.practiceId !== correction.practiceId
+    ) {
+      pushError(`${label}.practiceId must match all linked evidence.`);
+    }
+    if (
+      source.patientId !== replacement.patientId ||
+      (source.appointmentId ?? null) !== (replacement.appointmentId ?? null)
+    ) {
+      pushError(
+        `${label} source and replacement must belong to the same patient and appointment.`,
+      );
+    }
+    if (source.status !== "finalized" || replacement.status !== "finalized") {
+      pushError(`${label} must link finalized SOAP notes.`);
+    }
+    if (
+      row.actorId !== replacement.finalizedBy ||
+      row.actorName !== replacement.finalizerName
+    ) {
+      pushError(
+        `${label} actor attribution must match the replacement finalizer snapshot.`,
+      );
+    }
+    const createdAt = restoredTimestampMillis(row.createdAt);
+    const correctedAt = restoredTimestampMillis(correction.createdAt);
+    const sourceFinalizedAt = restoredTimestampMillis(source.finalizedAt);
+    const replacementFinalizedAt = restoredTimestampMillis(
+      replacement.finalizedAt,
+    );
+    const sourceDeletedAt =
+      source.deletedAt == null
+        ? null
+        : restoredTimestampMillis(source.deletedAt);
+    const replacementDeletedAt =
+      replacement.deletedAt == null
+        ? null
+        : restoredTimestampMillis(replacement.deletedAt);
+    const replacementCorrection = soapCorrectionByNoteId.get(
+      String(row.replacementSoapNoteId),
+    );
+    const replacementCorrectedAt = restoredTimestampMillis(
+      replacementCorrection?.createdAt,
+    );
+    if (
+      createdAt === null ||
+      correctedAt === null ||
+      sourceFinalizedAt === null ||
+      replacementFinalizedAt === null ||
+      sourceFinalizedAt > correctedAt ||
+      correctedAt > replacementFinalizedAt ||
+      createdAt < correctedAt ||
+      createdAt < replacementFinalizedAt ||
+      (source.deletedAt != null &&
+        (sourceDeletedAt === null || createdAt > sourceDeletedAt)) ||
+      (replacement.deletedAt != null &&
+        (replacementDeletedAt === null || createdAt > replacementDeletedAt)) ||
+      (replacementCorrection && replacementCorrectedAt === null) ||
+      (replacementCorrectedAt !== null && createdAt > replacementCorrectedAt) ||
+      createdAt > restoreValidationNow
+    ) {
+      pushError(
+        `${label} chronology must run from source finalization through correction, replacement finalization, link creation, and any later replacement correction.`,
+      );
+    }
+    if (soapReplacementSources.has(row.sourceSoapNoteId as string)) {
+      pushError(
+        `${label}.sourceSoapNoteId must be unique within its practice.`,
+      );
+    }
+    soapReplacementSources.add(row.sourceSoapNoteId as string);
+    if (soapReplacements.has(row.replacementSoapNoteId as string)) {
+      pushError(`${label}.replacementSoapNoteId may replace only one source.`);
+    }
+    soapReplacements.add(row.replacementSoapNoteId as string);
+    if (
+      typeof row.operationPayloadHash !== "string" ||
+      !/^[0-9a-f]{64}$/.test(row.operationPayloadHash)
+    ) {
+      pushError(`${label}.operationPayloadHash must be a SHA-256 hex digest.`);
+    }
+    if (typeof row.operationId === "string") {
+      if (soapReplacementOperations.has(row.operationId)) {
+        pushError(`${label}.operationId must be unique within its practice.`);
+      }
+      soapReplacementOperations.add(row.operationId);
+    }
+    if (
+      typeof row.actorName !== "string" ||
+      row.actorName.trim() !== row.actorName ||
+      row.actorName.length < 1 ||
+      row.actorName.length > 255
+    ) {
+      pushError(`${label}.actorName must contain bounded attribution.`);
+    }
+    if (
+      typeof row.sourceSoapNoteId === "string" &&
+      typeof row.actorId === "string" &&
+      typeof correction.reason === "string"
+    ) {
+      const expectedHash = createHash("sha256")
+        .update(
+          JSON.stringify({
+            patientId: source.patientId,
+            sourceNoteId: row.sourceSoapNoteId,
+            actorId: row.actorId,
+            reason: correction.reason,
+            subjective: replacement.subjective ?? null,
+            objective: replacement.objective ?? null,
+            assessment: replacement.assessment ?? null,
+            plan: replacement.plan ?? null,
+          }),
+        )
+        .digest("hex");
+      if (row.operationPayloadHash !== expectedHash) {
+        pushError(
+          `${label}.operationPayloadHash must match its exact correction and replacement payload.`,
+        );
+      }
+    }
+    soapReplacementEdges.set(
+      row.sourceSoapNoteId as string,
+      row.replacementSoapNoteId as string,
+    );
+  });
+
+  for (const sourceId of soapReplacementEdges.keys()) {
+    const visited = new Set<string>();
+    let current: string | undefined = sourceId;
+    while (current) {
+      if (visited.has(current)) {
+        pushError(
+          `soapNoteReplacements contains a directed replacement cycle at SOAP note "${current}".`,
+        );
+        break;
+      }
+      visited.add(current);
+      current = soapReplacementEdges.get(current);
+    }
+  }
+
   const replacementSources = new Set<string>();
   const replacements = new Set<string>();
   const replacementOperations = new Set<string>();
@@ -1655,6 +1856,7 @@ export async function exportPracticeData(
     wellnessEnrollmentRows,
     allSoapNoteRows,
     soapNoteAddendumRows,
+    soapNoteReplacementRows,
     allVaccinationRows,
     labRows,
     labResultEventRows,
@@ -1707,6 +1909,7 @@ export async function exportPracticeData(
     activeRows(db, wellnessEnrollments, practiceId),
     allPracticeRows(db, soapNotes, practiceId),
     allPracticeRows(db, soapNoteAddenda, practiceId),
+    allPracticeRows(db, soapNoteReplacements, practiceId),
     allPracticeRows(db, vaccinationRecords, practiceId),
     allPracticeRows(db, labResults, practiceId),
     allPracticeRows(db, labResultEvents, practiceId),
@@ -1756,6 +1959,10 @@ export async function exportPracticeData(
     [
       ...clinicalCorrectionRows.map((correction) => correction.soapNoteId),
       ...soapNoteAddendumRows.map((addendum) => addendum.soapNoteId),
+      ...soapNoteReplacementRows.flatMap((replacement) => [
+        replacement.sourceSoapNoteId,
+        replacement.replacementSoapNoteId,
+      ]),
     ].filter((id): id is string => typeof id === "string"),
   );
   const soapNoteRows = allSoapNoteRows.filter(
@@ -2063,6 +2270,7 @@ export async function exportPracticeData(
     insuranceClaims: insuranceClaimRows,
     soapNotes: soapNoteRows,
     soapNoteAddenda: soapNoteAddendumRows,
+    soapNoteReplacements: soapNoteReplacementRows,
     vaccinationRecords: vaccinationRows,
     labResults: labRows,
     labResultEvents: labResultEventRows,
@@ -2199,7 +2407,7 @@ async function restorePracticeDataRows(
       : {};
     const effectiveFollowUpStatus = clearFollowUp
       ? "not_required"
-      : row.followUpStatus ?? "not_required";
+      : (row.followUpStatus ?? "not_required");
     if (
       normalizedStatus === "reviewed" &&
       row.resultFlag === "critical" &&
@@ -2393,6 +2601,48 @@ async function restorePracticeDataRows(
       throw new Error("SOAP addendum restore returned invalid evidence.");
     }
     if (outcome.was_inserted) restored.soapNoteAddenda += 1;
+  }
+  restored.soapNoteReplacements = 0;
+  for (const row of coerceRowDates(
+    soapNoteReplacements,
+    rowsFor(data, "soapNoteReplacements"),
+  )) {
+    if (
+      typeof row.id !== "string" ||
+      !(row.createdAt instanceof Date) ||
+      typeof row.correctionId !== "string" ||
+      typeof row.sourceSoapNoteId !== "string" ||
+      typeof row.replacementSoapNoteId !== "string" ||
+      typeof row.actorId !== "string" ||
+      typeof row.actorName !== "string" ||
+      typeof row.operationId !== "string" ||
+      typeof row.operationPayloadHash !== "string"
+    ) {
+      throw new Error("Backup contains an invalid SOAP replacement row.");
+    }
+    const restoreResult = await db.execute(sql`
+      select result_id, was_inserted
+      from public.restore_soap_note_replacement(
+        ${row.id}::uuid,
+        ${row.createdAt},
+        ${practiceId}::uuid,
+        ${row.correctionId}::uuid,
+        ${row.sourceSoapNoteId}::uuid,
+        ${row.replacementSoapNoteId}::uuid,
+        ${row.actorId}::uuid,
+        ${row.actorName},
+        ${row.operationId}::uuid,
+        ${row.operationPayloadHash}
+      )
+    `);
+    const [outcome] = rowsFromExecute<{
+      result_id: string;
+      was_inserted: boolean;
+    }>(restoreResult);
+    if (!outcome || outcome.result_id !== row.id) {
+      throw new Error("SOAP replacement restore returned invalid evidence.");
+    }
+    if (outcome.was_inserted) restored.soapNoteReplacements += 1;
   }
   await restorePracticeRows("labResultReplacements", labResultReplacements);
   await restorePracticeRows("cases", cases);

--- a/apps/web/lib/pdf.ts
+++ b/apps/web/lib/pdf.ts
@@ -440,6 +440,7 @@ export interface MedicalSummaryData {
     authorName?: string;
     finalizerName?: string;
     finalizedAt?: string;
+    replacementForLabel?: string;
     addenda?: Array<{ content: string; authorName: string; createdAt: string }>;
   }>;
   recordCorrections?: Array<{
@@ -447,6 +448,7 @@ export interface MedicalSummaryData {
     reason: string;
     correctedByName: string;
     correctedAt: string;
+    replacementLabel?: string;
   }>;
   prescriptions: Array<{
     medication: string;
@@ -701,6 +703,16 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
         : `Authored by ${note.authorName ?? "Unknown clinician"}; finalized by ${note.finalizerName ?? "Unknown clinician"}${note.finalizedAt ? ` on ${note.finalizedAt}` : ""}`;
       writeWrappedText(attribution, PAGE_MARGIN, CONTENT_WIDTH);
       y += 2;
+      if (note.replacementForLabel) {
+        doc.setFont(FONT, "bold");
+        setColor(doc, COLOR_TEAL);
+        writeWrappedText(
+          `Signed replacement for retained ${note.replacementForLabel}`,
+          PAGE_MARGIN,
+          CONTENT_WIDTH,
+        );
+        y += 2;
+      }
 
       doc.setFontSize(9);
       const soapSections: [string, string | undefined][] = [
@@ -775,6 +787,15 @@ export function generateMedicalSummaryPdf(data: MedicalSummaryData): jsPDF {
         PAGE_MARGIN + 4,
         CONTENT_WIDTH - 8,
       );
+      if (correction.replacementLabel) {
+        doc.setFont(FONT, "bold");
+        setColor(doc, COLOR_TEAL);
+        writeWrappedText(
+          `Signed replacement: ${correction.replacementLabel}`,
+          PAGE_MARGIN + 4,
+          CONTENT_WIDTH - 8,
+        );
+      }
       y += 3;
     }
   }

--- a/apps/web/lib/records/__tests__/soap-lifecycle.test.ts
+++ b/apps/web/lib/records/__tests__/soap-lifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   createFinalizedAppointmentSoapNote,
   discardAppointmentSoapDraft,
   finalizeAppointmentSoapDraft,
+  replaceFinalizedSoapNote,
   saveAppointmentSoapDraft,
 } from "../soap-lifecycle";
 
@@ -59,6 +60,7 @@ function lifecycleDb(opts: {
     const rows = selectResults.shift() ?? [];
     const builder: Record<string, any> = {};
     builder.from = vi.fn(() => builder);
+    builder.innerJoin = vi.fn(() => builder);
     builder.where = vi.fn(() => builder);
     builder.limit = vi.fn(() => builder);
     builder.for = vi.fn(async () => rows);
@@ -93,6 +95,7 @@ function lifecycleDb(opts: {
     insert: vi.fn(() => ({ values: insertValues })),
     update: vi.fn(() => ({ set: updateSet })),
     delete: vi.fn(() => ({ where: deleteWhere })),
+    execute: vi.fn(async () => undefined),
   };
   return {
     db: db as unknown as Database,
@@ -107,6 +110,160 @@ function visitPrefix() {
 }
 
 describe("SOAP lifecycle service", () => {
+  it("atomically finalizes a replacement after checkout and records immutable lineage", async () => {
+    const source = note({
+      status: "finalized",
+      finalizedAt: new Date("2026-08-09T16:10:00.000Z"),
+      finalizedBy: USER_ID,
+      finalizerName: actor.name,
+    });
+    const correction = {
+      id: "00000000-0000-4000-8000-000000000007",
+      reason: "Assessment was signed on the wrong encounter.",
+    };
+    const replacement = note({
+      id: "00000000-0000-4000-8000-000000000008",
+      status: "finalized",
+      subjective: "Corrected history",
+      finalizedAt: new Date("2026-08-09T17:00:00.000Z"),
+      finalizedBy: USER_ID,
+      finalizerName: actor.name,
+    });
+    const { db, insertValues } = lifecycleDb({
+      selectResults: [
+        [],
+        [{ appointmentId: APPOINTMENT_ID }],
+        [{ id: APPOINTMENT_ID }],
+        [source],
+        [],
+        [],
+        [],
+        [],
+      ],
+      insertResults: [[correction], [replacement]],
+    });
+
+    await expect(
+      replaceFinalizedSoapNote(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        sourceNoteId: NOTE_ID,
+        operationId: OPERATION_ID,
+        reason: correction.reason,
+        actor,
+        sections: { subjective: " Corrected history " },
+      }),
+    ).resolves.toEqual({ note: replacement, replayed: false });
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recordType: "soap_note",
+        soapNoteId: NOTE_ID,
+        reason: correction.reason,
+      }),
+    );
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceSoapNoteId: NOTE_ID,
+        replacementSoapNoteId: replacement.id,
+        correctionId: correction.id,
+        operationId: OPERATION_ID,
+      }),
+    );
+    const finalizedReplacementValues = insertValues.mock.calls
+      .map(([values]) => values as Record<string, unknown>)
+      .find((values) => values.status === "finalized");
+    expect(finalizedReplacementValues?.finalizedAt).not.toBeInstanceOf(Date);
+  });
+
+  it("requires the existing permanent reason when recovering an already-corrected SOAP", async () => {
+    const source = note({
+      status: "finalized",
+      finalizedAt: new Date(),
+      finalizedBy: USER_ID,
+      finalizerName: actor.name,
+    });
+    const { db, insertValues } = lifecycleDb({
+      selectResults: [
+        [],
+        [{ appointmentId: APPOINTMENT_ID }],
+        [{ id: APPOINTMENT_ID }],
+        [source],
+        [],
+        [],
+        [],
+        [
+          {
+            id: "00000000-0000-4000-8000-000000000007",
+            reason: "Permanent reason",
+          },
+        ],
+      ],
+    });
+    await expect(
+      replaceFinalizedSoapNote(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        sourceNoteId: NOTE_ID,
+        operationId: OPERATION_ID,
+        reason: "Different reason",
+        actor,
+        sections: { plan: "Corrected plan" },
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("replays the exact SOAP replacement operation without creating another note", async () => {
+    const replacement = note({
+      id: "00000000-0000-4000-8000-000000000008",
+      status: "finalized",
+      subjective: "Corrected history",
+      finalizedAt: new Date(),
+      finalizedBy: USER_ID,
+      finalizerName: actor.name,
+    });
+    const reason = "Assessment was signed on the wrong encounter.";
+    const payloadHash = createHash("sha256")
+      .update(
+        JSON.stringify({
+          patientId: PATIENT_ID,
+          sourceNoteId: NOTE_ID,
+          actorId: USER_ID,
+          reason,
+          subjective: "Corrected history",
+          objective: null,
+          assessment: null,
+          plan: null,
+        }),
+      )
+      .digest("hex");
+    const { db, insertValues } = lifecycleDb({
+      selectResults: [
+        [
+          {
+            sourceNoteId: NOTE_ID,
+            replacementNote: replacement,
+            operationPayloadHash: payloadHash,
+            correctionReason: reason,
+            correctionSoapNoteId: NOTE_ID,
+          },
+        ],
+      ],
+    });
+    await expect(
+      replaceFinalizedSoapNote(db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        sourceNoteId: NOTE_ID,
+        operationId: OPERATION_ID,
+        reason,
+        actor,
+        sections: { subjective: "Corrected history" },
+      }),
+    ).resolves.toEqual({ note: replacement, replayed: true });
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
   it("creates one persisted draft with server attribution and explicit null sections", async () => {
     const created = note();
     const { db, insertValues } = lifecycleDb({
@@ -286,6 +443,21 @@ describe("SOAP lifecycle service", () => {
         actor,
       }),
     ).resolves.toEqual({ outcome: "conflict", note: finalized });
+  });
+
+  it("does not misreport an entered-in-error finalized note as a successful stale retry", async () => {
+    const closedVisit = { ...openVisit, status: "checked_out" };
+    const corrected = lifecycleDb({ selectResults: [[closedVisit], []] });
+    await expect(
+      finalizeAppointmentSoapDraft(corrected.db, {
+        practiceId: PRACTICE_ID,
+        patientId: PATIENT_ID,
+        appointmentId: APPOINTMENT_ID,
+        noteId: NOTE_ID,
+        expectedRevision: 1,
+        actor,
+      }),
+    ).rejects.toMatchObject({ code: "PRECONDITION_FAILED" });
   });
 
   it("reports remote finalization to save and discard after visit close", async () => {

--- a/apps/web/lib/records/soap-lifecycle.ts
+++ b/apps/web/lib/records/soap-lifecycle.ts
@@ -1,8 +1,11 @@
 import { createHash } from "node:crypto";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import {
+  appointments,
   clinicalRecordCorrections,
+  practices,
   soapNoteAddenda,
+  soapNoteReplacements,
   soapNotes,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
@@ -93,15 +96,14 @@ async function getScopedFinalizedSoapNote(
     eq(soapNotes.appointmentId, input.appointmentId),
     eq(soapNotes.status, "finalized"),
     isNull(soapNotes.deletedAt),
-  ];
-  if (input.noteId) {
-    predicates.push(eq(soapNotes.id, input.noteId));
-  } else {
-    predicates.push(sql`not exists (
+    sql`not exists (
       select 1 from ${clinicalRecordCorrections}
       where ${clinicalRecordCorrections.practiceId} = ${input.practiceId}
         and ${clinicalRecordCorrections.soapNoteId} = ${soapNotes.id}
-    )`);
+    )`,
+  ];
+  if (input.noteId) {
+    predicates.push(eq(soapNotes.id, input.noteId));
   }
   const [note] = await db
     .select()
@@ -192,8 +194,10 @@ export async function saveAppointmentSoapDraft(
     sections: SoapSections;
   },
 ): Promise<SaveSoapDraftResult> {
-  const finalizedAfterClose =
-    await assertOpenSoapVisitWithFinalizedRecovery(db, input);
+  const finalizedAfterClose = await assertOpenSoapVisitWithFinalizedRecovery(
+    db,
+    input,
+  );
   if (finalizedAfterClose) {
     if (!input.noteId || finalizedAfterClose.id === input.noteId) {
       return { outcome: "already_finalized", note: finalizedAfterClose };
@@ -366,8 +370,10 @@ export async function finalizeAppointmentSoapDraft(
     actor: SoapActor;
   },
 ): Promise<FinalizeSoapResult> {
-  const finalizedAfterClose =
-    await assertOpenSoapVisitWithFinalizedRecovery(db, input);
+  const finalizedAfterClose = await assertOpenSoapVisitWithFinalizedRecovery(
+    db,
+    input,
+  );
   if (finalizedAfterClose) {
     return finalizedAfterClose.revision === input.expectedRevision
       ? {
@@ -477,8 +483,10 @@ export async function discardAppointmentSoapDraft(
     expectedRevision: number;
   },
 ): Promise<DiscardSoapDraftResult> {
-  const finalizedAfterClose =
-    await assertOpenSoapVisitWithFinalizedRecovery(db, input);
+  const finalizedAfterClose = await assertOpenSoapVisitWithFinalizedRecovery(
+    db,
+    input,
+  );
   if (finalizedAfterClose) {
     return { outcome: "already_finalized", note: finalizedAfterClose };
   }
@@ -622,6 +630,298 @@ export async function createFinalizedAppointmentSoapNote(
     })
     .returning();
   return note!;
+}
+
+export async function replaceFinalizedSoapNote(
+  db: Database,
+  input: {
+    practiceId: string;
+    patientId: string;
+    sourceNoteId: string;
+    operationId: string;
+    reason: string;
+    actor: SoapActor;
+    sections: SoapSections;
+  },
+) {
+  const practiceId = input.practiceId.toLowerCase();
+  const patientId = input.patientId.toLowerCase();
+  const sourceNoteId = input.sourceNoteId.toLowerCase();
+  const actorId = input.actor.id.toLowerCase();
+  const operationId = input.operationId.toLowerCase();
+  const sections = normalizeSoapSections(input.sections);
+  const reason = input.reason.trim();
+  if (!hasSoapContent(sections)) {
+    throw new SoapLifecycleError(
+      "BAD_REQUEST",
+      "Replacement SOAP note must include at least one section.",
+    );
+  }
+  if (hasUnresolvedSoapTemplatePrompts(sections)) {
+    throw new SoapLifecycleError(
+      "BAD_REQUEST",
+      "Replace or delete every SOAP template prompt before finalization.",
+    );
+  }
+
+  const payloadHash = createHash("sha256")
+    .update(
+      JSON.stringify({
+        patientId,
+        sourceNoteId,
+        actorId,
+        reason,
+        ...sections,
+      }),
+    )
+    .digest("hex");
+
+  await db.execute(
+    sql`select pg_advisory_xact_lock(
+      hashtextextended(${`soap-replacement:${practiceId}:${operationId}`}, 0)
+    )`,
+  );
+
+  const replay = async () => {
+    const [existing] = await db
+      .select({
+        sourceNoteId: soapNoteReplacements.sourceSoapNoteId,
+        replacementNote: soapNotes,
+        operationPayloadHash: soapNoteReplacements.operationPayloadHash,
+        correctionReason: clinicalRecordCorrections.reason,
+        correctionSoapNoteId: clinicalRecordCorrections.soapNoteId,
+      })
+      .from(soapNoteReplacements)
+      .innerJoin(
+        soapNotes,
+        and(
+          eq(soapNotes.id, soapNoteReplacements.replacementSoapNoteId),
+          eq(soapNotes.practiceId, practiceId),
+        ),
+      )
+      .innerJoin(
+        clinicalRecordCorrections,
+        and(
+          eq(clinicalRecordCorrections.id, soapNoteReplacements.correctionId),
+          eq(clinicalRecordCorrections.practiceId, practiceId),
+        ),
+      )
+      .where(
+        and(
+          eq(soapNoteReplacements.practiceId, practiceId),
+          eq(soapNoteReplacements.operationId, operationId),
+        ),
+      )
+      .limit(1);
+    if (!existing) return null;
+    if (
+      existing.sourceNoteId !== sourceNoteId ||
+      existing.replacementNote.patientId !== patientId ||
+      existing.operationPayloadHash !== payloadHash ||
+      existing.correctionSoapNoteId !== sourceNoteId ||
+      existing.correctionReason !== reason
+    ) {
+      throw new SoapLifecycleError(
+        "CONFLICT",
+        "This replacement operation was already used for different SOAP details.",
+      );
+    }
+    return { note: existing.replacementNote, replayed: true as const };
+  };
+
+  const existingReplay = await replay();
+  if (existingReplay) return existingReplay;
+
+  const sourcePredicate = and(
+    eq(soapNotes.id, sourceNoteId),
+    eq(soapNotes.practiceId, practiceId),
+    eq(soapNotes.patientId, patientId),
+    eq(soapNotes.status, "finalized"),
+    isNull(soapNotes.deletedAt),
+    sql`exists (
+      select 1 from ${practices}
+      where ${practices.id} = ${practiceId}
+        and ${practices.deletedAt} is null
+    )`,
+  );
+  const [sourceIdentity] = await db
+    .select({ appointmentId: soapNotes.appointmentId })
+    .from(soapNotes)
+    .where(sourcePredicate)
+    .limit(1);
+  if (!sourceIdentity) {
+    throw new SoapLifecycleError("NOT_FOUND", "Finalized SOAP note not found.");
+  }
+
+  // Closeout and correction both lock appointment first. Preserve that order
+  // so a late replacement cannot race a closeout against different SOAP state.
+  if (sourceIdentity.appointmentId) {
+    const [appointment] = await db
+      .select({ id: appointments.id })
+      .from(appointments)
+      .where(
+        and(
+          eq(appointments.id, sourceIdentity.appointmentId),
+          eq(appointments.practiceId, practiceId),
+          isNull(appointments.deletedAt),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    if (!appointment) {
+      throw new SoapLifecycleError(
+        "PRECONDITION_FAILED",
+        "The source appointment is no longer available for a signed SOAP replacement.",
+      );
+    }
+  }
+
+  const [source] = await db
+    .select()
+    .from(soapNotes)
+    .where(sourcePredicate)
+    .limit(1)
+    .for("update");
+  if (!source) {
+    throw new SoapLifecycleError(
+      "CONFLICT",
+      "The source SOAP note changed. Refresh the chart and try again.",
+    );
+  }
+
+  const [existingReplacement] = await db
+    .select({ id: soapNoteReplacements.id })
+    .from(soapNoteReplacements)
+    .where(
+      and(
+        eq(soapNoteReplacements.practiceId, practiceId),
+        eq(soapNoteReplacements.sourceSoapNoteId, source.id),
+      ),
+    )
+    .limit(1);
+  if (existingReplacement) {
+    throw new SoapLifecycleError(
+      "CONFLICT",
+      "This SOAP note already has a replacement. Refresh the chart.",
+    );
+  }
+
+  if (source.appointmentId) {
+    const [competingDraft] = await db
+      .select({ id: soapNotes.id })
+      .from(soapNotes)
+      .where(
+        and(
+          eq(soapNotes.practiceId, practiceId),
+          eq(soapNotes.appointmentId, source.appointmentId),
+          eq(soapNotes.status, "draft"),
+          isNull(soapNotes.deletedAt),
+        ),
+      )
+      .limit(1);
+    if (competingDraft) {
+      throw new SoapLifecycleError(
+        "CONFLICT",
+        "This encounter has a SOAP draft. Review or discard it before creating a signed replacement.",
+      );
+    }
+    const [competingFinal] = await db
+      .select({ id: soapNotes.id })
+      .from(soapNotes)
+      .where(
+        and(
+          eq(soapNotes.practiceId, practiceId),
+          eq(soapNotes.appointmentId, source.appointmentId),
+          eq(soapNotes.status, "finalized"),
+          isNull(soapNotes.deletedAt),
+          sql`${soapNotes.id} <> ${source.id}`,
+          sql`not exists (
+            select 1 from ${clinicalRecordCorrections}
+            where ${clinicalRecordCorrections.practiceId} = ${practiceId}
+              and ${clinicalRecordCorrections.soapNoteId} = ${soapNotes.id}
+          )`,
+        ),
+      )
+      .limit(1);
+    if (competingFinal) {
+      throw new SoapLifecycleError(
+        "CONFLICT",
+        "This encounter already has current finalized SOAP documentation.",
+      );
+    }
+  }
+
+  let [correction] = await db
+    .select()
+    .from(clinicalRecordCorrections)
+    .where(
+      and(
+        eq(clinicalRecordCorrections.practiceId, practiceId),
+        eq(clinicalRecordCorrections.soapNoteId, source.id),
+      ),
+    )
+    .limit(1);
+  if (correction && correction.reason !== reason) {
+    throw new SoapLifecycleError(
+      "CONFLICT",
+      "Use the existing permanent correction reason when replacing this SOAP note.",
+    );
+  }
+  if (!correction) {
+    [correction] = await db
+      .insert(clinicalRecordCorrections)
+      .values({
+        practiceId,
+        recordType: "soap_note",
+        action: "entered_in_error",
+        soapNoteId: source.id,
+        patientId: source.patientId,
+        appointmentId: source.appointmentId,
+        reason,
+        correctedBy: actorId,
+        correctedByName: input.actor.name,
+      })
+      .returning();
+  }
+  if (!correction) {
+    throw new SoapLifecycleError(
+      "CONFLICT",
+      "The SOAP correction could not be recorded. Refresh and try again.",
+    );
+  }
+
+  const [replacement] = await db
+    .insert(soapNotes)
+    .values({
+      practiceId,
+      patientId: source.patientId,
+      appointmentId: source.appointmentId,
+      ...finalizedSoapInsertValues({ actor: input.actor, sections }),
+      // Keep finalization, correction, and evidence timestamps on the same
+      // PostgreSQL transaction clock. Application wall time can be later than
+      // transaction_timestamp() (or skewed across hosts), which would make an
+      // otherwise valid atomic replacement fail its chronology trigger.
+      finalizedAt: sql`transaction_timestamp()`,
+    })
+    .returning();
+  if (!replacement) {
+    throw new SoapLifecycleError(
+      "CONFLICT",
+      "The replacement SOAP note could not be finalized.",
+    );
+  }
+
+  await db.insert(soapNoteReplacements).values({
+    practiceId,
+    correctionId: correction.id,
+    sourceSoapNoteId: source.id,
+    replacementSoapNoteId: replacement.id,
+    actorId,
+    actorName: input.actor.name,
+    operationId,
+    operationPayloadHash: payloadHash,
+  });
+  return { note: replacement, replayed: false as const };
 }
 
 export async function addFinalizedSoapAddendum(

--- a/apps/web/server/__tests__/clinical-corrections.test.ts
+++ b/apps/web/server/__tests__/clinical-corrections.test.ts
@@ -23,6 +23,7 @@ const PATIENT_ID = "00000000-0000-0000-0000-000000000002";
 const APPOINTMENT_ID = "00000000-0000-0000-0000-000000000003";
 const RECORD_ID = "00000000-0000-0000-0000-000000000004";
 const CORRECTION_ID = "00000000-0000-0000-0000-000000000005";
+const OPERATION_ID = "00000000-0000-4000-8000-000000000006";
 
 function context(db: Record<string, unknown>, role = "veterinarian") {
   return {
@@ -109,6 +110,15 @@ describe("append-only clinical corrections", () => {
           }),
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
       await expect(
+        recordsRouter.createCaller(context(db, role)).replaceSoapNote({
+          patientId: PATIENT_ID,
+          sourceNoteId: RECORD_ID,
+          operationId: OPERATION_ID,
+          reason: "Signed on the wrong encounter.",
+          subjective: "Corrected history.",
+        }),
+      ).rejects.toMatchObject({ code: "FORBIDDEN" });
+      await expect(
         vitalsRouter.createCaller(context(db, role)).markEnteredInError({
           patientId: PATIENT_ID,
           recordId: RECORD_ID,
@@ -117,6 +127,20 @@ describe("append-only clinical corrections", () => {
       ).rejects.toMatchObject({ code: "FORBIDDEN" });
     }
 
+    expect(select).not.toHaveBeenCalled();
+    expect(insertValues).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty replacement SOAP before touching the database", async () => {
+    const { db, select, insertValues } = createDb({});
+    await expect(
+      recordsRouter.createCaller(context(db)).replaceSoapNote({
+        patientId: PATIENT_ID,
+        sourceNoteId: RECORD_ID,
+        operationId: OPERATION_ID,
+        reason: "Signed on the wrong encounter.",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
     expect(select).not.toHaveBeenCalled();
     expect(insertValues).not.toHaveBeenCalled();
   });
@@ -250,6 +274,7 @@ describe("append-only clinical corrections", () => {
       id: CORRECTION_ID,
       practiceId: PRACTICE_ID,
       soapNoteId: RECORD_ID,
+      reason: "Duplicate request after a network retry.",
     };
     const { db, select } = createDb({
       selectResults: [
@@ -268,6 +293,31 @@ describe("append-only clinical corrections", () => {
       }),
     ).resolves.toEqual(existing);
     expect(select).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not silently replace a permanent SOAP correction reason", async () => {
+    const { db } = createDb({
+      selectResults: [
+        [{ id: RECORD_ID, patientId: PATIENT_ID, appointmentId: null }],
+        [{ id: RECORD_ID, patientId: PATIENT_ID, appointmentId: null }],
+        [
+          {
+            id: CORRECTION_ID,
+            practiceId: PRACTICE_ID,
+            soapNoteId: RECORD_ID,
+            reason: "Original permanent reason.",
+          },
+        ],
+      ],
+      insertResults: [[]],
+    });
+    await expect(
+      recordsRouter.createCaller(context(db)).markSoapNoteEnteredInError({
+        patientId: PATIENT_ID,
+        recordId: RECORD_ID,
+        reason: "A different retry reason.",
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
   });
 
   it("restricts vaccination correction to an administrator or veterinarian", async () => {

--- a/apps/web/server/__tests__/encounters-closeout.test.ts
+++ b/apps/web/server/__tests__/encounters-closeout.test.ts
@@ -527,6 +527,31 @@ describe("encounter closeout safety", () => {
     expect(insertValues).not.toHaveBeenCalled();
   });
 
+  it("allows a bounded exception when a voided SOAP should not be replaced", async () => {
+    const { db, insertValues } = createDb({
+      selectResults: [
+        [openAppointment],
+        [{ id: PATIENT_ID }],
+        [],
+        [
+          {
+            id: "soap-source",
+            correctionId: "soap-correction",
+          },
+        ],
+        [],
+      ],
+    });
+    await expect(
+      callerWithDb(db, "veterinarian").finalizeClinical(clinicalInput),
+    ).resolves.toBeUndefined();
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentationExceptionReason: "Brief technician recheck",
+      }),
+    );
+  });
+
   it("finalizes a validated clinical handoff and increments its revision", async () => {
     const finalized = {
       ...clinicalFinalized,

--- a/apps/web/server/__tests__/settings-admin-safety.test.ts
+++ b/apps/web/server/__tests__/settings-admin-safety.test.ts
@@ -688,12 +688,16 @@ describe("settings demo data cleanup scoping", () => {
     );
   });
 
-  it("derives and records legacy demo SOAP ids before immutable cleanup", () => {
+  it("unions stored and user-created demo SOAP ids before immutable cleanup", () => {
     const clearDemoBlock = SETTINGS_SOURCE.match(
       /clearDemoData:[\s\S]+?reseedDemoData:/,
     )?.[0];
 
     expect(clearDemoBlock).toContain("let demoSoapNoteIds");
+    expect(clearDemoBlock).toContain("const storedDemoSoapNoteIds");
+    expect(clearDemoBlock).toContain("const discoveredDemoSoapNotes");
+    expect(clearDemoBlock).toContain("...storedDemoSoapNoteIds");
+    expect(clearDemoBlock).toContain("...discoveredDemoSoapNotes.map");
     expect(clearDemoBlock).toContain(
       "inArray(soapNotes.appointmentId, demo.appointmentIds)",
     );

--- a/apps/web/server/routers/encounters.ts
+++ b/apps/web/server/routers/encounters.ts
@@ -34,6 +34,7 @@ import {
   labResults,
   vaccinationRecords,
   services,
+  soapNoteReplacements,
   soapNotes,
   visitCloseouts,
   visitWorkItems,
@@ -656,6 +657,7 @@ export const encountersRouter = createRouter({
         closeout,
         linkedSoapRows,
         soapDraftRows,
+        missingSoapReplacementRows,
         medications,
         followUpAppointments,
         followUpAssignees,
@@ -694,6 +696,34 @@ export const encountersRouter = createRouter({
               isNull(soapNotes.deletedAt),
             ),
           )
+          .limit(1),
+        ctx.db
+          .select({
+            sourceNoteId: soapNotes.id,
+            correctionReason: clinicalRecordCorrections.reason,
+          })
+          .from(soapNotes)
+          .innerJoin(
+            clinicalRecordCorrections,
+            and(
+              eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+              eq(clinicalRecordCorrections.soapNoteId, soapNotes.id),
+            ),
+          )
+          .where(
+            and(
+              eq(soapNotes.appointmentId, input.appointmentId),
+              eq(soapNotes.practiceId, ctx.practiceId),
+              eq(soapNotes.status, "finalized"),
+              isNull(soapNotes.deletedAt),
+              sql`not exists (
+                select 1 from ${soapNoteReplacements}
+                where ${soapNoteReplacements.practiceId} = ${ctx.practiceId}
+                  and ${soapNoteReplacements.sourceSoapNoteId} = ${soapNotes.id}
+              )`,
+            ),
+          )
+          .orderBy(desc(clinicalRecordCorrections.createdAt))
           .limit(1),
         ctx.db
           .select({
@@ -827,6 +857,14 @@ export const encountersRouter = createRouter({
         },
         linkedSoapCount: linkedSoapRows.length,
         soapDraft: soapDraftRows[0] ?? null,
+        // A legacy or independently authored current SOAP satisfies the
+        // encounter even when an older corrected note has no explicit
+        // replacement edge. Only surface recovery when no effective final
+        // SOAP exists.
+        missingSoapReplacement:
+          linkedSoapRows.length === 0
+            ? (missingSoapReplacementRows[0] ?? null)
+            : null,
         medications: medicationHistory,
         activeMedications: medicationHistory.filter(
           (medication) => medication.effectiveStatus === "active",
@@ -1649,24 +1687,28 @@ export const encountersRouter = createRouter({
           });
         }
 
-        const [soap] = await tx
-          .select({ id: soapNotes.id })
+        const soapRows = await tx
+          .select({
+            id: soapNotes.id,
+            correctionId: clinicalRecordCorrections.id,
+          })
           .from(soapNotes)
+          .leftJoin(
+            clinicalRecordCorrections,
+            and(
+              eq(clinicalRecordCorrections.practiceId, ctx.practiceId),
+              eq(clinicalRecordCorrections.soapNoteId, soapNotes.id),
+            ),
+          )
           .where(
             and(
               eq(soapNotes.appointmentId, input.appointmentId),
               eq(soapNotes.practiceId, ctx.practiceId),
               eq(soapNotes.status, "finalized"),
               isNull(soapNotes.deletedAt),
-              sql`not exists (
-                select 1
-                from ${clinicalRecordCorrections}
-                where ${clinicalRecordCorrections.practiceId} = ${ctx.practiceId}
-                  and ${clinicalRecordCorrections.soapNoteId} = ${soapNotes.id}
-              )`
-            )
-          )
-          .limit(1);
+            ),
+          );
+        const soap = soapRows.find((row) => !row.correctionId);
         const [soapDraft] = await tx
           .select({ id: soapNotes.id })
           .from(soapNotes)

--- a/apps/web/server/routers/records.ts
+++ b/apps/web/server/routers/records.ts
@@ -42,6 +42,7 @@ import {
   visitWorkItems,
   clinicalRecordCorrections,
   soapNoteAddenda,
+  soapNoteReplacements,
 } from "@openpims/db";
 import type { Database } from "@openpims/db/client";
 import { formatDateInputForTimeZone } from "@/lib/date-input";
@@ -115,6 +116,7 @@ import {
   discardAppointmentSoapDraft,
   finalizeAppointmentSoapDraft,
   getAppointmentSoapDraft,
+  replaceFinalizedSoapNote,
   saveAppointmentSoapDraft,
   SoapLifecycleError,
 } from "@/lib/records/soap-lifecycle";
@@ -1121,6 +1123,14 @@ export const recordsRouter = createRouter({
   listSoapNotes: protectedProcedure
     .input(z.object({ patientId: z.string().uuid() }))
     .query(async ({ ctx, input }) => {
+      const replacementFromSource = alias(
+        soapNoteReplacements,
+        "soap_replacement_from_source",
+      );
+      const sourceFromReplacement = alias(
+        soapNoteReplacements,
+        "soap_source_from_replacement",
+      );
       const notes = await ctx.db
         .select({
           id: soapNotes.id,
@@ -1145,6 +1155,11 @@ export const recordsRouter = createRouter({
           correctedAt: clinicalRecordCorrections.createdAt,
           correctedBy: clinicalRecordCorrections.correctedBy,
           correctedByName: clinicalRecordCorrections.correctedByName,
+          replacementSoapNoteId:
+            replacementFromSource.replacementSoapNoteId,
+          replacementCreatedAt: replacementFromSource.createdAt,
+          replacementActorName: replacementFromSource.actorName,
+          replacesSoapNoteId: sourceFromReplacement.sourceSoapNoteId,
         })
         .from(soapNotes)
         .leftJoin(
@@ -1153,6 +1168,20 @@ export const recordsRouter = createRouter({
             eq(clinicalRecordCorrections.soapNoteId, soapNotes.id),
             eq(clinicalRecordCorrections.practiceId, ctx.practiceId)
           )
+        )
+        .leftJoin(
+          replacementFromSource,
+          and(
+            eq(replacementFromSource.sourceSoapNoteId, soapNotes.id),
+            eq(replacementFromSource.practiceId, ctx.practiceId),
+          ),
+        )
+        .leftJoin(
+          sourceFromReplacement,
+          and(
+            eq(sourceFromReplacement.replacementSoapNoteId, soapNotes.id),
+            eq(sourceFromReplacement.practiceId, ctx.practiceId),
+          ),
         )
         .where(
           and(
@@ -1299,7 +1328,16 @@ export const recordsRouter = createRouter({
             )
           )
           .limit(1);
-        if (existing) return existing;
+        if (existing) {
+          if (existing.reason !== input.reason) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "This SOAP note already has a different permanent correction reason. Refresh the chart.",
+            });
+          }
+          return existing;
+        }
 
         throw new TRPCError({
           code: "CONFLICT",
@@ -1307,6 +1345,57 @@ export const recordsRouter = createRouter({
         });
       })
     ),
+
+  replaceSoapNote: protectedProcedure
+    .use(requireRole("admin", "veterinarian"))
+    .input(
+      z.object({
+        patientId: z.string().uuid(),
+        sourceNoteId: z.string().uuid(),
+        operationId: z.string().uuid(),
+        reason: z
+          .string()
+          .trim()
+          .min(CLINICAL_CORRECTION_REASON_MIN_LENGTH)
+          .max(CLINICAL_CORRECTION_REASON_MAX_LENGTH),
+        ...soapSectionsInput,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      let result;
+      try {
+        result = await ctx.db.transaction((tx) =>
+          replaceFinalizedSoapNote(tx as unknown as Database, {
+            practiceId: ctx.practiceId,
+            patientId: input.patientId,
+            sourceNoteId: input.sourceNoteId,
+            operationId: input.operationId,
+            reason: input.reason,
+            actor: { id: ctx.user.id, name: ctx.user.name },
+            sections: input,
+          }),
+        );
+      } catch (error) {
+        rethrowSoapLifecycleError(error);
+      }
+      if (!result.replayed) {
+        const dispatch = () =>
+          dispatchWebhookEvent(ctx.practiceId, "soap_note.created", {
+            id: result.note.id,
+            patientId: result.note.patientId,
+            appointmentId: result.note.appointmentId,
+            authorId: result.note.authorId,
+            replacesSoapNoteId: input.sourceNoteId.toLowerCase(),
+            source: "dashboard",
+          });
+        if (ctx.postCommitEffect) {
+          ctx.postCommitEffect(async () => dispatch());
+        } else {
+          await dispatch();
+        }
+      }
+      return result.note;
+    }),
 
   createSoapNote: protectedProcedure
     .use(requireRole("admin", "veterinarian"))

--- a/apps/web/server/routers/settings.ts
+++ b/apps/web/server/routers/settings.ts
@@ -1310,12 +1310,12 @@ export const settingsRouter = createRouter({
     const demo = settings.demoData;
     if (demo) {
       const now = new Date();
-      let demoSoapNoteIds = demo.soapNoteIds ?? [];
-      if (
-        demoSoapNoteIds.length === 0 &&
-        (demo.appointmentIds.length > 0 || demo.patientIds.length > 0)
-      ) {
-        const legacyDemoSoapNotes = await ctx.db
+      const storedDemoSoapNoteIds = demo.soapNoteIds ?? [];
+      let demoSoapNoteIds = [...storedDemoSoapNoteIds];
+      if (demo.appointmentIds.length > 0 || demo.patientIds.length > 0) {
+        // Always discover every descendant note. Replacement SOAPs can be
+        // created after seeding and therefore are not present in saved IDs.
+        const discoveredDemoSoapNotes = await ctx.db
           .select({ id: soapNotes.id })
           .from(soapNotes)
           .where(
@@ -1327,8 +1327,13 @@ export const settingsRouter = createRouter({
               ),
             ),
           );
-        demoSoapNoteIds = legacyDemoSoapNotes.map((note) => note.id);
-        if (demoSoapNoteIds.length > 0) {
+        demoSoapNoteIds = [
+          ...new Set([
+            ...storedDemoSoapNoteIds,
+            ...discoveredDemoSoapNotes.map((note) => note.id),
+          ]),
+        ];
+        if (demoSoapNoteIds.length !== storedDemoSoapNoteIds.length) {
           await ctx.db
             .update(practices)
             .set({

--- a/packages/db/drizzle/0064_rainy_spacker_dave.sql
+++ b/packages/db/drizzle/0064_rainy_spacker_dave.sql
@@ -1,0 +1,295 @@
+CREATE TABLE "soap_note_replacements" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"practice_id" uuid NOT NULL,
+	"correction_id" uuid NOT NULL,
+	"source_soap_note_id" uuid NOT NULL,
+	"replacement_soap_note_id" uuid NOT NULL,
+	"actor_id" uuid NOT NULL,
+	"actor_name" varchar(255) NOT NULL,
+	"operation_id" uuid NOT NULL,
+	"operation_payload_hash" varchar(64) NOT NULL,
+	CONSTRAINT "soap_note_replacements_shape_check" CHECK ("soap_note_replacements"."source_soap_note_id" <> "soap_note_replacements"."replacement_soap_note_id"
+        and "soap_note_replacements"."actor_name" = btrim("soap_note_replacements"."actor_name")
+        and length(btrim("soap_note_replacements"."actor_name")) between 1 and 255
+        and "soap_note_replacements"."operation_payload_hash" ~ '^[0-9a-f]{64}$')
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "clinical_record_corrections_practice_record_soap_source_uq" ON "clinical_record_corrections" USING btree ("practice_id","id","soap_note_id");--> statement-breakpoint
+ALTER TABLE "soap_note_replacements" ADD CONSTRAINT "soap_note_replacements_practice_id_practices_id_fk" FOREIGN KEY ("practice_id") REFERENCES "public"."practices"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_note_replacements" ADD CONSTRAINT "soap_note_replacements_correction_id_clinical_record_corrections_id_fk" FOREIGN KEY ("correction_id") REFERENCES "public"."clinical_record_corrections"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_note_replacements" ADD CONSTRAINT "soap_note_replacements_source_soap_note_id_soap_notes_id_fk" FOREIGN KEY ("source_soap_note_id") REFERENCES "public"."soap_notes"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_note_replacements" ADD CONSTRAINT "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk" FOREIGN KEY ("replacement_soap_note_id") REFERENCES "public"."soap_notes"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_note_replacements" ADD CONSTRAINT "soap_note_replacements_actor_id_users_id_fk" FOREIGN KEY ("actor_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_note_replacements" ADD CONSTRAINT "soap_note_replacements_source_tenant_fk" FOREIGN KEY ("practice_id","source_soap_note_id") REFERENCES "public"."soap_notes"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_note_replacements" ADD CONSTRAINT "soap_note_replacements_replacement_tenant_fk" FOREIGN KEY ("practice_id","replacement_soap_note_id") REFERENCES "public"."soap_notes"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_note_replacements" ADD CONSTRAINT "soap_note_replacements_correction_source_tenant_fk" FOREIGN KEY ("practice_id","correction_id","source_soap_note_id") REFERENCES "public"."clinical_record_corrections"("practice_id","id","soap_note_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "soap_note_replacements" ADD CONSTRAINT "soap_note_replacements_actor_tenant_fk" FOREIGN KEY ("practice_id","actor_id") REFERENCES "public"."users"("practice_id","id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "soap_note_replacements_source_history_idx" ON "soap_note_replacements" USING btree ("practice_id","source_soap_note_id","created_at","id");--> statement-breakpoint
+CREATE UNIQUE INDEX "soap_note_replacements_source_uq" ON "soap_note_replacements" USING btree ("practice_id","source_soap_note_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "soap_note_replacements_replacement_uq" ON "soap_note_replacements" USING btree ("practice_id","replacement_soap_note_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "soap_note_replacements_operation_uq" ON "soap_note_replacements" USING btree ("practice_id","operation_id");--> statement-breakpoint
+CREATE OR REPLACE FUNCTION validate_soap_note_replacement_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+	lineage_matches boolean := false;
+	cycle_exists boolean := false;
+	historical_restore boolean := false;
+	expected_payload_hash text;
+BEGIN
+	historical_restore :=
+		coalesce(current_setting('app.soap_replacement_restore', true), '') = 'on'
+		AND current_user = (
+			SELECT pg_catalog.pg_get_userbyid(class.relowner)
+			FROM pg_catalog.pg_class AS class
+			JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = class.relnamespace
+			WHERE namespace.nspname = TG_TABLE_SCHEMA
+				AND class.relname = TG_TABLE_NAME
+		);
+
+	-- Serialize graph mutations per tenant so concurrent inserts cannot create a
+	-- cycle that neither transaction can observe.
+	PERFORM pg_catalog.pg_advisory_xact_lock(
+		pg_catalog.hashtextextended('soap-note-replacement-graph:' || NEW.practice_id::text, 0)
+	);
+
+	SELECT pg_catalog.encode(
+		pg_catalog.sha256(
+			pg_catalog.convert_to(
+				'{"patientId":' || pg_catalog.to_json(source.patient_id::text)::text ||
+				',"sourceNoteId":' || pg_catalog.to_json(NEW.source_soap_note_id::text)::text ||
+				',"actorId":' || pg_catalog.to_json(NEW.actor_id::text)::text ||
+				',"reason":' || pg_catalog.to_json(correction.reason)::text ||
+				',"subjective":' || coalesce(pg_catalog.to_json(replacement.subjective)::text, 'null') ||
+				',"objective":' || coalesce(pg_catalog.to_json(replacement.objective)::text, 'null') ||
+				',"assessment":' || coalesce(pg_catalog.to_json(replacement.assessment)::text, 'null') ||
+				',"plan":' || coalesce(pg_catalog.to_json(replacement.plan)::text, 'null') || '}',
+				'UTF8'
+			)
+		),
+		'hex'
+	)
+	INTO expected_payload_hash
+	FROM public.clinical_record_corrections AS correction
+	JOIN public.soap_notes AS source
+		ON source.practice_id = correction.practice_id
+		AND source.id = correction.soap_note_id
+	JOIN public.soap_notes AS replacement
+		ON replacement.practice_id = source.practice_id
+		AND replacement.id = NEW.replacement_soap_note_id
+	WHERE correction.practice_id = NEW.practice_id
+		AND correction.id = NEW.correction_id
+		AND correction.soap_note_id = NEW.source_soap_note_id;
+
+	IF NEW.operation_payload_hash IS DISTINCT FROM expected_payload_hash THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			MESSAGE = 'SOAP replacement payload hash is invalid.';
+	END IF;
+
+	SELECT EXISTS (
+		SELECT 1
+		FROM public.clinical_record_corrections AS correction
+		JOIN public.soap_notes AS source
+			ON source.practice_id = correction.practice_id
+			AND source.id = correction.soap_note_id
+		JOIN public.soap_notes AS replacement
+			ON replacement.practice_id = source.practice_id
+			AND replacement.id = NEW.replacement_soap_note_id
+		WHERE correction.practice_id = NEW.practice_id
+			AND correction.id = NEW.correction_id
+			AND correction.record_type = 'soap_note'
+			AND correction.action = 'entered_in_error'
+			AND correction.soap_note_id = NEW.source_soap_note_id
+			AND source.status = 'finalized'
+			AND replacement.status = 'finalized'
+			AND (
+				(source.deleted_at IS NULL AND replacement.deleted_at IS NULL)
+				OR (
+					historical_restore
+					AND (source.deleted_at IS NULL OR NEW.created_at <= source.deleted_at)
+					AND (replacement.deleted_at IS NULL OR NEW.created_at <= replacement.deleted_at)
+				)
+			)
+			AND replacement.patient_id = source.patient_id
+			AND replacement.appointment_id IS NOT DISTINCT FROM source.appointment_id
+			AND replacement.finalized_by = NEW.actor_id
+			AND replacement.finalizer_name = NEW.actor_name
+			AND source.finalized_at <= correction.created_at
+			AND correction.created_at <= replacement.finalized_at
+			AND replacement.finalized_at <= NEW.created_at
+			AND NEW.created_at <= pg_catalog.now()
+			-- A replacement may itself be corrected later and become the source of
+			-- another link. Historical restore therefore permits that correction
+			-- only when its evidence is not earlier than this link.
+			AND NOT EXISTS (
+				SELECT 1
+				FROM public.clinical_record_corrections AS replacement_correction
+				WHERE replacement_correction.practice_id = NEW.practice_id
+					AND replacement_correction.soap_note_id = NEW.replacement_soap_note_id
+					AND replacement_correction.created_at < NEW.created_at
+			)
+	) INTO lineage_matches;
+
+	IF NOT lineage_matches THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			MESSAGE = 'SOAP replacement must preserve the exact correction, encounter, patient, finalizer, and chronology.';
+	END IF;
+
+	WITH RECURSIVE descendants(id) AS (
+		SELECT link.replacement_soap_note_id
+		FROM public.soap_note_replacements AS link
+		WHERE link.practice_id = NEW.practice_id
+			AND link.source_soap_note_id = NEW.replacement_soap_note_id
+		UNION
+		SELECT link.replacement_soap_note_id
+		FROM public.soap_note_replacements AS link
+		JOIN descendants AS prior ON prior.id = link.source_soap_note_id
+		WHERE link.practice_id = NEW.practice_id
+	)
+	SELECT EXISTS (
+		SELECT 1 FROM descendants WHERE id = NEW.source_soap_note_id
+	) INTO cycle_exists;
+
+	IF cycle_exists THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23514',
+			MESSAGE = 'SOAP note replacement lineage cannot contain a cycle.';
+	END IF;
+
+	RETURN NEW;
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER soap_note_replacements_validate
+BEFORE INSERT ON soap_note_replacements
+FOR EACH ROW EXECUTE FUNCTION validate_soap_note_replacement_insert();--> statement-breakpoint
+CREATE OR REPLACE FUNCTION restore_soap_note_replacement(
+	p_id uuid,
+	p_created_at timestamptz,
+	p_practice_id uuid,
+	p_correction_id uuid,
+	p_source_soap_note_id uuid,
+	p_replacement_soap_note_id uuid,
+	p_actor_id uuid,
+	p_actor_name text,
+	p_operation_id uuid,
+	p_operation_payload_hash text
+)
+RETURNS TABLE(result_id uuid, was_inserted boolean)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+	restored_id uuid;
+	existing_replacement public.soap_note_replacements%ROWTYPE;
+BEGIN
+	IF p_practice_id IS DISTINCT FROM nullif(current_setting('app.current_practice_id', true), '')::uuid THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '42501',
+			MESSAGE = 'SOAP replacement restore tenant mismatch.';
+	END IF;
+
+	-- Only this definer-owned call can ask the validation trigger to accept
+	-- historically deleted endpoints. The trigger still validates exact evidence,
+	-- chronology, payload hash, and graph acyclicity.
+	PERFORM pg_catalog.set_config('app.soap_replacement_restore', 'on', true);
+	INSERT INTO public.soap_note_replacements (
+		id, created_at, practice_id, correction_id, source_soap_note_id,
+		replacement_soap_note_id, actor_id, actor_name, operation_id,
+		operation_payload_hash
+	) VALUES (
+		p_id, p_created_at, p_practice_id, p_correction_id,
+		p_source_soap_note_id, p_replacement_soap_note_id, p_actor_id,
+		p_actor_name, p_operation_id, p_operation_payload_hash
+	)
+	ON CONFLICT (practice_id, operation_id) DO NOTHING
+	RETURNING id INTO restored_id;
+
+	IF restored_id IS NOT NULL THEN
+		RETURN QUERY SELECT restored_id, true;
+		RETURN;
+	END IF;
+
+	SELECT * INTO existing_replacement
+	FROM public.soap_note_replacements
+	WHERE practice_id = p_practice_id
+		AND operation_id = p_operation_id;
+
+	IF existing_replacement.id IS NULL
+		OR existing_replacement.id IS DISTINCT FROM p_id
+		OR existing_replacement.created_at IS DISTINCT FROM p_created_at
+		OR existing_replacement.correction_id IS DISTINCT FROM p_correction_id
+		OR existing_replacement.source_soap_note_id IS DISTINCT FROM p_source_soap_note_id
+		OR existing_replacement.replacement_soap_note_id IS DISTINCT FROM p_replacement_soap_note_id
+		OR existing_replacement.actor_id IS DISTINCT FROM p_actor_id
+		OR existing_replacement.actor_name IS DISTINCT FROM p_actor_name
+		OR existing_replacement.operation_payload_hash IS DISTINCT FROM p_operation_payload_hash
+	THEN
+		RAISE EXCEPTION USING
+			ERRCODE = '23505',
+			MESSAGE = 'SOAP replacement restore operation conflicts with existing evidence.';
+	END IF;
+
+	RETURN QUERY SELECT existing_replacement.id, false;
+END;
+$$;--> statement-breakpoint
+REVOKE ALL ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) FROM PUBLIC;--> statement-breakpoint
+CREATE OR REPLACE FUNCTION reject_soap_note_replacement_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+	IF coalesce(current_setting('app.ledger_maintenance', true), '') = 'on'
+		AND current_user = (
+			SELECT pg_catalog.pg_get_userbyid(class.relowner)
+			FROM pg_catalog.pg_class AS class
+			JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = class.relnamespace
+			WHERE namespace.nspname = TG_TABLE_SCHEMA
+				AND class.relname = TG_TABLE_NAME
+		)
+	THEN
+		IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+		RETURN NEW;
+	END IF;
+
+	RAISE EXCEPTION USING
+		ERRCODE = '55000',
+		MESSAGE = 'SOAP note replacement evidence is append-only and cannot be updated or deleted.';
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER soap_note_replacements_immutable
+BEFORE UPDATE OR DELETE ON soap_note_replacements
+FOR EACH ROW EXECUTE FUNCTION reject_soap_note_replacement_mutation();--> statement-breakpoint
+ALTER TABLE soap_note_replacements ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+CREATE POLICY tenant_isolation ON soap_note_replacements
+	USING (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	)
+	WITH CHECK (
+		coalesce(current_setting('app.rls_bypass', true), '') = 'on'
+		OR practice_id = nullif(current_setting('app.current_practice_id', true), '')::uuid
+	);--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'openpims_app') THEN
+		REVOKE ALL ON soap_note_replacements FROM openpims_app;
+		GRANT SELECT, INSERT ON soap_note_replacements TO openpims_app;
+		GRANT EXECUTE ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) TO openpims_app;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+		REVOKE ALL ON soap_note_replacements FROM anon;
+		REVOKE ALL ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) FROM anon;
+	END IF;
+	IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+		REVOKE ALL ON soap_note_replacements FROM authenticated;
+		REVOKE ALL ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) FROM authenticated;
+	END IF;
+END
+$$;

--- a/packages/db/drizzle/meta/0064_snapshot.json
+++ b/packages/db/drizzle/meta/0064_snapshot.json
@@ -1,0 +1,20067 @@
+{
+  "id": "d709ad3f-b1e3-4ca2-8d8f-5d7dd551703f",
+  "prevId": "0c25647c-e2a9-4c58-94b0-7e0dacfd7d44",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "locations_practice_id_uq": {
+          "name": "locations_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_practice_idx": {
+          "name": "locations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "locations_primary_idx": {
+          "name": "locations_primary_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_primary",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_practice_id_practices_id_fk": {
+          "name": "locations_practice_id_practices_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practices": {
+      "name": "practices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_status": {
+          "name": "billing_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "tax_rate_percent": {
+          "name": "tax_rate_percent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'8.00'"
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_feed_token": {
+          "name": "calendar_feed_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practices_billing_trial_idx": {
+          "name": "practices_billing_trial_idx",
+          "columns": [
+            {
+              "expression": "billing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trial_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_customer_idx": {
+          "name": "practices_stripe_customer_idx",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_stripe_subscription_idx": {
+          "name": "practices_stripe_subscription_idx",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practices_calendar_feed_token_uq": {
+          "name": "practices_calendar_feed_token_uq",
+          "columns": [
+            {
+              "expression": "calendar_feed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'front_desk'"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_practice_id_uq": {
+          "name": "users_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_practice_idx": {
+          "name": "users_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_location_idx": {
+          "name": "users_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_practice_id_practices_id_fk": {
+          "name": "users_practice_id_practices_id_fk",
+          "tableFrom": "users",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "users_location_id_locations_id_fk": {
+          "name": "users_location_id_locations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact": {
+          "name": "emergency_contact",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_phone": {
+          "name": "emergency_phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_contact_method": {
+          "name": "preferred_contact_method",
+          "type": "contact_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'phone'"
+        },
+        "sms_consent": {
+          "name": "sms_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_source": {
+          "name": "sms_consent_source",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_disclosure": {
+          "name": "sms_consent_disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_practice_id_uq": {
+          "name": "clients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_practice_idx": {
+          "name": "clients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_conversion_created_idx": {
+          "name": "clients_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_name_trgm_idx": {
+          "name": "clients_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "first_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_email_idx": {
+          "name": "clients_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_external_id_uq": {
+          "name": "clients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"external_source\" is not null and \"clients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_import_fingerprint_uq": {
+          "name": "clients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"import_fingerprint\" is not null and \"clients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_practice_id_practices_id_fk": {
+          "name": "clients_practice_id_practices_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "clients_access_token_unique": {
+          "name": "clients_access_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "clients_import_fingerprint_check": {
+          "name": "clients_import_fingerprint_check",
+          "value": "\"clients\".\"import_fingerprint\" is null or \"clients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "clients_external_identity_pair_check": {
+          "name": "clients_external_identity_pair_check",
+          "value": "(\"clients\".\"external_source\" is null) = (\"clients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_allergies": {
+      "name": "patient_allergies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allergen": {
+          "name": "allergen",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reaction": {
+          "name": "reaction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "allergy_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'moderate'"
+        },
+        "noted_by": {
+          "name": "noted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noted_at": {
+          "name": "noted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "patient_allergies_patient_idx": {
+          "name": "patient_allergies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_allergies_patient_id_patients_id_fk": {
+          "name": "patient_allergies_patient_id_patients_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_allergies_noted_by_users_id_fk": {
+          "name": "patient_allergies_noted_by_users_id_fk",
+          "tableFrom": "patient_allergies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "noted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patient_weights": {
+      "name": "patient_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "patient_weights_patient_recorded_idx": {
+          "name": "patient_weights_patient_recorded_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_weights_patient_id_patients_id_fk": {
+          "name": "patient_weights_patient_id_patients_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_weights_recorded_by_users_id_fk": {
+          "name": "patient_weights_recorded_by_users_id_fk",
+          "tableFrom": "patient_weights",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.patients": {
+      "name": "patients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_source": {
+          "name": "external_source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "species": {
+          "name": "species",
+          "type": "species",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "breed": {
+          "name": "breed",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "sex",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dob": {
+          "name": "dob",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "microchip_number": {
+          "name": "microchip_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "patient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "patients_practice_id_uq": {
+          "name": "patients_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_practice_idx": {
+          "name": "patients_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_client_idx": {
+          "name": "patients_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_name_idx": {
+          "name": "patients_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_external_id_uq": {
+          "name": "patients_external_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"external_source\" is not null and \"patients\".\"external_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patients_import_fingerprint_uq": {
+          "name": "patients_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"patients\".\"import_fingerprint\" is not null and \"patients\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patients_practice_id_practices_id_fk": {
+          "name": "patients_practice_id_practices_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patients_client_id_clients_id_fk": {
+          "name": "patients_client_id_clients_id_fk",
+          "tableFrom": "patients",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patients_import_fingerprint_check": {
+          "name": "patients_import_fingerprint_check",
+          "value": "\"patients\".\"import_fingerprint\" is null or \"patients\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "patients_external_identity_pair_check": {
+          "name": "patients_external_identity_pair_check",
+          "value": "(\"patients\".\"external_source\" is null) = (\"patients\".\"external_id\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.patient_merge_events": {
+      "name": "patient_merge_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_patient_id": {
+          "name": "source_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_patient_id": {
+          "name": "target_patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by_name": {
+          "name": "performed_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_snapshot": {
+          "name": "source_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_snapshot": {
+          "name": "target_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "patient_merge_events_source_uq": {
+          "name": "patient_merge_events_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_operation_uq": {
+          "name": "patient_merge_events_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "patient_merge_events_target_history_idx": {
+          "name": "patient_merge_events_target_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "patient_merge_events_practice_id_practices_id_fk": {
+          "name": "patient_merge_events_practice_id_practices_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_source_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_patient_id_patients_id_fk": {
+          "name": "patient_merge_events_target_patient_id_patients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_id_clients_id_fk": {
+          "name": "patient_merge_events_client_id_clients_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_performed_by_users_id_fk": {
+          "name": "patient_merge_events_performed_by_users_id_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_source_tenant_fk": {
+          "name": "patient_merge_events_source_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "source_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_target_tenant_fk": {
+          "name": "patient_merge_events_target_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "target_patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_client_tenant_fk": {
+          "name": "patient_merge_events_client_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "patient_merge_events_actor_tenant_fk": {
+          "name": "patient_merge_events_actor_tenant_fk",
+          "tableFrom": "patient_merge_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "performed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "patient_merge_events_different_patients_check": {
+          "name": "patient_merge_events_different_patients_check",
+          "value": "\"patient_merge_events\".\"source_patient_id\" <> \"patient_merge_events\".\"target_patient_id\""
+        },
+        "patient_merge_events_attribution_check": {
+          "name": "patient_merge_events_attribution_check",
+          "value": "length(btrim(\"patient_merge_events\".\"performed_by_name\")) between 1 and 255"
+        },
+        "patient_merge_events_reason_check": {
+          "name": "patient_merge_events_reason_check",
+          "value": "length(btrim(\"patient_merge_events\".\"reason\")) between 5 and 500"
+        },
+        "patient_merge_events_snapshots_check": {
+          "name": "patient_merge_events_snapshots_check",
+          "value": "jsonb_typeof(\"patient_merge_events\".\"source_snapshot\") = 'object'\n        and jsonb_typeof(\"patient_merge_events\".\"target_snapshot\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.appointment_types": {
+      "name": "appointment_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#0d9488'"
+        },
+        "requires_doctor": {
+          "name": "requires_doctor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_room_type": {
+          "name": "default_room_type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "appointment_types_practice_name_idx": {
+          "name": "appointment_types_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_types_practice_id_practices_id_fk": {
+          "name": "appointment_types_practice_id_practices_id_fk",
+          "tableFrom": "appointment_types",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_waitlist": {
+      "name": "appointment_waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "waitlist_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'waiting'"
+        },
+        "preferred_from": {
+          "name": "preferred_from",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_to": {
+          "name": "preferred_to",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_practice_idx": {
+          "name": "waitlist_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_client_status_idx": {
+          "name": "waitlist_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_patient_status_idx": {
+          "name": "waitlist_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointment_waitlist_practice_id_practices_id_fk": {
+          "name": "appointment_waitlist_practice_id_practices_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_client_id_clients_id_fk": {
+          "name": "appointment_waitlist_client_id_clients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_patient_id_patients_id_fk": {
+          "name": "appointment_waitlist_patient_id_patients_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_type_id_appointment_types_id_fk": {
+          "name": "appointment_waitlist_type_id_appointment_types_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointment_waitlist_created_by_users_id_fk": {
+          "name": "appointment_waitlist_created_by_users_id_fk",
+          "tableFrom": "appointment_waitlist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_id": {
+          "name": "doctor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "appointment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring_series_id": {
+          "name": "recurring_series_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appointments_practice_id_uq": {
+          "name": "appointments_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_patient_id_uq": {
+          "name": "appointments_practice_patient_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_practice_time_idx": {
+          "name": "appointments_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_conversion_created_idx": {
+          "name": "appointments_conversion_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_idx": {
+          "name": "appointments_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_idx": {
+          "name": "appointments_doctor_idx",
+          "columns": [
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_client_status_idx": {
+          "name": "appointments_client_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_patient_status_idx": {
+          "name": "appointments_patient_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_doctor_status_idx": {
+          "name": "appointments_doctor_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "doctor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_type_status_idx": {
+          "name": "appointments_type_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "appointments_room_status_idx": {
+          "name": "appointments_room_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "room_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "appointments_practice_id_practices_id_fk": {
+          "name": "appointments_practice_id_practices_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_type_id_appointment_types_id_fk": {
+          "name": "appointments_type_id_appointment_types_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_patient_id_patients_id_fk": {
+          "name": "appointments_patient_id_patients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_client_id_clients_id_fk": {
+          "name": "appointments_client_id_clients_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_doctor_id_users_id_fk": {
+          "name": "appointments_doctor_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "doctor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_room_id_rooms_id_fk": {
+          "name": "appointments_room_id_rooms_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_recurring_series_id_recurring_series_id_fk": {
+          "name": "appointments_recurring_series_id_recurring_series_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "recurring_series",
+          "columnsFrom": [
+            "recurring_series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurring_series": {
+      "name": "recurring_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "recurring_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recurring_series_practice_id_practices_id_fk": {
+          "name": "recurring_series_practice_id_practices_id_fk",
+          "tableFrom": "recurring_series",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "room_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'exam'"
+        }
+      },
+      "indexes": {
+        "rooms_practice_name_idx": {
+          "name": "rooms_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rooms_location_idx": {
+          "name": "rooms_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rooms_practice_id_practices_id_fk": {
+          "name": "rooms_practice_id_practices_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "rooms_location_id_locations_id_fk": {
+          "name": "rooms_location_id_locations_id_fk",
+          "tableFrom": "rooms",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff_schedules": {
+      "name": "staff_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staff_schedules_location_idx": {
+          "name": "staff_schedules_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "staff_schedules_user_idx": {
+          "name": "staff_schedules_user_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staff_schedules_practice_id_practices_id_fk": {
+          "name": "staff_schedules_practice_id_practices_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_user_id_users_id_fk": {
+          "name": "staff_schedules_user_id_users_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "staff_schedules_location_id_locations_id_fk": {
+          "name": "staff_schedules_location_id_locations_id_fk",
+          "tableFrom": "staff_schedules",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_entries": {
+      "name": "case_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_type": {
+          "name": "medical_record_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medical_record_id": {
+          "name": "medical_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "case_entries_case_idx": {
+          "name": "case_entries_case_idx",
+          "columns": [
+            {
+              "expression": "case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_entries_case_id_cases_id_fk": {
+          "name": "case_entries_case_id_cases_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "cases",
+          "columnsFrom": [
+            "case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "case_entries_appointment_id_appointments_id_fk": {
+          "name": "case_entries_appointment_id_appointments_id_fk",
+          "tableFrom": "case_entries",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cases": {
+      "name": "cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_vet_id": {
+          "name": "primary_vet_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cases_patient_status_idx": {
+          "name": "cases_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cases_practice_status_idx": {
+          "name": "cases_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cases_practice_id_practices_id_fk": {
+          "name": "cases_practice_id_practices_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_patient_id_patients_id_fk": {
+          "name": "cases_patient_id_patients_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "cases_primary_vet_id_users_id_fk": {
+          "name": "cases_primary_vet_id_users_id_fk",
+          "tableFrom": "cases",
+          "tableTo": "users",
+          "columnsFrom": [
+            "primary_vet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clinical_notes": {
+      "name": "clinical_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note_type": {
+          "name": "note_type",
+          "type": "note_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clinical_notes_patient_idx": {
+          "name": "clinical_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "note_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_notes_practice_idx": {
+          "name": "clinical_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_notes_practice_id_practices_id_fk": {
+          "name": "clinical_notes_practice_id_practices_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_patient_id_patients_id_fk": {
+          "name": "clinical_notes_patient_id_patients_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_notes_author_id_users_id_fk": {
+          "name": "clinical_notes_author_id_users_id_fk",
+          "tableFrom": "clinical_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_results": {
+      "name": "lab_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_operation_id": {
+          "name": "creation_operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_payload_hash": {
+          "name": "creation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_name": {
+          "name": "test_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "ordered_by": {
+          "name": "ordered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_note": {
+          "name": "follow_up_note",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_by": {
+          "name": "follow_up_completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_completed_at": {
+          "name": "follow_up_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_outcome": {
+          "name": "follow_up_outcome",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lab_results_patient_idx": {
+          "name": "lab_results_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_status_idx": {
+          "name": "lab_results_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_review_inbox_idx": {
+          "name": "lab_results_review_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_follow_up_inbox_idx": {
+          "name": "lab_results_follow_up_inbox_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_practice_record_uq": {
+          "name": "lab_results_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_creation_operation_uq": {
+          "name": "lab_results_creation_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "creation_operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_appointment_idx": {
+          "name": "lab_results_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_results_visit_source_uq": {
+          "name": "lab_results_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_results_practice_id_practices_id_fk": {
+          "name": "lab_results_practice_id_practices_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_patient_id_patients_id_fk": {
+          "name": "lab_results_patient_id_patients_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_appointment_id_appointments_id_fk": {
+          "name": "lab_results_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_ordered_by_users_id_fk": {
+          "name": "lab_results_ordered_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_reviewed_by_users_id_fk": {
+          "name": "lab_results_reviewed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_results_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_follow_up_completed_by_users_id_fk": {
+          "name": "lab_results_follow_up_completed_by_users_id_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_patient_fk": {
+          "name": "lab_results_practice_patient_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_appointment_fk": {
+          "name": "lab_results_practice_appointment_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_ordered_by_fk": {
+          "name": "lab_results_practice_ordered_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "ordered_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_reviewed_by_fk": {
+          "name": "lab_results_practice_reviewed_by_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_assigned_fk": {
+          "name": "lab_results_practice_follow_up_assigned_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_results_practice_follow_up_completed_fk": {
+          "name": "lab_results_practice_follow_up_completed_fk",
+          "tableFrom": "lab_results",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_completed_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_results_lifecycle_shape_check": {
+          "name": "lab_results_lifecycle_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"completed_at\" is null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'completed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is null\n          and \"lab_results\".\"reviewed_by\" is null\n        ) or (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"completed_at\" is not null\n          and \"lab_results\".\"reviewed_at\" is not null\n          and \"lab_results\".\"reviewed_by\" is not null\n        )"
+        },
+        "lab_results_creation_operation_shape_check": {
+          "name": "lab_results_creation_operation_shape_check",
+          "value": "(\"lab_results\".\"creation_operation_id\" is null and \"lab_results\".\"creation_payload_hash\" is null)\n        or (\"lab_results\".\"creation_operation_id\" is not null and \"lab_results\".\"creation_payload_hash\" ~ '^[0-9a-f]{64}$')"
+        },
+        "lab_results_result_shape_check": {
+          "name": "lab_results_result_shape_check",
+          "value": "(\n          \"lab_results\".\"status\" = 'pending'\n          and \"lab_results\".\"result_value\" is null\n          and \"lab_results\".\"unit\" is null\n          and \"lab_results\".\"reference_range_low\" is null\n          and \"lab_results\".\"reference_range_high\" is null\n          and \"lab_results\".\"result_flag\" = 'unknown'\n        ) or (\n          \"lab_results\".\"status\" in ('completed', 'reviewed')\n          and length(btrim(coalesce(\"lab_results\".\"result_value\", ''))) > 0\n        )"
+        },
+        "lab_results_follow_up_shape_check": {
+          "name": "lab_results_follow_up_shape_check",
+          "value": "(\"lab_results\".\"status\" <> 'pending' or \"lab_results\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_results\".\"status\" = 'reviewed'\n          and \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_results\".\"result_flag\" = 'critical'\n          and \"lab_results\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_results\".\"follow_up_due_at\" is null\n        )\n        and ((\n          \"lab_results\".\"follow_up_status\" = 'not_required'\n          and \"lab_results\".\"follow_up_assigned_to\" is null\n          and \"lab_results\".\"follow_up_due_at\" is null\n          and \"lab_results\".\"follow_up_note\" is null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'open'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is null\n          and \"lab_results\".\"follow_up_completed_at\" is null\n          and \"lab_results\".\"follow_up_outcome\" is null\n        ) or (\n          \"lab_results\".\"follow_up_status\" = 'completed'\n          and \"lab_results\".\"follow_up_assigned_to\" is not null\n          and \"lab_results\".\"follow_up_completed_by\" is not null\n          and \"lab_results\".\"follow_up_completed_at\" is not null\n          and length(btrim(coalesce(\"lab_results\".\"follow_up_outcome\", ''))) between 3 and 1000\n        ))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.problem_list": {
+      "name": "problem_list",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "problem_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "onset_date": {
+          "name": "onset_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_date": {
+          "name": "resolved_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "problem_list_patient_status_idx": {
+          "name": "problem_list_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "problem_list_practice_status_idx": {
+          "name": "problem_list_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "problem_list_practice_id_practices_id_fk": {
+          "name": "problem_list_practice_id_practices_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "problem_list_patient_id_patients_id_fk": {
+          "name": "problem_list_patient_id_patients_id_fk",
+          "tableFrom": "problem_list",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.procedures": {
+      "name": "procedures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anesthesia_used": {
+          "name": "anesthesia_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "procedures_patient_idx": {
+          "name": "procedures_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_practice_idx": {
+          "name": "procedures_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_appointment_idx": {
+          "name": "procedures_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "procedures_visit_source_uq": {
+          "name": "procedures_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "procedures_practice_id_practices_id_fk": {
+          "name": "procedures_practice_id_practices_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_patient_id_patients_id_fk": {
+          "name": "procedures_patient_id_patients_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_appointment_id_appointments_id_fk": {
+          "name": "procedures_appointment_id_appointments_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_performed_by_users_id_fk": {
+          "name": "procedures_performed_by_users_id_fk",
+          "tableFrom": "procedures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "procedures_practice_appointment_fk": {
+          "name": "procedures_practice_appointment_fk",
+          "tableFrom": "procedures",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.soap_note_addenda": {
+      "name": "soap_note_addenda",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_addenda_history_idx": {
+          "name": "soap_note_addenda_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_addenda_operation_uq": {
+          "name": "soap_note_addenda_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_addenda_practice_id_practices_id_fk": {
+          "name": "soap_note_addenda_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_source_fk": {
+          "name": "soap_note_addenda_practice_source_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_addenda_practice_author_fk": {
+          "name": "soap_note_addenda_practice_author_fk",
+          "tableFrom": "soap_note_addenda",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_addenda_content_check": {
+          "name": "soap_note_addenda_content_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"content\")) between 1 and 10000"
+        },
+        "soap_note_addenda_author_name_check": {
+          "name": "soap_note_addenda_author_name_check",
+          "value": "length(btrim(\"soap_note_addenda\".\"author_name\")) between 1 and 255"
+        },
+        "soap_note_addenda_payload_hash_check": {
+          "name": "soap_note_addenda_payload_hash_check",
+          "value": "\"soap_note_addenda\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_notes": {
+      "name": "soap_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "soap_note_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'finalized'"
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_by": {
+          "name": "finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalizer_name": {
+          "name": "finalizer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjective": {
+          "name": "subjective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assessment": {
+          "name": "assessment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imported": {
+          "name": "imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "soap_notes_patient_idx": {
+          "name": "soap_notes_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_record_uq": {
+          "name": "soap_notes_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_import_fingerprint_uq": {
+          "name": "soap_notes_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"import_fingerprint\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_practice_idx": {
+          "name": "soap_notes_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_appointment_idx": {
+          "name": "soap_notes_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_notes_active_appointment_draft_uq": {
+          "name": "soap_notes_active_appointment_draft_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"soap_notes\".\"status\" = 'draft' and \"soap_notes\".\"appointment_id\" is not null and \"soap_notes\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_notes_practice_id_practices_id_fk": {
+          "name": "soap_notes_practice_id_practices_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_patient_id_patients_id_fk": {
+          "name": "soap_notes_patient_id_patients_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_appointment_id_appointments_id_fk": {
+          "name": "soap_notes_appointment_id_appointments_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_author_id_users_id_fk": {
+          "name": "soap_notes_author_id_users_id_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_patient_fk": {
+          "name": "soap_notes_practice_patient_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_appointment_fk": {
+          "name": "soap_notes_practice_appointment_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_author_fk": {
+          "name": "soap_notes_practice_author_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "author_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_notes_practice_finalizer_fk": {
+          "name": "soap_notes_practice_finalizer_fk",
+          "tableFrom": "soap_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "finalized_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_notes_import_fingerprint_check": {
+          "name": "soap_notes_import_fingerprint_check",
+          "value": "\"soap_notes\".\"import_fingerprint\" is null or \"soap_notes\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "soap_notes_revision_check": {
+          "name": "soap_notes_revision_check",
+          "value": "\"soap_notes\".\"revision\" >= 1"
+        },
+        "soap_notes_author_name_check": {
+          "name": "soap_notes_author_name_check",
+          "value": "length(btrim(\"soap_notes\".\"author_name\")) between 1 and 255"
+        },
+        "soap_notes_lifecycle_check": {
+          "name": "soap_notes_lifecycle_check",
+          "value": "(\n        \"soap_notes\".\"status\" = 'draft'\n        and \"soap_notes\".\"finalized_at\" is null\n        and \"soap_notes\".\"finalized_by\" is null\n        and \"soap_notes\".\"finalizer_name\" is null\n        and \"soap_notes\".\"imported\" = false\n      ) or (\n        \"soap_notes\".\"status\" = 'finalized'\n        and \"soap_notes\".\"finalized_at\" is not null\n        and \"soap_notes\".\"finalized_by\" is not null\n        and length(btrim(\"soap_notes\".\"finalizer_name\")) between 1 and 255\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.treatment_plan_items": {
+      "name": "treatment_plan_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_plan_items_plan_order_idx": {
+          "name": "treatment_plan_items_plan_order_idx",
+          "columns": [
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plan_items_plan_id_treatment_plans_id_fk": {
+          "name": "treatment_plan_items_plan_id_treatment_plans_id_fk",
+          "tableFrom": "treatment_plan_items",
+          "tableTo": "treatment_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_plans": {
+      "name": "treatment_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem_id": {
+          "name": "problem_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "treatment_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "treatment_plans_patient_idx": {
+          "name": "treatment_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "treatment_plans_practice_idx": {
+          "name": "treatment_plans_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_plans_practice_id_practices_id_fk": {
+          "name": "treatment_plans_practice_id_practices_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_patient_id_patients_id_fk": {
+          "name": "treatment_plans_patient_id_patients_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_problem_id_problem_list_id_fk": {
+          "name": "treatment_plans_problem_id_problem_list_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "problem_list",
+          "columnsFrom": [
+            "problem_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "treatment_plans_created_by_users_id_fk": {
+          "name": "treatment_plans_created_by_users_id_fk",
+          "tableFrom": "treatment_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vaccination_records": {
+      "name": "vaccination_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccine_name": {
+          "name": "vaccine_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_fingerprint": {
+          "name": "import_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manufacturer": {
+          "name": "manufacturer",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_by": {
+          "name": "administered_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "administered_at": {
+          "name": "administered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_url": {
+          "name": "certificate_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vaccination_records_patient_idx": {
+          "name": "vaccination_records_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_record_uq": {
+          "name": "vaccination_records_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_practice_due_idx": {
+          "name": "vaccination_records_practice_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_appointment_idx": {
+          "name": "vaccination_records_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_visit_source_uq": {
+          "name": "vaccination_records_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vaccination_records_import_fingerprint_uq": {
+          "name": "vaccination_records_import_fingerprint_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "import_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"vaccination_records\".\"import_fingerprint\" is not null and \"vaccination_records\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vaccination_records_practice_id_practices_id_fk": {
+          "name": "vaccination_records_practice_id_practices_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_patient_id_patients_id_fk": {
+          "name": "vaccination_records_patient_id_patients_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_appointment_id_appointments_id_fk": {
+          "name": "vaccination_records_appointment_id_appointments_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_administered_by_users_id_fk": {
+          "name": "vaccination_records_administered_by_users_id_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "administered_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vaccination_records_practice_appointment_fk": {
+          "name": "vaccination_records_practice_appointment_fk",
+          "tableFrom": "vaccination_records",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "vaccination_records_import_fingerprint_check": {
+          "name": "vaccination_records_import_fingerprint_check",
+          "value": "\"vaccination_records\".\"import_fingerprint\" is null or \"vaccination_records\".\"import_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.vital_signs": {
+      "name": "vital_signs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "temperature_c": {
+          "name": "temperature_c",
+          "type": "numeric(4, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heart_rate_bpm": {
+          "name": "heart_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "respiratory_rate_bpm": {
+          "name": "respiratory_rate_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight_kg": {
+          "name": "weight_kg",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_condition_score": {
+          "name": "body_condition_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pain_score": {
+          "name": "pain_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mucous_membrane": {
+          "name": "mucous_membrane",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capillary_refill_sec": {
+          "name": "capillary_refill_sec",
+          "type": "numeric(3, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vital_signs_patient_idx": {
+          "name": "vital_signs_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_record_uq": {
+          "name": "vital_signs_practice_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_practice_idx": {
+          "name": "vital_signs_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vital_signs_appointment_idx": {
+          "name": "vital_signs_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recorded_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vital_signs_practice_id_practices_id_fk": {
+          "name": "vital_signs_practice_id_practices_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_patient_id_patients_id_fk": {
+          "name": "vital_signs_patient_id_patients_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_appointment_id_appointments_id_fk": {
+          "name": "vital_signs_appointment_id_appointments_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_recorded_by_users_id_fk": {
+          "name": "vital_signs_recorded_by_users_id_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_patient_fk": {
+          "name": "vital_signs_practice_patient_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vital_signs_practice_appointment_fk": {
+          "name": "vital_signs_practice_appointment_fk",
+          "tableFrom": "vital_signs",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_result_events": {
+      "name": "lab_result_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "lab_result_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "lab_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_value": {
+          "name": "result_value",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_low": {
+          "name": "reference_range_low",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_range_high": {
+          "name": "reference_range_high",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_flag": {
+          "name": "result_flag",
+          "type": "lab_result_flag",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_up_status": {
+          "name": "follow_up_status",
+          "type": "lab_follow_up_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_at": {
+          "name": "follow_up_due_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_events_result_history_idx": {
+          "name": "lab_result_events_result_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_time_idx": {
+          "name": "lab_result_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_practice_operation_uq": {
+          "name": "lab_result_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_events_created_uq": {
+          "name": "lab_result_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"lab_result_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_events_practice_id_practices_id_fk": {
+          "name": "lab_result_events_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_events_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_id_patients_id_fk": {
+          "name": "lab_result_events_patient_id_patients_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_id_appointments_id_fk": {
+          "name": "lab_result_events_appointment_id_appointments_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_follow_up_assigned_to_users_id_fk": {
+          "name": "lab_result_events_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_id_users_id_fk": {
+          "name": "lab_result_events_actor_id_users_id_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_result_tenant_fk": {
+          "name": "lab_result_events_result_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_patient_tenant_fk": {
+          "name": "lab_result_events_patient_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_appointment_tenant_fk": {
+          "name": "lab_result_events_appointment_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_actor_tenant_fk": {
+          "name": "lab_result_events_actor_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_events_assignee_tenant_fk": {
+          "name": "lab_result_events_assignee_tenant_fk",
+          "tableFrom": "lab_result_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_events_shape_check": {
+          "name": "lab_result_events_shape_check",
+          "value": "length(btrim(\"lab_result_events\".\"actor_name\")) between 1 and 255\n        and \"lab_result_events\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        and (\"lab_result_events\".\"note\" is null or length(\"lab_result_events\".\"note\") <= 1000)\n        and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"follow_up_status\" = 'not_required')\n        and not (\n          \"lab_result_events\".\"status_after\" = 'reviewed'\n          and \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" = 'not_required'\n        )\n        and not (\n          \"lab_result_events\".\"result_flag\" = 'critical'\n          and \"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n          and \"lab_result_events\".\"follow_up_due_at\" is null\n        )\n        and (\n          (\"lab_result_events\".\"status_after\" = 'pending'\n            and \"lab_result_events\".\"result_value\" is null\n            and \"lab_result_events\".\"unit\" is null\n            and \"lab_result_events\".\"reference_range_low\" is null\n            and \"lab_result_events\".\"reference_range_high\" is null\n            and \"lab_result_events\".\"result_flag\" = 'unknown')\n          or (\"lab_result_events\".\"status_after\" in ('completed', 'reviewed')\n            and length(btrim(coalesce(\"lab_result_events\".\"result_value\", ''))) between 1 and 128)\n        )\n        and (\n          (\"lab_result_events\".\"follow_up_status\" = 'not_required'\n            and \"lab_result_events\".\"follow_up_assigned_to\" is null\n            and \"lab_result_events\".\"follow_up_due_at\" is null)\n          or (\"lab_result_events\".\"follow_up_status\" in ('open', 'completed')\n            and \"lab_result_events\".\"follow_up_assigned_to\" is not null)\n        )\n        and (\n          \"lab_result_events\".\"event_type\" = 'created'\n          and \"lab_result_events\".\"status_before\" is null\n          and \"lab_result_events\".\"status_after\" in ('pending', 'completed')\n          and (\"lab_result_events\".\"status_after\" <> 'pending' or \"lab_result_events\".\"result_flag\" = 'unknown')\n        or \"lab_result_events\".\"event_type\" = 'completed'\n          and \"lab_result_events\".\"status_before\" = 'pending'\n          and \"lab_result_events\".\"status_after\" = 'completed'\n        or \"lab_result_events\".\"event_type\" = 'reviewed'\n          and \"lab_result_events\".\"status_before\" = 'completed'\n          and \"lab_result_events\".\"status_after\" = 'reviewed'\n        or \"lab_result_events\".\"event_type\" in ('follow_up_assigned', 'follow_up_reassigned')\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'open'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n        or \"lab_result_events\".\"event_type\" = 'follow_up_completed'\n          and \"lab_result_events\".\"status_before\" = \"lab_result_events\".\"status_after\"\n          and \"lab_result_events\".\"follow_up_status\" = 'completed'\n          and \"lab_result_events\".\"follow_up_assigned_to\" is not null\n          and length(btrim(coalesce(\"lab_result_events\".\"note\", ''))) between 3 and 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clinical_record_corrections": {
+      "name": "clinical_record_corrections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_type": {
+          "name": "record_type",
+          "type": "clinical_correction_record_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "clinical_correction_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'entered_in_error'"
+        },
+        "soap_note_id": {
+          "name": "soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vital_sign_id": {
+          "name": "vital_sign_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by": {
+          "name": "corrected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "corrected_by_name": {
+          "name": "corrected_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clinical_record_corrections_practice_patient_history_idx": {
+          "name": "clinical_record_corrections_practice_patient_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_appointment_history_idx": {
+          "name": "clinical_record_corrections_practice_appointment_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_type_history_idx": {
+          "name": "clinical_record_corrections_practice_type_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "record_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_soap_note_uq": {
+          "name": "clinical_record_corrections_soap_note_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"soap_note_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vital_sign_uq": {
+          "name": "clinical_record_corrections_vital_sign_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vital_sign_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vital_sign_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_vaccination_record_uq": {
+          "name": "clinical_record_corrections_vaccination_record_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"vaccination_record_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_lab_result_uq": {
+          "name": "clinical_record_corrections_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"lab_result_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_operation_uq": {
+          "name": "clinical_record_corrections_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clinical_record_corrections\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_lab_source_uq": {
+          "name": "clinical_record_corrections_practice_record_lab_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clinical_record_corrections_practice_record_soap_source_uq": {
+          "name": "clinical_record_corrections_practice_record_soap_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clinical_record_corrections_practice_id_practices_id_fk": {
+          "name": "clinical_record_corrections_practice_id_practices_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_note_id_soap_notes_id_fk": {
+          "name": "clinical_record_corrections_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_sign_id_vital_signs_id_fk": {
+          "name": "clinical_record_corrections_vital_sign_id_vital_signs_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "clinical_record_corrections_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_id_lab_results_id_fk": {
+          "name": "clinical_record_corrections_lab_result_id_lab_results_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_patient_id_patients_id_fk": {
+          "name": "clinical_record_corrections_patient_id_patients_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_appointment_id_appointments_id_fk": {
+          "name": "clinical_record_corrections_appointment_id_appointments_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_corrected_by_users_id_fk": {
+          "name": "clinical_record_corrections_corrected_by_users_id_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_appointment_fk": {
+          "name": "clinical_record_corrections_practice_appointment_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "patient_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_patient_fk": {
+          "name": "clinical_record_corrections_practice_patient_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_practice_actor_fk": {
+          "name": "clinical_record_corrections_practice_actor_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "corrected_by"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_soap_source_fk": {
+          "name": "clinical_record_corrections_soap_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vital_source_fk": {
+          "name": "clinical_record_corrections_vital_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vital_signs",
+          "columnsFrom": [
+            "practice_id",
+            "vital_sign_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_vaccination_source_fk": {
+          "name": "clinical_record_corrections_vaccination_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "clinical_record_corrections_lab_result_source_fk": {
+          "name": "clinical_record_corrections_lab_result_source_fk",
+          "tableFrom": "clinical_record_corrections",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "clinical_record_corrections_source_type_check": {
+          "name": "clinical_record_corrections_source_type_check",
+          "value": "(\n        \"clinical_record_corrections\".\"record_type\" = 'soap_note'\n        and \"clinical_record_corrections\".\"soap_note_id\" is not null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vital_sign'\n        and \"clinical_record_corrections\".\"vital_sign_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'vaccination_record'\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"lab_result_id\" is null\n      ) or (\n        \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n        and \"clinical_record_corrections\".\"lab_result_id\" is not null\n        and \"clinical_record_corrections\".\"soap_note_id\" is null\n        and \"clinical_record_corrections\".\"vital_sign_id\" is null\n        and \"clinical_record_corrections\".\"vaccination_record_id\" is null\n      )"
+        },
+        "clinical_record_corrections_operation_shape_check": {
+          "name": "clinical_record_corrections_operation_shape_check",
+          "value": "(\n          \"clinical_record_corrections\".\"record_type\" = 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is not null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'\n        ) or (\n          \"clinical_record_corrections\".\"record_type\" <> 'lab_result'\n          and \"clinical_record_corrections\".\"operation_id\" is null\n          and \"clinical_record_corrections\".\"operation_payload_hash\" is null\n        )"
+        },
+        "clinical_record_corrections_reason_length_check": {
+          "name": "clinical_record_corrections_reason_length_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"reason\")) between 5 and 1000"
+        },
+        "clinical_record_corrections_actor_name_check": {
+          "name": "clinical_record_corrections_actor_name_check",
+          "value": "length(btrim(\"clinical_record_corrections\".\"corrected_by_name\")) between 1 and 255"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.lab_result_replacements": {
+      "name": "lab_result_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_lab_result_id": {
+          "name": "source_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_lab_result_id": {
+          "name": "replacement_lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lab_result_replacements_source_history_idx": {
+          "name": "lab_result_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_source_uq": {
+          "name": "lab_result_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_replacement_uq": {
+          "name": "lab_result_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lab_result_replacements_operation_uq": {
+          "name": "lab_result_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lab_result_replacements_practice_id_practices_id_fk": {
+          "name": "lab_result_replacements_practice_id_practices_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "lab_result_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_source_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk": {
+          "name": "lab_result_replacements_replacement_lab_result_id_lab_results_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_id_users_id_fk": {
+          "name": "lab_result_replacements_actor_id_users_id_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_source_tenant_fk": {
+          "name": "lab_result_replacements_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_replacement_tenant_fk": {
+          "name": "lab_result_replacements_replacement_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_correction_source_tenant_fk": {
+          "name": "lab_result_replacements_correction_source_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "lab_result_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_result_replacements_actor_tenant_fk": {
+          "name": "lab_result_replacements_actor_tenant_fk",
+          "tableFrom": "lab_result_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "lab_result_replacements_shape_check": {
+          "name": "lab_result_replacements_shape_check",
+          "value": "\"lab_result_replacements\".\"source_lab_result_id\" <> \"lab_result_replacements\".\"replacement_lab_result_id\"\n        and length(btrim(\"lab_result_replacements\".\"actor_name\")) between 1 and 255\n        and \"lab_result_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.soap_note_replacements": {
+      "name": "soap_note_replacements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correction_id": {
+          "name": "correction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_soap_note_id": {
+          "name": "source_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacement_soap_note_id": {
+          "name": "replacement_soap_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload_hash": {
+          "name": "operation_payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "soap_note_replacements_source_history_idx": {
+          "name": "soap_note_replacements_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_source_uq": {
+          "name": "soap_note_replacements_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_replacement_uq": {
+          "name": "soap_note_replacements_replacement_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "replacement_soap_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "soap_note_replacements_operation_uq": {
+          "name": "soap_note_replacements_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "soap_note_replacements_practice_id_practices_id_fk": {
+          "name": "soap_note_replacements_practice_id_practices_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_id_clinical_record_corrections_id_fk": {
+          "name": "soap_note_replacements_correction_id_clinical_record_corrections_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "correction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_source_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk": {
+          "name": "soap_note_replacements_replacement_soap_note_id_soap_notes_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "replacement_soap_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_id_users_id_fk": {
+          "name": "soap_note_replacements_actor_id_users_id_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_source_tenant_fk": {
+          "name": "soap_note_replacements_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_replacement_tenant_fk": {
+          "name": "soap_note_replacements_replacement_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "soap_notes",
+          "columnsFrom": [
+            "practice_id",
+            "replacement_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_correction_source_tenant_fk": {
+          "name": "soap_note_replacements_correction_source_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "clinical_record_corrections",
+          "columnsFrom": [
+            "practice_id",
+            "correction_id",
+            "source_soap_note_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id",
+            "soap_note_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "soap_note_replacements_actor_tenant_fk": {
+          "name": "soap_note_replacements_actor_tenant_fk",
+          "tableFrom": "soap_note_replacements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "soap_note_replacements_shape_check": {
+          "name": "soap_note_replacements_shape_check",
+          "value": "\"soap_note_replacements\".\"source_soap_note_id\" <> \"soap_note_replacements\".\"replacement_soap_note_id\"\n        and \"soap_note_replacements\".\"actor_name\" = btrim(\"soap_note_replacements\".\"actor_name\")\n        and length(btrim(\"soap_note_replacements\".\"actor_name\")) between 1 and 255\n        and \"soap_note_replacements\".\"operation_payload_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drug_interactions": {
+      "name": "drug_interactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drug_a": {
+          "name": "drug_a",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_b": {
+          "name": "drug_b",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "interaction_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescriptions": {
+      "name": "prescriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_name": {
+          "name": "medication_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dosage": {
+          "name": "dosage",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_remaining": {
+          "name": "refills_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prescribed_by": {
+          "name": "prescribed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescriptions_patient_status_idx": {
+          "name": "prescriptions_patient_status_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_status_idx": {
+          "name": "prescriptions_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_product_idx": {
+          "name": "prescriptions_product_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_appointment_idx": {
+          "name": "prescriptions_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_visit_source_uq": {
+          "name": "prescriptions_visit_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_operation_uq": {
+          "name": "prescriptions_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescriptions_practice_id_uq": {
+          "name": "prescriptions_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescriptions_practice_id_practices_id_fk": {
+          "name": "prescriptions_practice_id_practices_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_patient_id_patients_id_fk": {
+          "name": "prescriptions_patient_id_patients_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_appointment_id_appointments_id_fk": {
+          "name": "prescriptions_appointment_id_appointments_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_product_id_products_id_fk": {
+          "name": "prescriptions_product_id_products_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_prescribed_by_users_id_fk": {
+          "name": "prescriptions_prescribed_by_users_id_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "prescribed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescriptions_practice_appointment_fk": {
+          "name": "prescriptions_practice_appointment_fk",
+          "tableFrom": "prescriptions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prescription_events": {
+      "name": "prescription_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "prescription_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_before": {
+          "name": "status_before",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_after": {
+          "name": "status_after",
+          "type": "prescription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refills_before": {
+          "name": "refills_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refills_after": {
+          "name": "refills_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "prescription_events_prescription_history_idx": {
+          "name": "prescription_events_prescription_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_time_idx": {
+          "name": "prescription_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_operation_uq": {
+          "name": "prescription_events_practice_operation_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"operation_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_created_uq": {
+          "name": "prescription_events_created_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" = 'created'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_terminal_uq": {
+          "name": "prescription_events_terminal_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"prescription_events\".\"event_type\" in ('completed', 'cancelled', 'expired')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "prescription_events_practice_id_uq": {
+          "name": "prescription_events_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "prescription_events_practice_id_practices_id_fk": {
+          "name": "prescription_events_practice_id_practices_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_prescription_id_prescriptions_id_fk": {
+          "name": "prescription_events_prescription_id_prescriptions_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_patient_id_patients_id_fk": {
+          "name": "prescription_events_patient_id_patients_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_product_id_products_id_fk": {
+          "name": "prescription_events_product_id_products_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_actor_id_users_id_fk": {
+          "name": "prescription_events_actor_id_users_id_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_prescription_fk": {
+          "name": "prescription_events_practice_prescription_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_patient_fk": {
+          "name": "prescription_events_practice_patient_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_product_fk": {
+          "name": "prescription_events_practice_product_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prescription_events_practice_actor_fk": {
+          "name": "prescription_events_practice_actor_fk",
+          "tableFrom": "prescription_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prescription_events_shape_check": {
+          "name": "prescription_events_shape_check",
+          "value": "length(btrim(\"prescription_events\".\"actor_name\")) > 0\n        and \"prescription_events\".\"refills_after\" >= 0\n        and (\"prescription_events\".\"refills_before\" is null or \"prescription_events\".\"refills_before\" >= 0)\n        and (\"prescription_events\".\"reason\" is null or length(\"prescription_events\".\"reason\") <= 500)\n        and (\n          \"prescription_events\".\"event_type\" = 'created'\n          and \"prescription_events\".\"status_before\" is null\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"refills_before\" is null\n          and \"prescription_events\".\"actor_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_dispensed'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is not null\n          and \"prescription_events\".\"quantity\" > 0\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'refill_authorized'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'active'\n          and \"prescription_events\".\"product_id\" is null\n          and \"prescription_events\".\"refills_before\" > 0\n          and \"prescription_events\".\"refills_after\" = \"prescription_events\".\"refills_before\" - 1\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" in ('completed', 'cancelled')\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\"::text = \"prescription_events\".\"event_type\"::text\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n          and \"prescription_events\".\"actor_id\" is not null\n          and \"prescription_events\".\"operation_id\" is not null\n        or \"prescription_events\".\"event_type\" = 'expired'\n          and \"prescription_events\".\"status_before\" = 'active'\n          and \"prescription_events\".\"status_after\" = 'expired'\n          and length(btrim(coalesce(\"prescription_events\".\"reason\", ''))) >= 5\n          and \"prescription_events\".\"refills_before\" = \"prescription_events\".\"refills_after\"\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_adjustments": {
+      "name": "invoice_adjustments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_adjustment_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation_key": {
+          "name": "operation_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_adjustments_invoice_idx": {
+          "name": "invoice_adjustments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_adjustments_operation_key_uq": {
+          "name": "invoice_adjustments_operation_key_uq",
+          "columns": [
+            {
+              "expression": "operation_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_adjustments_invoice_id_invoices_id_fk": {
+          "name": "invoice_adjustments_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_adjustments_created_by_users_id_fk": {
+          "name": "invoice_adjustments_created_by_users_id_fk",
+          "tableFrom": "invoice_adjustments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoice_adjustments_operation_result_check": {
+          "name": "invoice_adjustments_operation_result_check",
+          "value": "(\"invoice_adjustments\".\"operation_key\" is null and \"invoice_adjustments\".\"balance_after\" is null)\n        or (\"invoice_adjustments\".\"operation_key\" is not null and \"invoice_adjustments\".\"balance_after\" is not null and \"invoice_adjustments\".\"balance_after\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_prescription_id": {
+          "name": "source_prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_dispense_charge_id": {
+          "name": "source_dispense_charge_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invoice_items_invoice_idx": {
+          "name": "invoice_items_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_item_idx": {
+          "name": "invoice_items_item_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_idx": {
+          "name": "invoice_items_source_prescription_idx",
+          "columns": [
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_prescription_invoice_uq": {
+          "name": "invoice_items_source_prescription_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_prescription_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_idx": {
+          "name": "invoice_items_source_dispense_charge_idx",
+          "columns": [
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_source_dispense_charge_invoice_uq": {
+          "name": "invoice_items_source_dispense_charge_invoice_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_dispense_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoice_items\".\"source_dispense_charge_id\" is not null and \"invoice_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoice_items_invoice_item_target_uq": {
+          "name": "invoice_items_invoice_item_target_uq",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoice_items_source_prescription_id_prescriptions_id_fk": {
+          "name": "invoice_items_source_prescription_id_prescriptions_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "source_prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "paid_amount": {
+          "name": "paid_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_estimate": {
+          "name": "is_estimate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "invoices_practice_idx": {
+          "name": "invoices_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_client_idx": {
+          "name": "invoices_client_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_patient_idx": {
+          "name": "invoices_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_appointment_idx": {
+          "name": "invoices_appointment_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_estimate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_active_appointment_uq": {
+          "name": "invoices_active_appointment_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"invoices\".\"appointment_id\" is not null\n          and \"invoices\".\"is_estimate\" = false\n          and \"invoices\".\"status\" <> 'void'\n          and \"invoices\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invoices_visit_target_uq": {
+          "name": "invoices_visit_target_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_practice_id_practices_id_fk": {
+          "name": "invoices_practice_id_practices_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_patient_id_patients_id_fk": {
+          "name": "invoices_patient_id_patients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_appointment_id_appointments_id_fk": {
+          "name": "invoices_appointment_id_appointments_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_by": {
+          "name": "received_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payments_invoice_idx": {
+          "name": "payments_invoice_idx",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_external_id_uq": {
+          "name": "payments_external_id_uq",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_received_by_users_id_fk": {
+          "name": "payments_received_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "received_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_payment_accounts": {
+      "name": "practice_payment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stripe_connect'"
+        },
+        "stripe_account_id": {
+          "name": "stripe_account_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "payment_account_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "charges_enabled": {
+          "name": "charges_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "payouts_enabled": {
+          "name": "payouts_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "details_submitted": {
+          "name": "details_submitted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requirements_currently_due": {
+          "name": "requirements_currently_due",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements_disabled_reason": {
+          "name": "requirements_disabled_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_payment_accounts_practice_provider_uq": {
+          "name": "practice_payment_accounts_practice_provider_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_stripe_account_uq": {
+          "name": "practice_payment_accounts_stripe_account_uq",
+          "columns": [
+            {
+              "expression": "stripe_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_payment_accounts_status_idx": {
+          "name": "practice_payment_accounts_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onboarding_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_payment_accounts_practice_id_practices_id_fk": {
+          "name": "practice_payment_accounts_practice_id_practices_id_fk",
+          "tableFrom": "practice_payment_accounts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sku": {
+          "name": "sku",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stock_quantity": {
+          "name": "stock_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reorder_point": {
+          "name": "reorder_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "products_practice_idx": {
+          "name": "products_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_name_idx": {
+          "name": "products_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_location_idx": {
+          "name": "products_location_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_sku_idx": {
+          "name": "products_sku_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sku",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_expiration_idx": {
+          "name": "products_expiration_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_stock_alert_idx": {
+          "name": "products_stock_alert_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stock_quantity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_practice_id_uq": {
+          "name": "products_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_practice_id_practices_id_fk": {
+          "name": "products_practice_id_practices_id_fk",
+          "tableFrom": "products",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "products_location_id_locations_id_fk": {
+          "name": "products_location_id_locations_id_fk",
+          "tableFrom": "products",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.purchase_orders": {
+      "name": "purchase_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "purchase_order_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "purchase_orders_practice_id_practices_id_fk": {
+          "name": "purchase_orders_practice_id_practices_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "purchase_orders_supplier_id_suppliers_id_fk": {
+          "name": "purchase_orders_supplier_id_suppliers_id_fk",
+          "tableFrom": "purchase_orders",
+          "tableTo": "suppliers",
+          "columnsFrom": [
+            "supplier_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taxable": {
+          "name": "taxable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "services_practice_name_idx": {
+          "name": "services_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "services_practice_id_practices_id_fk": {
+          "name": "services_practice_id_practices_id_fk",
+          "tableFrom": "services",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "services_default_price_nonnegative": {
+          "name": "services_default_price_nonnegative",
+          "value": "\"services\".\"default_price\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suppliers_practice_name_idx": {
+          "name": "suppliers_practice_name_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppliers_practice_id_practices_id_fk": {
+          "name": "suppliers_practice_id_practices_id_fk",
+          "tableFrom": "suppliers",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dispense_charge_queue": {
+      "name": "dispense_charge_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_event_id": {
+          "name": "prescription_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description_snapshot": {
+          "name": "description_snapshot",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price_snapshot": {
+          "name": "unit_price_snapshot",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "dispense_charge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_name": {
+          "name": "resolved_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_reason": {
+          "name": "resolution_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_review": {
+          "name": "legacy_review",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "dispense_charge_queue_source_uq": {
+          "name": "dispense_charge_queue_source_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_pending_idx": {
+          "name": "dispense_charge_queue_pending_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispense_charge_queue\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_patient_idx": {
+          "name": "dispense_charge_queue_patient_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dispense_charge_queue_invoice_item_uq": {
+          "name": "dispense_charge_queue_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"dispense_charge_queue\".\"invoice_item_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dispense_charge_queue_practice_id_practices_id_fk": {
+          "name": "dispense_charge_queue_practice_id_practices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_event_id_prescription_events_id_fk": {
+          "name": "dispense_charge_queue_prescription_event_id_prescription_events_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_prescription_id_prescriptions_id_fk": {
+          "name": "dispense_charge_queue_prescription_id_prescriptions_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_patient_id_patients_id_fk": {
+          "name": "dispense_charge_queue_patient_id_patients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_client_id_clients_id_fk": {
+          "name": "dispense_charge_queue_client_id_clients_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_appointment_id_appointments_id_fk": {
+          "name": "dispense_charge_queue_appointment_id_appointments_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_product_id_products_id_fk": {
+          "name": "dispense_charge_queue_product_id_products_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_id_invoices_id_fk": {
+          "name": "dispense_charge_queue_invoice_id_invoices_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_id_invoice_items_id_fk": {
+          "name": "dispense_charge_queue_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_resolved_by_users_id_fk": {
+          "name": "dispense_charge_queue_resolved_by_users_id_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_event_fk": {
+          "name": "dispense_charge_queue_practice_event_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescription_events",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_event_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_prescription_fk": {
+          "name": "dispense_charge_queue_practice_prescription_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_patient_fk": {
+          "name": "dispense_charge_queue_practice_patient_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "practice_id",
+            "patient_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_product_fk": {
+          "name": "dispense_charge_queue_practice_product_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "products",
+          "columnsFrom": [
+            "practice_id",
+            "product_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_practice_appointment_fk": {
+          "name": "dispense_charge_queue_practice_appointment_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dispense_charge_queue_invoice_item_target_fk": {
+          "name": "dispense_charge_queue_invoice_item_target_fk",
+          "tableFrom": "dispense_charge_queue",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "dispense_charge_queue_shape_check": {
+          "name": "dispense_charge_queue_shape_check",
+          "value": "\"dispense_charge_queue\".\"quantity\" > 0\n        and \"dispense_charge_queue\".\"unit_price_snapshot\" >= 0\n        and length(btrim(\"dispense_charge_queue\".\"description_snapshot\")) > 0\n        and (\n          \"dispense_charge_queue\".\"status\" = 'pending'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is null\n          and \"dispense_charge_queue\".\"resolved_by_name\" is null\n          and \"dispense_charge_queue\".\"resolved_at\" is null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'invoiced'\n          and \"dispense_charge_queue\".\"invoice_id\" is not null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is not null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and \"dispense_charge_queue\".\"resolution_reason\" is null\n        or \"dispense_charge_queue\".\"status\" = 'waived'\n          and \"dispense_charge_queue\".\"invoice_id\" is null\n          and \"dispense_charge_queue\".\"invoice_item_id\" is null\n          and \"dispense_charge_queue\".\"resolved_by\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolved_by_name\", ''))) > 0\n          and \"dispense_charge_queue\".\"resolved_at\" is not null\n          and length(btrim(coalesce(\"dispense_charge_queue\".\"resolution_reason\", ''))) >= 5\n          and length(\"dispense_charge_queue\".\"resolution_reason\") <= 1000\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_prefix_idx": {
+          "name": "api_keys_prefix_idx",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_practice_created_idx": {
+          "name": "api_keys_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_practice_id_practices_id_fk": {
+          "name": "api_keys_practice_id_practices_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "audit_log_practice_idx": {
+          "name": "audit_log_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_entity_idx": {
+          "name": "audit_log_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_practice_id_practices_id_fk": {
+          "name": "audit_log_practice_id_practices_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.communications": {
+      "name": "communications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "comm_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "comm_direction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "comm_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "communications_practice_id_uq": {
+          "name": "communications_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_practice_list_idx": {
+          "name": "communications_practice_list_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_client_timeline_idx": {
+          "name": "communications_client_timeline_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_inbox_status_idx": {
+          "name": "communications_inbox_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_assigned_idx": {
+          "name": "communications_assigned_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_dedupe_key_idx": {
+          "name": "communications_dedupe_key_idx",
+          "columns": [
+            {
+              "expression": "dedupe_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "communications_provider_message_idx": {
+          "name": "communications_provider_message_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "communications_practice_id_practices_id_fk": {
+          "name": "communications_practice_id_practices_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_client_id_clients_id_fk": {
+          "name": "communications_client_id_clients_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "communications_assigned_to_users_id_fk": {
+          "name": "communications_assigned_to_users_id_fk",
+          "tableFrom": "communications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "secret": {
+          "name": "secret",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "webhooks_practice_active_idx": {
+          "name": "webhooks_practice_active_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_practice_id_practices_id_fk": {
+          "name": "webhooks_practice_id_practices_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sessions_expires_idx": {
+          "name": "sessions_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_tokens_expires_idx": {
+          "name": "verification_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "verification_tokens_identifier_token_pk": {
+          "name": "verification_tokens_identifier_token_pk",
+          "columns": [
+            "identifier",
+            "token"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "verification_tokens_token_unique": {
+          "name": "verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.controlled_substance_log": {
+      "name": "controlled_substance_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drug_name": {
+          "name": "drug_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dea_schedule": {
+          "name": "dea_schedule",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "controlled_substance_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witnessed_by": {
+          "name": "witnessed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lot_number": {
+          "name": "lot_number",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cs_log_practice_drug_date_idx": {
+          "name": "cs_log_practice_drug_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "drug_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cs_log_practice_date_idx": {
+          "name": "cs_log_practice_date_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "performed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "controlled_substance_log_practice_id_practices_id_fk": {
+          "name": "controlled_substance_log_practice_id_practices_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_patient_id_patients_id_fk": {
+          "name": "controlled_substance_log_patient_id_patients_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_performed_by_users_id_fk": {
+          "name": "controlled_substance_log_performed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "controlled_substance_log_witnessed_by_users_id_fk": {
+          "name": "controlled_substance_log_witnessed_by_users_id_fk",
+          "tableFrom": "controlled_substance_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "witnessed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capture_sessions": {
+      "name": "capture_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "capture_sessions_token_uq": {
+          "name": "capture_sessions_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_practice_idx": {
+          "name": "capture_sessions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "capture_sessions_patient_idx": {
+          "name": "capture_sessions_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "capture_sessions_practice_id_practices_id_fk": {
+          "name": "capture_sessions_practice_id_practices_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_patient_id_patients_id_fk": {
+          "name": "capture_sessions_patient_id_patients_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_created_by_users_id_fk": {
+          "name": "capture_sessions_created_by_users_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "capture_sessions_appointment_id_appointments_id_fk": {
+          "name": "capture_sessions_appointment_id_appointments_id_fk",
+          "tableFrom": "capture_sessions",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_practice_idx": {
+          "name": "files_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_entity_idx": {
+          "name": "files_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_uploaded_by_idx": {
+          "name": "files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_category_idx": {
+          "name": "files_category_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_appointment_idx": {
+          "name": "files_appointment_idx",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_practice_id_practices_id_fk": {
+          "name": "files_practice_id_practices_id_fk",
+          "tableFrom": "files",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_users_id_fk": {
+          "name": "files_uploaded_by_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_appointment_id_appointments_id_fk": {
+          "name": "files_appointment_id_appointments_id_fk",
+          "tableFrom": "files",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_forms": {
+      "name": "consent_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "consent_forms_practice_slug_uq": {
+          "name": "consent_forms_practice_slug_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_forms_practice_idx": {
+          "name": "consent_forms_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_forms_practice_id_practices_id_fk": {
+          "name": "consent_forms_practice_id_practices_id_fk",
+          "tableFrom": "consent_forms",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_requests": {
+      "name": "consent_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "signer_name": {
+          "name": "signer_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consent_requests_token_uq": {
+          "name": "consent_requests_token_uq",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_practice_idx": {
+          "name": "consent_requests_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_requests_patient_idx": {
+          "name": "consent_requests_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_requests_practice_id_practices_id_fk": {
+          "name": "consent_requests_practice_id_practices_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_patient_id_patients_id_fk": {
+          "name": "consent_requests_patient_id_patients_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_created_by_users_id_fk": {
+          "name": "consent_requests_created_by_users_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_appointment_id_appointments_id_fk": {
+          "name": "consent_requests_appointment_id_appointments_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_form_id_consent_forms_id_fk": {
+          "name": "consent_requests_form_id_consent_forms_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "consent_forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "consent_requests_file_id_files_id_fk": {
+          "name": "consent_requests_file_id_files_id_fk",
+          "tableFrom": "consent_requests",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_template_items": {
+      "name": "treatment_template_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "invoice_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_quantity": {
+          "name": "default_quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "default_unit_price": {
+          "name": "default_unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "treatment_template_items_template_idx": {
+          "name": "treatment_template_items_template_idx",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_template_items_template_id_treatment_templates_id_fk": {
+          "name": "treatment_template_items_template_id_treatment_templates_id_fk",
+          "tableFrom": "treatment_template_items",
+          "tableTo": "treatment_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.treatment_templates": {
+      "name": "treatment_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "treatment_templates_practice_idx": {
+          "name": "treatment_templates_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "treatment_templates_practice_id_practices_id_fk": {
+          "name": "treatment_templates_practice_id_practices_id_fk",
+          "tableFrom": "treatment_templates",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_claims": {
+      "name": "insurance_claims",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claim_number": {
+          "name": "claim_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_amount": {
+          "name": "approved_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_claims_practice_idx": {
+          "name": "insurance_claims_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_policy_idx": {
+          "name": "insurance_claims_policy_idx",
+          "columns": [
+            {
+              "expression": "policy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_claims_status_idx": {
+          "name": "insurance_claims_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_claims_practice_id_practices_id_fk": {
+          "name": "insurance_claims_practice_id_practices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_policy_id_insurance_policies_id_fk": {
+          "name": "insurance_claims_policy_id_insurance_policies_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "insurance_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_claims_invoice_id_invoices_id_fk": {
+          "name": "insurance_claims_invoice_id_invoices_id_fk",
+          "tableFrom": "insurance_claims",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.insurance_policies": {
+      "name": "insurance_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_number": {
+          "name": "policy_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_number": {
+          "name": "group_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_type": {
+          "name": "coverage_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deductible": {
+          "name": "deductible",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverage_percent": {
+          "name": "coverage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_annual_benefit": {
+          "name": "max_annual_benefit",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "insurance_policies_practice_idx": {
+          "name": "insurance_policies_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_patient_idx": {
+          "name": "insurance_policies_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "insurance_policies_client_idx": {
+          "name": "insurance_policies_client_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insurance_policies_practice_id_practices_id_fk": {
+          "name": "insurance_policies_practice_id_practices_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_client_id_clients_id_fk": {
+          "name": "insurance_policies_client_id_clients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "insurance_policies_patient_id_patients_id_fk": {
+          "name": "insurance_policies_patient_id_patients_id_fk",
+          "tableFrom": "insurance_policies",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_enrollments": {
+      "name": "wellness_enrollments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "enrollment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_billing_date": {
+          "name": "next_billing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wellness_enrollments_practice_idx": {
+          "name": "wellness_enrollments_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_due_idx": {
+          "name": "wellness_enrollments_due_idx",
+          "columns": [
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_billing_due_idx": {
+          "name": "wellness_enrollments_billing_due_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_billing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wellness_enrollments_target_idx": {
+          "name": "wellness_enrollments_target_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_enrollments_practice_id_practices_id_fk": {
+          "name": "wellness_enrollments_practice_id_practices_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_plan_id_wellness_plans_id_fk": {
+          "name": "wellness_enrollments_plan_id_wellness_plans_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "wellness_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_client_id_clients_id_fk": {
+          "name": "wellness_enrollments_client_id_clients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "wellness_enrollments_patient_id_patients_id_fk": {
+          "name": "wellness_enrollments_patient_id_patients_id_fk",
+          "tableFrom": "wellness_enrollments",
+          "tableTo": "patients",
+          "columnsFrom": [
+            "patient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wellness_plans": {
+      "name": "wellness_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_interval": {
+          "name": "billing_interval",
+          "type": "billing_interval",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "wellness_plans_practice_created_idx": {
+          "name": "wellness_plans_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wellness_plans_practice_id_practices_id_fk": {
+          "name": "wellness_plans_practice_id_practices_id_fk",
+          "tableFrom": "wellness_plans",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reset_at": {
+          "name": "reset_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_reset_at_idx": {
+          "name": "rate_limit_buckets_reset_at_idx",
+          "columns": [
+            {
+              "expression": "reset_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_created_at": {
+          "name": "event_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_kind": {
+          "name": "evidence_kind",
+          "type": "stripe_conversion_evidence_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_conversion_evidence_idx": {
+          "name": "stripe_events_conversion_evidence_idx",
+          "columns": [
+            {
+              "expression": "evidence_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"stripe_events\".\"evidence_kind\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_events_practice_id_practices_id_fk": {
+          "name": "stripe_events_practice_id_practices_id_fk",
+          "tableFrom": "stripe_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "stripe_events_event_id_endpoint_pk": {
+          "name": "stripe_events_event_id_endpoint_pk",
+          "columns": [
+            "event_id",
+            "endpoint"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "stripe_events_conversion_evidence_shape_check": {
+          "name": "stripe_events_conversion_evidence_shape_check",
+          "value": "(\n        \"stripe_events\".\"evidence_kind\" is null and\n        \"stripe_events\".\"event_created_at\" is null and\n        \"stripe_events\".\"object_id\" is null and\n        \"stripe_events\".\"amount_cents\" is null and\n        \"stripe_events\".\"currency\" is null\n      ) or (\n        \"stripe_events\".\"evidence_kind\" is not null and\n        \"stripe_events\".\"event_created_at\" is not null and\n        \"stripe_events\".\"object_id\" is not null and\n        length(btrim(\"stripe_events\".\"object_id\")) > 0 and\n        (\n          (\"stripe_events\".\"evidence_kind\" = 'subscription_checkout_completed' and\n            \"stripe_events\".\"amount_cents\" is null and \"stripe_events\".\"currency\" is null) or\n          (\"stripe_events\".\"evidence_kind\" = 'positive_subscription_invoice_paid' and\n            \"stripe_events\".\"amount_cents\" is not null and \"stripe_events\".\"amount_cents\" > 0 and\n            \"stripe_events\".\"currency\" is not null and\n            \"stripe_events\".\"currency\" ~ '^[a-z]{3}$')\n        )\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "period_month": {
+          "name": "period_month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_meter_identifier": {
+          "name": "stripe_meter_identifier",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_metered_at": {
+          "name": "stripe_metered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "usage_practice_period_idx": {
+          "name": "usage_practice_period_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usage_meter_retry_idx": {
+          "name": "usage_meter_retry_idx",
+          "columns": [
+            {
+              "expression": "stripe_metered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_records_practice_id_practices_id_fk": {
+          "name": "usage_records_practice_id_practices_id_fk",
+          "tableFrom": "usage_records",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_tokens": {
+      "name": "auth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_tokens_hash_idx": {
+          "name": "auth_tokens_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_tokens_expires_idx": {
+          "name": "auth_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_tokens_user_id_users_id_fk": {
+          "name": "auth_tokens_user_id_users_id_fk",
+          "tableFrom": "auth_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_email_attempts": {
+      "name": "auth_email_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "auth_email_attempt_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reserved'"
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_email_attempts_idempotency_uq": {
+          "name": "auth_email_attempts_idempotency_uq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_provider_message_uq": {
+          "name": "auth_email_attempts_provider_message_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"auth_email_attempts\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_recovery_idx": {
+          "name": "auth_email_attempts_recovery_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_attempts_practice_created_idx": {
+          "name": "auth_email_attempts_practice_created_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_attempts_practice_id_practices_id_fk": {
+          "name": "auth_email_attempts_practice_id_practices_id_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_email_attempts_user_tenant_fk": {
+          "name": "auth_email_attempts_user_tenant_fk",
+          "tableFrom": "auth_email_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_attempts_provider_check": {
+          "name": "auth_email_attempts_provider_check",
+          "value": "\"auth_email_attempts\".\"provider\" in ('resend', 'console')"
+        },
+        "auth_email_attempts_outcome_shape_check": {
+          "name": "auth_email_attempts_outcome_shape_check",
+          "value": "(\n        \"auth_email_attempts\".\"outcome\" = 'reserved'\n        and \"auth_email_attempts\".\"resolved_at\" is null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" = 'accepted'\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"provider_message_id\", ''))) > 0\n        and \"auth_email_attempts\".\"failure_code\" is null\n      ) or (\n        \"auth_email_attempts\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n        and \"auth_email_attempts\".\"resolved_at\" is not null\n        and \"auth_email_attempts\".\"provider_message_id\" is null\n        and length(btrim(coalesce(\"auth_email_attempts\".\"failure_code\", ''))) > 0\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_delivery_events": {
+      "name": "auth_email_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_body_fingerprint": {
+          "name": "raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "auth_email_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attribution": {
+          "name": "attribution",
+          "type": "auth_email_delivery_attribution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_delivery_events_webhook_uq": {
+          "name": "auth_email_delivery_events_webhook_uq",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attempt_timeline_idx": {
+          "name": "auth_email_delivery_events_attempt_timeline_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_provider_timeline_idx": {
+          "name": "auth_email_delivery_events_provider_timeline_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_delivery_events_attribution_queue_idx": {
+          "name": "auth_email_delivery_events_attribution_queue_idx",
+          "columns": [
+            {
+              "expression": "attribution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk": {
+          "name": "auth_email_delivery_events_attempt_id_auth_email_attempts_id_fk",
+          "tableFrom": "auth_email_delivery_events",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_delivery_events_provider_check": {
+          "name": "auth_email_delivery_events_provider_check",
+          "value": "\"auth_email_delivery_events\".\"provider\" = 'resend'"
+        },
+        "auth_email_delivery_events_event_type_check": {
+          "name": "auth_email_delivery_events_event_type_check",
+          "value": "\"auth_email_delivery_events\".\"event_type\" ~ '^email\\.'"
+        },
+        "auth_email_delivery_events_raw_body_fingerprint_check": {
+          "name": "auth_email_delivery_events_raw_body_fingerprint_check",
+          "value": "\"auth_email_delivery_events\".\"raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        },
+        "auth_email_delivery_events_attribution_shape_check": {
+          "name": "auth_email_delivery_events_attribution_shape_check",
+          "value": "(\n        \"auth_email_delivery_events\".\"attribution\" in ('attempt_tag', 'provider_message_id')\n        and \"auth_email_delivery_events\".\"attempt_id\" is not null\n      ) or (\n        \"auth_email_delivery_events\".\"attribution\" in ('unmatched', 'identity_conflict')\n        and \"auth_email_delivery_events\".\"attempt_id\" is null\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_provider_identity_conflicts": {
+      "name": "auth_email_provider_identity_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "source": {
+          "name": "source",
+          "type": "auth_email_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_provider_message_id": {
+          "name": "durable_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflicting_provider_message_id": {
+          "name": "conflicting_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_provider_identity_conflicts_identity_uq": {
+          "name": "auth_email_provider_identity_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "durable_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conflicting_provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_provider_identity_conflicts_recovery_idx": {
+          "name": "auth_email_provider_identity_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_provider_identity_conflicts_attempt_fk": {
+          "name": "auth_email_provider_identity_conflicts_attempt_fk",
+          "tableFrom": "auth_email_provider_identity_conflicts",
+          "tableTo": "auth_email_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_provider_identity_conflicts_provider_check": {
+          "name": "auth_email_provider_identity_conflicts_provider_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_provider_identity_conflicts_distinct_id_check": {
+          "name": "auth_email_provider_identity_conflicts_distinct_id_check",
+          "value": "\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\" <> \"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\""
+        },
+        "auth_email_provider_identity_conflicts_id_shape_check": {
+          "name": "auth_email_provider_identity_conflicts_id_shape_check",
+          "value": "length(btrim(\"auth_email_provider_identity_conflicts\".\"durable_provider_message_id\")) > 0\n        and length(btrim(\"auth_email_provider_identity_conflicts\".\"conflicting_provider_message_id\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_email_webhook_conflicts": {
+      "name": "auth_email_webhook_conflicts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "original_webhook_id": {
+          "name": "original_webhook_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_raw_body_fingerprint": {
+          "name": "incoming_raw_body_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'resend'"
+        },
+        "incoming_provider_message_id": {
+          "name": "incoming_provider_message_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incoming_event_type": {
+          "name": "incoming_event_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_email_webhook_conflicts_identity_uq": {
+          "name": "auth_email_webhook_conflicts_identity_uq",
+          "columns": [
+            {
+              "expression": "original_webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "incoming_raw_body_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_webhook_conflicts_recovery_idx": {
+          "name": "auth_email_webhook_conflicts_recovery_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_webhook_conflicts_webhook_fk": {
+          "name": "auth_email_webhook_conflicts_webhook_fk",
+          "tableFrom": "auth_email_webhook_conflicts",
+          "tableTo": "auth_email_delivery_events",
+          "columnsFrom": [
+            "original_webhook_id"
+          ],
+          "columnsTo": [
+            "webhook_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_email_webhook_conflicts_provider_check": {
+          "name": "auth_email_webhook_conflicts_provider_check",
+          "value": "\"auth_email_webhook_conflicts\".\"provider\" = 'resend'"
+        },
+        "auth_email_webhook_conflicts_event_type_check": {
+          "name": "auth_email_webhook_conflicts_event_type_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_event_type\" ~ '^email\\.'"
+        },
+        "auth_email_webhook_conflicts_raw_body_fingerprint_check": {
+          "name": "auth_email_webhook_conflicts_raw_body_fingerprint_check",
+          "value": "\"auth_email_webhook_conflicts\".\"incoming_raw_body_fingerprint\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_suppressions": {
+      "name": "email_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "email_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bounce'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "email_suppressions_practice_email_uq": {
+          "name": "email_suppressions_practice_email_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_suppressions_practice_idx": {
+          "name": "email_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_suppressions_practice_id_practices_id_fk": {
+          "name": "email_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "email_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.location_messaging": {
+      "name": "location_messaging",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "messaging_profile_id": {
+          "name": "messaging_profile_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_source": {
+          "name": "number_source",
+          "type": "messaging_number_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_brand_id": {
+          "name": "a2p_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "a2p_campaign_id": {
+          "name": "a2p_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "registration_detail": {
+          "name": "registration_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ready": {
+          "name": "provider_profile_ready",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "provider_profile_synced_at": {
+          "name": "provider_profile_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "location_messaging_practice_idx": {
+          "name": "location_messaging_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "location_messaging_sender_idx": {
+          "name": "location_messaging_sender_idx",
+          "columns": [
+            {
+              "expression": "sender_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "location_messaging_practice_id_practices_id_fk": {
+          "name": "location_messaging_practice_id_practices_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "location_messaging_location_id_locations_id_fk": {
+          "name": "location_messaging_location_id_locations_id_fk",
+          "tableFrom": "location_messaging",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "location_messaging_location_id_unique": {
+          "name": "location_messaging_location_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "location_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messaging_registrations": {
+      "name": "messaging_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'telnyx'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "messaging_business_entity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_encrypted": {
+          "name": "tax_id_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id_last4": {
+          "name": "tax_id_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_first_name": {
+          "name": "contact_first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_last_name": {
+          "name": "contact_last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "business_phone": {
+          "name": "business_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'US'"
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_at": {
+          "name": "compliance_attested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compliance_attested_by": {
+          "name": "compliance_attested_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_usecase": {
+          "name": "campaign_usecase",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MIXED'"
+        },
+        "status": {
+          "name": "status",
+          "type": "messaging_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "status_detail": {
+          "name": "status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_id": {
+          "name": "provider_brand_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_brand_status": {
+          "name": "provider_brand_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_id": {
+          "name": "provider_campaign_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_campaign_status": {
+          "name": "provider_campaign_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_id": {
+          "name": "submission_lock_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_lock_at": {
+          "name": "submission_lock_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messaging_registrations_practice_idx": {
+          "name": "messaging_registrations_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_status_idx": {
+          "name": "messaging_registrations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messaging_registrations_attested_by_idx": {
+          "name": "messaging_registrations_attested_by_idx",
+          "columns": [
+            {
+              "expression": "compliance_attested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messaging_registrations_practice_id_practices_id_fk": {
+          "name": "messaging_registrations_practice_id_practices_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messaging_registrations_compliance_attested_by_users_id_fk": {
+          "name": "messaging_registrations_compliance_attested_by_users_id_fk",
+          "tableFrom": "messaging_registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "compliance_attested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messaging_registrations_tax_id_last4_check": {
+          "name": "messaging_registrations_tax_id_last4_check",
+          "value": "\"messaging_registrations\".\"tax_id_last4\" ~ '^[0-9]{4}$'"
+        },
+        "messaging_registrations_us_country_check": {
+          "name": "messaging_registrations_us_country_check",
+          "value": "\"messaging_registrations\".\"country\" = 'US'"
+        },
+        "messaging_registrations_us_state_check": {
+          "name": "messaging_registrations_us_state_check",
+          "value": "\"messaging_registrations\".\"state\" ~ '^[A-Z]{2}$'"
+        },
+        "messaging_registrations_attempt_count_check": {
+          "name": "messaging_registrations_attempt_count_check",
+          "value": "\"messaging_registrations\".\"attempt_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_suppressions": {
+      "name": "sms_suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "sms_suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stop'"
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_suppressions_practice_phone_uq": {
+          "name": "sms_suppressions_practice_phone_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_suppressions_practice_idx": {
+          "name": "sms_suppressions_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_suppressions_practice_id_practices_id_fk": {
+          "name": "sms_suppressions_practice_id_practices_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_suppressions_location_id_locations_id_fk": {
+          "name": "sms_suppressions_location_id_locations_id_fk",
+          "tableFrom": "sms_suppressions",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_consent_events": {
+      "name": "sms_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "sms_consent_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disclosure_version": {
+          "name": "disclosure_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disclosure": {
+          "name": "disclosure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_consent_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_consent_events_practice_event_key_uq": {
+          "name": "sms_consent_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_client_history_idx": {
+          "name": "sms_consent_events_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_destination_history_idx": {
+          "name": "sms_consent_events_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_consent_events_provider_message_uq": {
+          "name": "sms_consent_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_consent_events\".\"provider\" is not null and \"sms_consent_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_consent_events_practice_id_practices_id_fk": {
+          "name": "sms_consent_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_id_clients_id_fk": {
+          "name": "sms_consent_events_client_id_clients_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_id_locations_id_fk": {
+          "name": "sms_consent_events_location_id_locations_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_user_id_users_id_fk": {
+          "name": "sms_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_client_tenant_fk": {
+          "name": "sms_consent_events_client_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_location_tenant_fk": {
+          "name": "sms_consent_events_location_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_consent_events_actor_tenant_fk": {
+          "name": "sms_consent_events_actor_tenant_fk",
+          "tableFrom": "sms_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_consent_events_destination_check": {
+          "name": "sms_consent_events_destination_check",
+          "value": "\"sms_consent_events\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_consent_events_source_check": {
+          "name": "sms_consent_events_source_check",
+          "value": "length(btrim(\"sms_consent_events\".\"source\")) between 1 and 64"
+        },
+        "sms_consent_events_event_key_check": {
+          "name": "sms_consent_events_event_key_check",
+          "value": "length(btrim(\"sms_consent_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_consent_events_detail_check": {
+          "name": "sms_consent_events_detail_check",
+          "value": "\"sms_consent_events\".\"detail\" is null or length(\"sms_consent_events\".\"detail\") <= 2000"
+        },
+        "sms_consent_events_evidence_shape_check": {
+          "name": "sms_consent_events_evidence_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"action\" = 'granted'\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure_version\", ''))) > 0\n          and length(btrim(coalesce(\"sms_consent_events\".\"disclosure\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"action\" = 'revoked'\n          and \"sms_consent_events\".\"disclosure_version\" is null\n          and \"sms_consent_events\".\"disclosure\" is null\n        )"
+        },
+        "sms_consent_events_actor_shape_check": {
+          "name": "sms_consent_events_actor_shape_check",
+          "value": "(\n          \"sms_consent_events\".\"actor_type\" = 'staff'\n          and \"sms_consent_events\".\"actor_user_id\" is not null\n          and length(btrim(coalesce(\"sms_consent_events\".\"actor_name\", ''))) > 0\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'client'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" in ('telnyx', 'twilio')\n          and length(btrim(coalesce(\"sms_consent_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_consent_events\".\"actor_type\" = 'system'\n          and \"sms_consent_events\".\"actor_user_id\" is null\n          and \"sms_consent_events\".\"actor_name\" is null\n          and \"sms_consent_events\".\"provider\" is null\n          and \"sms_consent_events\".\"provider_message_id\" is null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_event_history": {
+      "name": "sms_delivery_event_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "delivery_event_id": {
+          "name": "delivery_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_history_id": {
+          "name": "reviewed_history_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_delivery_history_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "sms_delivery_history_result",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_reason_code": {
+          "name": "operator_reason_code",
+          "type": "sms_delivery_reconciliation_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_event_history_event_key_uq": {
+          "name": "sms_delivery_event_history_event_key_uq",
+          "columns": [
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_idx": {
+          "name": "sms_delivery_event_history_event_idx",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_event_id_uq": {
+          "name": "sms_delivery_event_history_event_id_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attribution_uq": {
+          "name": "sms_delivery_event_history_attribution_uq",
+          "columns": [
+            {
+              "expression": "delivery_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"result\" = 'attributed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_reviewed_history_uq": {
+          "name": "sms_delivery_event_history_reviewed_history_uq",
+          "columns": [
+            {
+              "expression": "reviewed_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_delivery_event_history\".\"reviewed_history_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_practice_queue_idx": {
+          "name": "sms_delivery_event_history_practice_queue_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "result",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_event_history_attempt_idx": {
+          "name": "sms_delivery_event_history_attempt_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk": {
+          "name": "sms_delivery_event_history_delivery_event_id_sms_delivery_events_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_events",
+          "columnsFrom": [
+            "delivery_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_practice_id_practices_id_fk": {
+          "name": "sms_delivery_event_history_practice_id_practices_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_id_communications_id_fk": {
+          "name": "sms_delivery_event_history_communication_id_communications_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_user_id_users_id_fk": {
+          "name": "sms_delivery_event_history_actor_user_id_users_id_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_attempt_tenant_fk": {
+          "name": "sms_delivery_event_history_attempt_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_communication_tenant_fk": {
+          "name": "sms_delivery_event_history_communication_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_actor_tenant_fk": {
+          "name": "sms_delivery_event_history_actor_tenant_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_delivery_event_history_reviewed_history_fk": {
+          "name": "sms_delivery_event_history_reviewed_history_fk",
+          "tableFrom": "sms_delivery_event_history",
+          "tableTo": "sms_delivery_event_history",
+          "columnsFrom": [
+            "delivery_event_id",
+            "reviewed_history_id"
+          ],
+          "columnsTo": [
+            "delivery_event_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_event_history_event_key_check": {
+          "name": "sms_delivery_event_history_event_key_check",
+          "value": "length(btrim(\"sms_delivery_event_history\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_event_history_detail_check": {
+          "name": "sms_delivery_event_history_detail_check",
+          "value": "\"sms_delivery_event_history\".\"detail\" is null or length(\"sms_delivery_event_history\".\"detail\") <= 2000"
+        },
+        "sms_delivery_event_history_target_shape_check": {
+          "name": "sms_delivery_event_history_target_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous', 'operator_reviewed')\n          and \"sms_delivery_event_history\".\"practice_id\" is null\n          and \"sms_delivery_event_history\".\"attempt_id\" is null\n          and \"sms_delivery_event_history\".\"communication_id\" is null\n          and (\n            (\"sms_delivery_event_history\".\"result\" = 'operator_reviewed' and \"sms_delivery_event_history\".\"reviewed_history_id\" is not null)\n            or (\"sms_delivery_event_history\".\"result\" in ('unmatched', 'ambiguous') and \"sms_delivery_event_history\".\"reviewed_history_id\" is null)\n          )\n        ) or (\n          \"sms_delivery_event_history\".\"result\" in ('attributed', 'projection_miss', 'reconciled')\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"result\" = 'projected'\n          and \"sms_delivery_event_history\".\"practice_id\" is not null\n          and \"sms_delivery_event_history\".\"attempt_id\" is not null\n          and \"sms_delivery_event_history\".\"communication_id\" is not null\n          and \"sms_delivery_event_history\".\"reviewed_history_id\" is null\n        )"
+        },
+        "sms_delivery_event_history_actor_shape_check": {
+          "name": "sms_delivery_event_history_actor_shape_check",
+          "value": "(\n          \"sms_delivery_event_history\".\"kind\" = 'automatic'\n          and \"sms_delivery_event_history\".\"result\" in (\n            'unmatched',\n            'ambiguous',\n            'attributed',\n            'projected',\n            'projection_miss'\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" is null\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and \"sms_delivery_event_history\".\"actor_identity\" is null\n          and \"sms_delivery_event_history\".\"actor_name\" is null\n          and \"sms_delivery_event_history\".\"operator_reason_code\" is null\n        ) or (\n          \"sms_delivery_event_history\".\"kind\" = 'operator_reconciliation'\n          and (\n            (\n              \"sms_delivery_event_history\".\"result\" = 'reconciled'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'exact_attribution_retry',\n                'provider_portal_status_review',\n                'projection_repair'\n              )\n            )\n            or (\n              \"sms_delivery_event_history\".\"result\" = 'operator_reviewed'\n              and \"sms_delivery_event_history\".\"operator_reason_code\" in (\n                'identity_conflict_review',\n                'unmatched_evidence_review'\n              )\n            )\n          )\n          and \"sms_delivery_event_history\".\"actor_type\" = 'platform_operator'\n          and \"sms_delivery_event_history\".\"actor_user_id\" is null\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_delivery_event_history\".\"actor_name\", ''))) between 1 and 255\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_delivery_events": {
+      "name": "sms_delivery_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_event_type": {
+          "name": "provider_event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error_code": {
+          "name": "provider_error_code",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "classification": {
+          "name": "classification",
+          "type": "sms_delivery_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_fingerprint_sha256": {
+          "name": "payload_fingerprint_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_delivery_events_provider_event_key_uq": {
+          "name": "sms_delivery_events_provider_event_key_uq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_provider_message_idx": {
+          "name": "sms_delivery_events_provider_message_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_delivery_events_classification_queue_idx": {
+          "name": "sms_delivery_events_classification_queue_idx",
+          "columns": [
+            {
+              "expression": "classification",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_delivery_events_provider_check": {
+          "name": "sms_delivery_events_provider_check",
+          "value": "\"sms_delivery_events\".\"provider\" in ('telnyx', 'twilio')"
+        },
+        "sms_delivery_events_event_type_check": {
+          "name": "sms_delivery_events_event_type_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"provider_event_type\")) between 1 and 80"
+        },
+        "sms_delivery_events_event_key_check": {
+          "name": "sms_delivery_events_event_key_check",
+          "value": "length(btrim(\"sms_delivery_events\".\"event_key\")) between 1 and 255"
+        },
+        "sms_delivery_events_fingerprint_check": {
+          "name": "sms_delivery_events_fingerprint_check",
+          "value": "\"sms_delivery_events\".\"payload_fingerprint_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_delivery_events_provider_event_id_check": {
+          "name": "sms_delivery_events_provider_event_id_check",
+          "value": "\"sms_delivery_events\".\"provider_event_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_event_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_message_id_check": {
+          "name": "sms_delivery_events_provider_message_id_check",
+          "value": "\"sms_delivery_events\".\"provider_message_id\" is null or length(btrim(\"sms_delivery_events\".\"provider_message_id\")) between 1 and 255"
+        },
+        "sms_delivery_events_provider_status_check": {
+          "name": "sms_delivery_events_provider_status_check",
+          "value": "\"sms_delivery_events\".\"provider_status\" is null or length(btrim(\"sms_delivery_events\".\"provider_status\")) between 1 and 80"
+        },
+        "sms_delivery_events_provider_error_code_check": {
+          "name": "sms_delivery_events_provider_error_code_check",
+          "value": "\"sms_delivery_events\".\"provider_error_code\" is null or length(btrim(\"sms_delivery_events\".\"provider_error_code\")) between 1 and 80"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempt_events": {
+      "name": "sms_send_attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "sms_send_attempt_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "sms_send_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_identity": {
+          "name": "actor_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sms_send_attempt_events_practice_event_key_uq": {
+          "name": "sms_send_attempt_events_practice_event_key_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_result_uq": {
+          "name": "sms_send_attempt_events_provider_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"kind\" = 'provider_result'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_attempt_history_idx": {
+          "name": "sms_send_attempt_events_attempt_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempt_events_provider_message_uq": {
+          "name": "sms_send_attempt_events_provider_message_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempt_events\".\"provider_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempt_events_practice_id_practices_id_fk": {
+          "name": "sms_send_attempt_events_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_user_id_users_id_fk": {
+          "name": "sms_send_attempt_events_actor_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_attempt_tenant_fk": {
+          "name": "sms_send_attempt_events_attempt_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempt_events_actor_tenant_fk": {
+          "name": "sms_send_attempt_events_actor_tenant_fk",
+          "tableFrom": "sms_send_attempt_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempt_events_event_key_check": {
+          "name": "sms_send_attempt_events_event_key_check",
+          "value": "length(btrim(\"sms_send_attempt_events\".\"event_key\")) between 1 and 200"
+        },
+        "sms_send_attempt_events_detail_check": {
+          "name": "sms_send_attempt_events_detail_check",
+          "value": "\"sms_send_attempt_events\".\"detail\" is null or length(\"sms_send_attempt_events\".\"detail\") <= 2000"
+        },
+        "sms_send_attempt_events_outcome_shape_check": {
+          "name": "sms_send_attempt_events_outcome_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"outcome\" = 'accepted'\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"provider_message_id\", ''))) > 0\n        ) or (\n          \"sms_send_attempt_events\".\"outcome\" in ('definite_failure', 'outcome_unknown')\n          and \"sms_send_attempt_events\".\"provider_message_id\" is null\n        )"
+        },
+        "sms_send_attempt_events_actor_shape_check": {
+          "name": "sms_send_attempt_events_actor_shape_check",
+          "value": "(\n          \"sms_send_attempt_events\".\"kind\" = 'provider_result'\n          and \"sms_send_attempt_events\".\"actor_type\" is null\n          and \"sms_send_attempt_events\".\"actor_user_id\" is null\n          and \"sms_send_attempt_events\".\"actor_identity\" is null\n          and \"sms_send_attempt_events\".\"actor_name\" is null\n        ) or (\n          \"sms_send_attempt_events\".\"kind\" = 'reconciliation'\n          and \"sms_send_attempt_events\".\"outcome\" in ('accepted', 'definite_failure')\n          and \"sms_send_attempt_events\".\"actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempt_events\".\"actor_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempt_events\".\"actor_type\" = 'clinic_user' and \"sms_send_attempt_events\".\"actor_user_id\" is not null)\n            or (\"sms_send_attempt_events\".\"actor_type\" = 'platform_operator' and \"sms_send_attempt_events\".\"actor_user_id\" is null)\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_send_attempts": {
+      "name": "sms_send_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "communication_id": {
+          "name": "communication_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_actor_type": {
+          "name": "requested_by_actor_type",
+          "type": "sms_send_actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_identity": {
+          "name": "requested_by_identity",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_name": {
+          "name": "requested_by_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resend_of_attempt_id": {
+          "name": "resend_of_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_e164": {
+          "name": "destination_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_display_name": {
+          "name": "registered_display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_sha256": {
+          "name": "body_sha256",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_messaging_service_id": {
+          "name": "sender_messaging_service_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_e164": {
+          "name": "sender_e164",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sms_send_attempts_practice_id_uq": {
+          "name": "sms_send_attempts_practice_id_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_practice_idempotency_uq": {
+          "name": "sms_send_attempts_practice_idempotency_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_resend_of_uq": {
+          "name": "sms_send_attempts_resend_of_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resend_of_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sms_send_attempts\".\"resend_of_attempt_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_client_history_idx": {
+          "name": "sms_send_attempts_client_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_communication_idx": {
+          "name": "sms_send_attempts_communication_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "communication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_source_history_idx": {
+          "name": "sms_send_attempts_source_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_send_attempts_destination_history_idx": {
+          "name": "sms_send_attempts_destination_history_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "destination_e164",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sms_send_attempts_practice_id_practices_id_fk": {
+          "name": "sms_send_attempts_practice_id_practices_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_id_clients_id_fk": {
+          "name": "sms_send_attempts_client_id_clients_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_id_locations_id_fk": {
+          "name": "sms_send_attempts_location_id_locations_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_id_communications_id_fk": {
+          "name": "sms_send_attempts_communication_id_communications_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "communication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requested_by_user_id_users_id_fk": {
+          "name": "sms_send_attempts_requested_by_user_id_users_id_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_resend_tenant_fk": {
+          "name": "sms_send_attempts_resend_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "sms_send_attempts",
+          "columnsFrom": [
+            "practice_id",
+            "resend_of_attempt_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_client_tenant_fk": {
+          "name": "sms_send_attempts_client_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "practice_id",
+            "client_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_location_tenant_fk": {
+          "name": "sms_send_attempts_location_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "practice_id",
+            "location_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_communication_tenant_fk": {
+          "name": "sms_send_attempts_communication_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "communications",
+          "columnsFrom": [
+            "practice_id",
+            "communication_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sms_send_attempts_requester_tenant_fk": {
+          "name": "sms_send_attempts_requester_tenant_fk",
+          "tableFrom": "sms_send_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "practice_id",
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sms_send_attempts_source_check": {
+          "name": "sms_send_attempts_source_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source\")) between 1 and 64"
+        },
+        "sms_send_attempts_source_id_check": {
+          "name": "sms_send_attempts_source_id_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"source_id\")) between 1 and 200"
+        },
+        "sms_send_attempts_idempotency_key_check": {
+          "name": "sms_send_attempts_idempotency_key_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"idempotency_key\")) between 1 and 200"
+        },
+        "sms_send_attempts_destination_check": {
+          "name": "sms_send_attempts_destination_check",
+          "value": "\"sms_send_attempts\".\"destination_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_display_name_check": {
+          "name": "sms_send_attempts_display_name_check",
+          "value": "length(btrim(\"sms_send_attempts\".\"registered_display_name\")) between 1 and 100"
+        },
+        "sms_send_attempts_body_check": {
+          "name": "sms_send_attempts_body_check",
+          "value": "length(\"sms_send_attempts\".\"body\") between 1 and 1600"
+        },
+        "sms_send_attempts_body_hash_check": {
+          "name": "sms_send_attempts_body_hash_check",
+          "value": "\"sms_send_attempts\".\"body_sha256\" ~ '^[0-9a-f]{64}$'"
+        },
+        "sms_send_attempts_provider_check": {
+          "name": "sms_send_attempts_provider_check",
+          "value": "\"sms_send_attempts\".\"provider\" in ('telnyx', 'twilio', 'console')"
+        },
+        "sms_send_attempts_sender_check": {
+          "name": "sms_send_attempts_sender_check",
+          "value": "\"sms_send_attempts\".\"provider\" = 'console'\n        or length(btrim(coalesce(\"sms_send_attempts\".\"sender_messaging_service_id\", ''))) > 0\n        or \"sms_send_attempts\".\"sender_e164\" ~ '^\\+[1-9][0-9]{7,14}$'"
+        },
+        "sms_send_attempts_requester_check": {
+          "name": "sms_send_attempts_requester_check",
+          "value": "(\n          \"sms_send_attempts\".\"source\" = 'operator_resend'\n          and \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n          and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n          and (\n            (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n            or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n          )\n        ) or (\n          \"sms_send_attempts\".\"source\" <> 'operator_resend'\n          and (\n            (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is null\n              and \"sms_send_attempts\".\"requested_by_user_id\" is null\n              and \"sms_send_attempts\".\"requested_by_identity\" is null\n              and \"sms_send_attempts\".\"requested_by_name\" is null\n            )\n            or (\n              \"sms_send_attempts\".\"requested_by_actor_type\" is not null\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_identity\", ''))) between 1 and 255\n              and length(btrim(coalesce(\"sms_send_attempts\".\"requested_by_name\", ''))) between 1 and 255\n              and (\n                (\"sms_send_attempts\".\"requested_by_actor_type\" = 'clinic_user' and \"sms_send_attempts\".\"requested_by_user_id\" is not null)\n                or (\"sms_send_attempts\".\"requested_by_actor_type\" = 'platform_operator' and \"sms_send_attempts\".\"requested_by_user_id\" is null)\n              )\n            )\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.demo_accesses": {
+      "name": "demo_accesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_accessed_at": {
+          "name": "first_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "feedback_opt_out_at": {
+          "name": "feedback_opt_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "demo_accesses_email_uq": {
+          "name": "demo_accesses_email_uq",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_email_hash_uq": {
+          "name": "demo_accesses_email_hash_uq",
+          "columns": [
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "demo_accesses_recent_idx": {
+          "name": "demo_accesses_recent_idx",
+          "columns": [
+            {
+              "expression": "last_accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_pages": {
+      "name": "booking_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "booking_pages_practice_idx": {
+          "name": "booking_pages_practice_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_pages_slug_published_idx": {
+          "name": "booking_pages_slug_published_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "booking_pages_practice_id_practices_id_fk": {
+          "name": "booking_pages_practice_id_practices_id_fk",
+          "tableFrom": "booking_pages",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "booking_pages_slug_unique": {
+          "name": "booking_pages_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.funnel_events": {
+      "name": "funnel_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous_id": {
+          "name": "anonymous_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "funnel_events_event_time_idx": {
+          "name": "funnel_events_event_time_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_anonymous_time_idx": {
+          "name": "funnel_events_anonymous_time_idx",
+          "columns": [
+            {
+              "expression": "anonymous_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_time_idx": {
+          "name": "funnel_events_practice_time_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "funnel_events_practice_stage_uq": {
+          "name": "funnel_events_practice_stage_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"funnel_events\".\"practice_id\" is not null and \"funnel_events\".\"event_name\" in ('registration', 'activation', 'card_added', 'paid')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "funnel_events_practice_id_practices_id_fk": {
+          "name": "funnel_events_practice_id_practices_id_fk",
+          "tableFrom": "funnel_events",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.practice_conversion_milestones": {
+      "name": "practice_conversion_milestones",
+      "schema": "",
+      "columns": {
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "practice_conversion_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "evidence_source": {
+          "name": "evidence_source",
+          "type": "conversion_evidence_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_key": {
+          "name": "evidence_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "practice_conversion_milestones_evidence_uq": {
+          "name": "practice_conversion_milestones_evidence_uq",
+          "columns": [
+            {
+              "expression": "evidence_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "evidence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "practice_conversion_milestones_stage_time_idx": {
+          "name": "practice_conversion_milestones_stage_time_idx",
+          "columns": [
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "practice_conversion_milestones_practice_id_practices_id_fk": {
+          "name": "practice_conversion_milestones_practice_id_practices_id_fk",
+          "tableFrom": "practice_conversion_milestones",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "practice_conversion_milestones_practice_id_milestone_pk": {
+          "name": "practice_conversion_milestones_practice_id_milestone_pk",
+          "columns": [
+            "practice_id",
+            "milestone"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "practice_conversion_milestones_payment_shape_check": {
+          "name": "practice_conversion_milestones_payment_shape_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is not null\n        and \"practice_conversion_milestones\".\"amount_cents\" > 0\n        and \"practice_conversion_milestones\".\"currency\" is not null\n        and \"practice_conversion_milestones\".\"currency\" ~ '^[a-z]{3}$'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" <> 'first_positive_payment'\n        and \"practice_conversion_milestones\".\"amount_cents\" is null\n        and \"practice_conversion_milestones\".\"currency\" is null\n      )"
+        },
+        "practice_conversion_milestones_evidence_source_check": {
+          "name": "practice_conversion_milestones_evidence_source_check",
+          "value": "(\n        \"practice_conversion_milestones\".\"milestone\" = 'registered'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'practice_created'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'practice:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" = 'activated'\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'product_records'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'client:%|appointment:%'\n      ) or (\n        \"practice_conversion_milestones\".\"milestone\" in (\n          'payment_method_collected', 'first_positive_payment'\n        )\n        and \"practice_conversion_milestones\".\"evidence_source\" = 'stripe_webhook'\n        and \"practice_conversion_milestones\".\"evidence_key\" like 'stripe:%'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.migration_runs": {
+      "name": "migration_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "migration_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_plan_hash": {
+          "name": "reviewed_plan_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "migration_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'previewed'"
+        },
+        "source_row_count": {
+          "name": "source_row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_insert_count": {
+          "name": "planned_insert_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "planned_reconcile_count": {
+          "name": "planned_reconcile_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate_count": {
+          "name": "duplicate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unmatched_count": {
+          "name": "unmatched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_count": {
+          "name": "reconciled_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preview_expires_at": {
+          "name": "preview_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_at": {
+          "name": "committed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "committed_by": {
+          "name": "committed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "migration_runs_active_preview_uq": {
+          "name": "migration_runs_active_preview_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"migration_runs\".\"status\" = 'previewed' and \"migration_runs\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_practice_status_idx": {
+          "name": "migration_runs_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_created_by_idx": {
+          "name": "migration_runs_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_committed_by_idx": {
+          "name": "migration_runs_committed_by_idx",
+          "columns": [
+            {
+              "expression": "committed_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "migration_runs_pending_expiry_idx": {
+          "name": "migration_runs_pending_expiry_idx",
+          "columns": [
+            {
+              "expression": "preview_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"migration_runs\".\"status\" = 'previewed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "migration_runs_practice_id_practices_id_fk": {
+          "name": "migration_runs_practice_id_practices_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_created_by_users_id_fk": {
+          "name": "migration_runs_created_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "migration_runs_committed_by_users_id_fk": {
+          "name": "migration_runs_committed_by_users_id_fk",
+          "tableFrom": "migration_runs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "committed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "migration_runs_file_hash_check": {
+          "name": "migration_runs_file_hash_check",
+          "value": "\"migration_runs\".\"file_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_reviewed_plan_hash_check": {
+          "name": "migration_runs_reviewed_plan_hash_check",
+          "value": "\"migration_runs\".\"reviewed_plan_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "migration_runs_file_size_check": {
+          "name": "migration_runs_file_size_check",
+          "value": "\"migration_runs\".\"file_size_bytes\" between 1 and 5000000"
+        },
+        "migration_runs_source_check": {
+          "name": "migration_runs_source_check",
+          "value": "\"migration_runs\".\"source\" ~ '^[a-z0-9][a-z0-9_-]{0,63}$'"
+        },
+        "migration_runs_preview_expiry_check": {
+          "name": "migration_runs_preview_expiry_check",
+          "value": "\"migration_runs\".\"preview_expires_at\" > \"migration_runs\".\"created_at\""
+        },
+        "migration_runs_committed_state_check": {
+          "name": "migration_runs_committed_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'committed' or (\"migration_runs\".\"committed_at\" is not null and \"migration_runs\".\"committed_by\" is not null))"
+        },
+        "migration_runs_superseded_state_check": {
+          "name": "migration_runs_superseded_state_check",
+          "value": "(\"migration_runs\".\"status\" <> 'superseded' or (\"migration_runs\".\"superseded_at\" is not null and \"migration_runs\".\"committed_at\" is null and \"migration_runs\".\"committed_by\" is null))"
+        },
+        "migration_runs_counts_check": {
+          "name": "migration_runs_counts_check",
+          "value": "\"migration_runs\".\"source_row_count\" >= 0\n        and \"migration_runs\".\"planned_insert_count\" >= 0\n        and \"migration_runs\".\"planned_reconcile_count\" >= 0\n        and \"migration_runs\".\"duplicate_count\" >= 0\n        and \"migration_runs\".\"unmatched_count\" >= 0\n        and \"migration_runs\".\"error_count\" >= 0\n        and \"migration_runs\".\"imported_count\" >= 0\n        and \"migration_runs\".\"reconciled_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_closeouts": {
+      "name": "visit_closeouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_closeout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "diagnosis_summary": {
+          "name": "diagnosis_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discharge_instructions": {
+          "name": "discharge_instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "warning_signs": {
+          "name": "warning_signs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_instructions_reason": {
+          "name": "no_instructions_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_disposition": {
+          "name": "prescription_disposition",
+          "type": "visit_prescription_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_disposition": {
+          "name": "follow_up_disposition",
+          "type": "visit_follow_up_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_notes": {
+          "name": "follow_up_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_appointment_id": {
+          "name": "follow_up_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_scheduled_at": {
+          "name": "follow_up_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_due_date": {
+          "name": "follow_up_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assigned_to": {
+          "name": "follow_up_assigned_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_assignee_name": {
+          "name": "follow_up_assignee_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution": {
+          "name": "follow_up_resolution",
+          "type": "visit_follow_up_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_appointment_id": {
+          "name": "follow_up_resolution_appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_scheduled_at": {
+          "name": "follow_up_resolution_scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolution_notes": {
+          "name": "follow_up_resolution_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_at": {
+          "name": "follow_up_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolved_by": {
+          "name": "follow_up_resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "follow_up_resolver_name": {
+          "name": "follow_up_resolver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medication_snapshot": {
+          "name": "medication_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_history": {
+          "name": "amendment_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "amendment_draft": {
+          "name": "amendment_draft",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_exception_reason": {
+          "name": "documentation_exception_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_at": {
+          "name": "clinical_finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalized_by": {
+          "name": "clinical_finalized_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clinical_finalizer_name": {
+          "name": "clinical_finalizer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "charge_disposition": {
+          "name": "charge_disposition",
+          "type": "visit_charge_disposition",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handoff_method": {
+          "name": "handoff_method",
+          "type": "visit_handoff_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by": {
+          "name": "completed_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "visit_closeouts_appointment_uq": {
+          "name": "visit_closeouts_appointment_uq",
+          "columns": [
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_practice_status_idx": {
+          "name": "visit_closeouts_practice_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_closeouts_pending_follow_up_idx": {
+          "name": "visit_closeouts_pending_follow_up_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_disposition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "follow_up_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_closeouts_practice_id_practices_id_fk": {
+          "name": "visit_closeouts_practice_id_practices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_appointment_id_appointments_id_fk": {
+          "name": "visit_closeouts_follow_up_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_assigned_to_users_id_fk": {
+          "name": "visit_closeouts_follow_up_assigned_to_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_follow_up_resolved_by_users_id_fk": {
+          "name": "visit_closeouts_follow_up_resolved_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follow_up_resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_clinical_finalized_by_users_id_fk": {
+          "name": "visit_closeouts_clinical_finalized_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "clinical_finalized_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_invoice_id_invoices_id_fk": {
+          "name": "visit_closeouts_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_completed_by_users_id_fk": {
+          "name": "visit_closeouts_completed_by_users_id_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "completed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_closeouts_resolution_appointment_fk": {
+          "name": "visit_closeouts_resolution_appointment_fk",
+          "tableFrom": "visit_closeouts",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "follow_up_resolution_appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_closeouts_revision_check": {
+          "name": "visit_closeouts_revision_check",
+          "value": "\"visit_closeouts\".\"revision\" >= 1"
+        },
+        "visit_closeouts_amendment_draft_check": {
+          "name": "visit_closeouts_amendment_draft_check",
+          "value": "(\"visit_closeouts\".\"status\" = 'draft' and \"visit_closeouts\".\"amendment_draft\" is null)\n        or (\n          \"visit_closeouts\".\"status\" in ('clinical_finalized', 'completed')\n          and (\n            \"visit_closeouts\".\"amendment_draft\" is null\n            or jsonb_typeof(\"visit_closeouts\".\"amendment_draft\") = 'object'\n          )\n        )"
+        },
+        "visit_closeouts_clinical_state_check": {
+          "name": "visit_closeouts_clinical_state_check",
+          "value": "\"visit_closeouts\".\"status\" = 'draft'\n        or (\n          \"visit_closeouts\".\"clinical_finalized_at\" is not null\n          and \"visit_closeouts\".\"clinical_finalized_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"clinical_finalizer_name\", ''))) > 0\n          and \"visit_closeouts\".\"prescription_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"prescription_disposition\" = 'prescribed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") > 0\n            or \"visit_closeouts\".\"prescription_disposition\" = 'not_needed'\n            and jsonb_array_length(\"visit_closeouts\".\"medication_snapshot\") = 0\n          )\n          and (\n            length(btrim(coalesce(\"visit_closeouts\".\"discharge_instructions\", ''))) > 0\n            or length(btrim(coalesce(\"visit_closeouts\".\"no_instructions_reason\", ''))) > 0\n          )\n          and \"visit_closeouts\".\"follow_up_disposition\" is not null\n          and (\n            \"visit_closeouts\".\"follow_up_disposition\" = 'none'\n            and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n            and \"visit_closeouts\".\"follow_up_due_date\" is null\n            and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n            and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'scheduled'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is not null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is not null\n              and \"visit_closeouts\".\"follow_up_due_date\" is null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is null\n              and \"visit_closeouts\".\"follow_up_assignee_name\" is null\n            )\n            or (\n              \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n              and \"visit_closeouts\".\"follow_up_appointment_id\" is null\n              and \"visit_closeouts\".\"follow_up_scheduled_at\" is null\n              and \"visit_closeouts\".\"follow_up_due_date\" is not null\n              and \"visit_closeouts\".\"follow_up_assigned_to\" is not null\n              and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_assignee_name\", ''))) > 0\n            )\n          )\n        )"
+        },
+        "visit_closeouts_completed_state_check": {
+          "name": "visit_closeouts_completed_state_check",
+          "value": "\"visit_closeouts\".\"status\" <> 'completed'\n        or (\n          \"visit_closeouts\".\"completed_at\" is not null\n          and \"visit_closeouts\".\"completed_by\" is not null\n          and \"visit_closeouts\".\"charge_disposition\" is not null\n          and \"visit_closeouts\".\"handoff_method\" is not null\n          and (\n            \"visit_closeouts\".\"charge_disposition\" = 'no_charge'\n            and \"visit_closeouts\".\"invoice_id\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"no_charge_reason\", ''))) > 0\n            or \"visit_closeouts\".\"charge_disposition\" in ('paid', 'accounts_receivable')\n            and \"visit_closeouts\".\"invoice_id\" is not null\n          )\n        )"
+        },
+        "visit_closeouts_follow_up_resolution_check": {
+          "name": "visit_closeouts_follow_up_resolution_check",
+          "value": "\"visit_closeouts\".\"follow_up_resolved_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n        and \"visit_closeouts\".\"follow_up_resolution_notes\" is null\n        and \"visit_closeouts\".\"follow_up_resolved_by\" is null\n        and \"visit_closeouts\".\"follow_up_resolver_name\" is null\n        or (\n          \"visit_closeouts\".\"follow_up_disposition\" = 'needed'\n          and \"visit_closeouts\".\"follow_up_resolved_at\" is not null\n          and \"visit_closeouts\".\"follow_up_resolution\" is not null\n          and \"visit_closeouts\".\"follow_up_resolved_by\" is not null\n          and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolver_name\", ''))) > 0\n          and (\n            \"visit_closeouts\".\"follow_up_resolution\" = 'scheduled'\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is not null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is not null\n            or \"visit_closeouts\".\"follow_up_resolution\" in ('completed', 'not_needed')\n            and \"visit_closeouts\".\"follow_up_resolution_appointment_id\" is null\n            and \"visit_closeouts\".\"follow_up_resolution_scheduled_at\" is null\n            and length(btrim(coalesce(\"visit_closeouts\".\"follow_up_resolution_notes\", ''))) > 0\n          )\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.visit_work_items": {
+      "name": "visit_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_id": {
+          "name": "practice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appointment_id": {
+          "name": "appointment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vaccination_record_id": {
+          "name": "vaccination_record_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lab_result_id": {
+          "name": "lab_result_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "procedure_id": {
+          "name": "procedure_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prescription_id": {
+          "name": "prescription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "visit_work_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unresolved'"
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_item_id": {
+          "name": "invoice_item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_charge_reason": {
+          "name": "no_charge_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "void_reason": {
+          "name": "void_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "visit_work_items_visit_status_idx": {
+          "name": "visit_work_items_visit_status_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_unresolved_idx": {
+          "name": "visit_work_items_unresolved_idx",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "appointment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"visit_work_items\".\"status\" = 'unresolved' and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_vaccination_uq": {
+          "name": "visit_work_items_vaccination_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vaccination_record_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"vaccination_record_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_lab_result_uq": {
+          "name": "visit_work_items_lab_result_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lab_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"lab_result_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_procedure_uq": {
+          "name": "visit_work_items_procedure_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "procedure_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"procedure_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_prescription_uq": {
+          "name": "visit_work_items_prescription_uq",
+          "columns": [
+            {
+              "expression": "practice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prescription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"prescription_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_work_items_invoice_item_uq": {
+          "name": "visit_work_items_invoice_item_uq",
+          "columns": [
+            {
+              "expression": "invoice_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"visit_work_items\".\"invoice_item_id\" is not null and \"visit_work_items\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_work_items_practice_id_practices_id_fk": {
+          "name": "visit_work_items_practice_id_practices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "practices",
+          "columnsFrom": [
+            "practice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_appointment_id_appointments_id_fk": {
+          "name": "visit_work_items_appointment_id_appointments_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_record_id_vaccination_records_id_fk": {
+          "name": "visit_work_items_vaccination_record_id_vaccination_records_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_id_lab_results_id_fk": {
+          "name": "visit_work_items_lab_result_id_lab_results_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_id_procedures_id_fk": {
+          "name": "visit_work_items_procedure_id_procedures_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_id_prescriptions_id_fk": {
+          "name": "visit_work_items_prescription_id_prescriptions_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_id_invoices_id_fk": {
+          "name": "visit_work_items_invoice_id_invoices_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_id_invoice_items_id_fk": {
+          "name": "visit_work_items_invoice_item_id_invoice_items_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_resolved_by_users_id_fk": {
+          "name": "visit_work_items_resolved_by_users_id_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_practice_appointment_fk": {
+          "name": "visit_work_items_practice_appointment_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "appointments",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_vaccination_source_fk": {
+          "name": "visit_work_items_vaccination_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "vaccination_records",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "vaccination_record_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_lab_result_source_fk": {
+          "name": "visit_work_items_lab_result_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "lab_results",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "lab_result_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_procedure_source_fk": {
+          "name": "visit_work_items_procedure_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "procedures",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "procedure_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_prescription_source_fk": {
+          "name": "visit_work_items_prescription_source_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "prescriptions",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "prescription_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_visit_fk": {
+          "name": "visit_work_items_invoice_visit_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "practice_id",
+            "appointment_id",
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "practice_id",
+            "appointment_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visit_work_items_invoice_item_fk": {
+          "name": "visit_work_items_invoice_item_fk",
+          "tableFrom": "visit_work_items",
+          "tableTo": "invoice_items",
+          "columnsFrom": [
+            "invoice_id",
+            "invoice_item_id"
+          ],
+          "columnsTo": [
+            "invoice_id",
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "visit_work_items_exactly_one_source_check": {
+          "name": "visit_work_items_exactly_one_source_check",
+          "value": "num_nonnulls(\n        \"visit_work_items\".\"vaccination_record_id\",\n        \"visit_work_items\".\"lab_result_id\",\n        \"visit_work_items\".\"procedure_id\",\n        \"visit_work_items\".\"prescription_id\"\n      ) = 1"
+        },
+        "visit_work_items_resolution_check": {
+          "name": "visit_work_items_resolution_check",
+          "value": "(\n          \"visit_work_items\".\"status\" = 'unresolved'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is null\n          and \"visit_work_items\".\"resolved_at\" is null\n        ) or (\n          \"visit_work_items\".\"status\" = 'charged'\n          and \"visit_work_items\".\"invoice_id\" is not null\n          and \"visit_work_items\".\"invoice_item_id\" is not null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'no_charge'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"no_charge_reason\", ''))) > 0\n          and \"visit_work_items\".\"void_reason\" is null\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        ) or (\n          \"visit_work_items\".\"status\" = 'voided'\n          and \"visit_work_items\".\"invoice_id\" is null\n          and \"visit_work_items\".\"invoice_item_id\" is null\n          and \"visit_work_items\".\"no_charge_reason\" is null\n          and length(btrim(coalesce(\"visit_work_items\".\"void_reason\", ''))) > 0\n          and \"visit_work_items\".\"resolved_by\" is not null\n          and \"visit_work_items\".\"resolved_at\" is not null\n        )"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "veterinarian",
+        "technician",
+        "front_desk",
+        "viewer"
+      ]
+    },
+    "public.contact_method": {
+      "name": "contact_method",
+      "schema": "public",
+      "values": [
+        "phone",
+        "email",
+        "sms",
+        "portal"
+      ]
+    },
+    "public.allergy_severity": {
+      "name": "allergy_severity",
+      "schema": "public",
+      "values": [
+        "mild",
+        "moderate",
+        "severe"
+      ]
+    },
+    "public.patient_status": {
+      "name": "patient_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "deceased"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "male_neutered",
+        "female_spayed"
+      ]
+    },
+    "public.species": {
+      "name": "species",
+      "schema": "public",
+      "values": [
+        "canine",
+        "feline",
+        "avian",
+        "rabbit",
+        "reptile",
+        "equine",
+        "other"
+      ]
+    },
+    "public.appointment_status": {
+      "name": "appointment_status",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "confirmed",
+        "checked_in",
+        "in_exam",
+        "checked_out",
+        "no_show",
+        "cancelled"
+      ]
+    },
+    "public.recurring_frequency": {
+      "name": "recurring_frequency",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.room_type": {
+      "name": "room_type",
+      "schema": "public",
+      "values": [
+        "exam",
+        "surgery",
+        "treatment",
+        "boarding"
+      ]
+    },
+    "public.waitlist_status": {
+      "name": "waitlist_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "scheduled",
+        "cancelled"
+      ]
+    },
+    "public.case_status": {
+      "name": "case_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed"
+      ]
+    },
+    "public.lab_follow_up_status": {
+      "name": "lab_follow_up_status",
+      "schema": "public",
+      "values": [
+        "not_required",
+        "open",
+        "completed"
+      ]
+    },
+    "public.lab_result_flag": {
+      "name": "lab_result_flag",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "normal",
+        "abnormal",
+        "critical"
+      ]
+    },
+    "public.lab_status": {
+      "name": "lab_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "reviewed"
+      ]
+    },
+    "public.note_type": {
+      "name": "note_type",
+      "schema": "public",
+      "values": [
+        "general",
+        "follow_up",
+        "phone_call"
+      ]
+    },
+    "public.problem_status": {
+      "name": "problem_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "resolved",
+        "chronic"
+      ]
+    },
+    "public.soap_note_status": {
+      "name": "soap_note_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "finalized"
+      ]
+    },
+    "public.treatment_plan_item_status": {
+      "name": "treatment_plan_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "done",
+        "skipped"
+      ]
+    },
+    "public.treatment_plan_status": {
+      "name": "treatment_plan_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "discontinued"
+      ]
+    },
+    "public.lab_result_event_type": {
+      "name": "lab_result_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "completed",
+        "reviewed",
+        "follow_up_assigned",
+        "follow_up_reassigned",
+        "follow_up_completed"
+      ]
+    },
+    "public.clinical_correction_action": {
+      "name": "clinical_correction_action",
+      "schema": "public",
+      "values": [
+        "entered_in_error"
+      ]
+    },
+    "public.clinical_correction_record_type": {
+      "name": "clinical_correction_record_type",
+      "schema": "public",
+      "values": [
+        "soap_note",
+        "vital_sign",
+        "vaccination_record",
+        "lab_result"
+      ]
+    },
+    "public.interaction_severity": {
+      "name": "interaction_severity",
+      "schema": "public",
+      "values": [
+        "minor",
+        "moderate",
+        "major"
+      ]
+    },
+    "public.prescription_status": {
+      "name": "prescription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.prescription_event_type": {
+      "name": "prescription_event_type",
+      "schema": "public",
+      "values": [
+        "created",
+        "refill_dispensed",
+        "refill_authorized",
+        "completed",
+        "cancelled",
+        "expired"
+      ]
+    },
+    "public.invoice_adjustment_type": {
+      "name": "invoice_adjustment_type",
+      "schema": "public",
+      "values": [
+        "credit",
+        "write_off"
+      ]
+    },
+    "public.invoice_item_type": {
+      "name": "invoice_item_type",
+      "schema": "public",
+      "values": [
+        "service",
+        "product"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "void"
+      ]
+    },
+    "public.payment_account_status": {
+      "name": "payment_account_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "action_required",
+        "disabled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "cash",
+        "credit_card",
+        "debit_card",
+        "check",
+        "online",
+        "other"
+      ]
+    },
+    "public.purchase_order_status": {
+      "name": "purchase_order_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "ordered",
+        "received"
+      ]
+    },
+    "public.dispense_charge_status": {
+      "name": "dispense_charge_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "invoiced",
+        "waived"
+      ]
+    },
+    "public.comm_channel": {
+      "name": "comm_channel",
+      "schema": "public",
+      "values": [
+        "phone",
+        "sms",
+        "email",
+        "portal"
+      ]
+    },
+    "public.comm_status": {
+      "name": "comm_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "delivered",
+        "read",
+        "failed"
+      ]
+    },
+    "public.comm_direction": {
+      "name": "comm_direction",
+      "schema": "public",
+      "values": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "public.controlled_substance_action": {
+      "name": "controlled_substance_action",
+      "schema": "public",
+      "values": [
+        "received",
+        "administered",
+        "wasted",
+        "returned"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted",
+        "in_review",
+        "approved",
+        "denied",
+        "paid"
+      ]
+    },
+    "public.billing_interval": {
+      "name": "billing_interval",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "annual"
+      ]
+    },
+    "public.enrollment_status": {
+      "name": "enrollment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled"
+      ]
+    },
+    "public.stripe_conversion_evidence_kind": {
+      "name": "stripe_conversion_evidence_kind",
+      "schema": "public",
+      "values": [
+        "subscription_checkout_completed",
+        "positive_subscription_invoice_paid"
+      ]
+    },
+    "public.auth_email_attempt_outcome": {
+      "name": "auth_email_attempt_outcome",
+      "schema": "public",
+      "values": [
+        "reserved",
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.auth_email_delivery_attribution": {
+      "name": "auth_email_delivery_attribution",
+      "schema": "public",
+      "values": [
+        "attempt_tag",
+        "provider_message_id",
+        "unmatched",
+        "identity_conflict"
+      ]
+    },
+    "public.auth_email_delivery_classification": {
+      "name": "auth_email_delivery_classification",
+      "schema": "public",
+      "values": [
+        "sent",
+        "delivered",
+        "delayed",
+        "failed",
+        "complained",
+        "opened",
+        "clicked",
+        "unknown"
+      ]
+    },
+    "public.auth_email_source": {
+      "name": "auth_email_source",
+      "schema": "public",
+      "values": [
+        "registration",
+        "authenticated_resend"
+      ]
+    },
+    "public.email_suppression_reason": {
+      "name": "email_suppression_reason",
+      "schema": "public",
+      "values": [
+        "manual",
+        "bounce",
+        "complaint",
+        "suppressed"
+      ]
+    },
+    "public.messaging_business_entity_type": {
+      "name": "messaging_business_entity_type",
+      "schema": "public",
+      "values": [
+        "PRIVATE_PROFIT",
+        "NON_PROFIT"
+      ]
+    },
+    "public.messaging_number_source": {
+      "name": "messaging_number_source",
+      "schema": "public",
+      "values": [
+        "hosted",
+        "purchased",
+        "toll_free"
+      ]
+    },
+    "public.messaging_registration_status": {
+      "name": "messaging_registration_status",
+      "schema": "public",
+      "values": [
+        "not_started",
+        "pending",
+        "active",
+        "action_required",
+        "failed",
+        "suspended"
+      ]
+    },
+    "public.sms_suppression_reason": {
+      "name": "sms_suppression_reason",
+      "schema": "public",
+      "values": [
+        "stop",
+        "manual",
+        "bounce",
+        "complaint"
+      ]
+    },
+    "public.sms_consent_action": {
+      "name": "sms_consent_action",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    },
+    "public.sms_consent_actor_type": {
+      "name": "sms_consent_actor_type",
+      "schema": "public",
+      "values": [
+        "staff",
+        "client",
+        "system"
+      ]
+    },
+    "public.sms_delivery_classification": {
+      "name": "sms_delivery_classification",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "sent",
+        "failed",
+        "delivered"
+      ]
+    },
+    "public.sms_delivery_history_kind": {
+      "name": "sms_delivery_history_kind",
+      "schema": "public",
+      "values": [
+        "automatic",
+        "operator_reconciliation"
+      ]
+    },
+    "public.sms_delivery_history_result": {
+      "name": "sms_delivery_history_result",
+      "schema": "public",
+      "values": [
+        "unmatched",
+        "ambiguous",
+        "attributed",
+        "projected",
+        "projection_miss",
+        "reconciled",
+        "operator_reviewed"
+      ]
+    },
+    "public.sms_delivery_reconciliation_reason": {
+      "name": "sms_delivery_reconciliation_reason",
+      "schema": "public",
+      "values": [
+        "exact_attribution_retry",
+        "provider_portal_status_review",
+        "projection_repair",
+        "identity_conflict_review",
+        "unmatched_evidence_review"
+      ]
+    },
+    "public.sms_send_actor_type": {
+      "name": "sms_send_actor_type",
+      "schema": "public",
+      "values": [
+        "clinic_user",
+        "platform_operator"
+      ]
+    },
+    "public.sms_send_attempt_event_kind": {
+      "name": "sms_send_attempt_event_kind",
+      "schema": "public",
+      "values": [
+        "provider_result",
+        "reconciliation"
+      ]
+    },
+    "public.sms_send_outcome": {
+      "name": "sms_send_outcome",
+      "schema": "public",
+      "values": [
+        "accepted",
+        "definite_failure",
+        "outcome_unknown"
+      ]
+    },
+    "public.conversion_evidence_source": {
+      "name": "conversion_evidence_source",
+      "schema": "public",
+      "values": [
+        "practice_created",
+        "product_records",
+        "stripe_webhook"
+      ]
+    },
+    "public.practice_conversion_milestone": {
+      "name": "practice_conversion_milestone",
+      "schema": "public",
+      "values": [
+        "registered",
+        "activated",
+        "payment_method_collected",
+        "first_positive_payment"
+      ]
+    },
+    "public.migration_run_mode": {
+      "name": "migration_run_mode",
+      "schema": "public",
+      "values": [
+        "clients",
+        "patients",
+        "vaccinations",
+        "soap_notes"
+      ]
+    },
+    "public.migration_run_status": {
+      "name": "migration_run_status",
+      "schema": "public",
+      "values": [
+        "previewed",
+        "superseded",
+        "committing",
+        "committed"
+      ]
+    },
+    "public.visit_charge_disposition": {
+      "name": "visit_charge_disposition",
+      "schema": "public",
+      "values": [
+        "paid",
+        "accounts_receivable",
+        "no_charge"
+      ]
+    },
+    "public.visit_closeout_status": {
+      "name": "visit_closeout_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "clinical_finalized",
+        "completed"
+      ]
+    },
+    "public.visit_follow_up_disposition": {
+      "name": "visit_follow_up_disposition",
+      "schema": "public",
+      "values": [
+        "none",
+        "needed",
+        "scheduled"
+      ]
+    },
+    "public.visit_follow_up_resolution": {
+      "name": "visit_follow_up_resolution",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "completed",
+        "not_needed"
+      ]
+    },
+    "public.visit_handoff_method": {
+      "name": "visit_handoff_method",
+      "schema": "public",
+      "values": [
+        "print",
+        "verbal",
+        "declined"
+      ]
+    },
+    "public.visit_prescription_disposition": {
+      "name": "visit_prescription_disposition",
+      "schema": "public",
+      "values": [
+        "prescribed",
+        "not_needed"
+      ]
+    },
+    "public.visit_work_status": {
+      "name": "visit_work_status",
+      "schema": "public",
+      "values": [
+        "unresolved",
+        "charged",
+        "no_charge",
+        "voided"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1786296785895,
       "tag": "0063_modern_starbolt",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1786307112561,
+      "tag": "0064_rainy_spacker_dave",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/reset.ts
+++ b/packages/db/reset.ts
@@ -32,6 +32,7 @@ const TABLES = [
   "dispense_charge_queue",
   "invoice_items",
   "invoices",
+  "soap_note_replacements",
   "lab_result_replacements",
   "clinical_record_corrections",
   "lab_result_events",

--- a/packages/db/rls/enable-rls.sql
+++ b/packages/db/rls/enable-rls.sql
@@ -55,7 +55,7 @@ DECLARE
     'capture_sessions','cases','clients','clinical_notes','clinical_record_corrections','communications','consent_forms','consent_requests','controlled_substance_log','dispense_charge_queue','email_suppressions',
     'files','insurance_claims','insurance_policies','invoices','lab_result_events','lab_result_replacements','lab_results','location_messaging','messaging_registrations','migration_runs',
     'locations','patient_merge_events','patients','practice_payment_accounts','prescription_events','prescriptions','problem_list','procedures','products','purchase_orders',
-    'recurring_series','rooms','services','sms_consent_events','sms_send_attempt_events','sms_send_attempts','sms_suppressions','soap_note_addenda','soap_notes','staff_schedules','suppliers',
+    'recurring_series','rooms','services','sms_consent_events','sms_send_attempt_events','sms_send_attempts','sms_suppressions','soap_note_addenda','soap_note_replacements','soap_notes','staff_schedules','suppliers',
     'treatment_plans','treatment_templates','usage_records','users','vaccination_records',
     'visit_closeouts','visit_work_items','vital_signs','webhooks','wellness_enrollments','wellness_plans'
   ];
@@ -98,6 +98,13 @@ GRANT SELECT, INSERT ON lab_result_events TO openpims_app;
 -- and read links but cannot rewrite which result replaces which source.
 REVOKE ALL ON lab_result_replacements FROM openpims_app;
 GRANT SELECT, INSERT ON lab_result_replacements TO openpims_app;
+
+-- SOAP replacement links are immutable amendment lineage. The app may create
+-- and read links but cannot rewrite which finalized note replaces its source.
+REVOKE ALL ON soap_note_replacements FROM openpims_app;
+GRANT SELECT, INSERT ON soap_note_replacements TO openpims_app;
+REVOKE ALL ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text) TO openpims_app;
 
 -- Patient merge events are an append-only identity correction ledger. The app
 -- can create and read attributed events but cannot rewrite or remove lineage.

--- a/packages/db/schema/clinical-corrections.ts
+++ b/packages/db/schema/clinical-corrections.ts
@@ -97,6 +97,9 @@ export const clinicalRecordCorrections = pgTable(
     practiceRecordLabSourceUq: uniqueIndex(
       "clinical_record_corrections_practice_record_lab_source_uq",
     ).on(table.practiceId, table.id, table.labResultId),
+    practiceRecordSoapSourceUq: uniqueIndex(
+      "clinical_record_corrections_practice_record_soap_source_uq",
+    ).on(table.practiceId, table.id, table.soapNoteId),
     appointmentPracticeFk: foreignKey({
       columns: [table.practiceId, table.appointmentId, table.patientId],
       foreignColumns: [

--- a/packages/db/schema/index.ts
+++ b/packages/db/schema/index.ts
@@ -8,6 +8,7 @@ export * from "./clinical";
 export * from "./lab-result-events";
 export * from "./clinical-corrections";
 export * from "./lab-result-replacements";
+export * from "./soap-note-replacements";
 export * from "./prescriptions";
 export * from "./prescription-events";
 export * from "./billing";

--- a/packages/db/schema/soap-note-replacements.ts
+++ b/packages/db/schema/soap-note-replacements.ts
@@ -1,0 +1,128 @@
+import { relations, sql } from "drizzle-orm";
+import {
+  check,
+  foreignKey,
+  index,
+  pgTable,
+  timestamp,
+  uniqueIndex,
+  uuid,
+  varchar,
+} from "drizzle-orm/pg-core";
+import { clinicalRecordCorrections } from "./clinical-corrections";
+import { soapNotes } from "./clinical";
+import { practices } from "./practices";
+import { users } from "./users";
+
+/**
+ * Immutable SOAP amendment lineage. A replacement is a new finalized SOAP
+ * note; this evidence row links it to the retained entered-in-error source.
+ */
+export const soapNoteReplacements = pgTable(
+  "soap_note_replacements",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    practiceId: uuid("practice_id")
+      .notNull()
+      .references(() => practices.id),
+    correctionId: uuid("correction_id")
+      .notNull()
+      .references(() => clinicalRecordCorrections.id),
+    sourceSoapNoteId: uuid("source_soap_note_id")
+      .notNull()
+      .references(() => soapNotes.id),
+    replacementSoapNoteId: uuid("replacement_soap_note_id")
+      .notNull()
+      .references(() => soapNotes.id),
+    actorId: uuid("actor_id")
+      .notNull()
+      .references(() => users.id),
+    actorName: varchar("actor_name", { length: 255 }).notNull(),
+    operationId: uuid("operation_id").notNull(),
+    operationPayloadHash: varchar("operation_payload_hash", {
+      length: 64,
+    }).notNull(),
+  },
+  (table) => ({
+    sourceHistoryIdx: index("soap_note_replacements_source_history_idx").on(
+      table.practiceId,
+      table.sourceSoapNoteId,
+      table.createdAt,
+      table.id,
+    ),
+    sourceUq: uniqueIndex("soap_note_replacements_source_uq").on(
+      table.practiceId,
+      table.sourceSoapNoteId,
+    ),
+    replacementUq: uniqueIndex("soap_note_replacements_replacement_uq").on(
+      table.practiceId,
+      table.replacementSoapNoteId,
+    ),
+    operationUq: uniqueIndex("soap_note_replacements_operation_uq").on(
+      table.practiceId,
+      table.operationId,
+    ),
+    sourceTenantFk: foreignKey({
+      columns: [table.practiceId, table.sourceSoapNoteId],
+      foreignColumns: [soapNotes.practiceId, soapNotes.id],
+      name: "soap_note_replacements_source_tenant_fk",
+    }),
+    replacementTenantFk: foreignKey({
+      columns: [table.practiceId, table.replacementSoapNoteId],
+      foreignColumns: [soapNotes.practiceId, soapNotes.id],
+      name: "soap_note_replacements_replacement_tenant_fk",
+    }),
+    correctionSourceTenantFk: foreignKey({
+      columns: [table.practiceId, table.correctionId, table.sourceSoapNoteId],
+      foreignColumns: [
+        clinicalRecordCorrections.practiceId,
+        clinicalRecordCorrections.id,
+        clinicalRecordCorrections.soapNoteId,
+      ],
+      name: "soap_note_replacements_correction_source_tenant_fk",
+    }),
+    actorTenantFk: foreignKey({
+      columns: [table.practiceId, table.actorId],
+      foreignColumns: [users.practiceId, users.id],
+      name: "soap_note_replacements_actor_tenant_fk",
+    }),
+    shapeCheck: check(
+      "soap_note_replacements_shape_check",
+      sql`${table.sourceSoapNoteId} <> ${table.replacementSoapNoteId}
+        and ${table.actorName} = btrim(${table.actorName})
+        and length(btrim(${table.actorName})) between 1 and 255
+        and ${table.operationPayloadHash} ~ '^[0-9a-f]{64}$'`,
+    ),
+  }),
+);
+
+export const soapNoteReplacementsRelations = relations(
+  soapNoteReplacements,
+  ({ one }) => ({
+    practice: one(practices, {
+      fields: [soapNoteReplacements.practiceId],
+      references: [practices.id],
+    }),
+    correction: one(clinicalRecordCorrections, {
+      fields: [soapNoteReplacements.correctionId],
+      references: [clinicalRecordCorrections.id],
+    }),
+    source: one(soapNotes, {
+      fields: [soapNoteReplacements.sourceSoapNoteId],
+      references: [soapNotes.id],
+      relationName: "soapReplacementSource",
+    }),
+    replacement: one(soapNotes, {
+      fields: [soapNoteReplacements.replacementSoapNoteId],
+      references: [soapNotes.id],
+      relationName: "soapReplacementNote",
+    }),
+    actor: one(users, {
+      fields: [soapNoteReplacements.actorId],
+      references: [users.id],
+    }),
+  }),
+);

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -20,6 +20,32 @@ function soapAddendumPayloadHash(
     .digest("hex");
 }
 
+function soapReplacementPayloadHash(input: {
+  patientId: string;
+  sourceNoteId: string;
+  actorId: string;
+  reason: string;
+  subjective?: string | null;
+  objective?: string | null;
+  assessment?: string | null;
+  plan?: string | null;
+}) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        patientId: input.patientId,
+        sourceNoteId: input.sourceNoteId,
+        actorId: input.actorId,
+        reason: input.reason,
+        subjective: input.subjective ?? null,
+        objective: input.objective ?? null,
+        assessment: input.assessment ?? null,
+        plan: input.plan ?? null,
+      }),
+    )
+    .digest("hex");
+}
+
 function nonBlankEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
   return value ? value : undefined;
@@ -60,6 +86,7 @@ const bAppointment = randomUUID();
 const aCloseout = randomUUID();
 const bCloseout = randomUUID();
 const aSoapLegalAppointment = randomUUID();
+const bSoapLegalAppointment = randomUUID();
 const aSoapDraftFinalAppointment = randomUUID();
 const aSoapDoubleFinalAppointment = randomUUID();
 const aSoapDiscardAppointment = randomUUID();
@@ -67,6 +94,17 @@ const aSoapSource = randomUUID();
 const aSoapReplacement = randomUUID();
 const aSoapDeletedSource = randomUUID();
 const aSoapCorrection = randomUUID();
+const bSoapSource = randomUUID();
+const bSoapReplacement = randomUUID();
+const bSoapCorrection = randomUUID();
+const aSoapReplacementEvidence = randomUUID();
+const bSoapReplacementEvidence = randomUUID();
+const aHistoricalSoapSource = randomUUID();
+const aHistoricalSoapReplacement = randomUUID();
+const aHistoricalSoapSourceCorrection = randomUUID();
+const aHistoricalSoapReplacementCorrection = randomUUID();
+const aHistoricalSoapReplacementEvidence = randomUUID();
+const aHistoricalSoapReplacementOperation = randomUUID();
 const aSoapAddendum = randomUUID();
 const aSoapRestoreAddendum = randomUUID();
 const aSoapDeletedRestoreAddendum = randomUUID();
@@ -121,6 +159,18 @@ const bSmsDeliveryHistory = randomUUID();
 const bSmsDeliveryConflictHistory = randomUUID();
 const funnelEventId = randomUUID();
 const conversionEvidenceKey = `practice:${aId}`;
+const aSoapCorrectionReason =
+  "Original note was documented on the wrong encounter.";
+const bSoapCorrectionReason =
+  "Original note B requires a legally retained replacement.";
+const historicalSoapSourceReason =
+  'Historical source correction: owner reported "wrong chart".\nRetain lineage.';
+const historicalSoapReplacementReason =
+  "Historical replacement later entered in error.";
+const historicalSoapReplacementSubjective =
+  'Restored replacement quote: "improved".\nDose remains ½ tablet 🐾';
+const historicalSoapOccurredAt = new Date(Date.now() - 3 * 60 * 60 * 1000);
+const historicalSoapDeletedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
 let failures = 0;
 
 async function appTransaction<T>(
@@ -339,6 +389,7 @@ try {
     (id, practice_id, client_id, patient_id, start_time, end_time, status)
     values
     (${aSoapLegalAppointment}, ${aId}, ${aClient}, ${aPatient}, now(), now() + interval '30 minutes', 'in_exam'),
+    (${bSoapLegalAppointment}, ${bId}, ${bClient}, ${bPatient}, now(), now() + interval '30 minutes', 'in_exam'),
     (${aSoapDraftFinalAppointment}, ${aId}, ${aClient}, ${aPatient}, now(), now() + interval '30 minutes', 'in_exam'),
     (${aSoapDoubleFinalAppointment}, ${aId}, ${aClient}, ${aPatient}, now(), now() + interval '30 minutes', 'in_exam'),
     (${aSoapDiscardAppointment}, ${aId}, ${aClient}, ${aPatient}, now(), now() + interval '30 minutes', 'in_exam')`;
@@ -356,24 +407,94 @@ try {
           ${aUser}, 'RLS Admin A', 'finalized', 1, now() - interval '2 hours', ${aUser},
           'RLS Admin A', 'Original SOAP', false),
         (${aSoapReplacement}, ${aId}, ${aPatient}, ${aSoapLegalAppointment},
-          ${aUser}, 'RLS Admin A', 'finalized', 1, now() - interval '2 hours', ${aUser},
+          ${aUser}, 'RLS Admin A', 'finalized', 1, now(), ${aUser},
           'RLS Admin A', 'Replacement SOAP', false)`;
       await tx`insert into clinical_record_corrections
         (id, created_at, practice_id, record_type, action, soap_note_id, patient_id,
          appointment_id, reason, corrected_by, corrected_by_name)
-        values (${aSoapCorrection}, now() - interval '1 hour', ${aId}, 'soap_note', 'entered_in_error',
+        values (${aSoapCorrection}, now(), ${aId}, 'soap_note', 'entered_in_error',
           ${aSoapSource}, ${aPatient}, ${aSoapLegalAppointment},
-          'Original note was documented on the wrong encounter.', ${aUser},
+          ${aSoapCorrectionReason}, ${aUser},
           'RLS Admin A')`;
+      await tx`insert into soap_note_replacements
+        (id, practice_id, correction_id, source_soap_note_id,
+         replacement_soap_note_id, actor_id, actor_name, operation_id,
+         operation_payload_hash)
+        values (${aSoapReplacementEvidence}, ${aId}, ${aSoapCorrection},
+          ${aSoapSource}, ${aSoapReplacement}, ${aUser}, 'RLS Admin A',
+          ${randomUUID()}, ${soapReplacementPayloadHash({
+              patientId: aPatient,
+              sourceNoteId: aSoapSource,
+              actorId: aUser,
+              reason: aSoapCorrectionReason,
+              subjective: "Replacement SOAP",
+            })})`;
     });
     correctedReplacementTransactionAllowed = true;
   } catch {
     correctedReplacementTransactionAllowed = false;
   }
   check(
-    "corrected source and replacement SOAP can commit atomically",
+    "corrected source, replacement SOAP, and lineage can commit atomically",
     correctedReplacementTransactionAllowed,
   );
+
+  let ordinarySoapReplacementHashMismatchBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into soap_note_replacements
+        (practice_id, correction_id, source_soap_note_id,
+         replacement_soap_note_id, actor_id, actor_name, operation_id,
+         operation_payload_hash)
+        values (${aId}, ${aSoapCorrection}, ${aSoapSource},
+          ${aSoapReplacement}, ${aUser}, 'RLS Admin A', ${randomUUID()},
+          ${"0".repeat(64)})`;
+    });
+  } catch (error) {
+    ordinarySoapReplacementHashMismatchBlocked = String(error).includes(
+      "SOAP replacement payload hash is invalid.",
+    );
+  }
+  check(
+    "ordinary SOAP replacement INSERT rejects a mismatched exact payload hash",
+    ordinarySoapReplacementHashMismatchBlocked,
+  );
+
+  await owner.begin(async (tx) => {
+    const setup = tx as unknown as typeof owner;
+    await setup`insert into soap_notes
+      (id, practice_id, patient_id, appointment_id, author_id, author_name,
+       status, revision, finalized_at, finalized_by, finalizer_name,
+       subjective, imported)
+      values
+      (${bSoapSource}, ${bId}, ${bPatient}, ${bSoapLegalAppointment}, ${bUser},
+        'RLS Admin B', 'finalized', 1, now() - interval '2 hours', ${bUser},
+        'RLS Admin B', 'Original SOAP B', false),
+      (${bSoapReplacement}, ${bId}, ${bPatient}, ${bSoapLegalAppointment}, ${bUser},
+        'RLS Admin B', 'finalized', 1, now(), ${bUser}, 'RLS Admin B',
+        'Replacement SOAP B', false)`;
+    await setup`insert into clinical_record_corrections
+      (id, practice_id, record_type, action, soap_note_id, patient_id,
+       appointment_id, reason, corrected_by, corrected_by_name)
+      values (${bSoapCorrection}, ${bId}, 'soap_note', 'entered_in_error',
+        ${bSoapSource}, ${bPatient}, ${bSoapLegalAppointment},
+        ${bSoapCorrectionReason}, ${bUser},
+        'RLS Admin B')`;
+    await setup`insert into soap_note_replacements
+      (id, practice_id, correction_id, source_soap_note_id,
+       replacement_soap_note_id, actor_id, actor_name, operation_id,
+       operation_payload_hash)
+      values (${bSoapReplacementEvidence}, ${bId}, ${bSoapCorrection},
+        ${bSoapSource}, ${bSoapReplacement}, ${bUser}, 'RLS Admin B',
+        ${randomUUID()}, ${soapReplacementPayloadHash({
+            patientId: bPatient,
+            sourceNoteId: bSoapSource,
+            actorId: bUser,
+            reason: bSoapCorrectionReason,
+            subjective: "Replacement SOAP B",
+          })})`;
+  });
 
   await owner`insert into soap_notes
     (id, created_at, updated_at, deleted_at, practice_id, patient_id,
@@ -384,6 +505,32 @@ try {
       ${aPatient}, null, ${aUser}, 'RLS Admin A', 'finalized', 1,
       now() - interval '2 hours', ${aUser}, 'RLS Admin A',
       'Retired finalized SOAP', false)`;
+
+  await owner`insert into soap_notes
+    (id, created_at, updated_at, deleted_at, practice_id, patient_id,
+     appointment_id, author_id, author_name, status, revision, finalized_at,
+     finalized_by, finalizer_name, subjective, imported)
+    values
+    (${aHistoricalSoapSource}, ${historicalSoapOccurredAt},
+      ${historicalSoapDeletedAt}, ${historicalSoapDeletedAt}, ${aId},
+      ${aPatient}, null, ${aUser}, 'RLS Admin A', 'finalized', 1,
+      ${historicalSoapOccurredAt}, ${aUser}, 'RLS Admin A',
+      'Historical source SOAP', false),
+    (${aHistoricalSoapReplacement}, ${historicalSoapOccurredAt},
+      ${historicalSoapDeletedAt}, ${historicalSoapDeletedAt}, ${aId},
+      ${aPatient}, null, ${aUser}, 'RLS Admin A', 'finalized', 1,
+      ${historicalSoapOccurredAt}, ${aUser}, 'RLS Admin A',
+      ${historicalSoapReplacementSubjective}, false)`;
+  await owner`insert into clinical_record_corrections
+    (id, created_at, practice_id, record_type, action, soap_note_id, patient_id,
+     appointment_id, reason, corrected_by, corrected_by_name)
+    values
+    (${aHistoricalSoapSourceCorrection}, ${historicalSoapOccurredAt}, ${aId},
+      'soap_note', 'entered_in_error', ${aHistoricalSoapSource}, ${aPatient},
+      null, ${historicalSoapSourceReason}, ${aUser}, 'RLS Admin A'),
+    (${aHistoricalSoapReplacementCorrection}, ${historicalSoapOccurredAt}, ${aId},
+      'soap_note', 'entered_in_error', ${aHistoricalSoapReplacement}, ${aPatient},
+      null, ${historicalSoapReplacementReason}, ${aUser}, 'RLS Admin A')`;
 
   let draftAndFinalBlocked = false;
   try {
@@ -719,6 +866,180 @@ try {
   check(
     "SOAP addendum restore cannot spoof tenant bypass GUCs",
     spoofedRestoreBypassBlocked,
+  );
+
+  const historicalSoapHash = soapReplacementPayloadHash({
+    patientId: aPatient,
+    sourceNoteId: aHistoricalSoapSource,
+    actorId: aUser,
+    reason: historicalSoapSourceReason,
+    subjective: historicalSoapReplacementSubjective,
+  });
+  let ordinaryHistoricalReplacementBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select set_config('app.soap_replacement_restore', 'on', true)`;
+      await tx`insert into soap_note_replacements
+        (id, created_at, practice_id, correction_id, source_soap_note_id,
+         replacement_soap_note_id, actor_id, actor_name, operation_id,
+         operation_payload_hash)
+        values (${aHistoricalSoapReplacementEvidence}, ${historicalSoapOccurredAt},
+          ${aId}, ${aHistoricalSoapSourceCorrection}, ${aHistoricalSoapSource},
+          ${aHistoricalSoapReplacement}, ${aUser}, 'RLS Admin A',
+          ${aHistoricalSoapReplacementOperation}, ${historicalSoapHash})`;
+    });
+  } catch {
+    ordinaryHistoricalReplacementBlocked = true;
+  }
+  check(
+    "ordinary app INSERT cannot spoof restore mode for deleted SOAP endpoints",
+    ordinaryHistoricalReplacementBlocked,
+  );
+
+  let historicalReplacementRestoreAllowed = false;
+  try {
+    const restored = await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      return tx`select result_id, was_inserted
+        from public.restore_soap_note_replacement(
+          ${aHistoricalSoapReplacementEvidence}, ${historicalSoapOccurredAt},
+          ${aId}, ${aHistoricalSoapSourceCorrection}, ${aHistoricalSoapSource},
+          ${aHistoricalSoapReplacement}, ${aUser}, 'RLS Admin A',
+          ${aHistoricalSoapReplacementOperation}, ${historicalSoapHash})`;
+    });
+    historicalReplacementRestoreAllowed =
+      restored.length === 1 &&
+      restored[0]!.result_id === aHistoricalSoapReplacementEvidence &&
+      restored[0]!.was_inserted === true;
+  } catch {
+    historicalReplacementRestoreAllowed = false;
+  }
+  check(
+    "tenant-bound restore accepts exact lineage before both SOAP deletions",
+    historicalReplacementRestoreAllowed,
+  );
+
+  let exactHistoricalReplacementReplayAllowed = false;
+  try {
+    const replayed = await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      return tx`select result_id, was_inserted
+        from public.restore_soap_note_replacement(
+          ${aHistoricalSoapReplacementEvidence}, ${historicalSoapOccurredAt},
+          ${aId}, ${aHistoricalSoapSourceCorrection}, ${aHistoricalSoapSource},
+          ${aHistoricalSoapReplacement}, ${aUser}, 'RLS Admin A',
+          ${aHistoricalSoapReplacementOperation}, ${historicalSoapHash})`;
+    });
+    exactHistoricalReplacementReplayAllowed =
+      replayed.length === 1 &&
+      replayed[0]!.result_id === aHistoricalSoapReplacementEvidence &&
+      replayed[0]!.was_inserted === false;
+  } catch {
+    exactHistoricalReplacementReplayAllowed = false;
+  }
+  check(
+    "SOAP replacement restore is idempotent only for exact replay evidence",
+    exactHistoricalReplacementReplayAllowed,
+  );
+
+  let conflictingHistoricalReplacementReplayBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_replacement(
+        ${randomUUID()}, ${historicalSoapOccurredAt}, ${aId},
+        ${aHistoricalSoapSourceCorrection}, ${aHistoricalSoapSource},
+        ${aHistoricalSoapReplacement}, ${aUser}, 'RLS Admin A',
+        ${aHistoricalSoapReplacementOperation}, ${historicalSoapHash})`;
+    });
+  } catch {
+    conflictingHistoricalReplacementReplayBlocked = true;
+  }
+  check(
+    "SOAP replacement restore rejects conflicting operation replay",
+    conflictingHistoricalReplacementReplayBlocked,
+  );
+
+  let historicalReplacementHashMismatchBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_replacement(
+        ${randomUUID()}, ${historicalSoapOccurredAt}, ${aId},
+        ${aHistoricalSoapSourceCorrection}, ${aHistoricalSoapSource},
+        ${aHistoricalSoapReplacement}, ${aUser}, 'RLS Admin A', ${randomUUID()},
+        ${"0".repeat(64)})`;
+    });
+  } catch {
+    historicalReplacementHashMismatchBlocked = true;
+  }
+  check(
+    "SOAP replacement restore rejects a mismatched exact payload hash",
+    historicalReplacementHashMismatchBlocked,
+  );
+
+  let postDeletionHistoricalReplacementBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_replacement(
+        ${randomUUID()},
+        ${new Date(historicalSoapDeletedAt.getTime() + 60_000)}, ${aId},
+        ${aHistoricalSoapSourceCorrection}, ${aHistoricalSoapSource},
+        ${aHistoricalSoapReplacement}, ${aUser}, 'RLS Admin A', ${randomUUID()},
+        ${historicalSoapHash})`;
+    });
+  } catch {
+    postDeletionHistoricalReplacementBlocked = true;
+  }
+  check(
+    "SOAP replacement restore rejects links created after endpoint deletion",
+    postDeletionHistoricalReplacementBlocked,
+  );
+
+  let crossTenantHistoricalReplacementRestoreBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${bId}, true)`;
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`select public.restore_soap_note_replacement(
+        ${randomUUID()}, ${historicalSoapOccurredAt}, ${aId},
+        ${aHistoricalSoapSourceCorrection}, ${aHistoricalSoapSource},
+        ${aHistoricalSoapReplacement}, ${aUser}, 'RLS Admin A', ${randomUUID()},
+        ${historicalSoapHash})`;
+    });
+  } catch {
+    crossTenantHistoricalReplacementRestoreBlocked = true;
+  }
+  check(
+    "SOAP replacement restore cannot spoof another tenant with bypass GUCs",
+    crossTenantHistoricalReplacementRestoreBlocked,
+  );
+
+  const reverseHistoricalSoapHash = soapReplacementPayloadHash({
+    patientId: aPatient,
+    sourceNoteId: aHistoricalSoapReplacement,
+    actorId: aUser,
+    reason: historicalSoapReplacementReason,
+    subjective: "Historical source SOAP",
+  });
+  let historicalReplacementCycleBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`select public.restore_soap_note_replacement(
+        ${randomUUID()}, ${historicalSoapOccurredAt}, ${aId},
+        ${aHistoricalSoapReplacementCorrection}, ${aHistoricalSoapReplacement},
+        ${aHistoricalSoapSource}, ${aUser}, 'RLS Admin A', ${randomUUID()},
+        ${reverseHistoricalSoapHash})`;
+    });
+  } catch {
+    historicalReplacementCycleBlocked = true;
+  }
+  check(
+    "historical SOAP replacement restore remains cycle-safe",
+    historicalReplacementCycleBlocked,
   );
 
   // Tenant A context sees only A's rows.
@@ -1147,6 +1468,17 @@ try {
       aLabReplacementRows[0]!.id === aLabReplacement &&
       aLabReplacementRows[0]!.practice_id === aId,
   );
+  const aSoapReplacementRows = await appTransaction(async (tx) => {
+    await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+    return tx`select id, practice_id from soap_note_replacements
+      where id in (${aSoapReplacementEvidence}, ${bSoapReplacementEvidence})`;
+  });
+  check(
+    "tenant A sees only A's SOAP replacement evidence",
+    aSoapReplacementRows.length === 1 &&
+      aSoapReplacementRows[0]!.id === aSoapReplacementEvidence &&
+      aSoapReplacementRows[0]!.practice_id === aId,
+  );
   const aLabCorrectionRows = await appTransaction(async (tx) => {
     await tx`select set_config('app.current_practice_id', ${aId}, true)`;
     return tx`select id, practice_id from clinical_record_corrections where id in (${aLabCorrection}, ${bLabCorrection})`;
@@ -1172,6 +1504,54 @@ try {
       labReplacementPrivileges[0]!.can_insert === true &&
       labReplacementPrivileges[0]!.can_update === false &&
       labReplacementPrivileges[0]!.can_delete === false,
+  );
+
+  const soapReplacementPrivileges = await owner`
+    select
+      has_table_privilege('openpims_app', 'soap_note_replacements', 'SELECT') as can_select,
+      has_table_privilege('openpims_app', 'soap_note_replacements', 'INSERT') as can_insert,
+      has_table_privilege('openpims_app', 'soap_note_replacements', 'UPDATE') as can_update,
+      has_table_privilege('openpims_app', 'soap_note_replacements', 'DELETE') as can_delete
+  `;
+  check(
+    "app role can append/read but cannot mutate SOAP replacement evidence",
+    soapReplacementPrivileges.length === 1 &&
+      soapReplacementPrivileges[0]!.can_select === true &&
+      soapReplacementPrivileges[0]!.can_insert === true &&
+      soapReplacementPrivileges[0]!.can_update === false &&
+      soapReplacementPrivileges[0]!.can_delete === false,
+  );
+
+  const soapReplacementRestorePrivileges = await owner`
+    select
+      has_function_privilege(
+        'openpims_app',
+        to_regprocedure('public.restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text)'),
+        'EXECUTE'
+      ) as app_can_execute,
+      coalesce((
+        select has_function_privilege(
+          role.oid,
+          to_regprocedure('public.restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text)'),
+          'EXECUTE'
+        )
+        from pg_roles as role where role.rolname = 'anon'
+      ), false) as anon_can_execute,
+      coalesce((
+        select has_function_privilege(
+          role.oid,
+          to_regprocedure('public.restore_soap_note_replacement(uuid,timestamptz,uuid,uuid,uuid,uuid,uuid,text,uuid,text)'),
+          'EXECUTE'
+        )
+        from pg_roles as role where role.rolname = 'authenticated'
+      ), false) as authenticated_can_execute
+  `;
+  check(
+    "only the app role can execute SOAP replacement restore",
+    soapReplacementRestorePrivileges.length === 1 &&
+      soapReplacementRestorePrivileges[0]!.app_can_execute === true &&
+      soapReplacementRestorePrivileges[0]!.anon_can_execute === false &&
+      soapReplacementRestorePrivileges[0]!.authenticated_can_execute === false,
   );
 
   let crossTenantLabReplacementInsertBlocked = false;
@@ -1213,6 +1593,46 @@ try {
     mixedTenantLabReplacementInsertBlocked,
   );
 
+  let crossTenantSoapReplacementInsertBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into soap_note_replacements
+        (practice_id, correction_id, source_soap_note_id,
+         replacement_soap_note_id, actor_id, actor_name, operation_id,
+         operation_payload_hash)
+        values (${bId}, ${bSoapCorrection}, ${bSoapSource},
+          ${bSoapReplacement}, ${bUser}, 'RLS Admin B', ${randomUUID()},
+          ${"9".repeat(64)})`;
+    });
+  } catch {
+    crossTenantSoapReplacementInsertBlocked = true;
+  }
+  check(
+    "cross-tenant SOAP replacement INSERT is blocked",
+    crossTenantSoapReplacementInsertBlocked,
+  );
+
+  let mixedTenantSoapReplacementInsertBlocked = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.current_practice_id', ${aId}, true)`;
+      await tx`insert into soap_note_replacements
+        (practice_id, correction_id, source_soap_note_id,
+         replacement_soap_note_id, actor_id, actor_name, operation_id,
+         operation_payload_hash)
+        values (${aId}, ${bSoapCorrection}, ${bSoapSource},
+          ${bSoapReplacement}, ${bUser}, 'Mixed tenant actor', ${randomUUID()},
+          ${"a".repeat(64)})`;
+    });
+  } catch {
+    mixedTenantSoapReplacementInsertBlocked = true;
+  }
+  check(
+    "tenant-safe SOAP replacement FKs reject mixed-practice evidence",
+    mixedTenantSoapReplacementInsertBlocked,
+  );
+
   let ownerReplacementMutationBlockedWithoutMaintenance = false;
   try {
     await owner`update lab_result_replacements set actor_name = actor_name where id = ${aLabReplacement}`;
@@ -1227,6 +1647,24 @@ try {
     const maintenance = tx as unknown as typeof owner;
     await maintenance`select set_config('app.ledger_maintenance', 'on', true)`;
     await maintenance`update lab_result_replacements set actor_name = actor_name where id = ${aLabReplacement}`;
+  });
+
+  let ownerSoapReplacementMutationBlockedWithoutMaintenance = false;
+  try {
+    await owner`update soap_note_replacements set actor_name = actor_name
+      where id = ${aSoapReplacementEvidence}`;
+  } catch {
+    ownerSoapReplacementMutationBlockedWithoutMaintenance = true;
+  }
+  check(
+    "SOAP replacement owner mutation requires the maintenance GUC",
+    ownerSoapReplacementMutationBlockedWithoutMaintenance,
+  );
+  await owner.begin(async (tx) => {
+    const maintenance = tx as unknown as typeof owner;
+    await maintenance`select set_config('app.ledger_maintenance', 'on', true)`;
+    await maintenance`update soap_note_replacements set actor_name = actor_name
+      where id = ${aSoapReplacementEvidence}`;
   });
 
   let ownerCorrectionMutationBlockedWithoutMaintenance = false;
@@ -1960,6 +2398,21 @@ try {
     "application role cannot delete lab replacement evidence even with bypass GUCs",
     bypassCannotDeleteLabReplacement,
   );
+  let bypassCannotDeleteSoapReplacement = false;
+  try {
+    await appTransaction(async (tx) => {
+      await tx`select set_config('app.rls_bypass', 'on', true)`;
+      await tx`select set_config('app.ledger_maintenance', 'on', true)`;
+      await tx`delete from soap_note_replacements
+        where id = ${aSoapReplacementEvidence}`;
+    });
+  } catch {
+    bypassCannotDeleteSoapReplacement = true;
+  }
+  check(
+    "application role cannot delete SOAP replacement evidence even with bypass GUCs",
+    bypassCannotDeleteSoapReplacement,
+  );
   let bypassCannotDeleteClinicalCorrection = false;
   try {
     await appTransaction(async (tx) => {
@@ -1990,9 +2443,10 @@ try {
     await cleanup`delete from sms_delivery_events where id in (${aSmsDeliveryEvent}, ${bSmsDeliveryEvent}, ${unmatchedSmsDeliveryEvent})`;
     await cleanup`delete from lab_result_events where id in (${aLabResultEvent}, ${bLabResultEvent})`;
     await cleanup`delete from lab_result_replacements where id in (${aLabReplacement}, ${bLabReplacement})`;
+    await cleanup`delete from soap_note_replacements where id in (${aSoapReplacementEvidence}, ${bSoapReplacementEvidence}, ${aHistoricalSoapReplacementEvidence})`;
     await cleanup`delete from soap_note_addenda where id in (${aSoapAddendum}, ${aSoapRestoreAddendum}, ${aSoapDeletedRestoreAddendum})`;
-    await cleanup`delete from clinical_record_corrections where id in (${aLabCorrection}, ${bLabCorrection}, ${aSoapCorrection})`;
-    await cleanup`delete from soap_notes where id in (${aSoapSource}, ${aSoapReplacement}, ${aSoapDeletedSource}, ${aSoapDraft})`;
+    await cleanup`delete from clinical_record_corrections where id in (${aLabCorrection}, ${bLabCorrection}, ${aSoapCorrection}, ${bSoapCorrection}, ${aHistoricalSoapSourceCorrection}, ${aHistoricalSoapReplacementCorrection})`;
+    await cleanup`delete from soap_notes where id in (${aSoapSource}, ${aSoapReplacement}, ${bSoapSource}, ${bSoapReplacement}, ${aSoapDeletedSource}, ${aSoapDraft}, ${aHistoricalSoapSource}, ${aHistoricalSoapReplacement})`;
     await cleanup`delete from lab_results where id in (${aLabResult}, ${bLabResult}, ${aReplacementLabResult}, ${bReplacementLabResult})`;
     await cleanup`delete from sms_send_attempt_events where id in (${aSmsSendAttemptEvent}, ${bSmsSendAttemptEvent}, ${aAppSmsSendAttemptEvent})`;
     await cleanup`delete from sms_send_attempts where id in (${aSmsSendAttempt}, ${bSmsSendAttempt}, ${aAppSmsSendAttempt})`;
@@ -2007,7 +2461,7 @@ try {
     await cleanup`delete from practice_conversion_milestones where practice_id = ${aId}`;
     await cleanup`delete from invoices where id in (${aInvoice}, ${bInvoice})`;
     await cleanup`delete from migration_runs where id in (${aMigrationRun}, ${bMigrationRun})`;
-    await cleanup`delete from appointments where id in (${aAppointment}, ${bAppointment}, ${aSoapLegalAppointment}, ${aSoapDraftFinalAppointment}, ${aSoapDoubleFinalAppointment}, ${aSoapDiscardAppointment})`;
+    await cleanup`delete from appointments where id in (${aAppointment}, ${bAppointment}, ${aSoapLegalAppointment}, ${bSoapLegalAppointment}, ${aSoapDraftFinalAppointment}, ${aSoapDoubleFinalAppointment}, ${aSoapDiscardAppointment})`;
     await cleanup`delete from prescriptions where id in (${aPrescription}, ${bPrescription})`;
     await cleanup`delete from products where id in (${aProduct}, ${bProduct})`;
     await cleanup`delete from patients where id in (${aPatient}, ${bPatient}, ${aMergeTargetPatient}, ${bMergeTargetPatient}, ${aLineageCandidatePatient})`;

--- a/packages/db/test-rls.ts
+++ b/packages/db/test-rls.ts
@@ -806,7 +806,11 @@ try {
     await appTransaction(async (tx) => {
       await tx`select set_config('app.current_practice_id', ${aId}, true)`;
       await tx`select public.restore_soap_note_addendum(
-        ${randomUUID()}, now() - interval '30 minutes', ${aId}, ${aSoapSource}, ${aUser},
+        ${randomUUID()}, (
+          select created_at + interval '1 millisecond'
+          from clinical_record_corrections
+          where id = ${aSoapCorrection}
+        ), ${aId}, ${aSoapSource}, ${aUser},
         'RLS Admin A', ${postCorrectionContent}, ${randomUUID()},
         ${soapAddendumPayloadHash(aSoapSource, aUser, postCorrectionContent)})`;
     });
@@ -2444,7 +2448,7 @@ try {
     await cleanup`delete from lab_result_events where id in (${aLabResultEvent}, ${bLabResultEvent})`;
     await cleanup`delete from lab_result_replacements where id in (${aLabReplacement}, ${bLabReplacement})`;
     await cleanup`delete from soap_note_replacements where id in (${aSoapReplacementEvidence}, ${bSoapReplacementEvidence}, ${aHistoricalSoapReplacementEvidence})`;
-    await cleanup`delete from soap_note_addenda where id in (${aSoapAddendum}, ${aSoapRestoreAddendum}, ${aSoapDeletedRestoreAddendum})`;
+    await cleanup`delete from soap_note_addenda where practice_id in (${aId}, ${bId})`;
     await cleanup`delete from clinical_record_corrections where id in (${aLabCorrection}, ${bLabCorrection}, ${aSoapCorrection}, ${bSoapCorrection}, ${aHistoricalSoapSourceCorrection}, ${aHistoricalSoapReplacementCorrection})`;
     await cleanup`delete from soap_notes where id in (${aSoapSource}, ${aSoapReplacement}, ${bSoapSource}, ${bSoapReplacement}, ${aSoapDeletedSource}, ${aSoapDraft}, ${aHistoricalSoapSource}, ${aHistoricalSoapReplacement})`;
     await cleanup`delete from lab_results where id in (${aLabResult}, ${bLabResult}, ${aReplacementLabResult}, ${bReplacementLabResult})`;


### PR DESCRIPTION
## Summary

- add an admin/veterinarian-only workflow to replace a finalized SOAP while retaining the original as entered-in-error evidence
- record immutable, tenant-bound source → replacement lineage with exact payload hashing, idempotent operations, and cycle-safe database validation
- preserve reciprocal lineage in patient/records views and medical-summary PDFs
- support checked-out encounter recovery without reopening invoices, payments, discharge, or handoff state
- keep true void-without-replacement cases valid through an attributable closeout exception
- make demo cleanup, practice export, and restore preserve historical replacement evidence, including later soft-deleted SOAP endpoints

## Safety properties

- correction, replacement finalization, and lineage creation are atomic and use the PostgreSQL transaction clock
- ordinary application inserts require active finalized endpoints and an exact canonical payload hash
- historical restore is tenant-bound, PUBLIC-revoked, exact-replay checked, and still enforces attribution, chronology, hash integrity, and acyclic lineage
- app role can only SELECT/INSERT replacement evidence; UPDATE/DELETE remain blocked
- production preflight found 0 corrected SOAPs, 0 ambiguous corrected/current encounters, and 0 missing-effective encounters, so no backfill is required

## Local verification

- web type-check
- database type-check
- full web suite: 321 files passed, 1 expected integration skip; 3,271 tests passed, 1 expected skip
- focused post-review matrix: 149 tests passed
- production Next.js build succeeded and includes `/records/replace-soap/[patientId]`
- Drizzle generation reports no schema changes
- `git diff --check`
- changed-file secret and local-path scan
- two adversarial integrity reviews; no remaining code-level blocker

## Required before merge

- real PostgreSQL migration apply
- schema drift check
- RLS apply + live RLS suite
- migration-runs integration test

No SMS provider send, participant outreach, payment activity, or production mutation was performed.